### PR TITLE
Access to HTTP POST body

### DIFF
--- a/Sming/SmingCore/Network/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/HttpRequest.cpp
@@ -29,6 +29,10 @@ HttpRequest::~HttpRequest()
 	delete requestPostParameters;
 	delete cookies;
 	postDataProcessed = 0;
+	if (bodyBuf != NULL)
+	{
+		os_free(bodyBuf);
+	}
 }
 
 String HttpRequest::getQueryParameter(String parameterName,
@@ -251,10 +255,7 @@ bool HttpRequest::extractParsingItemsList(pbuf* buf, int startPos, int endPos,
 
 void HttpRequest::parseRawData(HttpServer *server, pbuf* buf)
 {
-	if (!combinePostFrag)
-	{
-		bodyBuf = (char *) os_zalloc(sizeof(char) * buf->tot_len);
-	}
+	bodyBuf = (char *) os_zalloc(sizeof(char) * buf->tot_len);
 	int headerEnd = NetUtils::pbufFindStr(buf, "\r\n\r\n");
 	if (headerEnd + getContentLength() > NETWORK_MAX_HTTP_PARSING_LEN)
 	{

--- a/Sming/SmingCore/Network/HttpRequest.h
+++ b/Sming/SmingCore/Network/HttpRequest.h
@@ -42,6 +42,7 @@ public:
 	String getPostParameter(String parameterName, String defaultValue = "");
 	String getHeader(String headerName, String defaultValue = "");
 	String getCookie(String cookieName, String defaultValue = "");
+	char* getBody();
 
 public:
 	HttpParseResult parseHeader(HttpServer *server, pbuf* buf);
@@ -49,6 +50,7 @@ public:
 	bool extractParsingItemsList(pbuf* buf, int startPos, int endPos,
 			char delimChar, char endChar,
 			HashMap<String, String> *resultItems);
+	void parseRawData(HttpServer *server, pbuf* buf);
 
 private:
 	String method;
@@ -59,6 +61,7 @@ private:
 	HashMap<String, String> *cookies;
 	int postDataProcessed;
 	bool combinePostFrag;
+	char *bodyBuf;
 
 	friend class TemplateFileStream;
 };

--- a/Sming/SmingCore/Network/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/HttpServerConnection.cpp
@@ -11,8 +11,9 @@
 #include "TcpServer.h"
 #include "../../Services/cWebsocket/websocket.h"
 
-HttpServerConnection::HttpServerConnection(HttpServer *parentServer, tcp_pcb *clientTcp)
-	: TcpConnection(clientTcp, true), server(parentServer), state(eHCS_Ready)
+HttpServerConnection::HttpServerConnection(HttpServer *parentServer,
+		tcp_pcb *clientTcp) :
+		TcpConnection(clientTcp, true), server(parentServer), state(eHCS_Ready)
 {
 	TcpServer::totalConnections++;
 	response.setHeader("Connection", "close");
@@ -32,13 +33,13 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 	}
 
 	/*{
-	 	// split.buf.test
-		pbuf* dbghack = new pbuf();
-		dbghack->payload = (char*)buf->payload + 100;
-		dbghack->len = buf->len - 100;
-		buf->len = 100;
-		buf->next = dbghack;
-	}*/
+	 // split.buf.test
+	 pbuf* dbghack = new pbuf();
+	 dbghack->payload = (char*)buf->payload + 100;
+	 dbghack->len = buf->len - 100;
+	 buf->len = 100;
+	 buf->next = dbghack;
+	 }*/
 
 	if (state == eHCS_Ready)
 	{
@@ -54,11 +55,14 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 		else if (res == eHPR_Successful)
 		{
 			debugf("Request: %s, %s", request.getRequestMethod().c_str(),
-					(request.getContentLength() > 0 ? (String(request.getContentLength()) + " bytes").c_str() : "nodata"));
+					(request.getContentLength() > 0 ?
+							(String(request.getContentLength()) + " bytes").c_str() :
+							"nodata"));
 
 			String contType = request.getContentType();
 			contType.toLowerCase();
-			if (request.getContentLength() > 0 && contType.indexOf(ContentType::FormUrlEncoded) != -1)
+			if (request.getContentLength() > 0
+					&& contType.indexOf(ContentType::FormUrlEncoded) != -1)
 				state = eHCS_ParsePostData;
 			else
 				state = eHCS_ParsingCompleted;
@@ -86,6 +90,10 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 			state = eHCS_ParsingCompleted;
 		}
 	}
+	else if (state == eHCS_ParsingCompleted && request.getContentLength() > 0)
+	{
+		request.parseRawData(server, buf);
+	}
 
 	// Fire callbacks
 	TcpConnection::onReceive(buf);
@@ -102,7 +110,8 @@ void HttpServerConnection::beginSendData()
 		return;
 	}
 
-	if (!response.hasBody() && (response.getStatusCode() < 100 || response.getStatusCode() > 399))
+	if (!response.hasBody()
+			&& (response.getStatusCode() < 100 || response.getStatusCode() > 399))
 	{
 		// Show default error message
 		sendError();
@@ -173,7 +182,8 @@ void HttpServerConnection::onError(err_t err)
 	TcpConnection::onError(err);
 }
 
-void HttpServerConnection::setDisconnectionHandler(HttpServerConnectionDelegate handler)
+void HttpServerConnection::setDisconnectionHandler(
+		HttpServerConnectionDelegate handler)
 {
 	disconnection = handler;
 }


### PR DESCRIPTION
This small change allows access to the body of a HTTP POST in case it hasn't been parsed as Form values. For the server to read the body and put in a char array, the content length has to be set and bigger than 0. Otherwise the body is omitted.