### PR TITLE
Changed LED_WS2812 to be similar to Basic_Blink, the while loop cause…

### DIFF
--- a/LED_WS2812/app/application.cpp
+++ b/LED_WS2812/app/application.cpp
@@ -1,18 +1,27 @@
 #include <user_config.h>
 
-#include <WS2812/WS2812.h>
+#include <WS2812/WS2812.h>  //this includes SmingCore.h, which pulls in everything
 
 #define LED_PIN 2 // GPIO2
 
+Timer procTimer;
+bool state = true;
+
+void blink()
+{
+        char buffer1[] = "\x40\x00\x00\x00\x40\x00\x00\x00\x40";
+        char buffer2[] = "\x00\x40\x40\x40\x00\x40\x40\x40\x00";
+        if(state == 0){
+        ws2812_writergb(LED_PIN, buffer1, sizeof(buffer1));
+	} else {
+        ws2812_writergb(LED_PIN, buffer2, sizeof(buffer2));
+	}	
+        state = !state;
+}
+
 void init()
 {
-    while (true) {
-        char buffer1[] = "\x40\x00\x00\x00\x40\x00\x00\x00\x40";
-        ws2812_writergb(LED_PIN, buffer1, sizeof(buffer1));
-        os_delay_us(500000);
-
-        char buffer2[] = "\x00\x40\x40\x40\x00\x40\x40\x40\x00";
-        ws2812_writergb(LED_PIN, buffer2, sizeof(buffer2));
-        os_delay_us(500000);
-    }
+        pinMode(LED_PIN, OUTPUT);
+        procTimer.initializeMs(1000, blink).start();
 }
+


### PR DESCRIPTION
Using the same method as Basic_Blink will prevent the LED_WS2812 demo from a looping crash(issue https://github.com/SmingHub/Sming/issues/102)

Not sure why, but the while true loop is the culprit here, you can remove everything but the while loop and reproduce the crash.

 