### PR TITLE
Remove appinit from user app modules list. Closes #294

### DIFF
--- a/Basic_AirUpdate/app/application.cpp
+++ b/Basic_AirUpdate/app/application.cpp
@@ -34,6 +34,8 @@ void connectOk()
 
 void init()
 {
+	spiffs_mount(); // Mount file system, in order to work with files
+
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Debug output to serial
 

--- a/Basic_rBoot/readme.txt
+++ b/Basic_rBoot/readme.txt
@@ -17,10 +17,6 @@ Makefile-user.mk
 
 Building
 --------
- 0) Set environment variable DISABLE_SPIFFS_AUTO=1 before building Sming itself
-    (libsming), this prevents Sming trying to auto-mount a spiffs filesystem
-    from the wrong flash location (which is potentially destructive to flash
-    contents).
  1) Set ESP_HOME & SMING_HOME, as environment variables or edit Makefile-user.mk
     as you would for general Sming app compiling.
  2) Set ESPTOOL2 (env var or in Makefile-user.mk) to point to the esptool2
@@ -51,8 +47,6 @@ so the reason for this strange addressing is not clear.
 Important compiler flags used:
 BOOT_BIG_FLASH - when using big flash mode, ensures flash mapping code is built
   in to the rom.
-DISABLE_SPIFFS_AUTO - prevents automounting at the wrong location. (by code in
-  Sming/appinit/user_main.cpp). Instead we call spiffs_mount_manual from init.
 RBOOT_BUILD_SMING - ensures big flash support function is correcly marked to
   remain in iram (plus potentially other sming specific code in future).
 SPIFF_SIZE=value - passed through to code for mounting the filesystem. Also used

--- a/FtpServer_Files/app/application.cpp
+++ b/FtpServer_Files/app/application.cpp
@@ -31,6 +31,8 @@ void connectFail()
 
 void init()
 {
+	spiffs_mount(); // Mount file system, in order to work with files
+
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 

--- a/HttpClient_Instapush/app/application.cpp
+++ b/HttpClient_Instapush/app/application.cpp
@@ -92,6 +92,8 @@ void connectOk()
 
 void init()
 {
+	spiffs_mount(); // Mount file system, in order to work with files
+
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Debug output to serial
 

--- a/HttpClient_ThingSpeak/app/application.cpp
+++ b/HttpClient_ThingSpeak/app/application.cpp
@@ -62,6 +62,8 @@ void connectFail()
 
 void init()
 {
+	spiffs_mount(); // Mount file system, in order to work with files
+
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(false); // Disable debug output to serial
 

--- a/HttpServer_AJAX/app/application.cpp
+++ b/HttpServer_AJAX/app/application.cpp
@@ -97,6 +97,8 @@ void connectOk()
 
 void init()
 {
+	spiffs_mount(); // Mount file system, in order to work with files
+
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 

--- a/HttpServer_Bootstrap/app/application.cpp
+++ b/HttpServer_Bootstrap/app/application.cpp
@@ -104,6 +104,8 @@ void connectOk()
 
 void init()
 {
+	spiffs_mount(); // Mount file system, in order to work with files
+
 	pinMode(LED_PIN, OUTPUT);
 
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default

--- a/HttpServer_ConfigNetwork/app/application.cpp
+++ b/HttpServer_ConfigNetwork/app/application.cpp
@@ -191,6 +191,8 @@ void networkScanCompleted(bool succeeded, BssList list)
 
 void init()
 {
+	spiffs_mount(); // Mount file system, in order to work with files
+
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 	AppSettings.load();

--- a/HttpServer_WebSockets/app/application.cpp
+++ b/HttpServer_WebSockets/app/application.cpp
@@ -93,6 +93,8 @@ void connectOk()
 
 void init()
 {
+	spiffs_mount(); // Mount file system, in order to work with files
+
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 

--- a/MeteoControl/app/application.cpp
+++ b/MeteoControl/app/application.cpp
@@ -30,6 +30,8 @@ void connectFail();
 
 void init()
 {
+	spiffs_mount(); // Mount file system, in order to work with files
+
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(false); // Debug output to serial
 

--- a/Sming/.cproject
+++ b/Sming/.cproject
@@ -111,14 +111,6 @@
 				<useDefaultCommand>true</useDefaultCommand>
 				<runAllBuilders>true</runAllBuilders>
 			</target>
-			<target name="rebuild DISABLE_SPIFFS=1" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
-				<buildCommand>make</buildCommand>
-				<buildArguments/>
-				<buildTarget>rebuild DISABLE_SPIFFS=1</buildTarget>
-				<stopOnError>true</stopOnError>
-				<useDefaultCommand>true</useDefaultCommand>
-				<runAllBuilders>true</runAllBuilders>
-			</target>
 		</buildTargets>
 	</storageModule>
 </cproject>

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -157,13 +157,6 @@ INCDIR	:= $(addprefix -I,$(SRC_DIR))
 EXTRA_INCDIR	:= $(addprefix -I,$(EXTRA_INCDIR))
 MODULE_INCDIR	:= $(addsuffix /include,$(INCDIR))
 
-ifeq ($(DISABLE_SPIFFS), 1)
-	CFLAGS += -DDISABLE_SPIFFS=1
-endif
-ifeq ($(DISABLE_SPIFFS_AUTO), 1)
-	CFLAGS += -DDISABLE_SPIFFS_AUTO=1
-endif
-
 V ?= $(VERBOSE)
 ifeq ("$(V)","1")
 Q :=
@@ -201,12 +194,6 @@ $(APP_AR): $(OBJ)
 	$(vecho) "AR $@"
 	$(Q) $(AR) cru $@ $^
 	$(vecho) "Installing libsming"
-ifeq ($(DISABLE_SPIFFS), 1)
-	$(vecho) "(!) Spiffs support disabled. Remove 'DISABLE_SPIFFS' make argument to enable spiffs."
-endif
-ifeq ($(DISABLE_SPIFFS_AUTO), 1)
-	$(vecho) "(!) Spiffs auto-mount disabled. Call spiffs_mount or spiffs_mount_manual from init to use spiffs."
-endif
 	$(Q) cp -r $(APP_AR) $(USER_LIBDIR)/libsming.a  
 	$(vecho) "Done"
 

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -124,7 +124,6 @@ TARGET		= app
 # which modules (subdirectories) of the project to include in compiling
 # define your custom directories in the project's own Makefile before including this one
 MODULES 	?= app  # if not initialized by user 
-MODULES		+= $(SMING_HOME)/appinit
 EXTRA_INCDIR    ?= include $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SDK_BASE)/../include $(SMING_HOME)/rboot $(SMING_HOME)/rboot/appcode
 
 # libraries used in this project, mainly provided by the SDK

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -134,7 +134,6 @@ TARGET		= app
 # which modules (subdirectories) of the project to include in compiling
 # define your custom directories in the project's own Makefile before including this one
 MODULES 	?= app  # if not initialized by user 
-MODULES		+= $(SMING_HOME)/appinit
 MODULES		+= $(SMING_HOME)/rboot/appcode
 EXTRA_INCDIR    ?= include $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SDK_BASE)/../include $(SMING_HOME)/rboot $(SMING_HOME)/rboot/appcode
 
@@ -263,7 +262,6 @@ RBOOT_LD_1	:= $(addprefix -T,$(RBOOT_LD_1))
 
 # extra flags
 CFLAGS += -DRBOOT_BUILD_SMING
-CFLAGS += -DDISABLE_SPIFFS_AUTO
 
 RBOOT_BIN := $(FW_BASE)/rboot.bin
 RBOOT_BUILD_BASE := $(abspath $(BUILD_BASE))

--- a/Sming/appinit/user_main.cpp
+++ b/Sming/appinit/user_main.cpp
@@ -9,9 +9,6 @@ extern "C" void  __attribute__((weak)) user_init(void)
 	uart_div_modify(UART_ID_0, UART_CLK_FREQ / 115200);
 	cpp_core_initialize();
 	System.initialize();
-#if !defined(DISABLE_SPIFFS) && !defined(DISABLE_SPIFFS_AUTO)
-	spiffs_mount();
-#endif
 	init(); // User code init
 }
 


### PR DESCRIPTION
The local override doesn't actually work. This meant you needed to recompile
libsming with a #define which then fixed the behaviour for all your apps.
User apps that wants to use spiffs now need to call spiffs_mount() in
their init method.