### PR TITLE
exchange sprintf to os_sprintf

### DIFF
--- a/Sming/Services/DateTime/DateTime.cpp
+++ b/Sming/Services/DateTime/DateTime.cpp
@@ -121,7 +121,7 @@ time_t DateTime::toUnixTime()
 String DateTime::toShortDateString()
 {
 	char buf[64];
-	sprintf(buf, "%02d.%02d.%d", Day, Month + 1, Year);
+	os_sprintf(buf, "%02d.%02d.%d", Day, Month + 1, Year);
 	return String(buf);
 }
 
@@ -129,9 +129,9 @@ String DateTime::toShortTimeString(bool includeSeconds /* = false*/)
 {
 	char buf[64];
 	if (includeSeconds)
-		sprintf(buf, "%02d:%02d:%02d", Hour, Minute, Second);
+		os_sprintf(buf, "%02d:%02d:%02d", Hour, Minute, Second);
 	else
-		sprintf(buf, "%02d:%02d", Hour, Minute);
+		os_sprintf(buf, "%02d:%02d", Hour, Minute);
 
 	return String(buf);
 }


### PR DESCRIPTION
Without this change errors appear after some time of work, TCP errors -8. (in my particular application)
Probably the memory problem
@anakod
Btw. by the way if anyone explain to me whether actually use in sming "malloc", we should not use "os_malloc"? (The same applies free)

From  bss.expressif
The solution is to either use os_sprintf from the SDK, or to fix ulibc so that it would use os_malloc and os_free instead of malloc and free.