### PR TITLE
rBoot Delegate implementation

### DIFF
--- a/Sming/SmingCore/Network/rBootHttpUpdate.cpp
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.cpp
@@ -14,7 +14,7 @@
 rBootHttpUpdate::rBootHttpUpdate() {
 	currentItem = 0;
 	romSlot = NO_ROM_SWITCH;
-	callback = 0;
+	updateDelegate = nullptr;
 }
 
 rBootHttpUpdate::~rBootHttpUpdate() {
@@ -36,15 +36,19 @@ void rBootHttpUpdate::switchToRom(uint8 romSlot) {
 	this->romSlot = romSlot;
 }
 
-void rBootHttpUpdate::setCallback(otaCallback callback) {
-	this->callback = callback;
+void rBootHttpUpdate::setCallback(otaUpdateDelegate reqUpdateDelegate) {
+	setDelegate(reqUpdateDelegate);
+}
+
+void rBootHttpUpdate::setDelegate(otaUpdateDelegate reqUpdateDelegate) {
+	this->updateDelegate = reqUpdateDelegate;
 }
 
 void rBootHttpUpdate::updateFailed() {
 	timer.stop();
 	items.clear();
 	debugf("\r\nFirmware download failed..");
-	if (callback) callback(false);
+	if (updateDelegate) updateDelegate(false);
 }
 
 void rBootHttpUpdate::onTimer() {
@@ -100,7 +104,7 @@ void rBootHttpUpdate::applyUpdate() {
 	items.clear();
 	if (romSlot == NO_ROM_SWITCH) {
 		debugf("Firmware updated.");
-		if (callback) callback(true);
+		if (updateDelegate) updateDelegate(true);
 	} else {
 		// set to boot new rom and then reboot
 		debugf("Firmware updated, rebooting to rom %d...\r\n", romSlot);

--- a/Sming/SmingCore/Network/rBootHttpUpdate.h
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.h
@@ -15,7 +15,8 @@
 
 #define NO_ROM_SWITCH 0xff
 
-typedef void (*otaCallback)(bool result);
+//typedef void (*otaCallback)(bool result);
+typedef Delegate<void(bool result)> otaUpdateDelegate;
 
 struct rBootHttpUpdateItem {
 	String url;
@@ -31,7 +32,8 @@ public:
 	void addItem(int offset, String firmwareFileUrl);
 	void start();
 	void switchToRom(uint8 romSlot);
-	void setCallback(otaCallback callback);
+	void setCallback(otaUpdateDelegate reqUpdateDelegate);
+	void setDelegate(otaUpdateDelegate reqUpdateDelegate);
 
 protected:
 	void onTimer();
@@ -45,7 +47,7 @@ protected:
 	int currentItem;
 	rboot_write_status rBootWriteStatus;
 	uint8 romSlot;
-	otaCallback callback;
+	otaUpdateDelegate updateDelegate;
 };
 
 #endif /* SMINGCORE_NETWORK_RBOOTHTTPUPDATE_H_ */


### PR DESCRIPTION
Change otaCallback to use Delegates
Is standard implementation within Sming
Fully backward compatible with current implementation