### PR TITLE
Update rBoot, uses new integration options.

### DIFF
--- a/Basic_rBoot/readme.txt
+++ b/Basic_rBoot/readme.txt
@@ -47,8 +47,8 @@ so the reason for this strange addressing is not clear.
 Important compiler flags used:
 BOOT_BIG_FLASH - when using big flash mode, ensures flash mapping code is built
   in to the rom.
-RBOOT_BUILD_SMING - ensures big flash support function is correcly marked to
-  remain in iram (plus potentially other sming specific code in future).
+RBOOT_INTEGRATION - ensures Sming specific options are pulled in to the rBoot
+  source at compile time.
 SPIFF_SIZE=value - passed through to code for mounting the filesystem. Also used
   in the Makefile to create the spiffs.
 

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -261,7 +261,7 @@ RBOOT_LD_0	:= $(addprefix -T,$(RBOOT_LD_0))
 RBOOT_LD_1	:= $(addprefix -T,$(RBOOT_LD_1))
 
 # extra flags
-CFLAGS += -DRBOOT_BUILD_SMING
+CFLAGS += -DRBOOT_INTEGRATION
 
 RBOOT_BIN := $(FW_BASE)/rboot.bin
 RBOOT_BUILD_BASE := $(abspath $(BUILD_BASE))

--- a/Sming/rboot/Makefile
+++ b/Sming/rboot/Makefile
@@ -18,13 +18,16 @@ LD := $(addprefix $(XTENSA_BINDIR)/,xtensa-lx106-elf-gcc)
 endif
 
 CFLAGS    = -Os -O3 -Wpointer-arith -Wundef -Werror -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mtext-section-literals  -D__ets__ -DICACHE_FLASH
-LDFLAGS   = -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static -L $(SDK_BASE)/lib/
+LDFLAGS   = -nostdlib -Wl,--no-check-sections -u call_user_start -Wl,-static -L $(SDK_BASE)/ld/
 LD_SCRIPT = $(SDK_BASE)/ld/eagle.app.v6.ld
 
 E2_OPTS = -quiet -bin -boot0
 
 ifeq ($(RBOOT_BIG_FLASH),1)
 	CFLAGS += -DBOOT_BIG_FLASH
+endif
+ifeq ($(RBOOT_INTEGRATION),1)
+	CFLAGS += -DRBOOT_INTEGRATION
 endif
 ifeq ($(SPI_SIZE), 256K)
 	E2_OPTS += -256
@@ -37,6 +40,8 @@ else ifeq ($(SPI_SIZE), 2M)
 else ifeq ($(SPI_SIZE), 4M)
 	E2_OPTS += -4096
 endif
+
+RBOOT_EXTRA_INCDIR := $(addprefix -I,$(RBOOT_EXTRA_INCDIR))
 
 .SECONDARY:
 
@@ -51,7 +56,7 @@ $(RBOOT_FW_BASE):
 
 $(RBOOT_BUILD_BASE)/rboot-stage2a.o: rboot-stage2a.c rboot-private.h rboot.h
 	@echo "CC $<"
-	@$(CC) $(CFLAGS) -c $< -o $@
+	$(CC) $(CFLAGS) $(RBOOT_EXTRA_INCDIR) -c $< -o $@
 	
 $(RBOOT_BUILD_BASE)/rboot-stage2a.elf: $(RBOOT_BUILD_BASE)/rboot-stage2a.o
 	@echo "LD $@"
@@ -63,11 +68,11 @@ $(RBOOT_BUILD_BASE)/rboot-hex2a.h: $(RBOOT_BUILD_BASE)/rboot-stage2a.elf
 
 $(RBOOT_BUILD_BASE)/rboot.o: rboot.c rboot-private.h rboot.h $(RBOOT_BUILD_BASE)/rboot-hex2a.h
 	@echo "CC $<"
-	@$(CC) $(CFLAGS) -I$(RBOOT_BUILD_BASE) -c $< -o $@
+	@$(CC) $(CFLAGS) -I$(RBOOT_BUILD_BASE) $(RBOOT_EXTRA_INCDIR) -c $< -o $@
 
 $(RBOOT_BUILD_BASE)/%.o: %.c %.h
 	@echo "CC $<"
-	@$(CC) $(CFLAGS) -c $< -o $@
+	@$(CC) $(CFLAGS) $(RBOOT_EXTRA_INCDIR) -c $< -o $@
 
 $(RBOOT_BUILD_BASE)/%.elf: $(RBOOT_BUILD_BASE)/%.o
 	@echo "LD $@"

--- a/Sming/rboot/appcode/rboot-api.c
+++ b/Sming/rboot/appcode/rboot-api.c
@@ -6,9 +6,8 @@
 // OTA code based on SDK sample from Espressif.
 //////////////////////////////////////////////////
 
-#ifdef RBOOT_BUILD_SMING
-// prevent sming user_config.h being included
-#define __USER_CONFIG_H__
+#ifdef RBOOT_INTEGRATION
+#include <rboot-integration.h>
 #endif
 
 #include <c_types.h>

--- a/Sming/rboot/appcode/rboot-bigflash.c
+++ b/Sming/rboot/appcode/rboot-bigflash.c
@@ -5,6 +5,10 @@
 // See license.txt for license terms.
 //////////////////////////////////////////////////
 
+#ifdef RBOOT_INTEGRATION
+#include <rboot-integration.h>
+#endif
+
 typedef unsigned int uint32;
 typedef unsigned char uint8;
 
@@ -12,11 +16,8 @@ typedef unsigned char uint8;
 
 #ifdef BOOT_BIG_FLASH
 
-#ifdef RBOOT_BUILD_SMING
-// for sming mark for iram
-#define IRAM_ATTR __attribute__((section(".iram.text")))
-#else
-// for plain sdk don't mark, defaults to iram
+// plain sdk defaults to iram
+#ifndef IRAM_ATTR
 #define IRAM_ATTR
 #endif
 

--- a/Sming/rboot/rboot-stage2a.c
+++ b/Sming/rboot/rboot-stage2a.c
@@ -5,6 +5,10 @@
 // See license.txt for license terms.
 //////////////////////////////////////////////////
 
+#ifdef RBOOT_INTEGRATION
+#include <rboot-integration.h>
+#endif
+
 #include "rboot-private.h"
 
 usercode* NOINLINE load_rom(uint32 readpos) {

--- a/Sming/rboot/rboot.c
+++ b/Sming/rboot/rboot.c
@@ -5,6 +5,10 @@
 // See license.txt for license terms.
 //////////////////////////////////////////////////
 
+#ifdef RBOOT_INTEGRATION
+#include <rboot-integration.h>
+#endif
+
 #include "rboot-private.h"
 #include <rboot-hex2a.h>
 

--- a/Sming/rboot/readme.txt
+++ b/Sming/rboot/readme.txt
@@ -33,11 +33,15 @@ below for instructions.
 
 Building
 --------
-Makefile is included, which should work with the gcc xtensa cross compiler.
+A Makefile is included, which should work with the gcc xtensa cross compiler.
 There are two source files, the first is compiled and included as data in the
 second. When run this code is copied to memory and executed (there is a good
 reason for this, see my blog for an explanation). The make file will handle this
 for you, but you'll need my esptool2 (see github).
+
+To use the Makefile set SDK_BASE to point to the root of the Espressif SDK and
+either set XTENSA_BINDIR to the gcc xtensa bin directory or include it in your
+PATH. These can be set as environment variables or by editing the Makefile.
 
 Two small assembler stub functions allow the bootloader to launch the user code
 without reserving any space on the stack (while the SDK boot loader uses 144
@@ -204,3 +208,11 @@ make sure you are getting your version into the rom.
 Now when rBoot starts your rom, the SDK code linked in it that normally performs
 the memory mapping will delegate part of that task to rBoot code (linked in your
 rom, not in rBoot itself) to choose which part of the flash to map.
+
+Integration into other frameworks
+---------------------------------
+If you wish to integrate rBoot into a development framework (e.g. Sming) you
+can set the define RBOOT_INTEGRATION and at compile time the file
+rboot-integration.h will be included into the source. This should allow you to
+set some platform specific options without having to modify the source of rBoot
+which makes it easier to integrate and maintain.

--- a/Sming/system/include/rboot-integration.h
+++ b/Sming/system/include/rboot-integration.h
@@ -1,0 +1,13 @@
+#ifndef __RBOOT_INTEGRATION_H__
+#define __RBOOT_INTEGRATION_H__
+
+// prevent sming user_config.h being included
+#define __USER_CONFIG_H__
+
+// mark functions that need to be in iram
+#define IRAM_ATTR __attribute__((section(".iram.text")))
+
+// missing prototypes for sdk functions
+#include <esp_systemapi.h>
+
+#endif /* __RBOOT_INTEGRATION_H__ */


### PR DESCRIPTION
This removes Sming specific stuff from upstream and allow us to maintain a separate header file in Sming with the Sming specific customisations. It's cleaner for upstream but remains as easy for us to maintain our copy here. It also allows us to include extra header such as those that define Espressif sdk functions needed by some compilers.