### PR TITLE
include spiffy as standard

### DIFF
--- a/Basic_rBoot/Makefile-user.mk
+++ b/Basic_rBoot/Makefile-user.mk
@@ -55,5 +55,3 @@ SPIFF_SIZE      ?= 65536
 #RBOOT_SPIFFS_1  ?= 0x300000
 ## esptool2 path
 #ESPTOOL2        ?= esptool2
-## path to spiffy
-#SPIFFY          ?= spiffy

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -188,7 +188,12 @@ endef
 
 .PHONY: all checkdirs clean
 
-all: checkdirs $(APP_AR) $(FW_FILE_1) $(FW_FILE_2)
+all: checkdirs $(APP_AR) spiffy/spiffy
+
+spiffy/spiffy:
+	$(vecho) "Making spiffy utility"
+	$(Q) $(MAKE) --no-print-directory -C spiffy V=$(V)
+	$(vecho) "Done"
 
 $(APP_AR): $(OBJ)
 	$(vecho) "AR $@"
@@ -214,5 +219,6 @@ clean:
 	$(Q) rm -rf $(BUILD_DIR)
 	$(Q) rm -rf $(BUILD_BASE)
 	$(Q) rm -rf $(FW_BASE)
+	$(Q) $(MAKE) --no-print-directory -C spiffy clean V=$(V)
 
 $(foreach bdir,$(BUILD_DIR),$(eval $(call compile-objects,$(bdir))))

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -26,8 +26,8 @@ SPI_MODE ?= qio
 # SPI_SIZE: 512K, 256K, 1M, 2M, 4M
 SPI_SIZE ?= 512K
 
-# Full path spiffy command, if not in path.
-SPIFFY ?= spiffy
+# Path to spiffy
+SPIFFY ?= $(SMING_HOME)/spiffy/spiffy
 
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -319,8 +319,7 @@ else
 	$(vecho) "Checking for spiffs files"
 	$(Q) if [ -d "$(SPIFF_FILES)" ]; then \
     	echo "$(SPIFF_FILES) directory exists. Creating $(SPIFF_BIN_OUT)"; \
-    	$(SPIFFY) $(SPIFF_SIZE) $(SPIFF_FILES); \
-    	mv spiff_rom.bin $(SPIFF_BIN_OUT); \
+    	$(SPIFFY) $(SPIFF_SIZE) $(SPIFF_FILES) $(SPIFF_BIN_OUT); \
 	else \
     	echo "No files found in ./$(SPIFF_FILES)."; \
     	echo "Creating empty $(SPIFF_BIN_OUT) ($$($(GET_FILESIZE) $(SMING_HOME)/compiler/data/blankfs.bin) bytes)"; \

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -361,8 +361,7 @@ else
 	$(vecho) "Checking for spiffs files"
 	$(Q) if [ -d "$(SPIFF_FILES)" ]; then \
 		echo "$(SPIFF_FILES) directory exists. Creating $(SPIFF_BIN_OUT)"; \
-		$(SPIFFY) $(SPIFF_SIZE) $(SPIFF_FILES); \
-		mv spiff_rom.bin $(SPIFF_BIN_OUT); \
+		$(SPIFFY) $(SPIFF_SIZE) $(SPIFF_FILES) $(SPIFF_BIN_OUT); \
 	else \
 		echo "No files found in ./$(SPIFF_FILES)."; \
 		echo "Creating empty $(SPIFF_BIN_OUT) ($$($(GET_FILESIZE) $(SMING_HOME)/compiler/data/blankfs.bin) bytes)"; \

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -20,7 +20,7 @@ RBOOT_LD_1 ?= rom1.ld
 # esptool2 path
 ESPTOOL2 ?= esptool2
 # path to spiffy
-SPIFFY ?= spiffy
+SPIFFY ?= $(SMING_HOME)/spiffy/spiffy
 # filenames and options for generating rBoot rom images with esptool2
 RBOOT_E2_SECTS     ?= .text .data .rodata
 RBOOT_E2_USER_ARGS ?= -quiet -bin -boot2

--- a/Sming/Services/SpifFS/spiffs_config.h
+++ b/Sming/Services/SpifFS/spiffs_config.h
@@ -12,12 +12,23 @@
 // Following includes are for the linux test build of spiffs
 // These may/should/must be removed/altered/replaced in your target
 //#include "params_test.h"
-//#include <stdio.h>
-//#include <stdlib.h>
-//#include <string.h>
-//#include <stddef.h>
+#ifdef __ets__
 #include <user_config.h>
 #include "../system/flashmem.h"
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+#include <ctype.h>
+typedef signed int s32_t;
+typedef unsigned int u32_t;
+typedef signed short s16_t;
+typedef unsigned short u16_t;
+typedef signed char s8_t;
+typedef unsigned char u8_t;
+#define spiffs_printf(...) printf(__VA_ARGS__)
+#endif /* __ets__ */
 // ----------- >8 ------------
 
 // compile time switches

--- a/Sming/spiffy/.gitignore
+++ b/Sming/spiffy/.gitignore
@@ -1,0 +1,3 @@
+*.o
+spiffy
+spiffy.exe

--- a/Sming/spiffy/Makefile
+++ b/Sming/spiffy/Makefile
@@ -1,0 +1,35 @@
+#
+# Makefile for spiffy
+#
+
+CC := gcc
+LD := gcc
+
+INCDIR := -I../Services/SpifFS/
+CFLAGS := -O2 -Wall -Wno-unused-value
+
+ifeq ("$(V)","1")
+Q :=
+vecho := @true
+else
+Q := @
+vecho := @echo
+endif
+
+all: spiffy
+
+%.o: ../Services/SpifFS/%.c
+	$(vecho) "CC $<"
+	$(Q) $(CC) $(CFLAGS) $(INCDIR) -c $< -o $@
+
+spiffy.o: spiffy.c
+	$(vecho) "CC $<"
+	$(Q) $(CC) $(CFLAGS) $(INCDIR) -c $< -o $@
+
+spiffy: spiffy.o spiffs_cache.o spiffs_nucleus.o spiffs_hydrogen.o spiffs_gc.o spiffs_check.o
+	$(vecho) "LD $@"
+	$(Q) $(LD) -o $@ $^
+
+clean:
+	$(Q) rm -f *.o
+	$(Q) rm -f spiffy spiffy.exe

--- a/Sming/spiffy/spiffy.c
+++ b/Sming/spiffy/spiffy.c
@@ -1,0 +1,275 @@
+#include <stdlib.h>
+#include <unistd.h>
+#include <dirent.h>
+#include <spiffs.h>
+
+#define LOG_PAGE_SIZE       256
+#define SPI_FLASH_SEC_SIZE 4096
+
+#define ROM_ERASE 0xFF
+
+#define DEFAULT_FOLDER   "files"
+#define DEFAULT_ROM_NAME "spiff_rom.bin"
+#define DEFAULT_ROM_SIZE 0x30000
+
+static spiffs fs;
+static u8_t spiffs_work_buf[LOG_PAGE_SIZE*2];
+static u8_t spiffs_fds[32*4];
+static u8_t spiffs_cache_buf[(LOG_PAGE_SIZE+32)*4];
+
+#define S_DBG
+//#define S_DBG printf
+
+static FILE *rom = 0;
+
+void hexdump_mem(u8_t *b, u32_t len) {
+	int i;
+	for (i = 0; i < len; i++) {
+		S_DBG("%02x", *b++);
+		if ((i % 16) == 15) S_DBG("\n");
+		else if ((i % 16) == 7) S_DBG(" ");
+	}
+	if ((i % 16) != 0) S_DBG("\n");
+}
+
+static s32_t my_spiffs_read(u32_t addr, u32_t size, u8_t *dst) {
+
+	int res;
+
+	if (fseek(rom, addr, SEEK_SET)) {
+		printf("Unable to seek to %d.\n", addr);
+		return SPIFFS_ERR_END_OF_OBJECT;
+	}
+
+	res = fread(dst, 1, size, rom);
+	if (res != size) {
+		printf("Unable to read - tried to get %d bytes only got %d.\n", size, res);
+		return SPIFFS_ERR_NOT_READABLE;
+	}
+
+	S_DBG("Read %d bytes from offset %d.\n", size, addr);
+	hexdump_mem(dst, size);
+	return SPIFFS_OK;
+}
+
+static s32_t my_spiffs_write(u32_t addr, u32_t size, u8_t *src) {
+
+	if (fseek(rom, addr, SEEK_SET)) {
+		printf("Unable to seek to %d.\n", addr);
+		return SPIFFS_ERR_END_OF_OBJECT;
+	}
+
+	if (fwrite(src, 1, size, rom) != size) {
+		printf("Unable to write.\n");
+		return SPIFFS_ERR_NOT_WRITABLE;
+	}
+
+	fflush(rom);
+	S_DBG("Wrote %d bytes to offset %d.\n", size, addr);
+
+	return SPIFFS_OK;
+}
+
+static s32_t my_spiffs_erase(u32_t addr, u32_t size) {
+
+	int i;
+
+	if (fseek(rom, addr, SEEK_SET)) {
+		printf("Unable to seek to %d.\n", addr);
+		return SPIFFS_ERR_END_OF_OBJECT;
+	}
+
+	for (i = 0; i < size; i++) {
+		if (fputc(ROM_ERASE, rom) == EOF) {
+			printf("Unable to write.\n");
+			return SPIFFS_ERR_NOT_WRITABLE;
+		}
+	}
+
+	fflush(rom);
+	S_DBG("Erased %d bytes at offset %d.\n", size, addr);
+
+	return SPIFFS_OK;
+}
+
+int my_spiffs_mount(u32_t msize) {
+
+  spiffs_config cfg;
+
+  cfg.phys_size = msize;
+  cfg.phys_addr = 0;
+
+  cfg.phys_erase_block = SPI_FLASH_SEC_SIZE;
+  cfg.log_block_size = SPI_FLASH_SEC_SIZE * 2;
+  cfg.log_page_size = LOG_PAGE_SIZE;
+
+  cfg.hal_read_f = my_spiffs_read;
+  cfg.hal_write_f = my_spiffs_write;
+  cfg.hal_erase_f = my_spiffs_erase;
+
+  int res = SPIFFS_mount(&fs,
+		  &cfg,
+		  spiffs_work_buf,
+		  spiffs_fds,
+		  sizeof(spiffs_fds),
+		  spiffs_cache_buf,
+		  sizeof(spiffs_cache_buf),
+		  0);
+  S_DBG("Mount result: %d.\n", res);
+
+  if (res < SPIFFS_OK) {
+	  printf("Failed to mount spiffs, error %d.\n", res);
+	  return 0;
+  } else {
+	  return 1;
+  }
+}
+
+
+int write_to_spiffs(char *fname, u8_t *data, int size) {
+
+	int ret = 0;
+	spiffs_file fd = -1;
+
+	fd = SPIFFS_open(&fs, fname, SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
+	if (fd < 0) {
+		printf("Unable to open spiffs file '%s', error %d.\n", fname, fd);
+	} else {
+		S_DBG("Opened spiffs file '%s'.\n", fname);
+		if (SPIFFS_write(&fs, fd, (u8_t *)data, size) < SPIFFS_OK) {
+			printf("Unable to write to spiffs file '%s', errno %d.\n", fname, SPIFFS_errno(&fs));
+		} else {
+			ret = 1;
+		}
+	}
+
+	if (fd >= 0) {
+		SPIFFS_close(&fs, fd);
+		S_DBG("Closed spiffs file '%s'.\n", fname);
+	}
+	return ret;
+}
+
+int add_file(const char* fdir, char* fname) {
+
+	int ret = 0;
+	int size;
+	u8_t *buff = 0;
+	FILE *fp = 0;
+	char *path = 0;
+
+	path = malloc(1024);
+	if (!path) {
+		printf("Unable to malloc %d bytes.\n", 1024);
+	} else {
+		sprintf(path, "%s/%s", fdir, fname);
+		fp = fopen(path, "rb");
+		if (!fp) {
+			S_DBG("Unable to open '%s'.\n", path);
+		} else {
+			fseek(fp, 0L, SEEK_END);
+			size = ftell(fp);
+			fseek(fp, 0L, SEEK_SET);
+			buff = malloc(size);
+			if (!buff) {
+				printf("Unable to malloc %d bytes.\n", size);
+			} else {
+				if (fread(buff, 1, size, fp) != size) {
+					printf("Unable to read file '%s'.\n", fname);
+				} else {
+					S_DBG("%d bytes read from '%s'.\n", size, fname);
+					if (write_to_spiffs(fname, buff, size)) {
+						printf("Added '%s' to spiffs (%d bytes).\n", fname, size);
+						ret = 1;
+					}
+				}
+			}
+		}
+	}
+
+	if (buff) free(buff);
+	if (path) free(path);
+	if (fp) fclose(fp);
+
+	return ret;
+}
+
+int get_rom_size (const char *str) {
+
+	long val;
+
+	// accept decimal or hex, but not octal
+	if ((strlen(str) > 2) && (str[0] == '0') &&
+		(((str[1] == 'x')) || ((str[1] == 'X')))) {
+		val = strtol(str, NULL, 16);
+	} else {
+		val = strtol(str, NULL, 10);
+	}
+
+	return (int)val;
+}
+
+int main(int argc, char **argv) {
+
+	const char *folder;
+	const char *romfile;
+	int romsize;
+
+	if (argc == 1) {
+		romsize = DEFAULT_ROM_SIZE;
+		folder = DEFAULT_FOLDER;
+		romfile = DEFAULT_ROM_NAME;
+		printf("Usage: %s maxFsSizeinByte spiffsBaseDir [outfile.bin]\n"
+			   "There is no specific size or files directory.\n"
+			   "Starting in compatibility mode.\n"
+			   "Default fs size is 0x%x (%d) bytes and directory is '%s'.\n",
+			   argv[0], romsize, romsize, DEFAULT_FOLDER);
+	} else if (argc == 3) {
+		romsize = get_rom_size(argv[1]);
+		folder = argv[2];
+		romfile = DEFAULT_ROM_NAME;
+	} else if (argc == 4) {
+		romsize = get_rom_size(argv[1]);
+		folder = argv[2];
+		romfile = argv[3];
+	} else {
+		printf ("Usage: %s <FsSizeInBytes> <FilesDir> [OutFile.bin]\n", argv[0]);
+		exit(EXIT_FAILURE);
+	}
+
+	printf("Creating rom '%s' of size 0x%x (%d) bytes.\n", romfile, romsize, romsize);
+	rom = fopen(romfile, "wb+");
+
+	if (!rom) {
+		printf("Unable to open file '%s' for writing.\n", romfile);
+	} else {
+
+		int i;
+		for (i = 0; i < romsize; i++) {
+			fputc(ROM_ERASE, rom);
+		}
+		fflush(rom);
+
+		if (my_spiffs_mount(romsize)) {
+			printf("Adding files in directory '%s'.\n", folder);
+			DIR *dir;
+			struct dirent *ent;
+			if ((dir = opendir(folder)) != NULL) {
+				while ((ent = readdir(dir)) != NULL) {
+					if (ent->d_type == DT_REG) {
+						add_file(folder, ent->d_name);
+					}
+				}
+				closedir(dir);
+			} else {
+				printf("Unable to open directory '%s'.\n", folder);
+				fclose(rom);
+				unlink(romfile);
+				exit(EXIT_FAILURE);
+			}
+		}
+	}
+
+	if (rom) fclose(rom);
+	exit(EXIT_SUCCESS);
+}


### PR DESCRIPTION
Improved and bug fixed spiffy. Compiles as part of the libsming build, no need to obtain and build separately. Drives the same copy version (and copy) of spiffs that is used by libsming to ensure you always have the correct version.