### PR TITLE
Changed WS2812 example: removed delay and WDT refresh

### DIFF
--- a/Basic_WiFi/app/application.cpp
+++ b/Basic_WiFi/app/application.cpp
@@ -32,6 +32,14 @@ void connectOk()
 {
 	debugf("I'm CONNECTED");
 	Serial.println(WifiStation.getIP().toString());
+	
+	Serial.print("Connected to: ");
+	Serial.print(WifiStation.getSSID());
+	Serial.print(" Channel: ");
+	Serial.print(WifiStation.getChannel());
+	Serial.print(" Strength: ");
+	Serial.print(WifiStation.getRssi());
+	Serial.println(" dBm");
 }
 
 // Will be called when WiFi station timeout was reached

--- a/LED_WS2812/app/application.cpp
+++ b/LED_WS2812/app/application.cpp
@@ -1,21 +1,29 @@
 #include <user_config.h>
-
+#include <SmingCore/SmingCore.h>
 #include <WS2812/WS2812.h>
 
 #define LED_PIN 2 // GPIO2
 
-void init()
+Timer procTimer;
+int step;
+
+void readWS2812()
 {
-    while (true) {
+    if ((step++) & 1) {
         char buffer1[] = "\x40\x00\x00\x00\x40\x00\x00\x00\x40";
         ws2812_writergb(LED_PIN, buffer1, sizeof(buffer1));
-        os_delay_us(500000);
-        
-        //We need to feed WDT.
-        WDT.alive();
-        
+    }
+    else
+    {
         char buffer2[] = "\x00\x40\x40\x40\x00\x40\x40\x40\x00";
         ws2812_writergb(LED_PIN, buffer2, sizeof(buffer2));
-        os_delay_us(500000);
-    }
+    }        
+}
+
+void init()
+{
+	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.systemDebugOutput(true); // Allow debug output to serial
+
+	procTimer.initializeMs(500, readWS2812).start();   // every 0.5 seconds
 }

--- a/LED_WS2812/app/application.cpp
+++ b/LED_WS2812/app/application.cpp
@@ -7,7 +7,7 @@
 Timer procTimer;
 int step;
 
-void readWS2812()
+void writeWS2812()
 {
     if ((step++) & 1) {
         char buffer1[] = "\x40\x00\x00\x00\x40\x00\x00\x00\x40";
@@ -25,5 +25,5 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
-	procTimer.initializeMs(500, readWS2812).start();   // every 0.5 seconds
+	procTimer.initializeMs(500, writeWS2812).start();   // every 0.5 seconds
 }

--- a/Sming/SmingCore/Platform/Station.cpp
+++ b/Sming/SmingCore/Platform/Station.cpp
@@ -197,6 +197,20 @@ String StationClass::getSSID()
 	return String((char*)config.ssid);
 }
 
+sint8 StationClass::getRssi()
+{
+	debugf("Rssi: %d dBm", wifi_station_get_rssi());
+	return wifi_station_get_rssi();
+}
+
+uint8 StationClass::getChannel()
+{
+	debugf("Channel: %d CH", wifi_get_channel());
+	return wifi_get_channel();
+}
+
+
+
 String StationClass::getPassword()
 {
 	station_config config = {0};

--- a/Sming/SmingCore/Platform/Station.h
+++ b/Sming/SmingCore/Platform/Station.h
@@ -62,6 +62,8 @@ public:
 
 	String getSSID();
 	String getPassword();
+	sint8 getRssi();
+	uint8 getChannel();
 
 	bool startScan(ScanCompletedDelegate scanCompleted);
 	void waitConnection(ConnectionDelegate successfulConnected);


### PR DESCRIPTION
WS8212 example   it must be tested because I do not have WS2812
 Also added 2 new metods getRssi() and getChannel() in StationClass
(can read actual WiFi signal level and the channel number)
