### PR TITLE
StationClass::getBCast() and AccessPoint::getBCast() added.

### DIFF
--- a/Sming/SmingCore/Platform/AccessPoint.cpp
+++ b/Sming/SmingCore/Platform/AccessPoint.cpp
@@ -86,6 +86,13 @@ IPAddress AccessPointClass::getIP()
 	return info.ip;
 }
 
+IPAddress AccessPointClass::getBCast()
+{
+	struct ip_info info = {0};
+	wifi_get_ip_info(SOFTAP_IF, &info);
+	return (info.ip.addr | ~info.netmask.addr);
+}
+
 bool AccessPointClass::setIP(IPAddress address)
 {
 	if (System.isReady())

--- a/Sming/SmingCore/Platform/AccessPoint.h
+++ b/Sming/SmingCore/Platform/AccessPoint.h
@@ -26,6 +26,7 @@ public:
 	bool config(String ssid, String password, AUTH_MODE mode, bool hidden = false, int channel = 7, int beaconInterval = 200);
 
 	IPAddress getIP();
+	IPAddress getBCast();
 	bool setIP(IPAddress address);
 	String getMAC();
 

--- a/Sming/SmingCore/Platform/Station.cpp
+++ b/Sming/SmingCore/Platform/Station.cpp
@@ -122,6 +122,13 @@ IPAddress StationClass::getIP()
 	return info.ip;
 }
 
+IPAddress StationClass::getBCast()
+{
+	struct ip_info info = {0};
+	wifi_get_ip_info(STATION_IF, &info);
+	return (info.ip.addr | ~info.netmask.addr);
+}
+
 String StationClass::getMAC()
 {
 	String mac;

--- a/Sming/SmingCore/Platform/Station.h
+++ b/Sming/SmingCore/Platform/Station.h
@@ -53,6 +53,7 @@ public:
 	void enableDHCP(bool enable);
 
 	IPAddress getIP();
+	IPAddress getBCast();
 	String getMAC();
 	IPAddress getNetworkMask();
 	IPAddress getNetworkGateway();


### PR DESCRIPTION
Add StationClass::getBCast() and AccessPoint::getBCast(). This is usefull when AccessPoint and WifiStation are active at the same time and you want to send broadcast packets throught a specific network interface,