### PR TITLE
Initial V0.1 rBoot Generic

### DIFF
--- a/Basic_rBoot _test/.cproject
+++ b/Basic_rBoot _test/.cproject
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" moduleId="org.eclipse.cdt.core.settings" name="Sming">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" name="Sming" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.1164554300" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.521205673" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.393887888" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.712123812" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.2110485170" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option id="gnu.c.compiler.option.include.paths.357494572" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.313321806" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler">
+								<option id="gnu.cpp.compiler.option.include.paths.611746109" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.65193859" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.1795850540" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.364843833" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.525412186" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.587940548" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option id="gnu.both.asm.option.include.paths.1067006329" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.651581712" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="{{ProjectName}}.null.1347473968" name="{{ProjectName}}"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Sming">
+			<resource resourceType="PROJECT" workspacePath="/{{ProjectName}}"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets">
+		<buildTargets>
+			<target name="all" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>all</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="clean" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>clean</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flash" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flash</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashonefile" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashonefile</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashinit" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashinit</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashboot" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashboot</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="rebuild" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>rebuild</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+		</buildTargets>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.c.compiler.mingw.base.2032390008;cdt.managedbuild.tool.gnu.c.compiler.input.1700912488">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903;cdt.managedbuild.tool.gnu.c.compiler.input.313321806">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015;cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cpp.compiler.mingw.base.454898447;cdt.managedbuild.tool.gnu.cpp.compiler.input.501261625">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+</cproject>

--- a/Basic_rBoot _test/.project
+++ b/Basic_rBoot _test/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Basic_rBoot _test</name>
+	<comment></comment>
+	<projects>
+		<project>SmingFramework</project>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/Basic_rBoot _test/Makefile
+++ b/Basic_rBoot _test/Makefile
@@ -1,0 +1,24 @@
+#####################################################################
+#### Please don't change this file. Use Makefile-user.mk instead ####
+#####################################################################
+# Including user Makefile.
+# Should be used to set project-specific parameters
+include ./Makefile-user.mk
+
+# Important parameters check.
+# We need to make sure SMING_HOME and ESP_HOME variables are set.
+# You can use Makefile-user.mk in each project or use enviromental variables to set it globally.
+ 
+ifndef SMING_HOME
+$(error SMING_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+ifndef ESP_HOME
+$(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+
+# Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
+include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_rBoot _test/Makefile-user.mk
+++ b/Basic_rBoot _test/Makefile-user.mk
@@ -1,0 +1,57 @@
+## Local build configuration
+## Parameters configured here will override default and ENV values.
+## Uncomment and change examples:
+
+#Add your source directories here separated by space
+MODULES = app
+
+## ESP_HOME sets the path where ESP tools and SDK are located.
+## Windows:
+# ESP_HOME = c:/Espressif
+
+## MacOS / Linux:
+#ESP_HOME = /opt/esp-open-sdk
+
+## SMING_HOME sets the path where Sming framework is located.
+## Windows:
+# SMING_HOME = c:/tools/sming/Sming 
+
+# MacOS / Linux
+# SMING_HOME = /opt/sming/Sming
+
+## COM port parameter is reqruied to flash firmware correctly.
+## Windows: 
+# COM_PORT = COM3
+
+# MacOS / Linux:
+# COM_PORT = /dev/tty.usbserial
+
+# Com port speed
+# COM_SPEED	= 115200
+
+#### overridable rBoot options ####
+## use rboot build mode
+RBOOT_ENABLED ?= 1
+## enable big flash support (for multiple roms, each in separate 1mb block of flash)
+RBOOT_BIG_FLASH ?= 1
+## two rom mode (where two roms sit in the same 1mb block of flash)
+#RBOOT_TWO_ROMS  ?= 1
+## size of the flash chip
+SPI_SIZE        ?= 4M
+## output file for first rom (.bin will be appended)
+#RBOOT_ROM_0     ?= rom0
+## input linker file for first rom
+#RBOOT_LD_0      ?= rom0.ld
+## these next options only needed when using two rom mode
+#RBOOT_ROM_1     ?= rom1
+#RBOOT_LD_1      ?= rom1.ld
+## size of the spiffs to create
+SPIFF_SIZE      ?= 65536
+## option to completely disable spiffs
+#DISABLE_SPIFFS  = 1
+## flash offsets for spiffs, set if using two rom mode or not on a 4mb flash
+## (spiffs location defaults to the mb after the rom slot on 4mb flash)
+#RBOOT_SPIFFS_0  ?= 0x100000
+#RBOOT_SPIFFS_1  ?= 0x300000
+## esptool2 path
+#ESPTOOL2        ?= esptool2

--- a/Basic_rBoot _test/app/application.cpp
+++ b/Basic_rBoot _test/app/application.cpp
@@ -95,7 +95,7 @@ void ShowInfo() {
 void serialCallBack(Stream& stream, char arrivedChar, unsigned short availableCharsCount) {
 	
 
-	if (arrivedChar == '\r') {
+	if (arrivedChar == '\n') {
 		char str[availableCharsCount];
 		for (int i = 0; i < availableCharsCount; i++) {
 			str[i] = stream.read();
@@ -182,8 +182,6 @@ void init() {
 	debugf("spiffs disabled");
 #endif
 	WifiAccessPoint.enable(false);
-	WifiStation.config(WIFI_SSID, WIFI_PWD);
-	WifiStation.enable(true);
 	
 	Serial.printf("\r\nCurrently running rom %d.\r\n", slot);
 	Serial.println("Type 'help' and press enter for instructions.");

--- a/Basic_rBoot _test/files/testfile.txt
+++ b/Basic_rBoot _test/files/testfile.txt
@@ -1,0 +1,2 @@
+This line is the content of test file.
+

--- a/Basic_rBoot _test/include/user_config.h
+++ b/Basic_rBoot _test/include/user_config.h
@@ -5,9 +5,9 @@
 extern "C" {
 #endif
 	
-	#define ROM_0_URL  "http://10.0.0.201/rom0.bin"
-	#define ROM_1_URL  "http://10.0.0.201/rom1.bin"
-	#define SPIFFS_URL "http://10.0.0.201/spiff_rom.bin"
+	#define ROM_0_URL  "http://192.168.7.5:80/rom0.bin"
+	#define ROM_1_URL  "http://192.168.7.5:80/rom1.bin"
+	#define SPIFFS_URL "http://192.168.7.5:80/spiff_rom.bin"
 
 	// UART config
 	#define SERIAL_BAUD_RATE 115200

--- a/Basic_rBoot _test/readme.txt
+++ b/Basic_rBoot _test/readme.txt
@@ -1,0 +1,84 @@
+rBoot Sming sample
+------------------
+
+This sample integrates rBoot and Sming, for the many people who have been asking
+for it. It demonstrates dual rom booting, big flash support, OTA updates and
+dual spiffs filesystems. You must enable big flash support in rBoot and use on
+an ESP12 (or similar device with 4mb flash). When using rBoot big flash support
+with multiple 1mb slots only one rom image needs to be created. If you don't
+want to use big flash support (e.g. for a device with smaller flash) see the
+separate instructions below. You can easily take the ota files and add them to
+your own project to add OTA support.
+
+To build any Sming project (in threory) with rBoot support you should use
+Makefile-rboot.mk instead of Makefile-project.mk. In the sample the correct mk
+file is chosen automatically because of the setting RBOOT_ENABLED=1 in
+Makefile-user.mk
+
+Building
+--------
+ 1) Set ESP_HOME & SMING_HOME, as environment variables or edit Makefile-user.mk
+    as you would for general Sming app compiling.
+ 2) Set ESPTOOL2 (env var or in Makefile-user.mk) to point to the esptool2
+    binary. Source for esptool2 is here: https://github.com/raburton/esp8266
+ 3) Set WIFI_SSID & WIFI_PWD environment variables with your wifi details.
+ 4) Edit the OTA server details in include/user_config.h
+ 5) Check overridable variables in Makefile-user.mk, or set as env vars.
+ 6) make && make flash
+ 7) Put rom0.bin and spiff_rom.bin in the root of your webserver for OTA.
+ 8) Interact with the sample using a terminal, sorry no web-gui (yet).
+
+Flashing
+--------
+If flashing manually use esptool.py to flash rBoot, rom & spiffs e.g.:
+ esptool.py --port <port> write_flash -fs 32m 0x00000 rboot.bin 0x02000 rom0.bin
+   0x100000 spiffs.rom
+
+Using the correct -fs parameter is important. This will be -fs 32m on an ESP12.
+
+You can also flash rom0.bin to 0x202000, but booting and using OTA is quicker!
+
+Technical Notes
+---------------
+spiffs_mount_manual(address, length) must be called from init. The address must
+be 0x40200000 + physical flash address. Sming does not use memory mapped flash
+so the reason for this strange addressing is not clear.
+
+Important compiler flags used:
+BOOT_BIG_FLASH - when using big flash mode, ensures flash mapping code is built
+  in to the rom.
+RBOOT_INTEGRATION - ensures Sming specific options are pulled in to the rBoot
+  source at compile time.
+SPIFF_SIZE=value - passed through to code for mounting the filesystem. Also used
+  in the Makefile to create the spiffs.
+
+Disabling big flash
+-------------------
+If you want to use, for example, two 512k roms in the first 1mb block of flash
+(old style) then follow these instructions to produce two separately linked
+roms. If you are flashing a single rom to multiple 1mb flash blocks (using big
+flash) you only need one linked rom that can be used on each.
+
+This assumes you understand the concepts explained in the rBoot readme about
+memory mapping and setting linker script address. This is not covered here, just
+how to use this sample without bigflash support.
+
+- Copy rom0.ld to rom1.ld.
+- Adjust the rom offsets and length as appropriate in each ld file.
+- Uncomment 'RBOOT_TWO_ROMS ?= 1' in Makefile-user.mk (or set as an environment
+  variable).
+- Ensure RBOOT_BIG_FLASH is set to 0 in Makefile-user.mk
+- If using a very small flash (e.g. 512k) there may be no room for a spiffs
+  fileystem, disable it with DISABLE_SPIFFS = 1
+- If you are using spiffs set RBOOT_SPIFFS_0 & RBOOT_SPIFFS_1 to indicate where
+  the filesystems are located on the flash. This is the real flash offset, not
+  the address + 0x40200000 used in the mount call.
+- After building copy all the rom*.bin files to the root of your web server.
+
+If you want more than two roms you must be an advanced user and should be able
+to work out what to copy and edit to acheive this!
+
+Credits
+-------
+This sample was made possible with the assistance of piperpilot, gschmott and
+robotiko on the esp8266.com forum.

--- a/Basic_rBoot _test/rom0.ld
+++ b/Basic_rBoot _test/rom0.ld
@@ -1,0 +1,219 @@
+/* This linker script generated from xt-genldscripts.tpp for LSP . */
+/* Linker Script for ld -N */
+MEMORY
+{
+  dport0_0_seg :                        org = 0x3FF00000, len = 0x10
+  dram0_0_seg :                         org = 0x3FFE8000, len = 0x14000
+  iram1_0_seg :                         org = 0x40100000, len = 0x8000
+  irom0_0_seg :                         org = 0x40202010, len = 0x42000
+}
+
+PHDRS
+{
+  dport0_0_phdr PT_LOAD;
+  dram0_0_phdr PT_LOAD;
+  dram0_0_bss_phdr PT_LOAD;
+  iram1_0_phdr PT_LOAD;
+  irom0_0_phdr PT_LOAD;
+}
+
+
+/*  Default entry point:  */
+ENTRY(call_user_start)
+EXTERN(_DebugExceptionVector)
+EXTERN(_DoubleExceptionVector)
+EXTERN(_KernelExceptionVector)
+EXTERN(_NMIExceptionVector)
+EXTERN(_UserExceptionVector)
+PROVIDE(_memmap_vecbase_reset = 0x40000000);
+/* Various memory-map dependent cache attribute settings: */
+_memmap_cacheattr_wb_base = 0x00000110;
+_memmap_cacheattr_wt_base = 0x00000110;
+_memmap_cacheattr_bp_base = 0x00000220;
+_memmap_cacheattr_unused_mask = 0xFFFFF00F;
+_memmap_cacheattr_wb_trapnull = 0x2222211F;
+_memmap_cacheattr_wba_trapnull = 0x2222211F;
+_memmap_cacheattr_wbna_trapnull = 0x2222211F;
+_memmap_cacheattr_wt_trapnull = 0x2222211F;
+_memmap_cacheattr_bp_trapnull = 0x2222222F;
+_memmap_cacheattr_wb_strict = 0xFFFFF11F;
+_memmap_cacheattr_wt_strict = 0xFFFFF11F;
+_memmap_cacheattr_bp_strict = 0xFFFFF22F;
+_memmap_cacheattr_wb_allvalid = 0x22222112;
+_memmap_cacheattr_wt_allvalid = 0x22222112;
+_memmap_cacheattr_bp_allvalid = 0x22222222;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
+
+SECTIONS
+{
+
+  .dport0.rodata : ALIGN(4)
+  {
+    _dport0_rodata_start = ABSOLUTE(.);
+    *(.dport0.rodata)
+    *(.dport.rodata)
+    _dport0_rodata_end = ABSOLUTE(.);
+  } >dport0_0_seg :dport0_0_phdr
+
+  .dport0.literal : ALIGN(4)
+  {
+    _dport0_literal_start = ABSOLUTE(.);
+    *(.dport0.literal)
+    *(.dport.literal)
+    _dport0_literal_end = ABSOLUTE(.);
+  } >dport0_0_seg :dport0_0_phdr
+
+  .dport0.data : ALIGN(4)
+  {
+    _dport0_data_start = ABSOLUTE(.);
+    *(.dport0.data)
+    *(.dport.data)
+    _dport0_data_end = ABSOLUTE(.);
+  } >dport0_0_seg :dport0_0_phdr
+
+  .data : ALIGN(4)
+  {
+    _data_start = ABSOLUTE(.);
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    *(.jcr)
+    _data_end = ABSOLUTE(.);
+  } >dram0_0_seg :dram0_0_phdr
+
+  .rodata : ALIGN(4)
+  {
+    _rodata_start = ABSOLUTE(.);
+    *(.sdk.version)
+    *(.rodata)
+    *(.rodata.*)
+    *(.gnu.linkonce.r.*)
+    *(.rodata1)
+    __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
+    *(.xt_except_table)
+    *(.gcc_except_table)
+    *(.gnu.linkonce.e.*)
+    *(.gnu.version_r)
+    *(.eh_frame)
+    . = (. + 3) & ~ 3;
+    /*  C++ constructor and destructor tables, properly ordered:  */
+	__dso_handle = ABSOLUTE(.);
+    __init_array_start = ABSOLUTE(.);
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __init_array_end = ABSOLUTE(.);
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    /*  C++ exception handlers table:  */
+    __XT_EXCEPTION_DESCS__ = ABSOLUTE(.);
+    *(.xt_except_desc)
+    *(.gnu.linkonce.h.*)
+    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
+    *(.xt_except_desc_end)
+    *(.dynamic)
+    *(.gnu.version_d)
+    . = ALIGN(4);		/* this table MUST be 4-byte aligned */
+    _bss_table_start = ABSOLUTE(.);
+    LONG(_bss_start)
+    LONG(_bss_end)
+    _bss_table_end = ABSOLUTE(.);
+    _rodata_end = ABSOLUTE(.);
+  } >dram0_0_seg :dram0_0_phdr
+
+  .bss ALIGN(8) (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN (8);
+    _bss_start = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN (8);
+    _bss_end = ABSOLUTE(.);
+    _heap_start = ABSOLUTE(.);
+/*    _stack_sentry = ALIGN(0x8); */
+  } >dram0_0_seg :dram0_0_bss_phdr
+/* __stack = 0x3ffc8000; */
+
+  .irom0.text : ALIGN(4)
+  {
+    _irom0_text_start = ABSOLUTE(.);
+    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
+	out/build/app_app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+  *libsming.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    _irom0_text_end = ABSOLUTE(.);
+	_flash_code_end = ABSOLUTE(.);
+  } >irom0_0_seg :irom0_0_phdr
+
+  .text : ALIGN(4)
+  {
+    _stext = .;
+    _text_start = ABSOLUTE(.);
+     *(.UserEnter.text)
+    . = ALIGN(16);
+    *(.DebugExceptionVector.text)
+    . = ALIGN(16);
+    *(.NMIExceptionVector.text)
+    . = ALIGN(16);
+    *(.KernelExceptionVector.text)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    . = ALIGN(16);
+    *(.UserExceptionVector.text)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    . = ALIGN(16);
+    *(.DoubleExceptionVector.text)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    . = ALIGN (16);
+    *(.entry.text)
+    *(.init.literal)
+    *(.init)
+    *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+	  *(.iram.literal .iram.text.literal .iram.text)
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } >iram1_0_seg :iram1_0_phdr
+
+  .lit4 : ALIGN(4)
+  {
+    _lit4_start = ABSOLUTE(.);
+    *(*.lit4)
+    *(.lit4.*)
+    *(.gnu.linkonce.lit4.*)
+    _lit4_end = ABSOLUTE(.);
+  } >iram1_0_seg :iram1_0_phdr
+}
+
+/* get ROM code address */
+INCLUDE "../ld/eagle.rom.addr.v6.ld"

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -18,7 +18,7 @@ RBOOT_SPIFFS_1   ?= 0x300000
 RBOOT_LD_0 ?= rom0.ld
 RBOOT_LD_1 ?= rom1.ld
 # esptool2 path
-ESPTOOL2 ?= esptool2
+ESPTOOL2 ?= c:\userdata\esp8266\esptool2\esptool2.exe
 # path to spiffy
 SPIFFY ?= $(SMING_HOME)/spiffy/spiffy
 # filenames and options for generating rBoot rom images with esptool2

--- a/Sming/SmingCore/Network/rBootHttpUpdate.cpp
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.cpp
@@ -60,7 +60,7 @@ void rBootHttpUpdate::onTimer() {
 			updateFailed();
 			return;
 		}
-		
+		debugf("Firmware Loading");
 		currentItem++;
 		if (currentItem >= items.count()) {
 			debugf("\r\nFirmware download finished!");

--- a/Sming/SmingCore/RBootClass.cpp
+++ b/Sming/SmingCore/RBootClass.cpp
@@ -1,0 +1,223 @@
+/*
+ * RBoot.cpp
+ *
+ *  Created on: 5 nov. 2015
+ *      Author: Herman
+ */
+
+#include "RBootClass.h"
+
+RBoot::RBoot()
+{
+}
+
+RBoot::~RBoot()
+{
+	// TODO Auto-generated destructor stub
+}
+
+int RBoot::getCurrentRom()
+{
+	return rboot_get_current_rom();
+}
+
+bool RBoot::startRom(int reqSlot)
+{
+	rboot_config bootconf;
+	bootconf = rboot_get_config();
+	if (reqSlot >= bootconf.count)
+	{
+		return false;
+	}
+	rboot_set_current_rom(reqSlot);
+	System.restart();
+	return true; // Will never be executed;
+}
+
+bool RBoot::loadRom(uint8 loadType, uint8 reqSlot, String reqURL)
+{
+	// romStatus = loading
+	rboot_config bootconf;
+	bootconf = rboot_get_config();
+
+	if ((reqSlot >= bootconf.count) || (getCurrentRom() == reqSlot))
+	{
+		return false;
+	};
+	httpUpdate = new rBootHttpUpdate();
+	httpUpdate->setCallback(otaUpdateDelegate(&RBoot::OtaUpdateDelegate,this));
+	httpUpdate->addItem(bootconf.roms[reqSlot], reqURL);
+	httpUpdate->start();
+
+	return true;
+}
+
+void RBoot::setDelegate (RBootDelegate reqDelegate)
+{
+	rbootDelegate = reqDelegate;
+}
+
+bool RBoot::mountSpiffs(uint8 reqSlot)
+{
+	rboot_config bootconf;
+	bootconf = rboot_get_config();
+
+	if ((reqSlot >= bootconf.count) || (getCurrentRom() == reqSlot))
+	{
+		return false;
+	};
+
+	debugf("trying to mount spiffs at %x, length %d", bootconf.roms[reqSlot] + 0x40200000, 65536);
+	spiffs_mount_manual(bootconf.roms[reqSlot] + 0x40200000, 65536);
+	return true;
+}
+
+void RBoot::unmoutSpiffs()
+{
+	spiffs_unmount();
+}
+
+void RBoot::OtaUpdateDelegate(bool result)
+{
+	int romStatus;
+	romStatus = result ? 0 : 1; // valid : error
+	debugf("Delegate Called result = %d", result);
+
+	if (rbootDelegate)
+	{
+		rbootDelegate(result ? 0 : 1);
+	}
+}
+
+void RBoot::processRBootCommands(String commandLine, CommandOutput* commandOutput)
+{
+	Vector<String> commandToken;
+	int numToken = splitString(commandLine, ' ' , commandToken);
+
+	if (numToken == 1)
+	{
+		commandOutput->printf("RBoot Commands available : \r\n");
+		commandOutput->printf("info : Show Rominfo\r\n");
+		commandOutput->printf("load : Load ROM contents \r\n");
+		commandOutput->printf("start : Restart to <ROM>\r\n");
+		commandOutput->printf("mount : Mount Spiffs from <ROM>\r\n");
+		commandOutput->printf("unmount : Unmount spiffs filesystem\r\n");
+	}
+	else
+	{
+		if (commandToken[1] == "load")
+		{
+			if (numToken != 4)
+			{
+				commandOutput->printf("Usage : rboot load <Rom#> <URL>\r\n");
+			}
+			else
+			{
+				int rom = commandToken[2].toInt();
+				debugf("Loading Rom %s",commandToken[3].c_str());
+				if (loadRom(1,rom,commandToken[3]))
+				{
+					commandOutput->printf("Loading %s to ROM%d started\r\n",commandToken[3].c_str(),rom);
+				}
+				else
+				{
+					commandOutput->printf("Loading %s to ROM%d failed\r\n",commandToken[3].c_str(),rom);
+				}
+			}
+		}
+		else if (commandToken[1] == "start")
+		{
+			int rom = getCurrentRom();
+			if (numToken == 3)
+			{
+				rom = commandToken[2].toInt();
+			}
+			if (!startRom(rom))
+			{
+				commandOutput->printf("Invalid Rom for starting\r\n");
+			}
+		}
+		else if (commandToken[1] == "mount")
+		{
+			if (SPIFFS_mounted(&_filesystemStorageHandle))
+			{
+				commandOutput->printf("Spiffs filesystem already mounted\r\n");
+			}
+			else
+			if (numToken != 3)
+			{
+				commandOutput->printf("Usage : rboot spiffs <slot#> \r\n");
+			}
+			else
+			{
+				int slot = commandToken[2].toInt();
+				if (mountSpiffs(slot))
+				{
+					commandOutput->printf("Spiffs on ROM%d mounted\r\n",slot);
+				}
+				else
+				{
+					commandOutput->printf("Mounting spiffs on ROM%d failed\r\n",slot);
+				}
+			}
+
+		}
+		else if (commandToken[1] == "unmount")
+		{
+			unmoutSpiffs();
+			commandOutput->printf("Spiffs filesystem unmounted\r\n");
+		}
+		else if (commandToken[1] == "info")
+		{
+			showRomInfo(commandOutput);
+		}
+		else if (commandToken[1] == "ls")
+		{
+			showSpiffs(commandOutput);
+		}
+		else
+		{
+			commandOutput->printf("Unknown rboot command\r\n");
+		}
+
+	}
+}
+
+void RBoot::initCommand()
+{
+	commandHandler.registerCommand(CommandDelegate("rboot","Rboot related commands","RBoot",commandFunctionDelegate(&RBoot::processRBootCommands,this)));
+}
+
+void RBoot::showSpiffs(CommandOutput* commandOutput)
+{
+	if (!SPIFFS_mounted(&_filesystemStorageHandle))
+	{
+		commandOutput->printf("No Spiffs filesystem mounted\r\n");
+	}
+	else
+	{
+		Vector<String> files = fileList();
+		commandOutput->printf("filecount %d\r\n", files.count());
+		for (unsigned int i = 0; i < files.count(); i++)
+		{
+			commandOutput->println(files[i]);
+		}
+	}
+
+}
+
+
+void RBoot::showRomInfo(CommandOutput* commandOutput)
+{
+
+	rboot_config bootconf;
+	bootconf = rboot_get_config();
+	commandOutput->printf("\r\nROM Information\r\n");
+	commandOutput->printf("Current ROM = %d\r\n",getCurrentRom());
+	commandOutput->printf("Rboot Version %d\r\n",bootconf.version);
+	for (int i = 0; i < bootconf.count;i++)
+	{
+		commandOutput->printf("ROM%d :  value = %d, %X\r\n", i, bootconf.roms[i],bootconf.roms[i]);
+	}
+}
+

--- a/Sming/SmingCore/RBootClass.h
+++ b/Sming/SmingCore/RBootClass.h
@@ -14,7 +14,7 @@
 #include "../Wiring/WiringFrameworkDependencies.h"
 #include "../Services/CommandProcessing/CommandProcessingIncludes.h"
 #include <rboot-api.h>
-#include "Filesystem.h"
+#include "FileSystem.h"
 
 typedef struct
 {

--- a/Sming/SmingCore/RBootClass.h
+++ b/Sming/SmingCore/RBootClass.h
@@ -1,0 +1,56 @@
+/*
+ * RBoot.h
+ *
+ *  Created on: 5 nov. 2015
+ *      Author: Herman
+ */
+
+#ifndef SMINGCORE_RBOOT_H_
+#define SMINGCORE_RBOOT_H_
+
+
+#include "../SmingCore/Network/rBootHttpUpdate.h"
+
+#include "../Wiring/WiringFrameworkDependencies.h"
+#include "../Services/CommandProcessing/CommandProcessingIncludes.h"
+#include <rboot-api.h>
+#include "Filesystem.h"
+
+typedef struct
+{
+	uint32 StartAddress;     // Keep always as first to prevent updates to core rboot
+	uint8 RomType;           // -> AppCode, SpiffyFS
+	uint32 Size;
+	uint8 Status;
+} RBootRomInfo;
+
+typedef Delegate<void(int resultCode)> RBootDelegate;
+
+class RBoot
+{
+public:
+	RBoot();
+	virtual ~RBoot();
+	bool loadRom(uint8 loadType, uint8 reqSlot, String reqURL);
+
+	void OtaUpdateDelegate(bool result);
+	int getCurrentRom();
+	bool startRom(int reqSlot);
+
+	void initCommand();
+	void processRBootCommands(String commandLine, CommandOutput* commandOutput);
+	void showRomInfo(CommandOutput* commandOutput);
+	void showSpiffs(CommandOutput* commandOutput);
+
+	bool mountSpiffs(uint8 reqRom);
+	void unmoutSpiffs();
+
+	void setDelegate (RBootDelegate reqDelegate);
+
+	otaUpdateDelegate updateDelegate;
+	rBootHttpUpdate* httpUpdate = 0;
+
+	RBootDelegate rbootDelegate;
+};
+
+#endif /* SMINGCORE_RBOOT_H_ */

--- a/rBoot_Generic/.cproject
+++ b/rBoot_Generic/.cproject
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" moduleId="org.eclipse.cdt.core.settings" name="Sming">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" name="Sming" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.1164554300" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.521205673" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.393887888" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.712123812" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.2110485170" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option id="gnu.c.compiler.option.include.paths.357494572" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.313321806" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler">
+								<option id="gnu.cpp.compiler.option.include.paths.611746109" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.65193859" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.1795850540" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.364843833" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.525412186" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.587940548" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option id="gnu.both.asm.option.include.paths.1067006329" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.651581712" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="{{ProjectName}}.null.1347473968" name="{{ProjectName}}"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Sming">
+			<resource resourceType="PROJECT" workspacePath="/{{ProjectName}}"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets">
+		<buildTargets>
+			<target name="all" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>all</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="clean" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>clean</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flash" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flash</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashonefile" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashonefile</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashinit" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashinit</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashboot" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashboot</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="rebuild" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>rebuild</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+		</buildTargets>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.c.compiler.mingw.base.2032390008;cdt.managedbuild.tool.gnu.c.compiler.input.1700912488">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903;cdt.managedbuild.tool.gnu.c.compiler.input.313321806">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015;cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cpp.compiler.mingw.base.454898447;cdt.managedbuild.tool.gnu.cpp.compiler.input.501261625">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+</cproject>

--- a/rBoot_Generic/.project
+++ b/rBoot_Generic/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>rBoot_Generic</name>
+	<comment></comment>
+	<projects>
+		<project>SmingFramework</project>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/rBoot_Generic/Makefile
+++ b/rBoot_Generic/Makefile
@@ -1,0 +1,24 @@
+#####################################################################
+#### Please don't change this file. Use Makefile-user.mk instead ####
+#####################################################################
+# Including user Makefile.
+# Should be used to set project-specific parameters
+include ./Makefile-user.mk
+
+# Important parameters check.
+# We need to make sure SMING_HOME and ESP_HOME variables are set.
+# You can use Makefile-user.mk in each project or use enviromental variables to set it globally.
+ 
+ifndef SMING_HOME
+$(error SMING_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+ifndef ESP_HOME
+$(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+
+# Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
+include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/rBoot_Generic/Makefile-user.mk
+++ b/rBoot_Generic/Makefile-user.mk
@@ -1,0 +1,57 @@
+## Local build configuration
+## Parameters configured here will override default and ENV values.
+## Uncomment and change examples:
+
+#Add your source directories here separated by space
+MODULES = app
+
+## ESP_HOME sets the path where ESP tools and SDK are located.
+## Windows:
+# ESP_HOME = c:/Espressif
+
+## MacOS / Linux:
+#ESP_HOME = /opt/esp-open-sdk
+
+## SMING_HOME sets the path where Sming framework is located.
+## Windows:
+# SMING_HOME = c:/tools/sming/Sming 
+
+# MacOS / Linux
+# SMING_HOME = /opt/sming/Sming
+
+## COM port parameter is reqruied to flash firmware correctly.
+## Windows: 
+# COM_PORT = COM3
+
+# MacOS / Linux:
+# COM_PORT = /dev/tty.usbserial
+
+# Com port speed
+# COM_SPEED	= 115200
+
+#### overridable rBoot options ####
+## use rboot build mode
+RBOOT_ENABLED ?= 1
+## enable big flash support (for multiple roms, each in separate 1mb block of flash)
+RBOOT_BIG_FLASH ?= 1
+## two rom mode (where two roms sit in the same 1mb block of flash)
+#RBOOT_TWO_ROMS  ?= 1
+## size of the flash chip
+SPI_SIZE        ?= 4M
+## output file for first rom (.bin will be appended)
+#RBOOT_ROM_0     ?= rom0
+## input linker file for first rom
+#RBOOT_LD_0      ?= rom0.ld
+## these next options only needed when using two rom mode
+#RBOOT_ROM_1     ?= rom1
+#RBOOT_LD_1      ?= rom1.ld
+## size of the spiffs to create
+SPIFF_SIZE      ?= 65536
+## option to completely disable spiffs
+#DISABLE_SPIFFS  = 1
+## flash offsets for spiffs, set if using two rom mode or not on a 4mb flash
+## (spiffs location defaults to the mb after the rom slot on 4mb flash)
+#RBOOT_SPIFFS_0  ?= 0x100000
+#RBOOT_SPIFFS_1  ?= 0x300000
+## esptool2 path
+#ESPTOOL2        ?= esptool2

--- a/rBoot_Generic/app/application.cpp
+++ b/rBoot_Generic/app/application.cpp
@@ -1,0 +1,54 @@
+#include <user_config.h>
+#include <SmingCore/SmingCore.h>
+#include <SmingCore/RBootClass.h>
+#include <SmingCore/Network/TelnetServer.h>
+
+// If you want, you can define WiFi settings globally in Eclipse Environment Variables
+#ifndef WIFI_SSID
+	#define WIFI_SSID "PleaseEnterSSID" // Put you SSID and Password here
+	#define WIFI_PWD "PleaseEnterPass"
+#endif
+
+RBoot rBoot;
+TelnetServer telnetServer;
+
+void rbootDelegate(int resultCode) {
+
+	Serial.printf("rBoot resultcode =  %d\r\n", resultCode );
+}
+
+void addSpiffsRoms()
+{
+	rboot_config bootconf;
+	bootconf = rboot_get_config();
+	bootconf.count = 4;
+	bootconf.roms[2] = 0x100000;
+	bootconf.roms[3] = 0x300000;
+	rboot_set_config(&bootconf);
+}
+
+void init() {
+	
+	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.systemDebugOutput(true); // Debug output to serial
+
+	WifiAccessPoint.enable(false);
+	WifiStation.enable(true);
+	WifiStation.config(WIFI_SSID, WIFI_PWD);
+	WifiAccessPoint.enable(false);
+	
+	telnetServer.listen(23);
+	telnetServer.setDebug(true);
+
+	Serial.commandProcessing(true);
+
+	addSpiffsRoms();
+
+	rBoot.initCommand();
+	rBoot.setDelegate(rbootDelegate);
+	int slot = rBoot.getCurrentRom();
+	
+	Serial.printf("\r\nrBoot Generic running rom %d.\r\n", slot);
+
+	rBoot.mountSpiffs(2);
+}

--- a/rBoot_Generic/files/fetch.txt
+++ b/rBoot_Generic/files/fetch.txt
@@ -1,0 +1,2 @@
+git fetch origin pull/111/head
+https://github.com/SmingHub/Sming.git

--- a/rBoot_Generic/files/testfile.txt
+++ b/rBoot_Generic/files/testfile.txt
@@ -1,0 +1,2 @@
+This line is the content of test file.
+

--- a/rBoot_Generic/include/user_config.h
+++ b/rBoot_Generic/include/user_config.h
@@ -5,9 +5,9 @@
 extern "C" {
 #endif
 	
-	#define ROM_0_URL  "http://10.0.0.201/rom0.bin"
-	#define ROM_1_URL  "http://10.0.0.201/rom1.bin"
-	#define SPIFFS_URL "http://10.0.0.201/spiff_rom.bin"
+	#define ROM_0_URL  "http://192.168.7.5:80/rom0.bin"
+	#define ROM_1_URL  "http://192.168.7.5:80/rom1.bin"
+	#define SPIFFS_URL "http://192.168.7.5:80/spiff_rom.bin"
 
 	// UART config
 	#define SERIAL_BAUD_RATE 115200

--- a/rBoot_Generic/readme.txt
+++ b/rBoot_Generic/readme.txt
@@ -1,0 +1,84 @@
+rBoot Sming sample
+------------------
+
+This sample integrates rBoot and Sming, for the many people who have been asking
+for it. It demonstrates dual rom booting, big flash support, OTA updates and
+dual spiffs filesystems. You must enable big flash support in rBoot and use on
+an ESP12 (or similar device with 4mb flash). When using rBoot big flash support
+with multiple 1mb slots only one rom image needs to be created. If you don't
+want to use big flash support (e.g. for a device with smaller flash) see the
+separate instructions below. You can easily take the ota files and add them to
+your own project to add OTA support.
+
+To build any Sming project (in threory) with rBoot support you should use
+Makefile-rboot.mk instead of Makefile-project.mk. In the sample the correct mk
+file is chosen automatically because of the setting RBOOT_ENABLED=1 in
+Makefile-user.mk
+
+Building
+--------
+ 1) Set ESP_HOME & SMING_HOME, as environment variables or edit Makefile-user.mk
+    as you would for general Sming app compiling.
+ 2) Set ESPTOOL2 (env var or in Makefile-user.mk) to point to the esptool2
+    binary. Source for esptool2 is here: https://github.com/raburton/esp8266
+ 3) Set WIFI_SSID & WIFI_PWD environment variables with your wifi details.
+ 4) Edit the OTA server details in include/user_config.h
+ 5) Check overridable variables in Makefile-user.mk, or set as env vars.
+ 6) make && make flash
+ 7) Put rom0.bin and spiff_rom.bin in the root of your webserver for OTA.
+ 8) Interact with the sample using a terminal, sorry no web-gui (yet).
+
+Flashing
+--------
+If flashing manually use esptool.py to flash rBoot, rom & spiffs e.g.:
+ esptool.py --port <port> write_flash -fs 32m 0x00000 rboot.bin 0x02000 rom0.bin
+   0x100000 spiffs.rom
+
+Using the correct -fs parameter is important. This will be -fs 32m on an ESP12.
+
+You can also flash rom0.bin to 0x202000, but booting and using OTA is quicker!
+
+Technical Notes
+---------------
+spiffs_mount_manual(address, length) must be called from init. The address must
+be 0x40200000 + physical flash address. Sming does not use memory mapped flash
+so the reason for this strange addressing is not clear.
+
+Important compiler flags used:
+BOOT_BIG_FLASH - when using big flash mode, ensures flash mapping code is built
+  in to the rom.
+RBOOT_INTEGRATION - ensures Sming specific options are pulled in to the rBoot
+  source at compile time.
+SPIFF_SIZE=value - passed through to code for mounting the filesystem. Also used
+  in the Makefile to create the spiffs.
+
+Disabling big flash
+-------------------
+If you want to use, for example, two 512k roms in the first 1mb block of flash
+(old style) then follow these instructions to produce two separately linked
+roms. If you are flashing a single rom to multiple 1mb flash blocks (using big
+flash) you only need one linked rom that can be used on each.
+
+This assumes you understand the concepts explained in the rBoot readme about
+memory mapping and setting linker script address. This is not covered here, just
+how to use this sample without bigflash support.
+
+- Copy rom0.ld to rom1.ld.
+- Adjust the rom offsets and length as appropriate in each ld file.
+- Uncomment 'RBOOT_TWO_ROMS ?= 1' in Makefile-user.mk (or set as an environment
+  variable).
+- Ensure RBOOT_BIG_FLASH is set to 0 in Makefile-user.mk
+- If using a very small flash (e.g. 512k) there may be no room for a spiffs
+  fileystem, disable it with DISABLE_SPIFFS = 1
+- If you are using spiffs set RBOOT_SPIFFS_0 & RBOOT_SPIFFS_1 to indicate where
+  the filesystems are located on the flash. This is the real flash offset, not
+  the address + 0x40200000 used in the mount call.
+- After building copy all the rom*.bin files to the root of your web server.
+
+If you want more than two roms you must be an advanced user and should be able
+to work out what to copy and edit to acheive this!
+
+Credits
+-------
+This sample was made possible with the assistance of piperpilot, gschmott and
+robotiko on the esp8266.com forum.

--- a/rBoot_Generic/readme.txt
+++ b/rBoot_Generic/readme.txt
@@ -1,84 +1,46 @@
-rBoot Sming sample
-------------------
+rBoot Generic example
 
-This sample integrates rBoot and Sming, for the many people who have been asking
-for it. It demonstrates dual rom booting, big flash support, OTA updates and
-dual spiffs filesystems. You must enable big flash support in rBoot and use on
-an ESP12 (or similar device with 4mb flash). When using rBoot big flash support
-with multiple 1mb slots only one rom image needs to be created. If you don't
-want to use big flash support (e.g. for a device with smaller flash) see the
-separate instructions below. You can easily take the ota files and add them to
-your own project to add OTA support.
+This is an alpha implementation of a Generic rBoot layer for easing the use of rBoot and provide a rBoot Bios application to support ESP fully remote.
 
-To build any Sming project (in threory) with rBoot support you should use
-Makefile-rboot.mk instead of Makefile-project.mk. In the sample the correct mk
-file is chosen automatically because of the setting RBOOT_ENABLED=1 in
-Makefile-user.mk
+This PR includes a "RBootClass" which implements :
 
-Building
---------
- 1) Set ESP_HOME & SMING_HOME, as environment variables or edit Makefile-user.mk
-    as you would for general Sming app compiling.
- 2) Set ESPTOOL2 (env var or in Makefile-user.mk) to point to the esptool2
-    binary. Source for esptool2 is here: https://github.com/raburton/esp8266
- 3) Set WIFI_SSID & WIFI_PWD environment variables with your wifi details.
- 4) Edit the OTA server details in include/user_config.h
- 5) Check overridable variables in Makefile-user.mk, or set as env vars.
- 6) make && make flash
- 7) Put rom0.bin and spiff_rom.bin in the root of your webserver for OTA.
- 8) Interact with the sample using a terminal, sorry no web-gui (yet).
+    An initial layer around rBoot/rbootHttpUpdate
+    An initial way to mount/unmount spiffs filesystems, based on rBoot configuration
+    An initial CommandHandler interface to the functionality.
+    An example application using the above : rboot_generic
 
-Flashing
---------
-If flashing manually use esptool.py to flash rBoot, rom & spiffs e.g.:
- esptool.py --port <port> write_flash -fs 32m 0x00000 rboot.bin 0x02000 rom0.bin
-   0x100000 spiffs.rom
+Not much documentation yet,
 
-Using the correct -fs parameter is important. This will be -fs 32m on an ESP12.
+    see RBootClass.h for usage & interfaces
+    connect with telnet client to esp, rboot commands are then available : "rboot info" "rboot load 1 http://10.0.0.201/rom0.bin" "rboot ls" etc type "rboot" for all options.
 
-You can also flash rom0.bin to 0x202000, but booting and using OTA is quicker!
+All command examples have equivalent API's -> available within application
 
-Technical Notes
----------------
-spiffs_mount_manual(address, length) must be called from init. The address must
-be 0x40200000 + physical flash address. Sming does not use memory mapped flash
-so the reason for this strange addressing is not clear.
+Current V0.1 is only usable/has hardcoded values for use on 4Mb (esp-12) devices, no other supported yet.
 
-Important compiler flags used:
-BOOT_BIG_FLASH - when using big flash mode, ensures flash mapping code is built
-  in to the rom.
-RBOOT_INTEGRATION - ensures Sming specific options are pulled in to the rBoot
-  source at compile time.
-SPIFF_SIZE=value - passed through to code for mounting the filesystem. Also used
-  in the Makefile to create the spiffs.
+The used romconfig is the following :
 
-Disabling big flash
--------------------
-If you want to use, for example, two 512k roms in the first 1mb block of flash
-(old style) then follow these instructions to produce two separately linked
-roms. If you are flashing a single rom to multiple 1mb flash blocks (using big
-flash) you only need one linked rom that can be used on each.
+ROM0 -> 0x002000	-> number from initial rboot figures, application area
+ROM1 -> 0x202000	-> number from initial rboot figures, application area
+ROM2 -> 0x100000;	-> number set in application code, spiffs area, size 65536
+ROM3 -> 0x300000;	-> number set in application code, spiffs area, size 65536
 
-This assumes you understand the concepts explained in the rBoot readme about
-memory mapping and setting linker script address. This is not covered here, just
-how to use this sample without bigflash support.
+Running the example the functionality can be shown by the following commands :
 
-- Copy rom0.ld to rom1.ld.
-- Adjust the rom offsets and length as appropriate in each ld file.
-- Uncomment 'RBOOT_TWO_ROMS ?= 1' in Makefile-user.mk (or set as an environment
-  variable).
-- Ensure RBOOT_BIG_FLASH is set to 0 in Makefile-user.mk
-- If using a very small flash (e.g. 512k) there may be no room for a spiffs
-  fileystem, disable it with DISABLE_SPIFFS = 1
-- If you are using spiffs set RBOOT_SPIFFS_0 & RBOOT_SPIFFS_1 to indicate where
-  the filesystems are located on the flash. This is the real flash offset, not
-  the address + 0x40200000 used in the mount call.
-- After building copy all the rom*.bin files to the root of your web server.
+rboot info -> shows ROM info
+rboot load 0 http://10.0.0.200/rom0.bin -> error, don't allow current rom update
+rboot load 1 http://10.0.0.200/rom0.bin -> http update rom0.bin to ROM1
+rboot load 2 http://10.0.0.200/spiffs_rom.bin -> http update spiffs to ROM2
+rboot load 3 http://10.0.0.200/spiffs_rom2.bin -> http update spiffs2 to ROM3
 
-If you want more than two roms you must be an advanced user and should be able
-to work out what to copy and edit to acheive this!
+rboot start -> start current ROM (= restart)
+rboot start 1 -> start ROM1
 
-Credits
--------
-This sample was made possible with the assistance of piperpilot, gschmott and
-robotiko on the esp8266.com forum.
+rboot mount 2 -> mount ROM2 spiffs
+rboot ls -> show files on spiffs
+rboot unmount -> unmount spiffs
+rboot ls -> error not mounted
+rboot mount 3 -> mount ROM3 spiffs
+rboot ls -> show files on spiffs
+
+

--- a/rBoot_Generic/rom0.ld
+++ b/rBoot_Generic/rom0.ld
@@ -1,0 +1,219 @@
+/* This linker script generated from xt-genldscripts.tpp for LSP . */
+/* Linker Script for ld -N */
+MEMORY
+{
+  dport0_0_seg :                        org = 0x3FF00000, len = 0x10
+  dram0_0_seg :                         org = 0x3FFE8000, len = 0x14000
+  iram1_0_seg :                         org = 0x40100000, len = 0x8000
+  irom0_0_seg :                         org = 0x40202010, len = 0x42000
+}
+
+PHDRS
+{
+  dport0_0_phdr PT_LOAD;
+  dram0_0_phdr PT_LOAD;
+  dram0_0_bss_phdr PT_LOAD;
+  iram1_0_phdr PT_LOAD;
+  irom0_0_phdr PT_LOAD;
+}
+
+
+/*  Default entry point:  */
+ENTRY(call_user_start)
+EXTERN(_DebugExceptionVector)
+EXTERN(_DoubleExceptionVector)
+EXTERN(_KernelExceptionVector)
+EXTERN(_NMIExceptionVector)
+EXTERN(_UserExceptionVector)
+PROVIDE(_memmap_vecbase_reset = 0x40000000);
+/* Various memory-map dependent cache attribute settings: */
+_memmap_cacheattr_wb_base = 0x00000110;
+_memmap_cacheattr_wt_base = 0x00000110;
+_memmap_cacheattr_bp_base = 0x00000220;
+_memmap_cacheattr_unused_mask = 0xFFFFF00F;
+_memmap_cacheattr_wb_trapnull = 0x2222211F;
+_memmap_cacheattr_wba_trapnull = 0x2222211F;
+_memmap_cacheattr_wbna_trapnull = 0x2222211F;
+_memmap_cacheattr_wt_trapnull = 0x2222211F;
+_memmap_cacheattr_bp_trapnull = 0x2222222F;
+_memmap_cacheattr_wb_strict = 0xFFFFF11F;
+_memmap_cacheattr_wt_strict = 0xFFFFF11F;
+_memmap_cacheattr_bp_strict = 0xFFFFF22F;
+_memmap_cacheattr_wb_allvalid = 0x22222112;
+_memmap_cacheattr_wt_allvalid = 0x22222112;
+_memmap_cacheattr_bp_allvalid = 0x22222222;
+PROVIDE(_memmap_cacheattr_reset = _memmap_cacheattr_wb_trapnull);
+
+SECTIONS
+{
+
+  .dport0.rodata : ALIGN(4)
+  {
+    _dport0_rodata_start = ABSOLUTE(.);
+    *(.dport0.rodata)
+    *(.dport.rodata)
+    _dport0_rodata_end = ABSOLUTE(.);
+  } >dport0_0_seg :dport0_0_phdr
+
+  .dport0.literal : ALIGN(4)
+  {
+    _dport0_literal_start = ABSOLUTE(.);
+    *(.dport0.literal)
+    *(.dport.literal)
+    _dport0_literal_end = ABSOLUTE(.);
+  } >dport0_0_seg :dport0_0_phdr
+
+  .dport0.data : ALIGN(4)
+  {
+    _dport0_data_start = ABSOLUTE(.);
+    *(.dport0.data)
+    *(.dport.data)
+    _dport0_data_end = ABSOLUTE(.);
+  } >dport0_0_seg :dport0_0_phdr
+
+  .data : ALIGN(4)
+  {
+    _data_start = ABSOLUTE(.);
+    *(.data)
+    *(.data.*)
+    *(.gnu.linkonce.d.*)
+    *(.data1)
+    *(.sdata)
+    *(.sdata.*)
+    *(.gnu.linkonce.s.*)
+    *(.sdata2)
+    *(.sdata2.*)
+    *(.gnu.linkonce.s2.*)
+    *(.jcr)
+    _data_end = ABSOLUTE(.);
+  } >dram0_0_seg :dram0_0_phdr
+
+  .rodata : ALIGN(4)
+  {
+    _rodata_start = ABSOLUTE(.);
+    *(.sdk.version)
+    *(.rodata)
+    *(.rodata.*)
+    *(.gnu.linkonce.r.*)
+    *(.rodata1)
+    __XT_EXCEPTION_TABLE__ = ABSOLUTE(.);
+    *(.xt_except_table)
+    *(.gcc_except_table)
+    *(.gnu.linkonce.e.*)
+    *(.gnu.version_r)
+    *(.eh_frame)
+    . = (. + 3) & ~ 3;
+    /*  C++ constructor and destructor tables, properly ordered:  */
+	__dso_handle = ABSOLUTE(.);
+    __init_array_start = ABSOLUTE(.);
+    KEEP (*crtbegin.o(.ctors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+    KEEP (*(SORT(.ctors.*)))
+    KEEP (*(.ctors))
+    __init_array_end = ABSOLUTE(.);
+    KEEP (*crtbegin.o(.dtors))
+    KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+    KEEP (*(SORT(.dtors.*)))
+    KEEP (*(.dtors))
+    /*  C++ exception handlers table:  */
+    __XT_EXCEPTION_DESCS__ = ABSOLUTE(.);
+    *(.xt_except_desc)
+    *(.gnu.linkonce.h.*)
+    __XT_EXCEPTION_DESCS_END__ = ABSOLUTE(.);
+    *(.xt_except_desc_end)
+    *(.dynamic)
+    *(.gnu.version_d)
+    . = ALIGN(4);		/* this table MUST be 4-byte aligned */
+    _bss_table_start = ABSOLUTE(.);
+    LONG(_bss_start)
+    LONG(_bss_end)
+    _bss_table_end = ABSOLUTE(.);
+    _rodata_end = ABSOLUTE(.);
+  } >dram0_0_seg :dram0_0_phdr
+
+  .bss ALIGN(8) (NOLOAD) : ALIGN(4)
+  {
+    . = ALIGN (8);
+    _bss_start = ABSOLUTE(.);
+    *(.dynsbss)
+    *(.sbss)
+    *(.sbss.*)
+    *(.gnu.linkonce.sb.*)
+    *(.scommon)
+    *(.sbss2)
+    *(.sbss2.*)
+    *(.gnu.linkonce.sb2.*)
+    *(.dynbss)
+    *(.bss)
+    *(.bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN (8);
+    _bss_end = ABSOLUTE(.);
+    _heap_start = ABSOLUTE(.);
+/*    _stack_sentry = ALIGN(0x8); */
+  } >dram0_0_seg :dram0_0_bss_phdr
+/* __stack = 0x3ffc8000; */
+
+  .irom0.text : ALIGN(4)
+  {
+    _irom0_text_start = ABSOLUTE(.);
+    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
+	out/build/app_app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+  *libsming.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    _irom0_text_end = ABSOLUTE(.);
+	_flash_code_end = ABSOLUTE(.);
+  } >irom0_0_seg :irom0_0_phdr
+
+  .text : ALIGN(4)
+  {
+    _stext = .;
+    _text_start = ABSOLUTE(.);
+     *(.UserEnter.text)
+    . = ALIGN(16);
+    *(.DebugExceptionVector.text)
+    . = ALIGN(16);
+    *(.NMIExceptionVector.text)
+    . = ALIGN(16);
+    *(.KernelExceptionVector.text)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    . = ALIGN(16);
+    *(.UserExceptionVector.text)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    . = ALIGN(16);
+    *(.DoubleExceptionVector.text)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    LONG(0)
+    . = ALIGN (16);
+    *(.entry.text)
+    *(.init.literal)
+    *(.init)
+    *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+	  *(.iram.literal .iram.text.literal .iram.text)
+    *(.fini.literal)
+    *(.fini)
+    *(.gnu.version)
+    _text_end = ABSOLUTE(.);
+    _etext = .;
+  } >iram1_0_seg :iram1_0_phdr
+
+  .lit4 : ALIGN(4)
+  {
+    _lit4_start = ABSOLUTE(.);
+    *(*.lit4)
+    *(.lit4.*)
+    *(.gnu.linkonce.lit4.*)
+    _lit4_end = ABSOLUTE(.);
+  } >iram1_0_seg :iram1_0_phdr
+}
+
+/* get ROM code address */
+INCLUDE "../ld/eagle.rom.addr.v6.ld"


### PR DESCRIPTION
@All : 
This is an alpha implementation of a Generic rBoot layer for easing the use of rBoot and provide a rBoot Bios application to support ESP fully remote.

This PR includes a "RBootClass" which implements :  
- An initial layer around rBoot/rbootHttpUpdate
- An initial way to mount/unmount spiffs filesystems, based on rBoot configuration
- An initial CommandHandler interface to the functionality.
- An example application using the above : rboot_generic

Not much documentation yet, 
- see RBootClass.h for usage & interfaces
- connect with telnet client to esp, rboot commands are then available :
   "rboot info" "rboot load 1 http://10.0.0.201/rom0.bin" "rboot ls" etc
type "rboot" for all options.

All command examples have equivalent API's -> available within application

Current V0.1 is only usable/has hardcoded values for use on 4Mb  devices, no other supported yet.

The used romconfig is the following :

ROM0 -> 0x002000	-> number from initial rboot figures, application area
ROM1 -> 0x202000	-> number from initial rboot figures, application area
ROM2 -> 0x100000;	-> number set in application code, spiffs area, size 65536
ROM3 -> 0x300000;	-> number set in application code, spiffs area, size 65536

Running the example the functionality can be shown by the following commands :

rboot info -> shows ROM info
rboot load 0 http://10.0.0.200/rom0.bin -> error, don't allow current rom update
rboot load 1 http://10.0.0.200/rom0.bin -> http update rom0.bin to ROM1
rboot load 2 http://10.0.0.200/spiffs_rom.bin -> http update spiffs to ROM2
rboot load 3 http://10.0.0.200/spiffs_rom2.bin -> http update spiffs2 to ROM3

rboot start -> start current ROM (= restart)
rboot start 1 -> start ROM1

rboot mount 2 -> mount ROM2 spiffs
rboot ls -> show files on spiffs
rboot unmount -> unmount spiffs
rboot ls -> error not mounted
rboot mount 3 -> mount ROM3 spiffs
rboot ls -> show files on spiffs


Next version to come

Please comment 