### PR TITLE
* Replace esptool.py by esptool2 for image generation with new sdk >= 1.4.x

### DIFF
--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -29,6 +29,16 @@ SPI_SIZE ?= 512K
 # Path to spiffy
 SPIFFY ?= $(SMING_HOME)/spiffy/spiffy
 
+#ESPTOOL2 config to generate rBootLESS images
+IMAGE_MAIN	?= 0x00000.bin
+IMAGE_SDK	?= 0x09000.bin
+# esptool2 path
+ESPTOOL2 ?= esptool2
+# esptool2 parameters for rBootLESS images
+ESPTOOL2_SECTS		?= .text .data .rodata
+ESPTOOL2_MAIN_ARGS	?= -quiet -bin -boot0
+ESPTOOL2_SDK_ARGS	?= -quiet -lib
+
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 ## Windows:
 # ESP_HOME = c:/Espressif
@@ -291,7 +301,9 @@ $(TARGET_OUT): $(APP_AR)
 
 	$(vecho) "------------------------------------------------------------------------------"
 	$(vecho) "# Generating image..."
-	$(Q) $(ESPTOOL) elf2image $@ $(flashimageoptions) -o $(FW_BASE)/
+#	$(Q) $(ESPTOOL2) elf2image $@ $(flashimageoptions) -o $(FW_BASE)/
+	@$(ESPTOOL2) $(ESPTOOL2_MAIN_ARGS) $@ $(FW_BASE)/$(IMAGE_MAIN) $(ESPTOOL2_SECTS)
+	@$(ESPTOOL2) $(ESPTOOL2_SDK_ARGS) $@ $(FW_BASE)/$(IMAGE_SDK)
 	$(vecho) "Generate firmware images successully in folder $(FW_BASE)."
 	$(vecho) "Done"
 


### PR DESCRIPTION
* with recent update of develop branch there is no way to generate flashable image by esptool.py. There is workaround based on chat in gitter to generate images with esptool2. This method is for rBootLESS projects as rBoot aware projects already generate images by esptool2.