### PR TITLE
Send NACK and stop at the end of a requestFrom

### DIFF
--- a/Sming/SmingCore/Wire.cpp
+++ b/Sming/SmingCore/Wire.cpp
@@ -92,7 +92,10 @@ uint8_t TwoWire::requestFrom(int address, int quantity, bool sendStop /* = true*
 	if (!master->start(((uint8_t)(address << 1)) | I2C_READ)) return 0; // received NACK on transmit of address
 
 	for (int i = 0; i < quantity; i++)
-		rxBuf[rxLen++] = master->read(sendStop && (quantity == i + 1));
+		rxBuf[rxLen++] = master->read(quantity == i + 1);
+
+	if(sendStop)
+		master->stop();
 
 	return quantity;
 }


### PR DESCRIPTION
Send NACK at the end of a requestFrom and send stop condition according to sendStop argument, like standard Arduino twi :
* [Arduino](https://github.com/arduino/Arduino/blob/c71f5e9f883bac00f4013e4c94579bbd81002c58/hardware/arduino/avr/libraries/Wire/utility/twi.c#L131)
* [Arduino esp8266](https://github.com/esp8266/Arduino/blob/master/cores/esp8266/core_esp8266_si2c.c#L174)