### PR TITLE
m_printf guard against overflow for %s +snprintf

### DIFF
--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -133,12 +133,12 @@ TARGET		= app
 
 # which modules (subdirectories) of the project to include in compiling
 # define your custom directories in the project's own Makefile before including this one
-MODULES 	?= app  # if not initialized by user 
-EXTRA_INCDIR    ?= include $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SDK_BASE)/../include $(SMING_HOME)/rboot $(SMING_HOME)/rboot/appcode
+MODULES 	+= app  # if not initialized by user 
+EXTRA_INCDIR    += include $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SDK_BASE)/../include $(SMING_HOME)/rboot $(SMING_HOME)/rboot/appcode
 
 # libraries used in this project, mainly provided by the SDK
 USER_LIBDIR = $(SMING_HOME)/compiler/lib/
-LIBS		= microc microgcc hal phy pp net80211 lwip wpa main sming pwm $(EXTRA_LIBS)
+LIBS		= microc microgcc hal phy pp net80211 lwip wpa main sming crypto pwm $(EXTRA_LIBS)
 
 # compiler flags using during compilation of source files
 CFLAGS		= -Os -g -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 $(USER_CFLAGS)

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -133,8 +133,8 @@ TARGET		= app
 
 # which modules (subdirectories) of the project to include in compiling
 # define your custom directories in the project's own Makefile before including this one
-MODULES 	+= app  # if not initialized by user 
-EXTRA_INCDIR    += include $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SDK_BASE)/../include $(SMING_HOME)/rboot $(SMING_HOME)/rboot/appcode
+MODULES 	?= app  # if not initialized by user 
+EXTRA_INCDIR    ?= include $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SDK_BASE)/../include $(SMING_HOME)/rboot $(SMING_HOME)/rboot/appcode
 
 # libraries used in this project, mainly provided by the SDK
 USER_LIBDIR = $(SMING_HOME)/compiler/lib/

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -138,7 +138,7 @@ EXTRA_INCDIR    += include $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/sy
 
 # libraries used in this project, mainly provided by the SDK
 USER_LIBDIR = $(SMING_HOME)/compiler/lib/
-LIBS		= microc microgcc hal phy pp net80211 lwip wpa main sming crypto pwm $(EXTRA_LIBS)
+LIBS		= microc microgcc hal phy pp net80211 lwip wpa main sming pwm $(EXTRA_LIBS)
 
 # compiler flags using during compilation of source files
 CFLAGS		= -Os -g -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 $(USER_CFLAGS)

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -26,6 +26,7 @@
 #define STORE_ATTR __attribute__((aligned(4)))
 
 extern int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args);
+extern int m_snprintf(char* buf, int length, const char *fmt, ...);
 extern int m_printf(const char *fmt, ...);
 
 #undef assert

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -32,6 +32,35 @@ void setMPrintfPrinterCbc(void (*callback)(char))
 	cbc_printchar = callback;
 }
 
+/**
+ * @fn int m_snprintf(char* buf, int length, const char *fmt, ...);
+ *
+ * @param buf - destination buffer
+ * @param length - destination buffer size
+ * @param fmt - printf compatible format string
+ *
+ * @retval int - number of characters written
+ */
+int m_snprintf(char* buf, int length, const char *fmt, ...)
+{
+	char *p;
+	va_list args;
+	int n = 0;
+
+	va_start(args, fmt);
+	n = m_vsnprintf(buf, length, fmt, args);
+	va_end(args);
+
+	return n;
+}
+
+/**
+ * @fn int m_printf(const char *fmt, ...);
+ *
+ * @param fmt - printf compatible format string
+ *
+ * @retval int - number of characters written to console
+ */
 int m_printf(const char *fmt, ...)
 {
 	if(!cbc_printchar)
@@ -132,7 +161,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
 			}
 			else
 			{
-				while (*s)
+				while (*s && (maxLen - (uint32_t)(str - buf) > OVERFLOW_GUARD))
 					*str++ = *s++;
 			}
 


### PR DESCRIPTION
* Fix for #408 
* Implements snprintf
* Fix Makefile for SDK 1.5 (libcrypto required) 
* Fix Makefile for the case MODULES and EXTRA_INCDIR already defined in user Makefile
