### PR TITLE
Fixes out-of-bounds access when reading from UART

### DIFF
--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -101,7 +101,7 @@ int HardwareSerial::read()
 	char res = *(rxBuf.pReadPos);
 	rxBuf.pReadPos++;
 
-	if (rxBuf.pReadPos == (rxBuf.pRcvMsgBuff + RX_BUFF_SIZE))
+	if (rxBuf.pReadPos >= (rxBuf.pRcvMsgBuff + RX_BUFF_SIZE))
 		rxBuf.pReadPos = rxBuf.pRcvMsgBuff ;
 
 	interrupts();
@@ -122,7 +122,7 @@ int HardwareSerial::readMemoryBlock(char* buf, int max_len)
 
 			// Set pointer to next data word in ring buffer
 			rxBuf.pReadPos++;
-			if (rxBuf.pReadPos == (rxBuf.pRcvMsgBuff + RX_BUFF_SIZE))
+			if (rxBuf.pReadPos >= (rxBuf.pRcvMsgBuff + RX_BUFF_SIZE))
 				rxBuf.pReadPos = rxBuf.pRcvMsgBuff ;
 		}
 	}


### PR DESCRIPTION
This bug was triggered by uart0_rx_intr_handler leaving rxBuf.pReadPos
at the last element of rxBuf and subsequent reads from rxBuf incrementing
pReadPos past the bounds of array and then comparing to array size.