### PR TITLE
Fix hyperlink in Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -33,7 +33,7 @@ Sming - Open Source framework for high efficiency WiFi SoC ESP8266 native develo
 
 ## Additional needed software 
 - Spiffy  : Source included in Sming repository
-- [ESPtool2] (https://github.com/raburton/esp8266) esptool2 
+- [ESPtool2] (https://github.com/raburton/esptool2) esptool2 
 
 You can find more information about compilation and flashing process by reading esp8266.com forum discussion thread.
 


### PR DESCRIPTION
Esptool2 link was linking to wrong project.
