### PR TITLE
Fix #447, shrink Sming size

### DIFF
--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -135,7 +135,9 @@ void HttpServer::processWebSocketFrame(pbuf *buf, HttpServerConnection& connecti
 		msg.setString((char*)data, size);
 		debugf("WS: %s", msg.c_str());
 		if (sock && wsMessage) wsMessage(*sock, msg);
+#ifndef DISABLE_FEATURE_COMMAND_EXECUTOR
 		if (sock && sock->commandExecutor) sock->commandExecutor->executorReceive(msg+"\r");
+#endif
 	}
 	else if (frameType == WS_BINARY_FRAME)
 	{

--- a/Sming/SmingCore/Network/WebSocket.cpp
+++ b/Sming/SmingCore/Network/WebSocket.cpp
@@ -17,10 +17,12 @@ WebSocket::WebSocket(HttpServerConnection* conn)
 
 WebSocket::~WebSocket()
 {
+#ifndef DISABLE_FEATURE_COMMAND_EXECUTOR
 	if (commandExecutor)
 	{
 		delete commandExecutor;
 	}
+#endif
 }
 
 bool WebSocket::initialize(HttpRequest& request, HttpResponse& response)
@@ -66,8 +68,10 @@ void WebSocket::sendBinary(const uint8_t* data, int size)
 
 void WebSocket::enableCommand()
 {
+#ifndef DISABLE_FEATURE_COMMAND_EXECUTOR
 	if (!commandExecutor)
 	{
 		commandExecutor = new CommandExecutor(this);
 	}
+#endif
 }


### PR DESCRIPTION
If someone doesn't use the commandExecution geature, he/she can save 3.3KB flash and 1.3KB RAM if making libSming like this
make rebuild DISABLE_FEATURE_COMMAND_EXECUTOR=1 

Might fix #477

   Section |                   Description | Start (hex) |   End (hex) | Used space
------------ | ---------------------------- | -------------- | ---------- | ----
      data |        Initialized Data (RAM) |    3FFE8000 |    3FFE842D |    1069
    rodata |           ReadOnly Data (RAM) |    3FFE8430 |    3FFEA490 |    8288 (-1288)
       bss |      Uninitialized Data (RAM) |    3FFEA490 |    3FFF1018 |   27528 (-120)
      text |            Cached Code (IRAM) |    40100000 |    40105D0B |   23819
irom0_text |           Uncached Code (SPI) |    40209000 |    402430A7 |  237735 (-3372) 