### PR TITLE
Add ability to get raw http request body

### DIFF
--- a/Sming/SmingCore/Network/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/HttpRequest.cpp
@@ -229,6 +229,25 @@ bool HttpRequest::extractParsingItemsList(pbuf* buf, int startPos, int endPos, c
 	}
 	return continued;
 }
+void HttpRequest::parseRawData(HttpServer *server, pbuf* buf)
+{
+	if (!combinePostFrag)
+	{
+		bodyBuf = (char *) os_zalloc(sizeof(char) * buf->tot_len);
+	}
+	int headerEnd = NetUtils::pbufFindStr(buf, "\r\n\r\n");
+	if (headerEnd + getContentLength() > NETWORK_MAX_HTTP_PARSING_LEN)
+	{
+		debugf("NETWORK_MAX_HTTP_PARSING_LEN");
+		return;
+	}
+	pbuf_copy_partial(buf, bodyBuf, buf->tot_len, headerEnd + 4);
+}
+
+char* HttpRequest::getBody()
+{
+	return bodyBuf;
+}
 
 bool HttpRequest::isAjax()
 {

--- a/Sming/SmingCore/Network/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/HttpRequest.cpp
@@ -19,6 +19,7 @@ HttpRequest::HttpRequest()
 	cookies = NULL;
 	postDataProcessed = 0;
 	combinePostFrag = false;
+	bodyBuf = NULL;
 }
 
 HttpRequest::~HttpRequest()
@@ -28,6 +29,10 @@ HttpRequest::~HttpRequest()
 	delete requestPostParameters;
 	delete cookies;
 	postDataProcessed = 0;
+	if (bodyBuf != NULL)
+	{
+		os_free(bodyBuf);
+	}
 }
 
 String HttpRequest::getQueryParameter(String parameterName, String defaultValue /* = "" */)
@@ -231,10 +236,7 @@ bool HttpRequest::extractParsingItemsList(pbuf* buf, int startPos, int endPos, c
 }
 void HttpRequest::parseRawData(HttpServer *server, pbuf* buf)
 {
-	if (!combinePostFrag)
-	{
-		bodyBuf = (char *) os_zalloc(sizeof(char) * buf->tot_len);
-	}
+	bodyBuf = (char *) os_zalloc(sizeof(char) * buf->tot_len);
 	int headerEnd = NetUtils::pbufFindStr(buf, "\r\n\r\n");
 	if (headerEnd + getContentLength() > NETWORK_MAX_HTTP_PARSING_LEN)
 	{

--- a/Sming/SmingCore/Network/HttpRequest.h
+++ b/Sming/SmingCore/Network/HttpRequest.h
@@ -42,6 +42,7 @@ public:
 	String getPostParameter(String parameterName, String defaultValue = "");
 	String getHeader(String headerName, String defaultValue = "");
 	String getCookie(String cookieName, String defaultValue = "");
+	char* getBody();
 
 public:
 	HttpParseResult parseHeader(HttpServer *server, pbuf* buf);
@@ -49,6 +50,7 @@ public:
 	bool extractParsingItemsList(pbuf* buf, int startPos, int endPos,
 			char delimChar, char endChar,
 			HashMap<String, String> *resultItems);
+	void parseRawData(HttpServer *server, pbuf* buf);
 
 private:
 	String method;
@@ -59,6 +61,7 @@ private:
 	HashMap<String, String> *cookies;
 	int postDataProcessed;
 	bool combinePostFrag;
+	char *bodyBuf;
 
 	friend class TemplateFileStream;
 };

--- a/Sming/SmingCore/Network/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/HttpServerConnection.cpp
@@ -86,7 +86,10 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 			state = eHCS_ParsingCompleted;
 		}
 	}
-
+	else if (state == eHCS_ParsingCompleted && request.getContentLength() > 0)
+	{
+		request.parseRawData(server, buf);
+	}
 	// Fire callbacks
 	TcpConnection::onReceive(buf);
 

--- a/Sming/SmingCore/Network/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/HttpServerConnection.cpp
@@ -61,7 +61,12 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 			if (request.getContentLength() > 0 && contType.indexOf(ContentType::FormUrlEncoded) != -1)
 				state = eHCS_ParsePostData;
 			else
+			{
+				request.parseRawData(server, buf);
 				state = eHCS_ParsingCompleted;
+				TcpConnection::onReceive(buf);
+				return ERR_OK;
+			}
 		}
 	}
 	else if (state == eHCS_WebSocketFrames)
@@ -86,10 +91,10 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 			state = eHCS_ParsingCompleted;
 		}
 	}
-	else if (state == eHCS_ParsingCompleted && request.getContentLength() > 0)
-	{
-		request.parseRawData(server, buf);
-	}
+//	else if (state == eHCS_ParsingCompleted && request.getContentLength() > 0)
+//	{
+//		request.parseRawData(server, buf);
+//	}
 	// Fire callbacks
 	TcpConnection::onReceive(buf);
 


### PR DESCRIPTION
It is really cleaned version of PR #272 by @dereulenspiegel. I just polish it and remove unwanted formatting. It intendet to return raw http request body for further parsing, for example by ArduinoJson library. I think that POST-ing json from web is much more efficient and can send more complex and structured data than formURLencoded content-type. Moreover, by adding just little JS-code on frontend (web-page) we can make some data validation/modification/processing before sending to esp8266 web-server and off-load our little buddy on client (more powerful in fact!) :)