### PR TITLE
HttpClient - Rest client support

### DIFF
--- a/Basic_RestClient/README.md
+++ b/Basic_RestClient/README.md
@@ -1,0 +1,15 @@
+#Rest Test Server
+
+Deploy the Rest Test server on a machine that has Node.js installed.
+
+Move to the directory where resttest.js and package.json are copied.
+
+Do a: npm install
+
+to install dependencies.
+
+Run the Server with:  node resttest.js
+
+The REST API will be available at: http://mymachine_address:3003/api/test
+
+The Sming App running on the ESP8266 will call the API and check each REST verb.

--- a/Basic_RestClient/Sming_RestClient/Makefile
+++ b/Basic_RestClient/Sming_RestClient/Makefile
@@ -1,0 +1,24 @@
+#####################################################################
+#### Please don't change this file. Use Makefile-user.mk instead ####
+#####################################################################
+# Including user Makefile.
+# Should be used to set project-specific parameters
+include ./Makefile-user.mk
+
+# Important parameters check.
+# We need to make sure SMING_HOME and ESP_HOME variables are set.
+# You can use Makefile-user.mk in each project or use enviromental variables to set it globally.
+ 
+ifndef SMING_HOME
+$(error SMING_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+ifndef ESP_HOME
+$(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+
+# Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
+include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/Basic_RestClient/Sming_RestClient/Makefile-user.mk
+++ b/Basic_RestClient/Sming_RestClient/Makefile-user.mk
@@ -1,0 +1,30 @@
+## Local build configuration
+## Parameters configured here will override default and ENV values.
+## Uncomment and change examples:
+
+#Add your source directories here separated by space
+MODULES = app
+
+## ESP_HOME sets the path where ESP tools and SDK are located.
+## Windows:
+# ESP_HOME = c:/Espressif
+
+## MacOS / Linux:
+#ESP_HOME = /opt/esp-open-sdk
+
+## SMING_HOME sets the path where Sming framework is located.
+## Windows:
+# SMING_HOME = c:/tools/sming/Sming 
+
+# MacOS / Linux
+#SMING_HOME = /opt/Sming/Sming
+
+## COM port parameter is reqruied to flash firmware correctly.
+## Windows: 
+# COM_PORT = COM3
+
+# MacOS / Linux:
+# COM_PORT = /dev/tty.usbserial
+
+# Com port speed
+# COM_SPEED	= 115200

--- a/Basic_RestClient/Sming_RestClient/app/application.cpp
+++ b/Basic_RestClient/Sming_RestClient/app/application.cpp
@@ -2,13 +2,6 @@
 #include <user_config.h>
 
 #include <SmingCore/SmingCore.h>
-#include <Libraries/LiquidCrystal/LiquidCrystal_I2C.h>
-
-// For more information visit useful wiki page: http://arduino-info.wikispaces.com/LCD-Blue-I2C
-#define I2C_LCD_ADDR 0x27
-LiquidCrystal_I2C lcd(I2C_LCD_ADDR, 2, 1, 0, 4, 5, 6, 7, 3, POSITIVE);
-
-// URL of the test REST server:
 
 #define URL "http://192.168.1.17:3003/api/test"
 
@@ -18,15 +11,11 @@ int        idTest = 0;  // 0: GET 1:POST  2:PUT  3:DELETE
 
 // HTTP request callback.
 void onDataReceived(HttpClient& client, bool successful) {
-    lcd.setCursor(0,1);
     if (successful) {
         Serial.println("Success: Request to Rest Server worked!");
-        lcd.print("OK!");
     } else {
         Serial.println("Failure: Request failed..");
-        lcd.print("NOT OK :(");
     }
-
 }
 
 void ShowInfo() {
@@ -39,32 +28,26 @@ void ShowInfo() {
 }
 
 void startMain() {
-    lcd.clear();
-    lcd.setCursor(0,0);
 
     if ( idTest > 3 ) idTest = 0;
     httpServer.reset(); // Clear any data from previous requests.
     httpServer.setRequestContentType("application/json");
     
     switch ( idTest) {
-        case 0: lcd.print("Testing GET...");
-                Serial.println("Testing GET");
-                httpServer.setPostBody("{\"body\":\"for GET\"}"); // A zero lenght body will trigger a GET request.
+        case 0: Serial.println("Testing GET");
+                httpServer.setPostBody("{\"body\":\"for GET\"}"); // Per si a Post body on a get request doesn't make sense.
                 httpServer.doGet(URL, onDataReceived);
                 break;
-        case 1: lcd.print("Testing POST...");
-                Serial.println("Testing POST");
-                httpServer.setPostBody("{\"body\":\"for POST\"}"); // A zero lenght body will trigger a GET request.
+        case 1: Serial.println("Testing POST");
+                httpServer.setPostBody("{\"body\":\"for POST\"}"); 
                 httpServer.doPost(URL, onDataReceived);
                 break;
-        case 2: lcd.print("Testing PUT...");
-                Serial.println("Testing PUT");
-                httpServer.setPostBody("{\"body\":\"for PUT\"}"); // A zero lenght body will trigger a GET request.
+        case 2: Serial.println("Testing PUT");
+                httpServer.setPostBody("{\"body\":\"for PUT\"}"); 
                 httpServer.doPut(URL, onDataReceived);
                 break;
-        case 3: lcd.print("Testing DELETE...");
-                Serial.println("Testing DELETE");
-                httpServer.setPostBody("{\"body\":\"for DELETE\"}"); // A zero lenght body will trigger a GET request.
+        case 3: Serial.println("Testing DELETE");
+                httpServer.setPostBody("{\"body\":\"for DELETE\"}"); 
                 httpServer.doDelete(URL, onDataReceived);
                 break;
     }
@@ -78,7 +61,7 @@ void connectOk() {
 
     ShowInfo();
 
-    // Let's get the Mac address, that should be unique...
+    // Let's get the IP address
     Serial.println("Device ID: " + String(WifiStation.getIP()));
 
     checkTimer.initializeMs(5 * 1000, startMain).start();
@@ -95,20 +78,7 @@ void connectFail() {
 void sysReady() {
 
     Serial.println("System ready callback called....");
-    
-    lcd.begin(16, 2);   // initialize the lcd for 16 chars 2 lines, turn on backlight
-
-    // ------- Quick 3 blinks of backlight  -------------
-    for(int i = 0; i< 3; i++)
-    {
-            lcd.backlight();
-            delay(150);
-            lcd.noBacklight();
-            delay(250);
-    }
-    lcd.backlight(); // finish with backlight on
-
-}
+}    
 
 // Standard init function.
 void init() {

--- a/Basic_RestClient/Sming_RestClient/app/application.cpp
+++ b/Basic_RestClient/Sming_RestClient/app/application.cpp
@@ -1,0 +1,130 @@
+// Please configure your SSID, passwords and OW key on the user_config.h file
+#include <user_config.h>
+
+#include <SmingCore/SmingCore.h>
+#include <Libraries/LiquidCrystal/LiquidCrystal_I2C.h>
+
+// For more information visit useful wiki page: http://arduino-info.wikispaces.com/LCD-Blue-I2C
+#define I2C_LCD_ADDR 0x27
+LiquidCrystal_I2C lcd(I2C_LCD_ADDR, 2, 1, 0, 4, 5, 6, 7, 3, POSITIVE);
+
+// URL of the test REST server:
+
+#define URL "http://192.168.1.17:3003/api/test"
+
+HttpClient httpServer;
+Timer      checkTimer;  // To run tests in cycle
+int        idTest = 0;  // 0: GET 1:POST  2:PUT  3:DELETE 
+
+// HTTP request callback.
+void onDataReceived(HttpClient& client, bool successful) {
+    lcd.setCursor(0,1);
+    if (successful) {
+        Serial.println("Success: Request to Rest Server worked!");
+        lcd.print("OK!");
+    } else {
+        Serial.println("Failure: Request failed..");
+        lcd.print("NOT OK :(");
+    }
+
+}
+
+void ShowInfo() {
+    Serial.printf("\r\nSDK: v%s\r\n", system_get_sdk_version());
+    Serial.printf("Free Heap: %d\r\n", system_get_free_heap_size());
+    Serial.printf("CPU Frequency: %d MHz\r\n", system_get_cpu_freq());
+    Serial.printf("System Chip ID: 0x%x\r\n", system_get_chip_id());
+    Serial.printf("SPI Flash ID: 0x%x\r\n", spi_flash_get_id());
+    Serial.printf("SPI Flash Size: %d\r\n", (1 << ((spi_flash_get_id() >> 16) & 0xff)));
+}
+
+void startMain() {
+    lcd.clear();
+    lcd.setCursor(0,0);
+
+    if ( idTest > 3 ) idTest = 0;
+    httpServer.reset(); // Clear any data from previous requests.
+    httpServer.setRequestContentType("application/json");
+    
+    switch ( idTest) {
+        case 0: lcd.print("Testing GET...");
+                Serial.println("Testing GET");
+                httpServer.setPostBody("{\"body\":\"for GET\"}"); // A zero lenght body will trigger a GET request.
+                httpServer.doGet(URL, onDataReceived);
+                break;
+        case 1: lcd.print("Testing POST...");
+                Serial.println("Testing POST");
+                httpServer.setPostBody("{\"body\":\"for POST\"}"); // A zero lenght body will trigger a GET request.
+                httpServer.doPost(URL, onDataReceived);
+                break;
+        case 2: lcd.print("Testing PUT...");
+                Serial.println("Testing PUT");
+                httpServer.setPostBody("{\"body\":\"for PUT\"}"); // A zero lenght body will trigger a GET request.
+                httpServer.doPut(URL, onDataReceived);
+                break;
+        case 3: lcd.print("Testing DELETE...");
+                Serial.println("Testing DELETE");
+                httpServer.setPostBody("{\"body\":\"for DELETE\"}"); // A zero lenght body will trigger a GET request.
+                httpServer.doDelete(URL, onDataReceived);
+                break;
+    }
+               
+    idTest++;
+}
+
+// Will be called when WiFi station is connected to AP
+void connectOk() {
+    Serial.println("I'm CONNECTED");
+
+    ShowInfo();
+
+    // Let's get the Mac address, that should be unique...
+    Serial.println("Device ID: " + String(WifiStation.getIP()));
+
+    checkTimer.initializeMs(5 * 1000, startMain).start();
+}
+
+// Will be called when WiFi station timeout was reached
+
+void connectFail() {
+    Serial.println("I'm NOT CONNECTED. Need help :(");
+
+    WifiStation.waitConnection(connectOk, 20, connectFail); // We recommend 20+ seconds for connection timeout at start
+}
+
+void sysReady() {
+
+    Serial.println("System ready callback called....");
+    
+    lcd.begin(16, 2);   // initialize the lcd for 16 chars 2 lines, turn on backlight
+
+    // ------- Quick 3 blinks of backlight  -------------
+    for(int i = 0; i< 3; i++)
+    {
+            lcd.backlight();
+            delay(150);
+            lcd.noBacklight();
+            delay(250);
+    }
+    lcd.backlight(); // finish with backlight on
+
+}
+
+// Standard init function.
+void init() {
+
+    system_set_os_print(0);
+
+    Serial.begin(SERIAL_BAUD_RATE);  // 115200 by default
+    Serial.systemDebugOutput(false); // Disable debug output to serial
+
+    // Connect to WIFI
+    WifiStation.config(WIFI_SSID, WIFI_PWD);
+    WifiStation.enable(true);
+    WifiAccessPoint.enable(false);
+
+    // Run our method when station was connected to AP (or not connected)
+    WifiStation.waitConnection(connectOk, 20, connectFail); // We recommend 20+ seconds for connection timeout at start
+
+    System.onReady(sysReady);      
+}

--- a/Basic_RestClient/Sming_RestClient/include/user_config.h
+++ b/Basic_RestClient/Sming_RestClient/include/user_config.h
@@ -1,0 +1,50 @@
+#ifndef __USER_CONFIG_H__
+#define __USER_CONFIG_H__
+
+#ifndef WIFI_SSID
+    #define WIFI_SSID "SSID" // Put you SSID and Password here
+    #define WIFI_PWD "wifi_password"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	// UART config
+	#define SERIAL_BAUD_RATE 115200
+
+	// ESP SDK config
+	#define LWIP_OPEN_SRC
+	#define USE_US_TIMER
+
+	// Default types
+	#define __CORRECT_ISO_CPP_STDLIB_H_PROTO
+	#include <limits.h>
+	#include <stdint.h>
+
+	// Override c_types.h include and remove buggy espconn
+	#define _C_TYPES_H_
+	#define _NO_ESPCON_
+
+	// Updated, compatible version of c_types.h
+	// Just removed types declared in <stdint.h>
+	#include <espinc/c_types_compatible.h>
+
+	// System API declarations
+	#include <esp_systemapi.h>
+
+	// C++ Support
+	#include <esp_cplusplus.h>
+	// Extended string conversion for compatibility
+	#include <stringconversion.h>
+	// Network base API
+	#include <espinc/lwip_includes.h>
+
+	// Beta boards
+	#define BOARD_ESP01
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Basic_RestClient/rest_server/package.json
+++ b/Basic_RestClient/rest_server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "restproxy",
+  "description": "REST API proxy for sites without CORS",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fcgdam/RestProxy.git"
+  },
+  "dependencies": {
+    "body-parser": ">= 1.14",
+    "cors": ">= 2.7",
+    "express": ">= 4.0",
+    "morgan": "^1.6.1"
+  }
+}
+

--- a/Basic_RestClient/rest_server/resttest.js
+++ b/Basic_RestClient/rest_server/resttest.js
@@ -1,0 +1,51 @@
+var express    = require('express');
+var app        = express();
+var bodyParser = require('body-parser');
+var cors       = require('cors')
+var morgan     = require('morgan');
+var http       = require('http');
+
+//Configure Express
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+app.use(morgan('dev'));
+app.use(cors());
+var router = express.Router();
+
+// Root URI.
+router.get('/', function(req, res) {
+        res.json( {message: 'REST PROXY' });
+});
+
+
+router.route('/test')
+    .get( function(req, res) {
+	console.log("GET Request sucessuful.");
+	console.log("Body: " + JSON.stringify(req.body) );
+	res.json( { "status":"OK GET" } );
+    })
+    .post( function(req, res) {
+	console.log("POST Request sucessuful.");
+	console.log("Body: " + JSON.stringify(req.body) );
+	res.json( { "status":"OK POST" } );
+    })
+    .put( function(req, res) {
+	console.log("PUT Request sucessuful.");
+	console.log("Body: " + JSON.stringify(req.body) );
+	res.json( { "status":"OK PUT" } );
+    })
+    .delete( function(req, res) {
+	console.log("DELETE Request sucessuful.");
+	console.log("Body: " + JSON.stringify(req.body) );
+	res.json( { "status":"OK DELETE" } );
+    });
+
+// Our base url is /api
+app.use('/api', router);
+app.listen(3003);
+
+var datenow = new Date();
+console.log("========================================");
+console.log("REST TEST Server started at " + datenow );
+console.log("Api endpoint available at http://localhost:3003/api");
+

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -19,24 +19,24 @@ HttpClient::~HttpClient()
 }
 
 bool HttpClient::downloadString(String url, HttpClientCompletedDelegate onCompleted)
-{
-	if (isProcessing()) return false;
-	URL uri = URL(url);
-
-	return startDownload(uri, eHCM_String, onCompleted);
+{       
+	return startDownload( URL(url), eHCM_String, onCompleted);
 }
 
 bool HttpClient::downloadFile(String url, HttpClientCompletedDelegate onCompleted /* = NULL */)
 {
-	return downloadFile(url, "", onCompleted);
+	return downloadFile( url , "", onCompleted);
 }
 
 bool HttpClient::downloadFile(String url, String saveFileName, HttpClientCompletedDelegate onCompleted /* = NULL */)
 {
-	if (isProcessing()) return false;
-	URL uri = URL(url);
-
-	String file;
+        String file;
+        
+	if (isProcessing()) 
+            return false;
+	
+        URL uri = URL(url);
+        
 	if (saveFileName.length() == 0)
 	{
 		file = uri.Path;
@@ -55,38 +55,18 @@ bool HttpClient::downloadFile(String url, String saveFileName, HttpClientComplet
 
 bool HttpClient::startDownload(URL uri, HttpClientMode mode, HttpClientCompletedDelegate onCompleted)
 {
-	reset();
-	this->mode = mode;
-	this->onCompleted = onCompleted;
-
-	if (uri.Protocol != "http") 
-            return false;
-	debugf("Download: %s", uri.toString().c_str());
-
-	connect(uri.Host, uri.Port);
-	bool isPost = body.length();
-
-	sendString((isPost ? "POST " : "GET ") + uri.getPathWithQuery() + " HTTP/1.0\r\nHost: " + uri.Host + "\r\n");
-	for (int i = 0; i < requestHeaders.count(); i++)
-	{
-		String write = requestHeaders.keyAt(i) + ": " + requestHeaders.valueAt(i) + "\r\n";
-		sendString(write.c_str());
-	}
-	sendString("\r\n");
-	sendString(body);
-
-	return true;
+    bool isPost = body.length();
+    
+    return startDownload( uri, (isPost ? "POST" : "GET"), mode, onCompleted);
 }
 
-bool HttpClient::doRequest(String url, String method, HttpClientCompletedDelegate onCompleted)
+bool HttpClient::startDownload(URL uri, String method, HttpClientMode mode, HttpClientCompletedDelegate onCompleted)
 {
-        if (isProcessing()) 
+        if (isProcessing())
             return false;
-    
-        URL uri = URL(url);
         
 	reset();
-	this->mode = eHCM_String;
+	this->mode = mode;
 	this->onCompleted = onCompleted;
 
 	if (uri.Protocol != "http") 
@@ -109,27 +89,27 @@ bool HttpClient::doRequest(String url, String method, HttpClientCompletedDelegat
 
 bool HttpClient::doGet(String url, HttpClientCompletedDelegate onCompleted)
 {
-    return doRequest( url , "GET" , onCompleted);
+    return startDownload( URL(url) , "GET" , eHCM_String, onCompleted);
 }
 
 bool HttpClient::doPost(String url, HttpClientCompletedDelegate onCompleted)
 {    
-    return doRequest( url , "POST" , onCompleted);
+    return startDownload( URL(url) , "POST" , eHCM_String, onCompleted);
 }
 
 bool HttpClient::doPut(String url, HttpClientCompletedDelegate onCompleted)
 {
-    return doRequest( url , "PUT" , onCompleted);
+    return startDownload( URL(url) , "PUT" , eHCM_String, onCompleted);
 }
 
 bool HttpClient::doDelete(String url, HttpClientCompletedDelegate onCompleted)
 {
-    return doRequest( url , "DELETE" , onCompleted);
+    return startDownload( URL(url) , "DELETE" , eHCM_String, onCompleted);
 }
 
 bool HttpClient::doRestVerb(String url, String verb, HttpClientCompletedDelegate onCompleted)
 {
-    return doRequest( url , verb , onCompleted);
+    return startDownload( URL(url) , verb , eHCM_String, onCompleted);
 }
 
 void HttpClient::setRequestHeader(const String name, const String value)

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -78,8 +78,13 @@ bool HttpClient::startDownload(URL uri, HttpClientMode mode, HttpClientCompleted
 	return true;
 }
 
-bool HttpClient::doRequest(URL uri, String method, HttpClientCompletedDelegate onCompleted)
+bool HttpClient::doRequest(String url, String method, HttpClientCompletedDelegate onCompleted)
 {
+        if (isProcessing()) 
+            return false;
+    
+        URL uri = URL(url);
+        
 	reset();
 	this->mode = eHCM_String;
 	this->onCompleted = onCompleted;
@@ -104,47 +109,27 @@ bool HttpClient::doRequest(URL uri, String method, HttpClientCompletedDelegate o
 
 bool HttpClient::doGet(String url, HttpClientCompletedDelegate onCompleted)
 {
-    if (isProcessing()) 
-        return false;
-    
-    URL uri = URL(url);
-    return doRequest( uri , "GET" , onCompleted);
+    return doRequest( url , "GET" , onCompleted);
 }
 
 bool HttpClient::doPost(String url, HttpClientCompletedDelegate onCompleted)
 {    
-    if (isProcessing()) 
-        return false;
-    
-    URL uri = URL(url);
-    return doRequest( uri , "POST" , onCompleted);
+    return doRequest( url , "POST" , onCompleted);
 }
 
 bool HttpClient::doPut(String url, HttpClientCompletedDelegate onCompleted)
 {
-    if (isProcessing()) 
-        return false;
-    
-    URL uri = URL(url);
-    return doRequest( uri , "PUT" , onCompleted);
+    return doRequest( url , "PUT" , onCompleted);
 }
 
 bool HttpClient::doDelete(String url, HttpClientCompletedDelegate onCompleted)
 {
-    if (isProcessing()) 
-        return false;
-    
-    URL uri = URL(url);
-    return doRequest( uri , "DELETE" , onCompleted);
+    return doRequest( url , "DELETE" , onCompleted);
 }
 
 bool HttpClient::doRestVerb(String url, String verb, HttpClientCompletedDelegate onCompleted)
 {
-    if (isProcessing()) 
-        return false;
-    
-    URL uri = URL(url);
-    return doRequest( uri , verb , onCompleted);
+    return doRequest( url , verb , onCompleted);
 }
 
 void HttpClient::setRequestHeader(const String name, const String value)

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -59,7 +59,8 @@ bool HttpClient::startDownload(URL uri, HttpClientMode mode, HttpClientCompleted
 	this->mode = mode;
 	this->onCompleted = onCompleted;
 
-	if (uri.Protocol != "http") return false;
+	if (uri.Protocol != "http") 
+            return false;
 	debugf("Download: %s", uri.toString().c_str());
 
 	connect(uri.Host, uri.Port);
@@ -75,6 +76,75 @@ bool HttpClient::startDownload(URL uri, HttpClientMode mode, HttpClientCompleted
 	sendString(body);
 
 	return true;
+}
+
+bool HttpClient::doRequest(URL uri, String method, HttpClientCompletedDelegate onCompleted)
+{
+	reset();
+	this->mode = eHCM_String;
+	this->onCompleted = onCompleted;
+
+	if (uri.Protocol != "http") 
+            return false;
+	debugf("Download: %s", uri.toString().c_str());
+
+	connect(uri.Host, uri.Port);
+
+	sendString( method + " " + uri.getPathWithQuery() + " HTTP/1.0\r\nHost: " + uri.Host + "\r\n");
+	for (int i = 0; i < requestHeaders.count(); i++)
+	{
+		String write = requestHeaders.keyAt(i) + ": " + requestHeaders.valueAt(i) + "\r\n";
+		sendString(write.c_str());
+	}
+	sendString("\r\n");
+	sendString(body);
+
+	return true;
+}
+
+bool HttpClient::doGet(String url, HttpClientCompletedDelegate onCompleted)
+{
+    if (isProcessing()) 
+        return false;
+    
+    URL uri = URL(url);
+    return doRequest( uri , "GET" , onCompleted);
+}
+
+bool HttpClient::doPost(String url, HttpClientCompletedDelegate onCompleted)
+{    
+    if (isProcessing()) 
+        return false;
+    
+    URL uri = URL(url);
+    return doRequest( uri , "POST" , onCompleted);
+}
+
+bool HttpClient::doPut(String url, HttpClientCompletedDelegate onCompleted)
+{
+    if (isProcessing()) 
+        return false;
+    
+    URL uri = URL(url);
+    return doRequest( uri , "PUT" , onCompleted);
+}
+
+bool HttpClient::doDelete(String url, HttpClientCompletedDelegate onCompleted)
+{
+    if (isProcessing()) 
+        return false;
+    
+    URL uri = URL(url);
+    return doRequest( uri , "DELETE" , onCompleted);
+}
+
+bool HttpClient::doRestVerb(String url, String verb, HttpClientCompletedDelegate onCompleted)
+{
+    if (isProcessing()) 
+        return false;
+    
+    URL uri = URL(url);
+    return doRequest( uri , verb , onCompleted);
 }
 
 void HttpClient::setRequestHeader(const String name, const String value)

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -70,7 +70,7 @@ public:
 
 protected:
 	bool startDownload(URL uri, HttpClientMode mode, HttpClientCompletedDelegate onCompleted);
-        bool doRequest(URL uri, String method, HttpClientCompletedDelegate onCompleted);
+        bool doRequest(String url, String method, HttpClientCompletedDelegate onCompleted);
 	void onFinished(TcpClientState finishState);
 	virtual err_t onReceive(pbuf *buf);
 	virtual void writeRawData(pbuf* buf, int startPos);

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -69,8 +69,8 @@ public:
 	void reset(); // Reset current status, data and etc.
 
 protected:
-	bool startDownload(URL uri, HttpClientMode mode, HttpClientCompletedDelegate onCompleted);
-        bool doRequest(String url, String method, HttpClientCompletedDelegate onCompleted);
+        bool startDownload(URL uri, HttpClientMode mode, HttpClientCompletedDelegate onCompleted);
+	bool startDownload(URL uri, String method, HttpClientMode mode, HttpClientCompletedDelegate onCompleted);
 	void onFinished(TcpClientState finishState);
 	virtual err_t onReceive(pbuf *buf);
 	virtual void writeRawData(pbuf* buf, int startPos);

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -40,6 +40,13 @@ public:
 	// File mode
 	bool downloadFile(String url, HttpClientCompletedDelegate onCompleted = NULL);
 	bool downloadFile(String url, String saveFileName, HttpClientCompletedDelegate onCompleted = NULL);
+        
+        // REST mode
+        bool doGet(  String url, HttpClientCompletedDelegate onCompleted);
+        bool doPost( String url, HttpClientCompletedDelegate onCompleted);
+        bool doPut(  String url, HttpClientCompletedDelegate onCompleted);
+        bool doDelete(String url, HttpClientCompletedDelegate onCompleted);
+        bool doRestVerb(String url, String verb, HttpClientCompletedDelegate onCompleted);
 
 	void setPostBody(const String& _method);
 	String getPostBody();
@@ -63,6 +70,7 @@ public:
 
 protected:
 	bool startDownload(URL uri, HttpClientMode mode, HttpClientCompletedDelegate onCompleted);
+        bool doRequest(URL uri, String method, HttpClientCompletedDelegate onCompleted);
 	void onFinished(TcpClientState finishState);
 	virtual err_t onReceive(pbuf *buf);
 	virtual void writeRawData(pbuf* buf, int startPos);


### PR DESCRIPTION
The downloadString function for the HttpClient, only supports GET and POST requests. There is no other way to use this function to make, for example a PUT request, or other types of REST operations to a REST server.

So my changes add 5 new functions to HttpClient, that allow to do the GET/POST/PUT/DELETE verbs to be used directly, or any other, more uncommon verbs, like HEAD, PATCH for example to be used, allowing the Sming framework now to be used to build full REST clients.

I added an example for the client and for the server (in Node.Js). The Sming REST Client, cycles through the possible REST requests, while the REST server shows the request type and JSON body.
