### PR TITLE
[Websock Server] Add user data pointer per socket. Add disconnect method

### DIFF
--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -225,6 +225,7 @@ void TcpConnection::close()
 	tcp_poll(tcp, staticOnPoll, 1);
 	tcp_arg(tcp, NULL); // reset pointer to close connection on next callback
 	tcp = NULL;
+	checkSelfFree();
 }
 
 void TcpConnection::initialize(tcp_pcb* pcb)

--- a/Sming/SmingCore/Network/WebSocket.cpp
+++ b/Sming/SmingCore/Network/WebSocket.cpp
@@ -50,7 +50,7 @@ void WebSocket::send(const char* message, int length, wsFrameType type)
 	size_t headSize = sizeof(frameHeader);
 	wsMakeFrame(nullptr, length, frameHeader, &headSize, type);
 	connection->write((char*)frameHeader, headSize, TCP_WRITE_FLAG_COPY | TCP_WRITE_FLAG_MORE);
-	connection->writeString(message, TCP_WRITE_FLAG_COPY);
+	connection->write(message, length, TCP_WRITE_FLAG_COPY);
 	connection->flush();
 }
 
@@ -70,4 +70,9 @@ void WebSocket::enableCommand()
 	{
 		commandExecutor = new CommandExecutor(this);
 	}
+}
+
+void WebSocket::close()
+{
+	connection->close();
 }

--- a/Sming/SmingCore/Network/WebSocket.h
+++ b/Sming/SmingCore/Network/WebSocket.h
@@ -29,6 +29,7 @@ public:
 	void sendString(const String& message);
 	void sendBinary(const uint8_t* data, int size);
 	void enableCommand();
+	void close();
 
 protected:
 	bool initialize(HttpRequest &request, HttpResponse &response);


### PR DESCRIPTION
Sometimes you need to store additional information on every websock connection, this can be done by storing a pointer to a user structure. 
Also, the server could decide to close some unused websocks to free up heap, I've added a disconnect method.

There are some debugf traces I will remove them