### PR TITLE
Problem with TemplateFileStream

### DIFF
--- a/Sming/SmingCore/DataSourceStream.cpp
+++ b/Sming/SmingCore/DataSourceStream.cpp
@@ -223,10 +223,12 @@ uint16_t TemplateFileStream::readMemoryBlock(char* data, int bufSize)
 					memcpy(varname, cur + 1, p - cur - 1); // name without { and }
 					varName = varname;
 					state = eTES_Found;
-					varWaitSize = cur - tpl;
-					debugf("found var: %s, at %d (%d) - %d, send size %d", varName.c_str(), cur - tpl + 1, cur - tpl + getPos(), p - tpl, cur - tpl);
+					int sz = cur - tpl;
+					varWaitSize = sz;
+					debugf("found var: %s, at %d (%d) - %d, send size %d", varName.c_str(), sz + 1, sz + getPos(), p - tpl, sz);
 					skipBlockSize = block;
-					return cur - tpl; // return only plain text from template without our variable
+					if (sz == 0) state = eTES_StartVar;
+					return sz; // return only plain text from template without our variable
 				}
 			}
 			cur = (char*)memchr(p, '{', len - (p - tpl)); // continue searching..

--- a/Sming/SmingCore/DataSourceStream.h
+++ b/Sming/SmingCore/DataSourceStream.h
@@ -22,7 +22,7 @@ enum StreamType
 {
 	eSST_Memory,
 	eSST_File,
-	eSST_TepmplateFile,
+	eSST_TemplateFile,
 	eSST_JsonObject,
 	eSST_User,
 	eSST_Unknown
@@ -104,7 +104,7 @@ public:
 	TemplateFileStream(String templateFileName);
 	virtual ~TemplateFileStream();
 
-	virtual StreamType getStreamType() { return eSST_TepmplateFile; }
+	virtual StreamType getStreamType() { return eSST_TemplateFile; }
 
 	virtual uint16_t readMemoryBlock(char* data, int bufSize);
 	virtual bool seek(int len);


### PR DESCRIPTION
1)
In case variable is included in template in such a place that TemplateFileStream::readMemoryBlock would start with it, then TemplateFileStream::readMemoryBlock will change state to eTES_Found and return 0. It relies on ::seek to change state to eTES_StartVar, but since it returns 0 the ::seek never gets called so it is stuck in a eTES_Found state returning 0 over and over again. This occurs when variable is at beginning of file or is "split" by FileStream::readMemoryBlock in which case  TemplateFileStream::readMemoryBlock starts with variable at the beginning and same situation appear. The proposed fix changes state to eTES_StartVar immediatelly.

2)
Small typo fix.