### PR TITLE
Added MQTT disconnect callback

### DIFF
--- a/MqttClient_Hello/app/application.cpp
+++ b/MqttClient_Hello/app/application.cpp
@@ -11,11 +11,24 @@
 void startMqttClient();
 void onMessageReceived(String topic, String message);
 
-Timer procTimer;
+Timer procTimer, mqttTimer;
 
 // MQTT client
 // For quickly check you can use: http://www.hivemq.com/demos/websocket-client/ (Connection= test.mosquitto.org:8080)
 MqttClient mqtt("test.mosquitto.org", 1883, onMessageReceived);
+
+// Check for MQTT Disconnection
+void IRAM_ATTR checkMQTTDisconnect(TcpClient& client, bool flag){
+	
+	// Called whenever MQTT connection is failed.
+	if (flag == true)
+		Serial.println("MQTT Broker Disconnected!!");
+	else
+		Serial.println("MQTT Broker Unreachable!!");
+	
+	// Restart connection attempt after few seconds
+	mqttTimer.initializeMs(2 * 1000, startMqttClient).start(); // every 2 seconds
+}
 
 // Publish our message
 void publishMessage()
@@ -41,6 +54,8 @@ void startMqttClient()
 	if(!mqtt.setWill("last/will","The connection from this device is lost:(", 1, true)) {
 		debugf("Unable to set the last will and testament. Most probably there is not enough memory on the device.");
 	}
+	// Assign a disconnect callback function
+	mqtt.setDisconnectCb(checkMQTTDisconnect);
 	mqtt.connect("esp8266");
 	mqtt.subscribe("main/status/#");
 }

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -273,3 +273,8 @@ void MqttClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 	}
 	TcpClient::onReadyToSendData(sourceEvent);
 }
+
+void MqttClient::setDisconnectCb(TcpClientCompleteDelegate dcb /* = NULL*/){
+	if(dcb)
+		TcpClient::setTcpCompleteCb(dcb);
+}

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -34,6 +34,8 @@ public:
 
 	bool connect(String clientName);
 	bool connect(String clientName, String username, String password);
+	
+	void setDisconnectCb(TcpClientCompleteDelegate dcb = NULL);
 
 	__forceinline bool isProcessing()  { return TcpClient::isProcessing(); }
 	__forceinline TcpClientState getConnectionState() { return TcpClient::getConnectionState(); }

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -212,3 +212,8 @@ void TcpClient::onFinished(TcpClientState finishState)
 	if (completed)
 		completed(*this, state == eTCS_Successful);
 }
+
+void TcpClient::setTcpCompleteCb(TcpClientCompleteDelegate completeCb)
+{
+	completed = completeCb;
+}

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -46,6 +46,8 @@ public:
 	virtual bool connect(String server, int port);
 	virtual bool connect(IPAddress addr, uint16_t port);
 	virtual void close();
+	
+	void setTcpCompleteCb(TcpClientCompleteDelegate completeCb);
 
 	bool send(const char* data, uint8_t len, bool forceCloseAfterSent = false);
 	bool sendString(String data, bool forceCloseAfterSent = false);


### PR DESCRIPTION
@all Updated the files to add callback support on MQTT disconnection.
Check the MqttClient_Hello example for functionality.
Also added a workaround solution for checking whether MQTT is properly connected upon initialization or not.
Fixes issue #517 

@hreintke  As per your guidelines, I have modified the callback function to utilize the TcpClientCompleteDelegate of TcpClient class. Also separated the PRs for different features.