### PR TITLE
Issue #524: Explicitly set uninitialized member values to null in TelnetServer.h.

### DIFF
--- a/Sming/SmingCore/Network/TelnetServer.h
+++ b/Sming/SmingCore/Network/TelnetServer.h
@@ -36,8 +36,8 @@ private:
 	bool onClientReceive (TcpClient& client, char *data, int size);
 	void onClientComplete(TcpClient& client, bool succesfull);
 	void wrchar(char c);
-	TcpClient *curClient;
-	CommandExecutor* commandExecutor;
+	TcpClient *curClient = nullptr;
+	CommandExecutor* commandExecutor = nullptr;
 	bool telnetDebug = true;
 	bool telnetCommand = true;
 };


### PR DESCRIPTION
As requested I've initialized both curClient and commandExecutor to nullptr in TelnetServer.h. If these are not initialized then randomly you cannot telnet into your system because it already thinks there is an attached client (e.g. curClient != nullptr).
