### PR TITLE
fix FTP LIST command didn't sent complete list if it is bigger than bufer (#538)

### DIFF
--- a/Sming/SmingCore/FileSystem.cpp
+++ b/Sming/SmingCore/FileSystem.cpp
@@ -126,7 +126,12 @@ void fileSetContent(const String fileName, const char *content)
 
 uint32_t fileGetSize(const String fileName)
 {
-	file_t file = fileOpen(fileName.c_str(), eFO_ReadOnly);
+	return fileGetSize(fileName.c_str());
+}
+
+uint32_t fileGetSize(const char* fileName)
+{
+	file_t file = fileOpen(fileName, eFO_ReadOnly);
 	// Get size
 	fileSeek(file, 0, eSO_FileEnd);
 	int size = fileTell(file);

--- a/Sming/SmingCore/FileSystem.h
+++ b/Sming/SmingCore/FileSystem.h
@@ -49,6 +49,7 @@ void fileClearLastError(file_t fd);
 void fileSetContent(const String fileName, const char *content);
 void fileSetContent(const String fileName, const String& content);
 uint32_t fileGetSize(const String fileName);
+uint32_t fileGetSize(const char* fileName);
 void fileRename(const String oldName, const String newName);
 Vector<String> fileList();
 

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -140,13 +140,18 @@ int TcpConnection::writeString(const String data, uint8_t apiflags /* = TCP_WRIT
 
 int TcpConnection::writeString(const char* data, uint8_t apiflags /* = TCP_WRITE_FLAG_COPY*/)
 {
+	if (getAvailableWriteSize() < strlen(data))
+	{
+		// we should not write part of the String if we now that is doesn't fit to the buffer
+		// it allows to react on this situation with repeat attempt next iteration
+		return -1;
+	}
+
 	return write(data, strlen(data), apiflags);
 }
 
 int TcpConnection::write(const char* data, int len, uint8_t apiflags /* = TCP_WRITE_FLAG_COPY*/)
 {
-   //int original = len;
-
    u16_t available = getAvailableWriteSize();
    if (available < len)
    {


### PR DESCRIPTION
```class FTPDataFileList``` didn't support multiple iteration if list was bigger than send buffer.
I removed also ```fileList()``` because it created vector of Strings which can consume also a lot of memory. I think that code like this should not be used on low memory device.