### PR TITLE
Fix MQTTClient not sending PINGREQ when receiving messages

### DIFF
--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -267,7 +267,8 @@ err_t MqttClient::onReceive(pbuf *buf)
 
 void MqttClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 {
-	if (lastMessage and millis() - lastMessage >= 10000)
+	// Send PINGREQ every keepAlive time, if there is no outgoing traffic
+	if (lastMessage && (millis() - lastMessage >= keepAlive*1000))
 	{
 		mqtt_ping(&broker);
 	}

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -96,6 +96,7 @@ int MqttClient::staticSendPacket(void* userInfo, const void* buf, unsigned int c
 {
 	MqttClient* client = (MqttClient*)userInfo;
 	bool sent = client->send((const char*)buf, count);
+	client->lastMessage = millis();
 	return sent ? count : 0;
 }
 
@@ -266,10 +267,9 @@ err_t MqttClient::onReceive(pbuf *buf)
 
 void MqttClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 {
-	if (sleep >= 10)
+	if (lastMessage and millis() - lastMessage >= 10000)
 	{
 		mqtt_ping(&broker);
-		sleep = 0;
 	}
 	TcpClient::onReadyToSendData(sourceEvent);
 }

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -61,7 +61,7 @@ private:
 	int posHeader;
 	MqttStringSubscriptionCallback callback;
 	int keepAlive = 20;
-
+	unsigned long lastMessage;
 };
 
 #endif /* _SMING_CORE_NETWORK_MqttClient_H_ */


### PR DESCRIPTION
Suggested fix for #549. Tested, seems to work fine.