### PR TITLE
Edit SPI class to allow for adjusting the frequency

### DIFF
--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -17,7 +17,11 @@ SPIClass::SPIClass(uint8_t spiID) : id(spiID)
 	// Only SPI_HSPI tested on hardware for now!
 }
 
-void SPIClass::begin()
+void SPIClass::begin() {
+	SPIClass::begin(2, 4);
+}
+
+void SPIClass::begin(uint16_t predivider, uint8_t divider)
 {
 	//bit9 of PERIPHS_IO_MUX should be cleared when HSPI clock doesn't equal CPU clock
 	//bit8 of PERIPHS_IO_MUX should be cleared when SPI clock doesn't equal CPU clock
@@ -46,8 +50,14 @@ void SPIClass::begin()
 	// time length HIGHT level = (CPU clock / 10 / 2) ^ -1,
 	// time length LOW level = (CPU clock / 10 / 2) ^ -1
 	// Frequency calculation: 80Mhz / predivider / divider
-	uint16 predivider = 2;	// (1 ... 8192)
-	uint8 divider = 4;		// (1 ... 64)
+	if (predivider < 1 || predivider > 8192) {
+		SYSTEM_ERROR("SPI PRE-DIVIDER [%d] OUT OF BOUNDS [1-8192]", predivider);
+	}
+
+	if (divider < 1 || divider > 64) {
+		SYSTEM_ERROR("SPI DIVIDER [%d] OUT OF BOUNDS [1-64]", predivider);
+	}
+
 	WRITE_PERI_REG(SPI_FLASH_CLOCK(id),
 		(((predivider-1) & SPI_CLKDIV_PRE) << SPI_CLKDIV_PRE_S) |
 		(((divider-1) & SPI_CLKCNT_N) << SPI_CLKCNT_N_S) |

--- a/Sming/SmingCore/SPI.h
+++ b/Sming/SmingCore/SPI.h
@@ -17,7 +17,8 @@ class SPIClass {
 public:
 	SPIClass(uint8_t spiID);
 
-	void begin(); // Default
+	void begin(); // Default begin(2, 4)
+	void begin(uint16_t predivider, uint8_t divider);
 	void end();
 
 	void transfer(uint8_t * data, uint8_t count);


### PR DESCRIPTION
The SPI class is currently stuck at a fixed frequency. This adds the ability to set the frequency divider(s) in `SPIClass::begin`.