### PR TITLE
Add esptool2 as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Sming/esptool2"]
+	path = Sming/esptool2
+	url = git@github.com:raburton/esptool2.git

--- a/Readme.md
+++ b/Readme.md
@@ -32,8 +32,8 @@ Sming - Open Source framework for high efficiency WiFi SoC ESP8266 native develo
 - [MacOS](https://github.com/SmingHub/Sming/wiki/MacOS-Quickstart)
 
 ## Additional needed software 
-- Spiffy  : Source included in Sming repository
-- [ESPtool2] (https://github.com/raburton/esptool2) esptool2 
+- [Spiffy](https://github.com/xlfe/spiffy): Source included in Sming repository
+- [ESPtool2](https://github.com/raburton/esptool2): Source included in Sming repository
 
 You can find more information about compilation and flashing process by reading esp8266.com forum discussion thread.
 

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -188,7 +188,14 @@ endef
 
 .PHONY: all checkdirs clean spiffy test samples recurse-samples $(SAMPLES_DIRS)
 
-all: checkdirs $(APP_AR)
+all: checkdirs $(APP_AR) esptool2
+
+esptool2: esptool2/esptool2
+
+esptool2/esptool2:
+	$(vecho) "Making esptool2 utility"
+	$(Q) $(MAKE) --no-print-directory -C esptool2 V=$(V)
+	$(vecho) "Done"
 
 spiffy: spiffy/spiffy
 
@@ -222,6 +229,7 @@ clean:
 	$(Q) rm -rf $(BUILD_BASE)
 	$(Q) rm -rf $(FW_BASE)
 	$(Q) $(MAKE) --no-print-directory -C spiffy clean V=$(V)
+	$(Q) $(MAKE) --no-print-directory -C esptool2 clean V=$(V)
 
 
 test: all spiffy samples

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -33,7 +33,7 @@ SPIFFY ?= $(SMING_HOME)/spiffy/spiffy
 IMAGE_MAIN	?= 0x00000.bin
 IMAGE_SDK	?= 0x09000.bin
 # esptool2 path
-ESPTOOL2 ?= esptool2
+ESPTOOL2 ?= $(SMING_HOME)/esptool2/esptool2
 # esptool2 parameters for rBootLESS images
 ESPTOOL2_SECTS		?= .text .data .rodata
 ESPTOOL2_MAIN_ARGS	?= -quiet -bin -boot0


### PR DESCRIPTION
Adds `esptool2` as a submodule. This gives a better 'works out of the box'-experience. You don't have to install an external tool and then dig in makefiles to set the path to that tool.

By using a submodule, you can just pull in changes if esptool2 gets improved in the future. The source will automatically be checked out by git when you clone the Sming repo.

Also updated the Readme to reflect these changes.

(only tested this under OSX)

note: I have no affiliation with esptool2