### PR TITLE
fixed support for HW SPI for Adafruit_ST7735 TFT's

### DIFF
--- a/Sming/Libraries/Adafruit_ST7735/Adafruit_ST7735.cpp
+++ b/Sming/Libraries/Adafruit_ST7735/Adafruit_ST7735.cpp
@@ -86,6 +86,8 @@ inline void Adafruit_ST7735::spiwrite(uint8_t c) {
       SPI.setClockDivider(21); //4MHz
       SPI.setDataMode(SPI_MODE0);
       SPI.transfer(c);
+#elif defined (__ESP8266_EX__)
+      SPI.transfer(c);
 #endif
   } else {
     // Fast SPI bitbang swiped from LPD8806 library
@@ -332,6 +334,8 @@ void Adafruit_ST7735::commonInit(const uint8_t *cmdList) {
     SPI.begin();
     SPI.setClockDivider(21); //4MHz
     SPI.setDataMode(SPI_MODE0);
+#elif defined (__ESP8266_EX__)
+    SPI.begin();
 #endif
   } else {
     pinMode(_sclk, OUTPUT);

--- a/samples/ScreenTFT_ST7735/app/application.cpp
+++ b/samples/ScreenTFT_ST7735/app/application.cpp
@@ -82,6 +82,11 @@ void tftPrintTest2() {
 }
 
 void testlines(uint16_t color) {
+
+  // testlines takes more than 3000ms on SW SPI
+  // so we need to prevent the watchdog from kicking in
+  WDT.enable(false);
+
   tft.fillScreen(ST7735_BLACK);
   for (int16_t x=0; x < tft.width(); x+=6) {
     tft.drawLine(0, 0, x, tft.height()-1, color);
@@ -98,8 +103,6 @@ void testlines(uint16_t color) {
     tft.drawLine(tft.width()-1, 0, 0, y, color);
   }
 
-  /*  Hangs on SW SPI -> ok with HW SPI !!
-
   tft.fillScreen(ST7735_BLACK);
   for (int16_t x=0; x < tft.width(); x+=6) {
     tft.drawLine(0, tft.height()-1, x, 0, color);
@@ -115,7 +118,9 @@ void testlines(uint16_t color) {
   for (int16_t y=0; y < tft.height(); y+=6) {
     tft.drawLine(tft.width()-1, tft.height()-1, 0, y, color);
   }
-  */
+
+  WDT.enable(true);
+
 }
 
 void testfastlines(uint16_t color1, uint16_t color2) {

--- a/samples/ScreenTFT_ST7735/app/application.cpp
+++ b/samples/ScreenTFT_ST7735/app/application.cpp
@@ -10,17 +10,23 @@
  * VCC      (VCC)         3.3v
  * D0       (CLK)         GPIO14
  * D1       (MOSI)        GPIO13
+ * CS       (CS)          GPI015
  * RES      (RESET)       GPIO16
- * DC       (DC)          GPIO0
- * CS       (CS)          GPIO2
+ * DC       (DC)          GPIO2
  */
-#define TFT_SCLK 	14
+#define TFT_SCLK 	14  // HW SPI pins - dont change
 #define TFT_MOSI 	13
-#define TFT_RST  	16
-#define	TFT_DC   	0
-#define TFT_CS   	2
+#define TFT_MISO	12
 
-Adafruit_ST7735 tft = Adafruit_ST7735(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
+#define TFT_CS   	15	// this pins are free to change
+#define TFT_RST  	16
+#define	TFT_DC   	2
+
+// constructor for SW SPI
+//Adafruit_ST7735 tft = Adafruit_ST7735(TFT_CS, TFT_DC, TFT_MOSI, TFT_SCLK, TFT_RST);
+
+// constructor for HW SPI
+Adafruit_ST7735 tft = Adafruit_ST7735(TFT_CS, TFT_DC, TFT_RST);
 
 Timer DemoScreenTimer;
 float p = 3.1415926;
@@ -92,8 +98,7 @@ void testlines(uint16_t color) {
     tft.drawLine(tft.width()-1, 0, 0, y, color);
   }
 
-  // TODO: drawing from all 4 corners does kick in a watchdog reboot !
-  /*
+  /*  Hangs on SW SPI -> ok with HW SPI !!
 
   tft.fillScreen(ST7735_BLACK);
   for (int16_t x=0; x < tft.width(); x+=6) {


### PR DESCRIPTION
fully tested now in SW and HW SPI mode. HW SPI is based on swing-core/SPI
