### PR TITLE
add check for length of header buffer (fixes #585)

### DIFF
--- a/Sming/SmingCore/Network/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/HttpRequest.cpp
@@ -84,9 +84,12 @@ String HttpRequest::getContentType()
 HttpParseResult HttpRequest::parseHeader(HttpServer *server, pbuf* buf)
 {
 	int headerEnd = NetUtils::pbufFindStr(buf, "\r\n\r\n");
-	headerDataProcessed += buf->tot_len;
+	if (headerEnd == -1) {
+		headerDataProcessed += buf->tot_len;
+		return eHPR_Wait;
+	}
+	headerDataProcessed += headerEnd;
 	debugf("header length %i", headerDataProcessed);
-	if (headerEnd == -1) return eHPR_Wait;
 	if (headerEnd > NETWORK_MAX_HTTP_PARSING_LEN || headerDataProcessed > NETWORK_MAX_HTTP_PARSING_LEN )
 	{
 		debugf("NETWORK_MAX_HTTP_PARSING_LEN");

--- a/Sming/SmingCore/Network/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/HttpRequest.cpp
@@ -30,6 +30,7 @@ HttpRequest::~HttpRequest()
 	delete requestPostParameters;
 	delete cookies;
 	postDataProcessed = 0;
+	headerDataProcessed = 0;
 	if (bodyBuf != NULL)
 	{
 		os_free(bodyBuf);

--- a/Sming/SmingCore/Network/HttpRequest.h
+++ b/Sming/SmingCore/Network/HttpRequest.h
@@ -59,6 +59,7 @@ private:
 	HashMap<String, String> *requestGetParameters;
 	HashMap<String, String> *requestPostParameters;
 	HashMap<String, String> *cookies;
+	int headerDataProcessed;
 	int postDataProcessed;
 	bool combinePostFrag;
 	char *bodyBuf;


### PR DESCRIPTION
Should stop the header buffer from overflowing #585 