### PR TITLE
Integrated rBoot SwitchOnce mode.

### DIFF
--- a/Sming/rboot/appcode/rboot-api.h
+++ b/Sming/rboot/appcode/rboot-api.h
@@ -85,6 +85,14 @@ rboot_write_status ICACHE_FLASH_ATTR rboot_write_init(uint32 start_addr);
 */
 bool ICACHE_FLASH_ATTR rboot_write_flash(rboot_write_status *status, uint8 *data, uint16 len);
 
+#ifdef BOOT_RTC_ENABLED
+bool ICACHE_FLASH_ATTR rboot_get_rtc_data(rboot_rtc_data *rtc);
+bool ICACHE_FLASH_ATTR rboot_set_rtc_data(rboot_rtc_data *rtc);
+bool ICACHE_FLASH_ATTR rboot_set_temp_rom(uint8 rom);
+bool ICACHE_FLASH_ATTR rboot_get_last_boot_rom(uint8 *rom);
+bool ICACHE_FLASH_ATTR rboot_get_last_boot_mode(uint8 *mode);
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/rboot/rboot.c
+++ b/Sming/rboot/rboot.c
@@ -13,7 +13,7 @@
 #include <rboot-hex2a.h>
 
 static uint32 check_image(uint32 readpos) {
-	
+
 	uint8 buffer[BUFFER_SIZE];
 	uint8 sectcount;
 	uint8 sectcurrent;
@@ -22,19 +22,19 @@ static uint32 check_image(uint32 readpos) {
 	uint32 loop;
 	uint32 remaining;
 	uint32 romaddr;
-	
+
 	rom_header_new *header = (rom_header_new*)buffer;
 	section_header *section = (section_header*)buffer;
-	
+
 	if (readpos == 0 || readpos == 0xffffffff) {
 		return 0;
 	}
-	
+
 	// read rom header
 	if (SPIRead(readpos, header, sizeof(rom_header_new)) != 0) {
 		return 0;
 	}
-	
+
 	// check header type
 	if (header->magic == ROM_MAGIC) {
 		// old type, no extra header or irom section to skip over
@@ -63,10 +63,10 @@ static uint32 check_image(uint32 readpos) {
 	} else {
 		return 0;
 	}
-	
+
 	// test each section
 	for (sectcurrent = 0; sectcurrent < sectcount; sectcurrent++) {
-		
+
 		// read section header
 		if (SPIRead(readpos, section, sizeof(section_header)) != 0) {
 			return 0;
@@ -76,7 +76,7 @@ static uint32 check_image(uint32 readpos) {
 		// get section address and length
 		writepos = section->address;
 		remaining = section->length;
-		
+
 		while (remaining > 0) {
 			// work out how much to read, up to BUFFER_SIZE
 			uint32 readlen = (remaining < BUFFER_SIZE) ? remaining : BUFFER_SIZE;
@@ -94,7 +94,7 @@ static uint32 check_image(uint32 readpos) {
 				chksum ^= buffer[loop];
 			}
 		}
-		
+
 #ifdef BOOT_IROM_CHKSUM
 		if (sectcount == 0xff) {
 			// just processed the irom section, now
@@ -107,21 +107,23 @@ static uint32 check_image(uint32 readpos) {
 		}
 #endif
 	}
-	
+
 	// round up to next 16 and get checksum
 	readpos = readpos | 0x0f;
 	if (SPIRead(readpos, buffer, 1) != 0) {
 		return 0;
 	}
-	
+
 	// compare calculated and stored checksums
 	if (buffer[0] != chksum) {
 		return 0;
 	}
-	
+
 	return romaddr;
 }
 
+#ifdef BOOT_GPIO_ENABLED
+// sample gpio code for gpio16
 #define ETS_UNCACHED_ADDR(addr) (addr)
 #define READ_PERI_REG(addr) (*((volatile uint32 *)ETS_UNCACHED_ADDR(addr)))
 #define WRITE_PERI_REG(addr, val) (*((volatile uint32 *)ETS_UNCACHED_ADDR(addr))) = (uint32)(val)
@@ -135,18 +137,50 @@ static uint32 check_image(uint32 readpos) {
 static uint32 get_gpio16(void) {
 	// set output level to 1
 	WRITE_PERI_REG(RTC_GPIO_OUT, (READ_PERI_REG(RTC_GPIO_OUT) & (uint32)0xfffffffe) | (uint32)(1));
-	
+
 	// read level
 	WRITE_PERI_REG(PAD_XPD_DCDC_CONF, (READ_PERI_REG(PAD_XPD_DCDC_CONF) & 0xffffffbc) | (uint32)0x1);	// mux configuration for XPD_DCDC and rtc_gpio0 connection
 	WRITE_PERI_REG(RTC_GPIO_CONF, (READ_PERI_REG(RTC_GPIO_CONF) & (uint32)0xfffffffe) | (uint32)0x0);	//mux configuration for out enable
 	WRITE_PERI_REG(RTC_GPIO_ENABLE, READ_PERI_REG(RTC_GPIO_ENABLE) & (uint32)0xfffffffe);	//out disable
-	
+
 	uint32 x = (READ_PERI_REG(RTC_GPIO_IN_DATA) & 1);
-	
+
 	return x;
 }
+#endif
 
-#ifdef BOOT_CONFIG_CHKSUM
+#ifdef BOOT_RTC_ENABLED
+uint32 system_rtc_mem(int32 addr, void *buff, int32 length, uint32 mode) {
+
+    int32 blocks;
+
+    // validate reading a user block
+    if (addr < 64) return 0;
+    if (buff == 0) return 0;
+    // validate 4 byte aligned
+    if (((uint32)buff & 0x3) != 0) return 0;
+    // validate length is multiple of 4
+    if ((length & 0x3) != 0) return 0;
+
+    // check valid length from specified starting point
+    if (length > (0x300 - (addr * 4))) return 0;
+
+    // copy the data
+    for (blocks = (length >> 2) - 1; blocks >= 0; blocks--) {
+        volatile uint32 *ram = ((uint32*)buff) + blocks;
+        volatile uint32 *rtc = ((uint32*)0x60001100) + addr + blocks;
+		if (mode == RBOOT_RTC_WRITE) {
+			*rtc = *ram;
+		} else {
+			*ram = *rtc;
+		}
+    }
+
+    return 1;
+}
+#endif
+
+#if defined(BOOT_CONFIG_CHKSUM) || defined(BOOT_RTC_ENABLED)
 // calculate checksum for block of data
 // from start up to (but excluding) end
 static uint8 calc_chksum(uint8 *start, uint8 *end) {
@@ -164,26 +198,32 @@ static uint8 calc_chksum(uint8 *start, uint8 *end) {
 // don't mark as static or it'll be optimised out when
 // using the assembler stub
 uint32 NOINLINE find_image(void) {
-	
+
 	uint8 flag;
 	uint32 runAddr;
 	uint32 flashsize;
 	int32 romToBoot;
-	uint8 gpio_boot = FALSE;
 	uint8 updateConfig = FALSE;
 	uint8 buffer[SECTOR_SIZE];
+#ifdef BOOT_GPIO_ENABLED
+	uint8 gpio_boot = FALSE;
+#endif
+#ifdef BOOT_RTC_ENABLED
+	rboot_rtc_data rtc;
+	uint8 temp_boot = FALSE;
+#endif
 
 	rboot_config *romconf = (rboot_config*)buffer;
 	rom_header *header = (rom_header*)buffer;
-	
+
 	// delay to slow boot (help see messages when debugging)
-	//ets_delay_us(2000000);
-	
+	ets_delay_us(2000000);
+
 	ets_printf("\r\nrBoot v1.2.1 - richardaburton@gmail.com\r\n");
-	
+
 	// read rom header
 	SPIRead(0, header, sizeof(rom_header));
-	
+
 	// print and get flash size
 	ets_printf("Flash Size:   ");
 	flag = header->flags2 >> 4;
@@ -215,7 +255,7 @@ uint32 NOINLINE find_image(void) {
 		// assume at least 4mbit
 		flashsize = 0x80000;
 	}
-	
+
 	// print spi mode
 	ets_printf("Flash Mode:   ");
 	if (header->flags1 == 0) {
@@ -229,7 +269,7 @@ uint32 NOINLINE find_image(void) {
 	} else {
 		ets_printf("unknown\r\n");
 	}
-	
+
 	// print spi speed
 	ets_printf("Flash Speed:  ");
 	flag = header->flags2 & 0x0f;
@@ -238,7 +278,7 @@ uint32 NOINLINE find_image(void) {
 	else if (flag == 2) ets_printf("20 MHz\r\n");
 	else if (flag == 0x0f) ets_printf("80 MHz\r\n");
 	else ets_printf("unknown\r\n");
-	
+
 	// print enabled options
 #ifdef BOOT_BIG_FLASH
 	ets_printf("rBoot Option: Big flash\r\n");
@@ -246,12 +286,17 @@ uint32 NOINLINE find_image(void) {
 #ifdef BOOT_CONFIG_CHKSUM
 	ets_printf("rBoot Option: Config chksum\r\n");
 #endif
+#ifdef BOOT_GPIO_ENABLED
+	ets_printf("rBoot Option: GPIO mode\r\n");
+#endif
+#ifdef BOOT_RTC_ENABLED
+	ets_printf("rBoot Option: RTC data\r\n");
+#endif
 #ifdef BOOT_IROM_CHKSUM
 	ets_printf("rBoot Option: irom chksum\r\n");
 #endif
-	
 	ets_printf("\r\n");
-	
+
 	// read boot config
 	SPIRead(BOOT_CONFIG_SECTOR * SECTOR_SIZE, buffer, SECTOR_SIZE);
 	// fresh install or old version?
@@ -275,48 +320,88 @@ uint32 NOINLINE find_image(void) {
 		SPIEraseSector(BOOT_CONFIG_SECTOR);
 		SPIWrite(BOOT_CONFIG_SECTOR * SECTOR_SIZE, buffer, SECTOR_SIZE);
 	}
-	
+
+	// try rom selected in the config, unless overriden by gpio/temp boot
+	romToBoot = romconf->current_rom;
+
+#ifdef BOOT_RTC_ENABLED
+	// if rtc data enabled, check for valid data
+	if (system_rtc_mem(RBOOT_RTC_ADDR, &rtc, sizeof(rboot_rtc_data), RBOOT_RTC_READ) &&
+		(rtc.chksum == calc_chksum((uint8*)&rtc, (uint8*)&rtc.chksum))) {
+
+		if (rtc.next_mode & MODE_TEMP_ROM) {
+			if (rtc.temp_rom >= romconf->count) {
+				ets_printf("Invalid temp rom selected.\r\n");
+				return 0;
+			}
+			ets_printf("Booting temp rom.\r\n");
+			temp_boot = TRUE;
+			romToBoot = rtc.temp_rom;
+		}
+	}
+#endif
+#ifdef BOOT_GPIO_ENABLED
 	// if gpio mode enabled check status of the gpio
 	if ((romconf->mode & MODE_GPIO_ROM) && (get_gpio16() == 0)) {
-		ets_printf("Booting GPIO-selected.\r\n");
+		if (romconf->gpio_rom >= romconf->count) {
+			ets_printf("Invalid GPIO rom selected.\r\n");
+			return 0;
+		}
+		ets_printf("Booting GPIO-selected rom.\r\n");
 		romToBoot = romconf->gpio_rom;
 		gpio_boot = TRUE;
 		updateConfig = TRUE;
-	} else if (romconf->current_rom >= romconf->count) {
+	}
+#endif
+
+	// check valid rom number
+	// gpio/temp boots will have already validated this
+	if (romconf->current_rom >= romconf->count) {
 		// if invalid rom selected try rom 0
-		ets_printf("Invalid rom selected, defaulting.\r\n");
+		ets_printf("Invalid rom selected, defaulting to 0.\r\n");
 		romToBoot = 0;
 		romconf->current_rom = 0;
 		updateConfig = TRUE;
-	} else {
-		// try rom selected in the config
-		romToBoot = romconf->current_rom;
 	}
-	
-	// try to find a good rom
-	do {
-		runAddr = check_image(romconf->roms[romToBoot]);
-		if (runAddr == 0) {
-			ets_printf("Rom %d is bad.\r\n", romToBoot);
-			if (gpio_boot) {
-				// don't switch to backup for gpio-selected rom
-				ets_printf("GPIO boot failed.\r\n");
-				return 0;
-			} else {
-				// for normal mode try each previous rom
-				// until we find a good one or run out
-				updateConfig = TRUE;
-				romToBoot--;
-				if (romToBoot < 0) romToBoot = romconf->count - 1;
-				if (romToBoot == romconf->current_rom) {
-					// tried them all and all are bad!
-					ets_printf("No good rom available.\r\n");
-					return 0;
-				}
-			}
+
+	// check rom is valid
+	runAddr = check_image(romconf->roms[romToBoot]);
+
+#ifdef BOOT_GPIO_ENABLED
+	if (gpio_boot && runAddr == 0) {
+		// don't switch to backup for gpio-selected rom
+		ets_printf("GPIO boot rom (%d) is bad.\r\n", romToBoot);
+		return 0;
+	}
+#endif
+#ifdef BOOT_RTC_ENABLED
+	if (temp_boot && runAddr == 0) {
+		// don't switch to backup for temp rom
+		ets_printf("Temp boot rom (%d) is bad.\r\n", romToBoot);
+		// make sure rtc temp boot mode doesn't persist
+		rtc.next_mode = MODE_STANDARD;
+		rtc.chksum = calc_chksum((uint8*)&rtc, (uint8*)&rtc.chksum);
+		system_rtc_mem(RBOOT_RTC_ADDR, &rtc, sizeof(rboot_rtc_data), RBOOT_RTC_WRITE);
+		return 0;
+	}
+#endif
+
+	// check we have a good rom
+	while (runAddr == 0) {
+		ets_printf("Rom %d is bad.\r\n", romToBoot);
+		// for normal mode try each previous rom
+		// until we find a good one or run out
+		updateConfig = TRUE;
+		romToBoot--;
+		if (romToBoot < 0) romToBoot = romconf->count - 1;
+		if (romToBoot == romconf->current_rom) {
+			// tried them all and all are bad!
+			ets_printf("No good rom available.\r\n");
+			return 0;
 		}
-	} while (runAddr == 0);
-	
+		runAddr = check_image(romconf->roms[romToBoot]);
+	}
+
 	// re-write config, if required
 	if (updateConfig) {
 		romconf->current_rom = romToBoot;
@@ -326,7 +411,22 @@ uint32 NOINLINE find_image(void) {
 		SPIEraseSector(BOOT_CONFIG_SECTOR);
 		SPIWrite(BOOT_CONFIG_SECTOR * SECTOR_SIZE, buffer, SECTOR_SIZE);
 	}
-	
+
+#ifdef BOOT_RTC_ENABLED
+	// set rtc boot data for app to read
+	rtc.magic = RBOOT_RTC_MAGIC;
+	rtc.next_mode = MODE_STANDARD;
+	rtc.last_mode = MODE_STANDARD;
+	if (temp_boot) rtc.last_mode |= MODE_TEMP_ROM;
+#ifdef BOOT_GPIO_ENABLED
+	if (gpio_boot) rtc.last_mode |= MODE_GPIO_ROM;
+#endif
+	rtc.last_rom = romToBoot;
+	rtc.temp_rom = 0;
+	rtc.chksum = calc_chksum((uint8*)&rtc, (uint8*)&rtc.chksum);
+	system_rtc_mem(RBOOT_RTC_ADDR, &rtc, sizeof(rboot_rtc_data), RBOOT_RTC_WRITE);
+#endif
+
 	ets_printf("Booting rom %d.\r\n", romToBoot);
 	// copy the loader to top of iram
 	ets_memcpy((void*)_text_addr, _text_data, _text_len);
@@ -341,7 +441,7 @@ uint32 NOINLINE find_image(void) {
 void call_user_start(void) {
 	uint32 addr;
 	stage2a *loader;
-	
+
 	addr = find_image();
 	if (addr != 0) {
 		loader = (stage2a*)entry_addr;
@@ -361,8 +461,8 @@ void call_user_start(void) {
 		"bnez a2, 1f\n"          // ?success
 		"ret\n"                  // no, return
 		"1:\n"                   // yes...
-		"movi a3, entry_addr\n"  // actually gives us a pointer to entry_addr
-		"l32i a3, a3, 0\n"       // now really load entry_addr
+		"movi a3, entry_addr\n"  // get pointer to entry_addr
+		"l32i a3, a3, 0\n"       // get value of entry_addr
 		"jx a3\n"                // now jump to it
 	);
 }

--- a/Sming/rboot/rboot.h
+++ b/Sming/rboot/rboot.h
@@ -22,6 +22,13 @@ extern "C" {
 // uncomment to enable big flash support (>1MB)
 //#define BOOT_BIG_FLASH
 
+// uncomment to enable 2 way communication between
+// rBoot and the user app via the esp rtc data area
+#define BOOT_RTC_ENABLED
+
+// uncomment to enable GPIO booting
+//#define BOOT_GPIO_ENABLED
+
 // uncomment to include .irom0.text section in the checksum
 // roms must be built with esptool2 using -iromchksum option
 //#define BOOT_IROM_CHKSUM
@@ -39,6 +46,12 @@ extern "C" {
 
 #define MODE_STANDARD 0x00
 #define MODE_GPIO_ROM 0x01
+#define MODE_TEMP_ROM 0x02
+
+#define RBOOT_RTC_MAGIC 0x2334ae68
+#define RBOOT_RTC_READ 1
+#define RBOOT_RTC_WRITE 0
+#define RBOOT_RTC_ADDR 64
 
 /**	@brief  Structure containing rBoot configuration
  *  @note   ROM addresses must be multiples of 0x1000 (flash sector aligned).
@@ -63,6 +76,17 @@ typedef struct {
 	uint8 chksum;          ///< Checksum of this configuration structure (if BOOT_CONFIG_CHKSUM defined)
 #endif
 } rboot_config;
+
+#ifdef BOOT_RTC_ENABLED
+typedef struct {
+	uint32 magic;
+	uint8 next_mode;
+	uint8 last_mode;
+	uint8 last_rom;
+	uint8 temp_rom;
+	uint8 chksum;
+} rboot_rtc_data;
+#endif
 
 #ifdef __cplusplus
 }

--- a/Sming/system/include/rboot-integration.h
+++ b/Sming/system/include/rboot-integration.h
@@ -1,6 +1,8 @@
 #ifndef __RBOOT_INTEGRATION_H__
 #define __RBOOT_INTEGRATION_H__
 
+#define BOOT_GPIO_ENABLED
+
 // prevent sming user_config.h being included
 #define __USER_CONFIG_H__
 


### PR DESCRIPTION
In order to avoid having "bricked" devices after OTA it would be great after a new ROM is downloaded to switch temporarily to that ROM and once it is confirmed to work to switch permanently to it.
This patch adds exactly that functionality by integrating the R. Burton rBoot rtc branch into Sming. 