### PR TITLE
Added optional onDelivery callback for publishing messages with QoS 1 and 2.

### DIFF
--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -13,10 +13,12 @@
 #include "TcpClient.h"
 #include "../Delegate.h"
 #include "../../Wiring/WString.h"
+#include "../../Wiring/WHashMap.h"
 #include "../../Services/libemqtt/libemqtt.h"
 
 //typedef void (*MqttStringSubscriptionCallback)(String topic, String message);
 typedef Delegate<void(String topic, String message)> MqttStringSubscriptionCallback;
+typedef Delegate<void(uint16_t msgId, int type)> MqttMessageDeliveredCallback;
 
 class MqttClient;
 class URL;
@@ -42,7 +44,7 @@ public:
 	__forceinline TcpClientState getConnectionState() { return TcpClient::getConnectionState(); }
 
 	bool publish(String topic, String message, bool retained = false);
-	bool publishWithQoS(String topic, String message, int QoS, bool retained = false);
+	bool publishWithQoS(String topic, String message, int QoS, bool retained = false, MqttMessageDeliveredCallback onDelivery = NULL);
 
 	bool subscribe(String topic);
 	bool unsubscribe(String topic);
@@ -74,6 +76,7 @@ private:
 	int keepAlive = 60;
 	int PingRepeatTime = 20;
 	unsigned long lastMessage;
+	HashMap<uint16_t, MqttMessageDeliveredCallback> onDeliveryQueue;
 };
 
 #endif /* _SMING_CORE_NETWORK_MqttClient_H_ */

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -46,6 +46,10 @@ void checkMQTTDisconnect(TcpClient& client, bool flag){
 	procTimer.initializeMs(2 * 1000, startMqttClient).start(); // every 2 seconds
 }
 
+void onMessageDelivered(uint16_t msgId, int type) {
+	Serial.printf("Message with id %d and QoS %d was delivered successfully.", msgId, (type==MQTT_MSG_PUBREC? 2: 1));
+}
+
 // Publish our message
 void publishMessage()
 {
@@ -53,7 +57,9 @@ void publishMessage()
 		startMqttClient(); // Auto reconnect
 
 	Serial.println("Let's publish message now!");
-	mqtt->publish("main/frameworks/sming", "Hello friends, from Internet of things :)"); // or publishWithQoS
+	mqtt->publish("main/frameworks/sming", "Hello friends, from Internet of things :)"); 
+
+	mqtt->publishWithQoS("important/frameworks/sming", "Request Return Delivery", 1, false, onMessageDelivered); // or publishWithQoS
 }
 
 // Callback for messages, arrived from MQTT server


### PR DESCRIPTION
Useful if you want to publish a message, make sure that it was delivered and execute a callback once the message was delivered.
