### PR TITLE
Added support for "TX only UART".

### DIFF
--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -33,8 +33,9 @@ HardwareSerial::HardwareSerial(const int uartPort)
 	system_os_task(delegateTask,USER_TASK_PRIO_0,serialQueue,SERIAL_QUEUE_LEN);
 }
 
-void HardwareSerial::begin(const uint32_t baud/* = 9600*/)
+void HardwareSerial::begin(const uint32_t baud/* = 9600*/, bool disableRx /*=false*/)
 {
+	rxDisabled = disableRx;
 	//TODO: Move to params!
 	UartDev.baut_rate = (UartBautRate)baud;
 	UartDev.parity = NONE_BITS;
@@ -42,7 +43,10 @@ void HardwareSerial::begin(const uint32_t baud/* = 9600*/)
 	UartDev.stop_bits = ONE_STOP_BIT;
 	UartDev.data_bits = EIGHT_BITS;
 
-	ETS_UART_INTR_ATTACH((void*)uart0_rx_intr_handler,  &(UartDev.rcv_buff));
+	if(!rxDisabled)
+	{
+	  ETS_UART_INTR_ATTACH((void*)uart0_rx_intr_handler,  &(UartDev.rcv_buff));
+	}
 	PIN_PULLUP_DIS(PERIPHS_IO_MUX_U0TXD_U);
 	PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD);
 
@@ -53,20 +57,26 @@ void HardwareSerial::begin(const uint32_t baud/* = 9600*/)
 				   | (UartDev.stop_bits << UART_STOP_BIT_NUM_S)
 				   | (UartDev.data_bits << UART_BIT_NUM_S));
 
+	if(!rxDisabled)
+	{
+		//clear rx and tx fifo,not ready
+		SET_PERI_REG_MASK(UART_CONF0(uart), UART_RXFIFO_RST | UART_TXFIFO_RST);
+		CLEAR_PERI_REG_MASK(UART_CONF0(uart), UART_RXFIFO_RST | UART_TXFIFO_RST);
 
-	//clear rx and tx fifo,not ready
-	SET_PERI_REG_MASK(UART_CONF0(uart), UART_RXFIFO_RST | UART_TXFIFO_RST);
-	CLEAR_PERI_REG_MASK(UART_CONF0(uart), UART_RXFIFO_RST | UART_TXFIFO_RST);
-
-	//set rx fifo trigger
-	WRITE_PERI_REG(UART_CONF1(uart), (UartDev.rcv_buff.TrigLvl & UART_RXFIFO_FULL_THRHD) << UART_RXFIFO_FULL_THRHD_S);
-
+		//set rx fifo trigger
+		WRITE_PERI_REG(UART_CONF1(uart), (UartDev.rcv_buff.TrigLvl & UART_RXFIFO_FULL_THRHD) << UART_RXFIFO_FULL_THRHD_S);
+	}
+	
 	//clear all interrupt
 	WRITE_PERI_REG(UART_INT_CLR(uart), 0xffff);
-	//enable rx_interrupt
-	SET_PERI_REG_MASK(UART_INT_ENA(uart), UART_RXFIFO_FULL_INT_ENA);
 
-	ETS_UART_INTR_ENABLE();
+	if(!rxDisabled)
+	{	
+		//enable rx_interrupt
+		SET_PERI_REG_MASK(UART_INT_ENA(uart), UART_RXFIFO_FULL_INT_ENA);
+
+		ETS_UART_INTR_ENABLE();
+	}
 	delay(10);
 	Serial.println("\r\n"); // after SPAM :)
 }
@@ -96,7 +106,7 @@ int HardwareSerial::available()
 
 int HardwareSerial::read()
 {
-	if (available() == 0)
+	if (rxDisabled || available() == 0)
 		return -1;
 
 	noInterrupts();
@@ -136,7 +146,7 @@ int HardwareSerial::readMemoryBlock(char* buf, int max_len)
 
 int HardwareSerial::peek()
 {
-	if (available() == 0)
+	if (rxDisabled || available() == 0)
 		return -1;
 
 	noInterrupts();

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -33,7 +33,7 @@ HardwareSerial::HardwareSerial(const int uartPort)
 	system_os_task(delegateTask,USER_TASK_PRIO_0,serialQueue,SERIAL_QUEUE_LEN);
 }
 
-void HardwareSerial::begin(const uint32_t baud/* = 9600*/, bool disableRx /*=false*/)
+void HardwareSerial::internalBegin(const uint32_t baud/* = 9600*/, bool disableRx /*=false*/)
 {
 	rxDisabled = disableRx;
 	//TODO: Move to params!

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -53,13 +53,11 @@ public:
 
     /** @brief  Initialise the serial port
      *  @param  baud BAUD rate of the serial port (Default: 9600)
-     *  @todo   This code only initialises UART0, uartPort is never used.           
      */
 	void inline begin(const uint32_t baud = 9600) { internalBegin(baud, false); };
 
     /** @brief   Initialise the serial port but disable the receiving part of the UART.
      *  @param   baud BAUD rate of the serial port (Default: 9600)
-     *  @todo    This code only initialises UART0, uartPort is never used.
      *  @warning If you use this method you must make sure that 
      *           the RX pin is *not* hardwired to something that drives the pin.
      *           e.g. your usb serial adapter. Use a >= 10Kohm resistor if you must

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -53,8 +53,12 @@ public:
 
     /** @brief  Initialise the serial port
      *  @param  baud BAUD rate of the serial port (Default: 9600)
+     *  @param  disableRx when true the UART won't use the RX pin.
+     *          read(), peek() and available() won't work anymore but you will 
+     *          be able to use the RX pin as a GPIO.
+     *  @todo   This code only initialises UART0, uartPort is never used.           
      */
-	void begin(const uint32_t baud = 9600);
+	void begin(const uint32_t baud = 9600, bool disableRx=false);
 
     /** @brief  Get quantity characters available from serial input
      *  @retval int Quantity of characters in receive buffer
@@ -129,6 +133,7 @@ public:
 	static void delegateTask (os_event_t *inputEvent);
 
 private:
+	bool rxDisabled = false;
 	int uart;
 	static HWSerialMemberData memberData[NUMBER_UARTS];
 

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -55,7 +55,7 @@ public:
      *  @param  baud BAUD rate of the serial port (Default: 9600)
      *  @todo   This code only initialises UART0, uartPort is never used.           
      */
-	void inline begin(const uint32_t baud = 9600) { begin(baud, false); };
+	void inline begin(const uint32_t baud = 9600) { internalBegin(baud, false); };
 
     /** @brief   Initialise the serial port but disable the receiving part of the UART.
      *  @param   baud BAUD rate of the serial port (Default: 9600)
@@ -65,7 +65,7 @@ public:
      *           e.g. your usb serial adapter. Use a >= 10Kohm resistor if you must
      *           flash the device over serial.
      */
-	void inline beginNoRx(const uint32_t baud = 9600) { begin(baud, true); };
+	void inline beginNoRx(const uint32_t baud = 9600) { internalBegin(baud, true); };
 
     /** @brief  Get quantity characters available from serial input
      *  @retval int Quantity of characters in receive buffer
@@ -140,14 +140,14 @@ public:
 	static void delegateTask (os_event_t *inputEvent);
 
 protected:
-    /** @brief  Initialise the serial port
+    /** @brief  Initialise the serial port. (named 'internal' as a disambiguation)
      *  @param  baud BAUD rate of the serial port (Default: 9600)
      *  @param  disableRx when true the UART won't use the RX pin.
      *          read(), peek() and available() won't work anymore but you will 
      *          be able to use the RX pin as a GPIO.
      *  @todo   This code only initialises UART0, uartPort is never used.
      */
-	void begin(const uint32_t baud = 9600, bool disableRx=false);
+	void internalBegin(const uint32_t baud = 9600, bool disableRx=false);
 
 private:
 	bool rxDisabled = false;

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -53,12 +53,19 @@ public:
 
     /** @brief  Initialise the serial port
      *  @param  baud BAUD rate of the serial port (Default: 9600)
-     *  @param  disableRx when true the UART won't use the RX pin.
-     *          read(), peek() and available() won't work anymore but you will 
-     *          be able to use the RX pin as a GPIO.
      *  @todo   This code only initialises UART0, uartPort is never used.           
      */
-	void begin(const uint32_t baud = 9600, bool disableRx=false);
+	void inline begin(const uint32_t baud = 9600) { begin(baud, false); };
+
+    /** @brief   Initialise the serial port but disable the receiving part of the UART.
+     *  @param   baud BAUD rate of the serial port (Default: 9600)
+     *  @todo    This code only initialises UART0, uartPort is never used.
+     *  @warning If you use this method you must make sure that 
+     *           the RX pin is *not* hardwired to something that drives the pin.
+     *           e.g. your usb serial adapter. Use a >= 10Kohm resistor if you must
+     *           flash the device over serial.
+     */
+	void inline beginNoRx(const uint32_t baud = 9600) { begin(baud, true); };
 
     /** @brief  Get quantity characters available from serial input
      *  @retval int Quantity of characters in receive buffer
@@ -131,6 +138,16 @@ public:
 	 *  @todo   Should HardwareSerial::delgateTask be private?
 	 */
 	static void delegateTask (os_event_t *inputEvent);
+
+protected:
+    /** @brief  Initialise the serial port
+     *  @param  baud BAUD rate of the serial port (Default: 9600)
+     *  @param  disableRx when true the UART won't use the RX pin.
+     *          read(), peek() and available() won't work anymore but you will 
+     *          be able to use the RX pin as a GPIO.
+     *  @todo   This code only initialises UART0, uartPort is never used.
+     */
+	void begin(const uint32_t baud = 9600, bool disableRx=false);
 
 private:
 	bool rxDisabled = false;


### PR DESCRIPTION
In this mode the esp RX pin can be used as GPIO3.

I have just too many esp-1 modules, and i want to use them for something useful. 
So i simply need more than 2 gpios while still using UART0 for debugging.

I've successfully tested this with SDK 1.5.2. `pinMode(3, INPUT)` and `pinMode(3, OUTPUT)`.

Caution: If you use GPIO3 as output you better make sure that esp RX isn't wired directly to your serial adapter. Instead the esp RX pin should be connected to the serial adapter via 10KOhm or more.

~~Maybe it's better to create a brand new `Serial.begin()` method (e.g. `Serial.beginNoRx()`) instead of just adding a  `disableRx` parameter to it.
That way there will be fewer Arduino incompatibilities.~~ Did that already.