### PR TITLE
use COM_SPEED_SERIAL from Makefile instead of SERIAL_BAUD_RATE

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -111,7 +111,7 @@ USER_LIBDIR = compiler/lib
 LIBS		= microc microgcc hal phy pp net80211 lwip wpa main
 
 # compiler flags using during compilation of source files. Add '-pg' for debugging
-CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106
+CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL)
 ifeq ($(ENABLE_GDB), 1)
 	CFLAGS += -Og -ggdb -DGDBSTUB_FREERTOS=0 -DENABLE_GDB=1
 	MODULES		 += gdbstub

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -142,7 +142,7 @@ USER_LIBDIR = $(SMING_HOME)/compiler/lib/
 LIBS		= microc microgcc hal phy pp net80211 lwip wpa main sming crypto pwm smartconfig $(EXTRA_LIBS)
 
 # compiler flags using during compilation of source files
-CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 $(USER_CFLAGS)
+CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS)
 ifeq ($(ENABLE_GDB), 1)
 	CFLAGS += -Og -ggdb -DGDBSTUB_FREERTOS=0 -DENABLE_GDB=1
 	MODULES		 += $(SMING_HOME)/gdbstub

--- a/Sming/include/user_config.h
+++ b/Sming/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Accelerometer_MMA7455/app/application.cpp
+++ b/samples/Accelerometer_MMA7455/app/application.cpp
@@ -24,7 +24,7 @@ void readSensor()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Debug output to serial
 	Serial.println("Starting...");
 

--- a/samples/Accelerometer_MMA7455/include/user_config.h
+++ b/samples/Accelerometer_MMA7455/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_AirUpdate/app/application.cpp
+++ b/samples/Basic_AirUpdate/app/application.cpp
@@ -36,7 +36,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Debug output to serial
 
 	WifiStation.enable(true);

--- a/samples/Basic_AirUpdate/include/user_config.h
+++ b/samples/Basic_AirUpdate/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_Blink/include/user_config.h
+++ b/samples/Basic_Blink/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_Capsense/include/user_config.h
+++ b/samples/Basic_Capsense/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_Delegates/include/user_config.h
+++ b/samples/Basic_Delegates/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_HwPWM/app/application.cpp
+++ b/samples/Basic_HwPWM/app/application.cpp
@@ -41,7 +41,7 @@ void doPWM() {
 }
 
 void init() {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 	// WIFI not needed for demo. So disabling WIFI.

--- a/samples/Basic_HwPWM/include/user_config.h
+++ b/samples/Basic_HwPWM/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_Interrupts/app/application.cpp
+++ b/samples/Basic_Interrupts/app/application.cpp
@@ -19,7 +19,7 @@ void IRAM_ATTR interruptHandler()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 or 9600 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 
 	delay(3000);
 	say("======= Bring GPIO");

--- a/samples/Basic_Interrupts/include/user_config.h
+++ b/samples/Basic_Interrupts/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -176,7 +176,7 @@ void connect_Fail()
 void init()
 {
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(false); // Disable debug output to serial
 
 	Serial.print("NeoPixel demo .. start");

--- a/samples/Basic_Neopixel/include/user_config.h
+++ b/samples/Basic_Neopixel/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_PWM/include/user_config.h
+++ b/samples/Basic_PWM/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_ProgMem/app/application.cpp
+++ b/samples/Basic_ProgMem/app/application.cpp
@@ -122,7 +122,7 @@ void testPgm()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 or 9600 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 
 	testPgm();
 

--- a/samples/Basic_ProgMem/include/user_config.h
+++ b/samples/Basic_ProgMem/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_ScannerI2C/app/application.cpp
+++ b/samples/Basic_ScannerI2C/app/application.cpp
@@ -76,7 +76,7 @@ void scanBus()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(false); // Disable debug output
 
 	WDT.enable(false); // First (but not the best) option: fully disable watch dog timer

--- a/samples/Basic_ScannerI2C/include/user_config.h
+++ b/samples/Basic_ScannerI2C/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_Serial/app/application.cpp
+++ b/samples/Basic_Serial/app/application.cpp
@@ -71,7 +71,7 @@ void testPrintf()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 
 	procTimer.initializeMs(2000, sayHello).start();
 

--- a/samples/Basic_Serial/include/user_config.h
+++ b/samples/Basic_Serial/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_Servo/include/user_config.h
+++ b/samples/Basic_Servo/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_SmartConfig/app/application.cpp
+++ b/samples/Basic_SmartConfig/app/application.cpp
@@ -31,7 +31,7 @@ void smartConfigCallback(sc_status status, void *pdata) {
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Debug output to serial
 
 	WifiAccessPoint.enable(false);

--- a/samples/Basic_SmartConfig/include/user_config.h
+++ b/samples/Basic_SmartConfig/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_WebSkeletonApp/app/application.cpp
+++ b/samples/Basic_WebSkeletonApp/app/application.cpp
@@ -11,7 +11,7 @@ void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway);
 void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(false);
 	Serial.commandProcessing(false);
 

--- a/samples/Basic_WebSkeletonApp/include/user_config.h
+++ b/samples/Basic_WebSkeletonApp/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_WiFi/app/application.cpp
+++ b/samples/Basic_WiFi/app/application.cpp
@@ -53,7 +53,7 @@ void ready()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE);
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug print to serial
 	Serial.println("Sming. Let's do smart things!");
 

--- a/samples/Basic_WiFi/include/user_config.h
+++ b/samples/Basic_WiFi/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Basic_rBoot/app/application.cpp
+++ b/samples/Basic_rBoot/app/application.cpp
@@ -160,7 +160,7 @@ void serialCallBack(Stream& stream, char arrivedChar, unsigned short availableCh
 
 void init() {
 	
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Debug output to serial
 	
 	// mount spiffs

--- a/samples/Basic_rBoot/include/user_config.h
+++ b/samples/Basic_rBoot/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -124,7 +124,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 
 	commandHandler.registerSystemCommands();
 	Debug.setDebug(Serial);

--- a/samples/CommandProcessing_Debug/include/user_config.h
+++ b/samples/CommandProcessing_Debug/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Compass_HMC5883L/app/application.cpp
+++ b/samples/Compass_HMC5883L/app/application.cpp
@@ -14,7 +14,7 @@ void readCompass();
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(false); // Disable debug output to serial
 
 	// join I2C bus (I2Cdev library doesn't do this automatically)

--- a/samples/Compass_HMC5883L/include/user_config.h
+++ b/samples/Compass_HMC5883L/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/DS3232RTC_NTP_Setter/app/application.cpp
+++ b/samples/DS3232RTC_NTP_Setter/app/application.cpp
@@ -56,7 +56,7 @@ void connectFail()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE);
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug print to serial
 	Serial.println("Sming. Let's do smart things!");
 

--- a/samples/DS3232RTC_NTP_Setter/include/user_config.h
+++ b/samples/DS3232RTC_NTP_Setter/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -33,7 +33,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 	fileSetContent("example.txt", "hello world!");

--- a/samples/FtpServer_Files/include/user_config.h
+++ b/samples/FtpServer_Files/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Gesture_APDS-9960/app/application.cpp
+++ b/samples/Gesture_APDS-9960/app/application.cpp
@@ -44,7 +44,7 @@ void IRAM_ATTR interruptRoutine() {
 }
 
 void init() {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 	// WIFI not needed for demo. So disabling WIFI.

--- a/samples/Gesture_APDS-9960/include/user_config.h
+++ b/samples/Gesture_APDS-9960/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/HttpClient_Instapush/app/application.cpp
+++ b/samples/HttpClient_Instapush/app/application.cpp
@@ -96,7 +96,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Debug output to serial
 
 	WifiStation.config(WIFI_SSID, WIFI_PWD);

--- a/samples/HttpClient_Instapush/include/user_config.h
+++ b/samples/HttpClient_Instapush/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -64,7 +64,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(false); // Disable debug output to serial
 
 	WifiStation.config(WIFI_SSID, WIFI_PWD);

--- a/samples/HttpClient_ThingSpeak/include/user_config.h
+++ b/samples/HttpClient_ThingSpeak/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -114,7 +114,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 	WifiStation.enable(true);

--- a/samples/HttpServer_AJAX/include/user_config.h
+++ b/samples/HttpServer_AJAX/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -108,7 +108,7 @@ void init()
 
 	pinMode(LED_PIN, OUTPUT);
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 	WifiStation.enable(true);

--- a/samples/HttpServer_Bootstrap/include/user_config.h
+++ b/samples/HttpServer_Bootstrap/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/HttpServer_ConfigNetwork/app/application.cpp
+++ b/samples/HttpServer_ConfigNetwork/app/application.cpp
@@ -193,7 +193,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 	AppSettings.load();
 

--- a/samples/HttpServer_ConfigNetwork/include/user_config.h
+++ b/samples/HttpServer_ConfigNetwork/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -95,7 +95,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 	WifiStation.enable(true);

--- a/samples/HttpServer_WebSockets/include/user_config.h
+++ b/samples/HttpServer_WebSockets/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Humidity_DHT22/app/application.cpp
+++ b/samples/Humidity_DHT22/app/application.cpp
@@ -10,7 +10,7 @@ void displayComfort();
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
 	Serial.println("\t\t DHT improved lib");

--- a/samples/Humidity_DHT22/include/user_config.h
+++ b/samples/Humidity_DHT22/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/IR_lib/app/application.cpp
+++ b/samples/IR_lib/app/application.cpp
@@ -31,7 +31,7 @@ void receiveIR()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.println("Setting up...");
 	irrecv.blink13(1);
 	irrecv.enableIRIn(); // Start the receiver

--- a/samples/IR_lib/include/user_config.h
+++ b/samples/IR_lib/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/LED_WS2812/include/user_config.h
+++ b/samples/LED_WS2812/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Light_BH1750/app/application.cpp
+++ b/samples/Light_BH1750/app/application.cpp
@@ -23,7 +23,7 @@ void readLight()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(false); // Disable debug output to serial
 
 	if (LightSensor.begin() == 0)

--- a/samples/Light_BH1750/include/user_config.h
+++ b/samples/Light_BH1750/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/LiquidCrystal_44780/app/application.cpp
+++ b/samples/LiquidCrystal_44780/app/application.cpp
@@ -14,7 +14,7 @@ LiquidCrystal_I2C lcd(I2C_LCD_ADDR, 2, 1, 0, 4, 5, 6, 7, 3, POSITIVE);
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
 	Serial.println("Initializing lcd via I2C (IIC/TWI) interface");

--- a/samples/LiquidCrystal_44780/include/user_config.h
+++ b/samples/LiquidCrystal_44780/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/MeteoControl/app/application.cpp
+++ b/samples/MeteoControl/app/application.cpp
@@ -32,7 +32,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(false); // Debug output to serial
 
 	ActiveConfig = loadConfig();

--- a/samples/MeteoControl/include/user_config.h
+++ b/samples/MeteoControl/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -95,7 +95,7 @@ void connectFail()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Debug output to serial
 
 	WifiStation.config(WIFI_SSID, WIFI_PWD);

--- a/samples/MqttClient_Hello/include/user_config.h
+++ b/samples/MqttClient_Hello/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/PortExpander_MCP23017/include/user_config.h
+++ b/samples/PortExpander_MCP23017/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/PortExpander_MCP23S17/app/application.cpp
+++ b/samples/PortExpander_MCP23S17/app/application.cpp
@@ -21,7 +21,7 @@ void init()
 	inputchip.begin();
 	outputchip.begin();
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	WifiStation.enable(false);
 	WifiAccessPoint.enable(false);
 

--- a/samples/PortExpander_MCP23S17/include/user_config.h
+++ b/samples/PortExpander_MCP23S17/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Pressure_BMP180/app/application.cpp
+++ b/samples/Pressure_BMP180/app/application.cpp
@@ -5,7 +5,7 @@
 BMP180 barometer;
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
 	Wire.begin();

--- a/samples/Pressure_BMP180/include/user_config.h
+++ b/samples/Pressure_BMP180/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Radio_nRF24L01/app/application.cpp
+++ b/samples/Radio_nRF24L01/app/application.cpp
@@ -65,7 +65,7 @@ void loopListen()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
 	Serial.println("start");

--- a/samples/Radio_nRF24L01/include/user_config.h
+++ b/samples/Radio_nRF24L01/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Radio_si4432/app/application.cpp
+++ b/samples/Radio_si4432/app/application.cpp
@@ -96,7 +96,7 @@ void loopListen()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 
 	Serial.systemDebugOutput(true); //Allow debug output to serial
 

--- a/samples/Radio_si4432/include/user_config.h
+++ b/samples/Radio_si4432/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/SDCard/app/application.cpp
+++ b/samples/SDCard/app/application.cpp
@@ -146,7 +146,7 @@ void init()
 	FRESULT fRes;
 	uint32_t actual;
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
 	SDCardSPI = new SPISoft(PIN_CARD_DO, PIN_CARD_DI, PIN_CARD_CK, PIN_CARD_SS);

--- a/samples/SDCard/include/user_config.h
+++ b/samples/SDCard/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/ScreenLCD_5110/app/application.cpp
+++ b/samples/ScreenLCD_5110/app/application.cpp
@@ -33,7 +33,7 @@ void displayTest()
 }
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 	WifiStation.enable(false);

--- a/samples/ScreenLCD_5110/include/user_config.h
+++ b/samples/ScreenLCD_5110/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/ScreenOLED_SSD1306/app/application.cpp
+++ b/samples/ScreenOLED_SSD1306/app/application.cpp
@@ -81,7 +81,7 @@ void Demo1()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 	
 	// Wifi could be used eg. for display info from internet

--- a/samples/ScreenOLED_SSD1306/include/user_config.h
+++ b/samples/ScreenOLED_SSD1306/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/ScreenTFT_ILI9163C/app/application.cpp
+++ b/samples/ScreenTFT_ILI9163C/app/application.cpp
@@ -16,7 +16,7 @@ TFT_ILI9163C tft(2, 0);
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
 	Serial.println("Display start");

--- a/samples/ScreenTFT_ILI9163C/include/user_config.h
+++ b/samples/ScreenTFT_ILI9163C/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/ScreenTFT_ILI9340-ILI9341/app/application.cpp
+++ b/samples/ScreenTFT_ILI9340-ILI9341/app/application.cpp
@@ -69,7 +69,7 @@ void basicGui()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 	//WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(false);

--- a/samples/ScreenTFT_ILI9340-ILI9341/include/user_config.h
+++ b/samples/ScreenTFT_ILI9340-ILI9341/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/ScreenTFT_ST7735/app/application.cpp
+++ b/samples/ScreenTFT_ST7735/app/application.cpp
@@ -317,7 +317,7 @@ void init()
 {
 	spiffs_mount(); // Mount file system, in order to work with files
 
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
 	//WifiStation.config(WIFI_SSID, WIFI_PWD);

--- a/samples/ScreenTFT_ST7735/include/user_config.h
+++ b/samples/ScreenTFT_ST7735/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/SystemClock_NTP/app/application.cpp
+++ b/samples/SystemClock_NTP/app/application.cpp
@@ -100,7 +100,7 @@ void connectFail()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE);
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug print to serial
 	Serial.println("Sming. Let's do smart things!");
 

--- a/samples/SystemClock_NTP/include/user_config.h
+++ b/samples/SystemClock_NTP/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/TcpClient_NarodMon/include/user_config.h
+++ b/samples/TcpClient_NarodMon/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Telnet_TCPServer_TCPClient/app/application.cpp
+++ b/samples/Telnet_TCPServer_TCPClient/app/application.cpp
@@ -130,7 +130,7 @@ void connectFail()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 	Serial.commandProcessing(true);
 	WifiStation.enable(true);

--- a/samples/Telnet_TCPServer_TCPClient/include/user_config.h
+++ b/samples/Telnet_TCPServer_TCPClient/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Temperature_DS1820/app/application.cpp
+++ b/samples/Temperature_DS1820/app/application.cpp
@@ -63,7 +63,7 @@ void readData()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
     ReadTemp.Init(4);  			// select PIN It's required for one-wire initialization!

--- a/samples/Temperature_DS1820/include/user_config.h
+++ b/samples/Temperature_DS1820/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/UdpServer_Echo/app/application.cpp
+++ b/samples/UdpServer_Echo/app/application.cpp
@@ -42,7 +42,7 @@ void onConnected()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true);
 
 	WifiStation.config(WIFI_SSID, WIFI_PWD);

--- a/samples/UdpServer_Echo/include/user_config.h
+++ b/samples/UdpServer_Echo/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -109,7 +109,7 @@ void connectFail()
 
 void init()
 {
-	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.begin(COM_SPEED_SERIAL); // 115200 by default, change it in Makefile-user.mk
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
 

--- a/samples/UdpServer_mDNS/include/user_config.h
+++ b/samples/UdpServer_mDNS/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER

--- a/samples/Ultrasonic_HCSR04/include/user_config.h
+++ b/samples/Ultrasonic_HCSR04/include/user_config.h
@@ -5,9 +5,6 @@
 extern "C" {
 #endif
 
-	// UART config
-	#define SERIAL_BAUD_RATE 115200
-
 	// ESP SDK config
 	#define LWIP_OPEN_SRC
 	#define USE_US_TIMER


### PR DESCRIPTION
the Makefiles define COM_SPEED_SERIAL and use this to start the
terminal, but this value isn't passed to the code. inside user_config.h
there is SERIAL_BAUD_RATE that configures the port speed. this means
it's left up to the user to keep the two in sync, which is less than
ideal. this commit passes COM_SPEED_SERIAL to gcc as a define, and
changes all Serial.begin lines to use this instead of SERIAL_BAUD_RATE.