### PR TITLE
fixing autocomplete on some libraray for netbeans 

### DIFF
--- a/Sming/Libraries/Adafruit_GFX/Adafruit_GFX.h
+++ b/Sming/Libraries/Adafruit_GFX/Adafruit_GFX.h
@@ -21,45 +21,33 @@ class Adafruit_GFX : public Print {
 
   // These MAY be overridden by the subclass to provide device-specific
   // optimized code.  Otherwise 'generic' versions are used.
-  virtual void
-    drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color),
-    drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),
-    drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
-    drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
-    fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color),
-    fillScreen(uint16_t color),
-    invertDisplay(boolean i);
+  virtual void drawLine(int16_t x0, int16_t y0, int16_t x1, int16_t y1, uint16_t color);
+  virtual void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  virtual void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  virtual void drawRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  virtual void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  virtual void fillScreen(uint16_t color);
+  virtual void invertDisplay(boolean i);
 
   // These exist only with Adafruit_GFX (no subclass overrides)
-  void
-    drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-    drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-      uint16_t color),
-    fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color),
-    fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername,
-      int16_t delta, uint16_t color),
-    drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
-      int16_t x2, int16_t y2, uint16_t color),
-    fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1,
-      int16_t x2, int16_t y2, uint16_t color),
-    drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-      int16_t radius, uint16_t color),
-    fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h,
-      int16_t radius, uint16_t color),
-    drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color),
-    drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap,
-      int16_t w, int16_t h, uint16_t color, uint16_t bg),
-    drawXBitmap(int16_t x, int16_t y, const uint8_t *bitmap, 
-      int16_t w, int16_t h, uint16_t color),
-    drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color,
-      uint16_t bg, uint8_t size),
-    setCursor(int16_t x, int16_t y),
-    setTextColor(uint16_t c),
-    setTextColor(uint16_t c, uint16_t bg),
-    setTextSize(uint8_t s),
-    setTextWrap(boolean w),
-    setRotation(uint8_t r);
+  void drawCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
+  void drawCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, uint16_t color);
+  void fillCircle(int16_t x0, int16_t y0, int16_t r, uint16_t color);
+  void fillCircleHelper(int16_t x0, int16_t y0, int16_t r, uint8_t cornername, int16_t delta, uint16_t color);
+  void drawTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color);
+  void fillTriangle(int16_t x0, int16_t y0, int16_t x1, int16_t y1, int16_t x2, int16_t y2, uint16_t color);
+  void drawRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius, uint16_t color);
+  void fillRoundRect(int16_t x0, int16_t y0, int16_t w, int16_t h, int16_t radius, uint16_t color);
+  void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color);
+  void drawBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color, uint16_t bg);
+  void drawXBitmap(int16_t x, int16_t y, const uint8_t *bitmap, int16_t w, int16_t h, uint16_t color);
+  void drawChar(int16_t x, int16_t y, unsigned char c, uint16_t color, uint16_t bg, uint8_t size);
+  void setCursor(int16_t x, int16_t y);
+  void setTextColor(uint16_t c);
+  void setTextColor(uint16_t c, uint16_t bg);
+  void setTextSize(uint8_t s);
+  void setTextWrap(boolean w);
+  void setRotation(uint8_t r);
 
 #if ARDUINO >= 100
   virtual size_t write(uint8_t);

--- a/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.h
+++ b/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.h
@@ -140,15 +140,14 @@ private:
 public:
   Adafruit_ILI9341();
 
-  void     begin(void),
-           fillScreen(uint16_t color),
-           drawPixel(int16_t x, int16_t y, uint16_t color),
-           drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),
-           drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
-           fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
-             uint16_t color),
-           setRotation(uint8_t r),
-           invertDisplay(bool i);
+  void begin(void);
+  void fillScreen(uint16_t color);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  void setRotation(uint8_t r);
+  void invertDisplay(bool i);
   inline void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1)
   {	  transmitCmdData(ILI9341_CASET, MAKEWORD(x0 >> 8, x0 & 0xFF, x1 >> 8, x1 & 0xFF));
   	  transmitCmdData(ILI9341_PASET, MAKEWORD(y0 >> 8, y0 & 0xFF, y1 >> 8, y1 & 0xFF));

--- a/Sming/Libraries/Adafruit_NeoPixel/Adafruit_NeoPixel.h
+++ b/Sming/Libraries/Adafruit_NeoPixel/Adafruit_NeoPixel.h
@@ -49,25 +49,19 @@ class Adafruit_NeoPixel {
   Adafruit_NeoPixel(uint16_t n, uint8_t p=6, uint8_t t=NEO_GRB + NEO_KHZ800);
   ~Adafruit_NeoPixel();
 
-  void
-    begin(void),
-    show(void),
-    setPin(uint8_t p),
-    setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b),
-    setPixelColor(uint16_t n, uint32_t c),
-    setBrightness(uint8_t),
-    clear();
-  uint8_t
-   *getPixels(void) const,
-    getBrightness(void) const;
-  uint16_t
-    numPixels(void) const;
-  static uint32_t
-    Color(uint8_t r, uint8_t g, uint8_t b);
-  uint32_t
-    getPixelColor(uint16_t n) const;
-  inline bool
-    canShow(void) { return (micros() - endTime) >= 50L; }
+  void begin(void);
+  void show(void);
+  void setPin(uint8_t p);
+  void setPixelColor(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
+  void setPixelColor(uint16_t n, uint32_t c);
+  void setBrightness(uint8_t);
+  void clear();
+  uint8_t *getPixels(void) const;
+  uint8_t getBrightness(void) const;
+  uint16_t numPixels(void) const;
+  static uint32_t Color(uint8_t r, uint8_t g, uint8_t b);
+  uint32_t getPixelColor(uint16_t n) const;
+  inline bool canShow(void) { return (micros() - endTime) >= 50L; }
 
  private:
 

--- a/Sming/Libraries/Adafruit_ST7735/Adafruit_ST7735.h
+++ b/Sming/Libraries/Adafruit_ST7735/Adafruit_ST7735.h
@@ -134,18 +134,17 @@ class Adafruit_ST7735 : public Adafruit_GFX {
   Adafruit_ST7735(int8_t CS, int8_t RS, int8_t SID, int8_t SCLK, int8_t RST = -1);
   Adafruit_ST7735(int8_t CS, int8_t RS, int8_t RST = -1);
 
-  void     initB(void),                             // for ST7735B displays
-           initR(uint8_t options = INITR_GREENTAB), // for ST7735R
-           setAddrWindow(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1),
-           pushColor(uint16_t color),
-           fillScreen(uint16_t color),
-           drawPixel(int16_t x, int16_t y, uint16_t color),
-           drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),
-           drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
-           fillRect(int16_t x, int16_t y, int16_t w, int16_t h,
-             uint16_t color),
-           setRotation(uint8_t r),
-           invertDisplay(boolean i);
+  void initB(void);                             // for ST7735B displays
+  void initR(uint8_t options = INITR_GREENTAB); // for ST7735R
+  void setAddrWindow(uint8_t x0, uint8_t y0, uint8_t x1, uint8_t y1);
+  void pushColor(uint16_t color);
+  void fillScreen(uint16_t color);
+  void drawPixel(int16_t x, int16_t y, uint16_t color);
+  void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+  void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+  void fillRect(int16_t x, int16_t y, int16_t w, int16_t h, uint16_t color);
+  void setRotation(uint8_t r);
+  void invertDisplay(boolean i);
   uint16_t Color565(uint8_t r, uint8_t g, uint8_t b);
 
   /* These are not for current use, 8-bit protocol only!
@@ -159,11 +158,11 @@ class Adafruit_ST7735 : public Adafruit_GFX {
  private:
   uint8_t  tabcolor;
 
-  void     spiwrite(uint8_t),
-           writecommand(uint8_t c),
-           writedata(uint8_t d),
-           commandList(const uint8_t *addr),
-           commonInit(const uint8_t *cmdList);
+  void spiwrite(uint8_t);
+  void writecommand(uint8_t c);
+  void writedata(uint8_t d);
+  void commandList(const uint8_t *addr);
+  void commonInit(const uint8_t *cmdList);
 //uint8_t  spiread(void);
 
   boolean  hwSPI;

--- a/Sming/Libraries/TFT_ILI9163C/TFT_ILI9163C.h
+++ b/Sming/Libraries/TFT_ILI9163C/TFT_ILI9163C.h
@@ -247,20 +247,20 @@ class TFT_ILI9163C : public Adafruit_GFX {
 	TFT_ILI9163C(uint8_t cspin,uint8_t dcpin,uint8_t rstpin);
 	TFT_ILI9163C(uint8_t CS, uint8_t DC);//connect rst pin to VDD
 	
-	void     	begin(void),
-				setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1),//graphic Addressing
-				setCursor(int16_t x,int16_t y),//char addressing
-				pushColor(uint16_t color),
-				fillScreen(uint16_t color=0x0000),
-				clearScreen(uint16_t color=0x0000),//same as fillScreen
-				drawPixel(int16_t x, int16_t y, uint16_t color),
-				drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color),
-				drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color),
-				fillRect(int16_t x, int16_t y, int16_t w, int16_t h,uint16_t color),
-				setRotation(uint8_t r),
-				invertDisplay(boolean i);
-  uint16_t 		Color565(uint8_t r, uint8_t g, uint8_t b);
-  void 			setBitrate(uint32_t n);	
+	void begin(void);
+        void setAddrWindow(uint16_t x0, uint16_t y0, uint16_t x1, uint16_t y1);//graphic Addressing
+	void setCursor(int16_t x,int16_t y);//char addressing
+	void pushColor(uint16_t color);
+        void fillScreen(uint16_t color=0x0000);
+        void clearScreen(uint16_t color=0x0000);//same as fillScreen
+        void drawPixel(int16_t x, int16_t y, uint16_t color);
+        void drawFastVLine(int16_t x, int16_t y, int16_t h, uint16_t color);
+	void drawFastHLine(int16_t x, int16_t y, int16_t w, uint16_t color);
+        void fillRect(int16_t x, int16_t y, int16_t w, int16_t h,uint16_t color);
+	void setRotation(uint8_t r);
+        void invertDisplay(boolean i);
+        uint16_t Color565(uint8_t r, uint8_t g, uint8_t b);
+        void setBitrate(uint32_t n);	
 
  private:
 	uint8_t		_Mactrl_Data;//container for the memory access control data


### PR DESCRIPTION
Netbeans has a problem with the short declaration of methods like: 
`
void a(int i),b(int v, int x),c();
`

so i changed it to the more readable declaration:
```
void a(int i);
void b(int v, int x);
void c();
```