### PR TITLE
MQTT ping sending modification (setPingRepeatTime added)

### DIFF
--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -279,7 +279,8 @@ err_t MqttClient::onReceive(pbuf *buf)
 
 void MqttClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 {
-	// Send PINGREQ every keepAlive time, if there is no outgoing traffic
+	// Send PINGREQ every PingRepeatTime time, if there is no outgoing traffic
+	// PingRepeatTime should be <= keepAlive
 	if (lastMessage && (millis() - lastMessage >= PingRepeatTime*1000))
 	{
 		mqtt_ping(&broker);

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -43,6 +43,14 @@ void MqttClient::setKeepAlive(int seconds)
 	keepAlive = seconds;
 }
 
+void MqttClient::setPingRepeatTime(int seconds)
+{
+	if (PingRepeatTime > keepAlive)
+	   PingRepeatTime = keepAlive;
+	else   
+	   PingRepeatTime = seconds;
+}
+
 bool MqttClient::setWill(String topic, String message, int QoS, bool retained /* = false*/)
 {
 	return mqtt_set_will(&broker, topic.c_str(), message.c_str(), QoS, retained);
@@ -272,7 +280,7 @@ err_t MqttClient::onReceive(pbuf *buf)
 void MqttClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 {
 	// Send PINGREQ every keepAlive time, if there is no outgoing traffic
-	if (lastMessage && (millis() - lastMessage >= keepAlive*1000))
+	if (lastMessage && (millis() - lastMessage >= PingRepeatTime*1000))
 	{
 		mqtt_ping(&broker);
 	}

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -29,6 +29,7 @@ public:
 	virtual ~MqttClient();
 
 	void setKeepAlive(int seconds);
+	void setPingRepeatTime(int seconds);
 	// Sets Last Will and Testament
 	bool setWill(String topic, String message, int QoS, bool retained = false);
 
@@ -62,7 +63,8 @@ private:
 	uint8_t *current;
 	int posHeader;
 	MqttStringSubscriptionCallback callback;
-	int keepAlive = 20;
+	int keepAlive = 60;
+	int PingRepeatTime = 20;
 	unsigned long lastMessage;
 };
 

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -28,8 +28,8 @@ public:
 	MqttClient(IPAddress serverIp, int serverPort, MqttStringSubscriptionCallback callback = NULL);
 	virtual ~MqttClient();
 
-	void setKeepAlive(int seconds);
-	void setPingRepeatTime(int seconds);
+	void setKeepAlive(int seconds);			//send to broker
+	void setPingRepeatTime(int seconds);            //used by client
 	// Sets Last Will and Testament
 	bool setWill(String topic, String message, int QoS, bool retained = false);
 


### PR DESCRIPTION
in accordance with the #628  
This solution lets you freely modify the Mqtt client ping frequency regardless of the broker keepAlive.
Default: PingRepeatTime (used on client side) = 20s, KeepAlive (used on broker side) = 60s
It can be changed by:
setKeepAlive(seconds)  and setPingRepeatTime(seconds) metod.
PingRepeatTime should be less than or equal to keepAlive.

