### PR TITLE
use printTo instead of prettyPrintTo

### DIFF
--- a/Sming/SmingCore/DataSourceStream.cpp
+++ b/Sming/SmingCore/DataSourceStream.cpp
@@ -296,7 +296,7 @@ uint16_t JsonObjectStream::readMemoryBlock(char* data, int bufSize)
 {
 	if (rootNode != JsonObject::invalid() && send)
 	{
-		int len = rootNode.prettyPrintTo(*this);
+		int len = rootNode.printTo(*this);
 		send = false;
 	}
 


### PR DESCRIPTION
saves memory for larger json objects