### PR TITLE
Tests malloc/realloc return values in MemoryDataStream->write

### DIFF
--- a/Sming/SmingCore/DataSourceStream.cpp
+++ b/Sming/SmingCore/DataSourceStream.cpp
@@ -50,10 +50,15 @@ size_t MemoryDataStream::write(const uint8_t* data, size_t len)
 		{
 			capacity = required < 256 ? required + 128 : required + 64;
 			debugf("realloc %d -> %d", size, capacity);
-			buf = (char*)realloc(buf, capacity);
+			char * new_buf;
+			//realloc can fail, store the result in temporary pointer
+			new_buf = (char*)realloc(buf, capacity);
 
-			if (buf == NULL)
+			if (new_buf == NULL)
+			{
 				return 0;
+			}
+			buf = new_buf;
 		}
 		buf[cur + len] = '\0';
 		memcpy(buf + cur, data, len);

--- a/Sming/SmingCore/DataSourceStream.cpp
+++ b/Sming/SmingCore/DataSourceStream.cpp
@@ -37,6 +37,8 @@ size_t MemoryDataStream::write(const uint8_t* data, size_t len)
 	if (buf == NULL)
 	{
 		buf = (char*)malloc(len + 1);
+		if (buf == NULL)
+			return 0;
 		buf[len] = '\0';
 		memcpy(buf, data, len);
 	}
@@ -49,6 +51,9 @@ size_t MemoryDataStream::write(const uint8_t* data, size_t len)
 			capacity = required < 256 ? required + 128 : required + 64;
 			debugf("realloc %d -> %d", size, capacity);
 			buf = (char*)realloc(buf, capacity);
+
+			if (buf == NULL)
+				return 0;
 		}
 		buf[cur + len] = '\0';
 		memcpy(buf + cur, data, len);

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -81,7 +81,9 @@ bool TcpClient::send(const char* data, uint16_t len, bool forceCloseAfterSent /*
 	if (stream == NULL)
 		stream = new MemoryDataStream();
 
-	stream->write((const uint8_t*)data, len);
+	if (stream->write((const uint8_t*)data, len) != len)
+		return false;
+
 	asyncTotalLen += len;
 	asyncCloseAfterSent = forceCloseAfterSent;
 


### PR DESCRIPTION
malloc/realloc function call return values were not checked and used as buffers which could lead to NULL pointer de-referencing crashes.

Additionally, TcpClient->send now fails when there was no free space in underlying memory stream.