### PR TITLE
Disable extra debug info from WifiEvents

### DIFF
--- a/Sming/SmingCore/Platform/WifiEvents.cpp
+++ b/Sming/SmingCore/Platform/WifiEvents.cpp
@@ -56,7 +56,7 @@ void WifiEventsClass::staticWifiEventHandler(System_Event_t *evt)
 
 void WifiEventsClass::WifiEventHandler(System_Event_t *evt)
 {
-	debugf("event %x\n", evt->event);
+//	debugf("event %x\n", evt->event);
 
 	switch (evt->event)
 	{


### PR DESCRIPTION
Disable logging to console every wifi event