### PR TITLE
Make Wifi*.enable(*,true) consistent

### DIFF
--- a/Sming/SmingCore/Platform/AccessPoint.cpp
+++ b/Sming/SmingCore/Platform/AccessPoint.cpp
@@ -18,7 +18,11 @@ AccessPointClass::AccessPointClass()
 
 void AccessPointClass::enable(bool enabled, bool save)
 {
-	uint8 mode = wifi_get_opmode() & ~SOFTAP_MODE;
+	uint8 mode;
+	if (save)
+		mode = wifi_get_opmode_default() & ~SOFTAP_MODE;
+	else
+		mode = wifi_get_opmode() & ~SOFTAP_MODE;
 	if (enabled) mode |= SOFTAP_MODE;
 	if (save)
 		wifi_set_opmode(mode);

--- a/Sming/SmingCore/Platform/Station.cpp
+++ b/Sming/SmingCore/Platform/Station.cpp
@@ -28,7 +28,11 @@ StationClass::~StationClass()
 
 void StationClass::enable(bool enabled, bool save)
 {
-	uint8 mode = wifi_get_opmode() & ~STATION_MODE;
+	uint8 mode;
+	if (save)
+		mode = wifi_get_opmode_default() & ~STATION_MODE;
+	else
+		mode = wifi_get_opmode() & ~STATION_MODE;
 	if (enabled) mode |= STATION_MODE;
 	if (save)
 		wifi_set_opmode(mode);


### PR DESCRIPTION
WifiStation & WifiAccessPoin.enable with second argument true (save
config to flash) now save JUST what was asked to save.
Testcase:
WifiAccessPoint.enable(true);
WifiStation.enable(true,true);

will enable SOFTAP runtime then enable STA runtime and save STA enable
to flash, no SOFTAP enable will be savedto flash
