### PR TITLE
Return content-length with HttpResponse

### DIFF
--- a/Sming/SmingCore/Network/HttpResponse.cpp
+++ b/Sming/SmingCore/Network/HttpResponse.cpp
@@ -64,6 +64,17 @@ int HttpResponse::getStatusCode()
 	return status.substring(0, p).toInt();
 }
 
+void HttpResponse::setStatus(String statusline) {
+	status = statusline;
+}
+
+void HttpResponse::setStatus(int code, String msg /* = "" */)
+{
+	status = String(code) + " " + msg;
+}
+
+
+
 bool HttpResponse::hasBody()
 {
 	return stream != NULL || bodySent;

--- a/Sming/SmingCore/Network/HttpResponse.h
+++ b/Sming/SmingCore/Network/HttpResponse.h
@@ -30,6 +30,8 @@ public:
 	void authorizationRequired();
 	void redirect(String location = "");
 
+	void setStatus(int code, String msg = "");
+	void setStatus(String statusline);
 	void setContentType(const String type);
 	void setCookie(const String name, const String value);
 	void setHeader(const String name, const String value);


### PR DESCRIPTION
- allow for setting custom response codes / messages 
  The respond messages provided with sming are limited to a small amount, this allows for setting a custom / non-provided response code and makes the webserver more versatile
- return Content-Length header field for files, json and memory messages  
  It is recommended practice for http-server to also return a content-length as response

Unfortunatly I haven`t found a way to create a buffer-length with the template method - any hints or ideas and I will try to also include this
