### PR TITLE
fix ArduinoJson overloading String define

### DIFF
--- a/Sming/Services/ArduinoJson/include/ArduinoJson/Arduino/String.hpp
+++ b/Sming/Services/ArduinoJson/include/ArduinoJson/Arduino/String.hpp
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#ifndef ARDUINO
+#if !defined(ARDUINO) && !defined(SMING_VERSION)
 
 #include <string>
 typedef std::string String;


### PR DESCRIPTION
Eclipse would show errors, that String is ambiguous. 
This was a result of ArduinoJson providing a second definition for String.

Adding a check for SMING_VERSION and ARDUINO resolves this problem.

I am not sure if defining ARDUINO would provide a better alternative to having to include this modified check with every arduinojson version?
