### PR TITLE
make header-fields case-insensitive

### DIFF
--- a/Sming/SmingCore/Network/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/HttpRequest.cpp
@@ -53,6 +53,7 @@ String HttpRequest::getPostParameter(String parameterName, String defaultValue /
 
 String HttpRequest::getHeader(String headerName, String defaultValue /* = "" */)
 {
+	headerName.toLowerCase();
 	if (requestHeaders && requestHeaders->contains(headerName))
 		return (*requestHeaders)[headerName];
 
@@ -130,10 +131,11 @@ HttpParseResult HttpRequest::parseHeader(HttpServer *server, pbuf* buf)
 			if (delim != -1)
 			{
 				String name = tmpbuf.substring(line, delim);
+				name.toLowerCase();
 				if (server->isHeaderProcessingEnabled(name))
 				{
 					debugf("Name: %s", name.c_str());
-					if (name == "Cookie")
+					if (name == "cookie")
 					{
 						if (cookies == NULL) cookies = new HashMap<String, String>();
 						extractParsingItemsList(tmpbuf, delim + 1, nextLine, ';', '\r', cookies);

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -41,6 +41,7 @@ TcpConnection* HttpServer::createClient(tcp_pcb *clientTcp)
 
 void HttpServer::enableHeaderProcessing(String headerName)
 {
+	headerName.toLowerCase();
 	for (int i = 0; i < processingHeaders.count(); i++)
 		if (processingHeaders[i].equals(headerName))
 			return;


### PR DESCRIPTION
In order to comply with rfc7230 headerfields are now parsed case-insensitive and retrieved case-insensitive

fixes #672