### PR TITLE
Feature/http multipart post (file upload to sming webserver)

### DIFF
--- a/Sming/SmingCore/Network/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/HttpRequest.cpp
@@ -9,6 +9,7 @@
 #include "HttpServer.h"
 #include "NetUtils.h"
 #include <stdlib.h>
+#include "../SmingCore.h"
 #include "../../Services/WebHelpers/escape.h"
 
 HttpRequest::HttpRequest()
@@ -19,7 +20,9 @@ HttpRequest::HttpRequest()
 	cookies = NULL;
 	headerDataProcessed = 0;
 	postDataProcessed = 0;
-	bodyBuf = NULL;
+	postParamSize = 0;
+	multipart = NULL;
+	uploads = NULL;
 	tmpbuf = "";
 }
 
@@ -29,11 +32,28 @@ HttpRequest::~HttpRequest()
 	delete requestGetParameters;
 	delete requestPostParameters;
 	delete cookies;
+	headerDataProcessed = 0;
 	postDataProcessed = 0;
-	if (bodyBuf != NULL)
+	postParamSize = 0;
+
+	// cleanup multipart
+	if(multipart != NULL )
 	{
-		os_free(bodyBuf);
+		if (multipart->buf != NULL)
+		{
+			delete[] multipart-> buf;
+		}
+		delete multipart;
 	}
+	// cleanup upload objects
+	if(uploads != NULL)
+	{
+		for (int i = 0; i < uploads->count(); i++) {
+			delete uploads->get(i);
+		}
+		delete uploads;
+	}
+
 }
 
 String HttpRequest::getQueryParameter(String parameterName, String defaultValue /* = "" */)
@@ -88,7 +108,7 @@ HttpParseResult HttpRequest::parseHeader(HttpServer *server, pbuf* buf)
 		|| (headerEnd != -1 && buf->tot_len > NETWORK_MAX_HTTP_PARSING_LEN))
 	{
 		debugf("NETWORK_MAX_HTTP_PARSING_LEN");
-		return eHPR_Failed;
+		return eHPR_Failed_Header_Too_Large;
 	}
 	int urlEnd = 0;
 	tmpbuf += NetUtils::pbufStrCopy(buf, 0, buf->tot_len);
@@ -114,6 +134,10 @@ HttpParseResult HttpRequest::parseHeader(HttpServer *server, pbuf* buf)
 		}
 		else
 			path = tmpbuf.substring(urlStart, urlEnd);
+		//TODO: uri unescape path
+		char* ppath = uri_unescape(NULL, 0, path.c_str(), -1);
+		path = ppath;
+		free(ppath);
 		debugf("path=%s", path.c_str());
 		urlEnd = tmpbuf.indexOf("\r\n", urlEnd)+2;
 	}
@@ -134,11 +158,31 @@ HttpParseResult HttpRequest::parseHeader(HttpServer *server, pbuf* buf)
 				name.toLowerCase();
 				if (server->isHeaderProcessingEnabled(name))
 				{
-					debugf("Name: %s", name.c_str());
 					if (name == "cookie")
 					{
 						if (cookies == NULL) cookies = new HashMap<String, String>();
 						extractParsingItemsList(tmpbuf, delim + 1, nextLine, ';', '\r', cookies);
+					}
+					else if(name == "content-type")
+					{
+						String value = tmpbuf.substring(delim + 1, nextLine);
+						value.trim();
+						String tmpvalue = value;
+						tmpvalue.toLowerCase();
+						if (tmpvalue.indexOf(ContentType::FormMultipart) != -1) {
+							//is multipart header
+							int boundary_start = tmpvalue.indexOf("boundary=");
+							if(boundary_start == -1) {
+								debugf("missing boundary param");
+								return eHPR_Failed;
+							}
+							String boundary = extractHeaderValue(value, "=", ";", boundary_start+8);
+							(*requestHeaders)["boundary"] = boundary;
+							debugf("multipart - boundary === %s",  boundary.c_str());
+							value = value.substring(0, value.indexOf(";"));
+						}
+						(*requestHeaders)[name] = value;
+						debugf("%s === %s", name.c_str(), value.c_str());
 					}
 					else
 					{
@@ -176,7 +220,7 @@ HttpParseResult HttpRequest::parsePostData(HttpServer *server, pbuf* buf)
 	// First enter
 	if (requestPostParameters == NULL)
 	{
-		int headerEnd = NetUtils::pbufFindStr(buf, "\r\n\r\n");
+		int headerEnd = tmpbuf.indexOf("\r\n\r\n");
 		if (headerEnd == -1) return eHPR_Failed;
 		if (headerEnd + getContentLength() > NETWORK_MAX_HTTP_PARSING_LEN)
 		{
@@ -185,13 +229,18 @@ HttpParseResult HttpRequest::parsePostData(HttpServer *server, pbuf* buf)
 		}
 		requestPostParameters = new HashMap<String, String>();
 		start = headerEnd + 4;
+		if(buf->len - start == 0)
+		{
+			tmpbuf = "";
+			return eHPR_Wait; // no more data
+		}
 		tmpbuf = tmpbuf.substring(start, tmpbuf.length());
 	}
 
 	//parse if it is FormUrlEncoded - otherwise keep in buffer
-	String contType = getContentType();
-	contType.toLowerCase();
-	if (contType.indexOf(ContentType::FormUrlEncoded) != -1)
+	String conType = getContentType();
+	conType.toLowerCase();
+	if (conType.indexOf(ContentType::FormUrlEncoded) != -1)
 	{
 		tmpbuf = extractParsingItemsList(tmpbuf, 0, tmpbuf.length(), '&', ' ', requestPostParameters);
 	}
@@ -212,6 +261,463 @@ HttpParseResult HttpRequest::parsePostData(HttpServer *server, pbuf* buf)
 	{
 		return eHPR_Wait;
 	}
+}
+
+HttpParseResult HttpRequest::parseMultipartPostData(HttpServer *server, pbuf* buf)
+{
+	int start = 0;
+
+	// First enter
+	if (requestPostParameters == NULL)
+	{
+		debugf("First Enter");
+
+		int headerEnd = NetUtils::pbufFindStr(buf, "\r\n\r\n");
+		if (headerEnd == -1) return eHPR_Failed;
+
+
+		if(!server->isUploadEnabled(path)) {
+			debugf("Upload not allowed for %s", path.c_str());
+			return eHPR_Failed;
+		}
+		// multipart - create buffer and set initial status
+		multipart = new Multipart();
+		multipart->buflen = 0;
+		multipart->buf = NULL;
+		multipart->status = MULTIPART_START;
+		multipart->begin_boundary = "--"+getHeader("boundary");
+		multipart->end_boundary = "--"+getHeader("boundary")+"--";
+		multipart->upload = NULL;
+
+		// TODO: better method for checking free space
+		u32_t total, used;
+		long res = SPIFFS_info(&_filesystemStorageHandle, &total, &used);
+		// check if we have enough free space
+		debugf("Free space: %i - content-length: %i", total-used, getContentLength());
+		if(total - used <= getContentLength()) {
+
+			debugf("UPLOAD TOO LARGE!");
+			return eHPR_Failed_Not_Enough_Space;
+		}
+
+
+
+		requestPostParameters = new HashMap<String, String>();
+		start = headerEnd + 4;
+		if(buf->len - start == 0) return eHPR_Wait;
+
+	}
+
+	String name, filename, cdisp, ctype;
+	int mpheaderstart = start;
+	int mpheaderend = 0;
+	int curbuflen = 0;
+
+	char* curbuf;
+
+
+	if(multipart->buf ==  NULL )
+	{
+
+		// no previous buffer - just copy the data over to curbuf
+		debugf("mpbuf->len == 0");
+		curbuflen = buf->len - start;
+		curbuf = new char[curbuflen];
+		pbuf_copy_partial(buf, curbuf, curbuflen, start);
+
+		debugf("curbuflen %i ", curbuflen);
+	}
+	else
+	{
+
+		// previous buffer - combine the old buffer and the pbuf data
+		debugf("mpbuf->len >> 0");
+		curbuflen =  buf->len - start + multipart->buflen;
+		curbuf = new char[curbuflen];
+		os_memcpy(curbuf, multipart->buf, multipart->buflen);
+		pbuf_copy_partial(buf, &curbuf[multipart->buflen], buf->len - start, start);
+		delete[] multipart->buf;
+		multipart->buf = NULL;
+
+		debugf("curbuflen %i mpbuf->len %i", curbuflen, multipart->buflen);
+	}
+
+
+	while(true)
+	{
+		if (multipart->status == MULTIPART_START)
+		{
+
+			// looking for header in multipart
+			debugf("parsing multipart header");
+			mpheaderend = NetUtils::cbufFindStr(curbuf, "\r\n\r\n", curbuflen, mpheaderstart);
+
+			//debugf("mpheaderstart %i - mpheaderend %i", mpheaderstart, mpheaderend);
+			if (mpheaderend == -1 )
+			{
+
+				if(curbuflen > NETWORK_MAX_HTTP_PARSING_LEN) {
+					debugf("missing multipart header");
+					return eHPR_Failed_Body_Too_Large;
+				}
+				multipart->buflen = curbuflen-mpheaderstart;
+				if(multipart->buf != NULL) delete[] multipart->buf;
+				multipart->buf = new char[curbuflen-mpheaderstart];
+				os_memcpy(multipart->buf, &curbuf[mpheaderstart], curbuflen-mpheaderstart);
+				debugf("waiting for multipart header");
+				break;
+			}
+			String header = NetUtils::cbufStrCopy(curbuf, mpheaderstart, mpheaderend-mpheaderstart+4);
+			//debugf("===== HEADER ==========");
+			//debugf("%s", header.c_str());
+			//debugf("=======================");
+
+			int boundary = header.indexOf(multipart->begin_boundary.c_str());
+			if(boundary == -1)
+			{
+				debugf("missing boundary");
+				return eHPR_Failed;
+			}
+
+			ctype = "";
+			cdisp = "";
+			filename = "";
+			name = "";
+			int line, nextLine;
+			line = boundary + multipart->begin_boundary.length()+2;
+			do
+			{
+
+				nextLine = header.indexOf("\r\n", line);
+				if (nextLine - line > 2)
+
+				{
+					int delim = header.indexOf(":", line);
+					if (delim != -1)
+					{
+						String name = header.substring(line, delim);
+						name.toLowerCase();
+						String value = header.substring(delim + 1, nextLine);
+						value.trim();
+						debugf("%s === %s", name.c_str(), value.c_str());
+						if(name == "content-disposition")
+						{
+							cdisp = value;
+						}
+						else if (name == "content-type")
+						{
+							ctype = value;
+						}
+
+					}
+
+				}
+				if (nextLine != -1) line = nextLine + 2;
+
+			} while(nextLine != -1);
+
+			if (cdisp == "")
+			{
+				debugf("missing ctype");
+				return eHPR_Failed;
+			}
+			else
+			{
+
+				int n = cdisp.indexOf("name");
+				if(n != -1) name = extractHeaderValue(cdisp, "=", ";", n);
+
+				int fn = cdisp.indexOf("filename");
+				if(fn != -1) filename = extractHeaderValue(cdisp, "=", ";", fn);
+
+
+			}
+
+			if(name == "") {
+				debugf("missing variable name");
+				return eHPR_Failed;
+			}
+
+			// HTTP RFC - if no Content-Type supplied assume text/plain
+			if(ctype == "") ctype = "text/plain";
+
+			if(filename != "")
+			{
+				//TODO: check that filename is not longer than 31chars
+				//TODO: check that filename only has valid chars
+				//if(multipart->upload != NULL) delete multipart->upload;
+
+				multipart->upload = new HttpUpload();
+
+				multipart->upload->filename = filename;
+				multipart->upload->totalSize = 0;
+				multipart->upload->name = name;
+				multipart->upload->type = ctype;
+				multipart->upload->status = HTTP_UPLOAD_BEGIN;
+				if(uploads == NULL) uploads = new Vector<HttpUpload*>;
+				uploads->add(multipart->upload);
+
+				debugf("callback for HTTP upload start");
+				server->uploads[path](*this, *multipart->upload);
+
+				if(multipart->upload->status != HTTP_UPLOAD_WRITE_CUSTOM)
+				{
+					//multipart->upload->status = HTTP_UPLOAD_BEGIN; //ensure we are at begin
+					handleUpload();
+					multipart->upload->status = HTTP_UPLOAD_WRITE;
+				}
+
+
+			}
+			else
+			{
+				// not a file upload
+				//if(multipart->upload != NULL) delete multipart->upload;
+				multipart->upload = NULL;
+			}
+
+			multipart->status = MULTIPART_CONTENT;
+			mpheaderend += 4;
+
+		}
+
+		int nextboundary = NetUtils::cbufFindStr(curbuf, multipart->begin_boundary.c_str(), curbuflen, mpheaderend);
+
+		if (nextboundary == -1) {
+			debugf("no boundary");
+			// if we didn`t find boundary - we need to write last packet until current
+			// packetend substracing X chars and keep them in buffer to see if the
+			// boundary is split between packets/pbufs
+
+			int boundarylen = getHeader("boundary").length() + 2;
+			if (curbuflen < boundarylen) boundarylen = curbuflen;
+			multipart->buflen = boundarylen;
+			if(multipart->buf != NULL) delete[] multipart->buf;
+			multipart->buf = new char[boundarylen];
+			os_memcpy(multipart->buf, &curbuf[curbuflen-boundarylen], boundarylen);
+
+			debugf("curfbuflen %i boundarylen %i mpbuf->len ", curbuflen, boundarylen, multipart->buflen);
+
+			if(multipart->upload == NULL)
+			{
+				//not a file parsing as normal post parameter
+				postParamSize += curbuflen-mpheaderend;
+
+				// check if we can actually parse it
+				if (postParamSize > NETWORK_MAX_HTTP_PARSING_LEN)
+				{
+
+					debugf("NETWORK_MAX_HTTP_PARSING_LEN");
+					return eHPR_Failed_Body_Too_Large;
+				}
+
+				String value = NetUtils::cbufStrCopy(curbuf, mpheaderend, curbuflen-mpheaderend-boundarylen);
+
+				if(getPostParameter(name) == "")
+				{
+					(*requestPostParameters)[name] = value;
+				}
+				else
+				{
+
+					(*requestPostParameters)[name] += value;
+				}
+				debugf("requestPostParameter %s === %s", name.c_str(), getPostParameter(name).c_str());
+
+			}
+			else
+			{
+				if(multipart->upload->status != HTTP_UPLOAD_SKIP && multipart->upload->status != HTTP_UPLOAD_ABORT)
+				{
+					multipart->upload->bufferdata = &curbuf[mpheaderend];
+					multipart->upload->curSize = curbuflen - mpheaderend -boundarylen;
+
+					multipart->upload->totalSize += multipart->upload->curSize;
+
+					//debugf("startPos %i - curSize %i", mpheaderend, multipart->upload->curSize);
+					if(multipart->upload->status == HTTP_UPLOAD_WRITE_CUSTOM)
+					{
+
+						server->uploads[path](*this, *multipart->upload);
+					}
+					else
+					{
+						handleUpload();
+					}
+				}
+			}
+
+			//end loop since there is no more boundary in the buffer
+			break;
+
+		} else {
+			debugf("found boundary");
+			if(multipart->upload == NULL)
+			{
+
+				//not a file parsing as normal post parameter
+				postParamSize += nextboundary - mpheaderend - 2;
+
+				// check if we can actually parse it
+				if (postParamSize > NETWORK_MAX_HTTP_PARSING_LEN)
+				{
+
+					debugf("NETWORK_MAX_HTTP_PARSING_LEN");
+					return eHPR_Failed_Body_Too_Large;
+				}
+
+				String value = NetUtils::cbufStrCopy(curbuf, mpheaderend, nextboundary - mpheaderend - 2);
+
+				if(getPostParameter(name) == "")
+				{
+
+					(*requestPostParameters)[name] = value;
+				}
+				else
+				{
+
+					(*requestPostParameters)[name] += value;
+				}
+
+				debugf("requestPostParameter %s === %s", name.c_str(), getPostParameter(name).c_str());
+
+			}
+			else
+			{
+				if(multipart->upload->status != HTTP_UPLOAD_SKIP && multipart->upload->status != HTTP_UPLOAD_ERROR)
+				{
+					multipart->upload->bufferdata = &curbuf[mpheaderend];
+					multipart->upload->curSize = nextboundary - mpheaderend - 2;
+					debugf("startPos %i - curSize %i", mpheaderend, multipart->upload->curSize);
+					multipart->upload->totalSize += multipart->upload->curSize;
+
+					if(multipart->upload->status == HTTP_UPLOAD_WRITE_CUSTOM)
+					{
+						//write data
+						server->uploads[path](*this, *multipart->upload);
+
+						// signal end of upload reached
+						multipart->upload->status = HTTP_UPLOAD_FINISHED;
+						server->uploads[path](*this, *multipart->upload);
+
+						// set bufferdata/curSize to zero
+						multipart->upload->bufferdata = NULL;
+						multipart->upload->curSize = 0;
+
+					}
+					else
+					{
+						//write data
+						handleUpload();
+
+						// signal we reached the end of upload
+						multipart->upload->status = HTTP_UPLOAD_FINISHED;
+						handleUpload();
+
+						// set bufferdata/curSize to zero
+						multipart->upload->bufferdata = NULL;
+						multipart->upload->curSize = 0;
+
+					}
+				}
+			}
+			if(curbuf[nextboundary + getHeader("boundary").length() + 1] == '-' && curbuf[nextboundary + getHeader("boundary").length() + 2] == '-')
+			{
+				// finished parsing, end the loop
+				debugf("finished parsing multipart");
+				multipart->status = MULTIPART_END;
+				break;
+			}
+			else
+			{
+				// continue to next part in the current buffer
+				multipart->status = MULTIPART_START;
+				mpheaderstart = nextboundary;
+			}
+		}
+	}
+		// cleanup heap
+	delete[] curbuf;
+
+
+	postDataProcessed += buf->tot_len - start ;
+	//debugf("processed %i", postDataProcessed);
+	if (postDataProcessed == getContentLength())
+	{
+		return eHPR_Successful;
+	}
+	else if (postDataProcessed > getContentLength())
+	{
+		//avoid bufferoverflow if client announces non-correct content-length
+		debugf("NETWORK_MAX_HTTP_PARSING_LEN");
+		return eHPR_Failed;
+	}
+	else
+	{
+		return eHPR_Wait;
+	}
+}
+
+void HttpRequest::handleUpload() {
+	debugf("HttpRequest::handleUpload");
+	if(multipart->upload->status == HTTP_UPLOAD_BEGIN)
+	{
+		debugf("starting file write");
+		multipart->upload->file = fileOpen(multipart->upload->filename, eFO_CreateNewAlways | eFO_WriteOnly);
+
+	}
+	else if(multipart->upload->status == HTTP_UPLOAD_WRITE)
+	{
+		debugf("writing upload data");
+		int res = fileWrite(multipart->upload->file, multipart->upload->bufferdata, multipart->upload->curSize);
+		if (res < 0) {
+			debugf("failed writing");
+			// cleanup
+			fileClose(multipart->upload->file);
+			fileDelete(multipart->upload->file);
+			fileFlush(multipart->upload->file);
+			multipart->upload->status = HTTP_UPLOAD_ERROR;
+
+		}
+
+	}
+	else if(multipart->upload->status == HTTP_UPLOAD_FINISHED)
+	{
+		debugf("closing file");
+		fileClose(multipart->upload->file);
+		fileFlush(multipart->upload->file);
+	}
+	else if(multipart->upload->status == HTTP_UPLOAD_ABORT)
+	{
+		// client aborted/timeout - cleanup
+		debugf("upload abort %s", multipart->upload->filename.c_str());
+
+		fileClose(multipart->upload->file);
+		fileFlush(multipart->upload->file);
+		fileDelete(multipart->upload->filename);
+
+	}
+
+}
+
+void HttpRequest::cleanupMultipart(HttpServerConnection& connection) {
+	debugf("HttpRequest::cleanupMultipart");
+	if(multipart == NULL) return;
+	if(multipart->upload == NULL) return;
+	if(multipart->upload->status == HTTP_UPLOAD_WRITE_CUSTOM)
+	{
+		debugf("upload failed");
+		multipart->upload->status = HTTP_UPLOAD_ABORT;
+		connection.server->uploads[path](*this, *multipart->upload);
+
+	}
+	else if(multipart->upload->status == HTTP_UPLOAD_WRITE)
+	{
+		debugf("upload failed");
+		multipart->upload->status = HTTP_UPLOAD_ABORT;
+		handleUpload();
+	}
+
 }
 
 String HttpRequest::extractParsingItemsList(String& buf, int startPos, int endPos, char delimChar, char endChar,
@@ -248,6 +754,19 @@ String HttpRequest::extractParsingItemsList(String& buf, int startPos, int endPo
 
 }
 
+String HttpRequest::extractHeaderValue(String& buf, String delimChar, String endChar, int startPos /*  = 0 */)
+{
+	int delim = buf.indexOf(delimChar, startPos);
+	if(delim == -1) return "";
+	int end = buf.indexOf(endChar, delim);
+	if(end == -1) end = buf.length();
+	String retVal = buf.substring(delim+1, end);
+	if(retVal.charAt(0) == '"' && retVal.charAt(retVal.length()-1) == '"')
+	{
+		retVal = retVal.substring(1, retVal.length()-1);
+	}
+	return retVal;
+}
 
 String HttpRequest::getBody()
 {

--- a/Sming/SmingCore/Network/HttpResponse.cpp
+++ b/Sming/SmingCore/Network/HttpResponse.cpp
@@ -69,6 +69,15 @@ bool HttpResponse::hasBody()
 	return stream != NULL || bodySent;
 }
 
+void HttpResponse::setStatus(String statusline) {
+	status = statusline;
+}
+
+void HttpResponse::setStatus(int code, String msg /* = "" */)
+{
+	status = String(code) + " " + msg;
+}
+
 ///
 
 void HttpResponse::setContentType(const String type)

--- a/Sming/SmingCore/Network/HttpResponse.h
+++ b/Sming/SmingCore/Network/HttpResponse.h
@@ -30,6 +30,8 @@ public:
 	void authorizationRequired();
 	void redirect(String location = "");
 
+	void setStatus(int code, String msg = "");
+	void setStatus(String statusline);
 	void setContentType(const String type);
 	void setCookie(const String name, const String value);
 	void setHeader(const String name, const String value);

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -48,16 +48,28 @@ void HttpServer::enableHeaderProcessing(String headerName)
 
 	processingHeaders.add(headerName);
 }
-
-void HttpServer::addPath(String path, HttpPathDelegate callback)
-{
+void HttpServer::addPath(String path, HttpPathDelegate callback) {
 	if (path.length() > 1 && path.endsWith("/"))
 		path = path.substring(0, path.length() - 1);
 	if (!path.startsWith("/"))
 		path = "/" + path;
 	debugf("'%s' registered", path.c_str());
+
 	paths[path] = callback;
 }
+
+void HttpServer::addPath(String path, HttpPathDelegate callback, HttpUploadDelegate uploadcallback)
+{
+	addPath(path, callback);
+	if (path.length() > 1 && path.endsWith("/"))
+		path = path.substring(0, path.length() - 1);
+	if (!path.startsWith("/"))
+		path = "/" + path;
+	debugf("'%s' upload handler registered", path.c_str());
+	uploads[path] = uploadcallback;
+}
+
+
 
 void HttpServer::setDefaultHandler(HttpPathDelegate callback)
 {
@@ -90,6 +102,11 @@ bool HttpServer::processRequest(HttpServerConnection &connection, HttpRequest &r
 
 	debugf("ERROR at server 404: '%s' not found", path.c_str());
 	return false;
+}
+
+bool HttpServer::isUploadEnabled(String path)
+{
+	return uploads.contains(path);
 }
 
 bool HttpServer::isHeaderProcessingEnabled(String name)

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -19,9 +19,11 @@ class String;
 class HttpServerConnection;
 class HttpRequest;
 class HttpResponse;
+struct HttpUpload;
 
 typedef Vector<WebSocket> WebSocketsList;
 
+typedef Delegate<void(HttpRequest&, HttpUpload&)> HttpUploadDelegate;
 typedef Delegate<void(HttpRequest&, HttpResponse&)> HttpPathDelegate;
 typedef Delegate<void(WebSocket&)> WebSocketDelegate;
 typedef Delegate<void(WebSocket&, const String&)> WebSocketMessageDelegate;
@@ -36,8 +38,10 @@ public:
 
 	void enableHeaderProcessing(String headerName);
 	bool isHeaderProcessingEnabled(String name);
+	bool isUploadEnabled(String path);
 
 	void addPath(String path, HttpPathDelegate callback);
+	void addPath(String path, HttpPathDelegate callback, HttpUploadDelegate uploadcallback);
 	void setDefaultHandler(HttpPathDelegate callback);
 
 	/// Web Sockets
@@ -63,6 +67,7 @@ private:
 	HttpPathDelegate defaultHandler;
 	Vector<String> processingHeaders;
 	HashMap<String, HttpPathDelegate> paths;
+	HashMap<String, HttpUploadDelegate> uploads;
 	WebSocketsList wsocks;
 
 	bool wsEnabled = false;
@@ -73,6 +78,8 @@ private:
 
 	bool wsCommandEnabled = false;
 	String wsCommandRequestParam;
+
+	friend class HttpRequest;
 };
 
 #endif /* _SMING_CORE_HTTPSERVER_H_ */

--- a/Sming/SmingCore/Network/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/HttpServerConnection.h
@@ -20,6 +20,7 @@ enum HttpConnectionState
 {
 	eHCS_Ready,
 	eHCS_ParsePostData,
+	eHCS_ParseMultipartPostData,
 	eHCS_ParsingCompleted,
 	eHCS_Sending,
 	eHCS_WebSocketFrames,

--- a/Sming/SmingCore/Network/NetUtils.cpp
+++ b/Sming/SmingCore/Network/NetUtils.cpp
@@ -112,6 +112,67 @@ String NetUtils::pbufStrCopy(pbuf *buf, int startPos, int length)
 	return res;
 }
 
+int NetUtils::cbufFindChar(char* buf, char wtf, int length, int startPos /* = 0*/) {
+	if(buf == NULL) return -1;
+	if (startPos < 0) startPos = 0;
+	for (int i = startPos; i < length; i++) {
+		if(buf[i] == wtf) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+bool NetUtils::cbufStrEqual(char* buf, const char* compared, int length, int startPos) {
+	int cur = startPos;
+	if (startPos < 0) startPos = 0;
+	if(startPos >= length) return false;
+	for (const char* cmp = compared; *cmp; cmp++)
+	{
+		if (buf[cur] != *cmp)
+			return false;
+		cur++;
+		if (cur >= length) return false;
+	}
+	return true;
+}
+
+int NetUtils::cbufFindStr(char* buf, const char* wtf, int length, int startPos /* = 0*/)
+{
+	int cur = startPos;
+	if (startPos < 0) startPos = 0;
+	if (wtf == NULL || strlen(wtf) == -1) return -1;
+
+	while (true)
+	{
+		cur = cbufFindChar(buf, wtf[0], length, cur);
+		if (cur == -1) return -1;
+
+		if (cbufStrEqual(buf, wtf, length, cur))
+			return cur;
+		cur++;
+	}
+
+	return -1;
+}
+
+String NetUtils::cbufStrCopy(char* buf, int startPos, int length) {
+	char* stringPtr = new char[length + 1];
+	stringPtr[length] = '\0';
+	os_memcpy(stringPtr, &buf[startPos], length);
+	String res = String(stringPtr);
+	delete[] stringPtr;
+	return res;
+}
+
+char* NetUtils::cbufAllocateStrCopy(char* buf, int startPos, int length)
+{
+	char* stringPtr = new char[length + 1];
+	stringPtr[length] = '\0';
+	os_memcpy(stringPtr, &buf[startPos], length);
+	return stringPtr;
+}
+
 bool NetUtils::FixNetworkRouting()
 {
 //	if (ipClientRoutingFixed) return true;

--- a/Sming/SmingCore/Network/NetUtils.h
+++ b/Sming/SmingCore/Network/NetUtils.h
@@ -28,6 +28,12 @@ public:
 	static char* pbufAllocateStrCopy(pbuf *buf, int startPos, int length);
 	static String pbufStrCopy(pbuf *buf, int startPos, int length);
 
+	static int cbufFindChar(char* buf, char wtf, int length, int startPos = 0);
+	static int cbufFindStr(char* buf, const char* wtf, int length, int startPos = 0);
+	static bool cbufStrEqual(char* buf, const char* compared, int length, int startPos);
+	static char* cbufAllocateStrCopy(char* buf, int startPos, int length);
+	static String cbufStrCopy(char* buf, int start, int length);
+
 	static bool FixNetworkRouting();
 
 	// Debug

--- a/Sming/SmingCore/Network/WebConstants.h
+++ b/Sming/SmingCore/Network/WebConstants.h
@@ -77,16 +77,28 @@ namespace RequestMethod
 
 namespace HttpStatusCode
 {
-	static const char* OK = "200 OK";
 	static const char* SwitchingProtocols = "101 Switching Protocols";
+	static const char* OK = "200 OK";
+	static const char* NoContent = "204 No Content";
+
+	// 3xx
 	static const char* Found = "302 Found";
+	static const char* NotModified = "304 Not Modified";
 
+	// 4xx
 	static const char* BadRequest = "400 Bad Request";
-	static const char* NotFound = "404 Not Found";
-	static const char* Forbidden = "403 Forbidden";
 	static const char* Unauthorized = "401 Unauthorized";
+	static const char* Forbidden = "403 Forbidden";
+	static const char* NotFound = "404 Not Found";
+	static const char* MethodNotAllowed = "405 Method Not Allowed";
+	static const char* Conflic = "409 Conflict";
+	static const char* ContentLenghtRequired = "411 Length Required";
+	static const char* RequestEntityTooLarge = "413	Request Entity Too Large";
+	static const char* RequestHeaderTooLarge = "431	Request Header Fields Too Large";
 
+	static const char* InternalServerError = "500 Internal Server Error";
 	static const char* NotImplemented = "501 Not Implemented";
+	static const char* InsufficientStorage = "507 Insufficient Storage";
 };
 
 #endif /* _SMING_CORE_NETWORK_WEBCONSTANTS_H_ */

--- a/samples/HttpServer_Upload/.cproject
+++ b/samples/HttpServer_Upload/.cproject
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" moduleId="org.eclipse.cdt.core.settings" name="Sming">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" name="Sming" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.1164554300" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.521205673" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.393887888" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.712123812" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.2110485170" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option id="gnu.c.compiler.option.include.paths.357494572" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.313321806" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler">
+								<option id="gnu.cpp.compiler.option.include.paths.611746109" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.65193859" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.1795850540" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.364843833" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.525412186" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.587940548" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option id="gnu.both.asm.option.include.paths.1067006329" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.651581712" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="Basic_Blink.null.1347473968" name="Basic_Blink"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Sming">
+			<resource resourceType="PROJECT" workspacePath="/Basic_Blink"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets">
+		<buildTargets>
+			<target name="all" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>all</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="clean" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>clean</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flash" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flash</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashonefile" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashonefile</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashinit" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashinit</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashboot" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashboot</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="rebuild" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>rebuild</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+		</buildTargets>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.c.compiler.mingw.base.2032390008;cdt.managedbuild.tool.gnu.c.compiler.input.1700912488">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903;cdt.managedbuild.tool.gnu.c.compiler.input.313321806">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015;cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cpp.compiler.mingw.base.454898447;cdt.managedbuild.tool.gnu.cpp.compiler.input.501261625">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+</cproject>

--- a/samples/HttpServer_Upload/.project
+++ b/samples/HttpServer_Upload/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>HttpServer_Upload</name>
+	<comment></comment>
+	<projects>
+		<project>SmingFramework</project>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/samples/HttpServer_Upload/Makefile
+++ b/samples/HttpServer_Upload/Makefile
@@ -1,0 +1,24 @@
+#####################################################################
+#### Please don't change this file. Use Makefile-user.mk instead ####
+#####################################################################
+# Including user Makefile.
+# Should be used to set project-specific parameters
+include ./Makefile-user.mk
+
+# Important parameters check.
+# We need to make sure SMING_HOME and ESP_HOME variables are set.
+# You can use Makefile-user.mk in each project or use enviromental variables to set it globally.
+ 
+ifndef SMING_HOME
+$(error SMING_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+ifndef ESP_HOME
+$(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+
+# Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
+include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/samples/HttpServer_Upload/Makefile-user.mk
+++ b/samples/HttpServer_Upload/Makefile-user.mk
@@ -1,0 +1,41 @@
+## Local build configuration
+## Parameters configured here will override default and ENV values.
+## Uncomment and change examples:
+
+## Add your source directories here separated by space
+# MODULES = app
+# EXTRA_INCDIR = include
+
+## ESP_HOME sets the path where ESP tools and SDK are located.
+## Windows:
+# ESP_HOME = c:/Espressif
+
+## MacOS / Linux:
+# ESP_HOME = /opt/esp-open-sdk
+
+## SMING_HOME sets the path where Sming framework is located.
+## Windows:
+# SMING_HOME = c:/tools/sming/Sming 
+
+## MacOS / Linux
+# SMING_HOME = /opt/sming/Sming
+
+## COM port parameter is reqruied to flash firmware correctly.
+## Windows: 
+# COM_PORT = COM3
+
+## MacOS / Linux:
+# COM_PORT = /dev/tty.usbserial
+
+## Com port speed
+# COM_SPEED	= 115200
+
+## Configure flash parameters (for ESP12-E and other new boards):
+# SPI_MODE = dio
+SPI_SIZE        ?= 4M
+
+## SPIFFS options
+SPIFF_FILES = files
+
+# size of filesystem
+SPIFF_SIZE      ?= 500000 #~500KB spiffs size

--- a/samples/HttpServer_Upload/app/application.cpp
+++ b/samples/HttpServer_Upload/app/application.cpp
@@ -1,0 +1,311 @@
+#include <user_config.h>
+#include <SmingCore/SmingCore.h>
+
+HttpServer server;
+
+void Index(HttpRequest &request, HttpResponse &response)
+{
+	String body = "<html>\r\n";
+	body += "<head>\r\n";
+	body += "<title>SMING HTTP Upload example</title>\r\n";
+	body += "</head>\r\n";
+	body += "<body><br>\r\n";
+	body += "This example illustrates the FileUpload mechanism in Sming<br>\r\n";
+	body += "Please ensure that your SPIFFs Filesystem is large enough to for the uploaded data<br>\r\n";
+	body += "<br><br>\r\n";
+	body += "<a href=\"/list\">File List on SPIFFs</a><br>\r\n";
+	body += "<br>\r\n";
+	body += "<a href=\"/upload\">Simple file upload</a><br>\r\n";
+	body += "<a href=\"/upload_with_vars\">File upload with extra variables</a><br>\r\n";
+	body += "<a href=\"/upload_two_files\">File upload with 2 files at the same time</a><br>\r\n";
+	body += "<a href=\"/custom_upload\">File upload with custom write mechanism</a><br>\r\n";
+	body += "<a href=\"/upload_forbidden\">File uploading not allowed</a><br>\r\n";
+	body += "</body>\r\n";
+	body += "</html>\r\n";
+	response.sendString(body);
+}
+
+void List(HttpRequest &request, HttpResponse &response)
+{
+	Vector<String> files = fileList();
+	String body = "<html>\r\n";
+	body += "<head>\r\n";
+	body += "<title>SMING HTTP File List</title>\r\n";
+	body += "</head>\r\n";
+	body += "<body><br>\r\n";
+	body += "File list<br>\r\n";
+	body += "<hr>\r\n";
+
+
+	for (int i = 0; i < files.size(); i++)
+	{
+		body += "<a href=\"/"+ files[i] +"\" target=\"_blank\">"+ files[i] +"</a><br>\r\n";
+	}
+
+
+	body += "</body>\r\n";
+	body += "</html>\r\n";
+	response.sendString(body);
+}
+
+void UploadPage(HttpRequest &request, HttpResponse &response)
+{
+	String body = "<html>\r\n";
+	body += "<head>\r\n";
+	body += "<title>SMING HTTP Upload example</title>\r\n";
+	body += "</head>\r\n";
+	body += "<body><br>\r\n";
+	if(request.getRequestMethod() == RequestMethod::POST)
+	{
+		if(request.hasUpload()) {
+			Vector<HttpUpload*> uploads = request.getUploads();
+			HttpUpload* upload = uploads.get(0);
+			if (upload->status == HTTP_UPLOAD_FINISHED) {
+				body += "Successfully uploaded <a href=\"/"+ String(upload->filename) +"\" target=\"_blank\">"+ String(upload->filename) +" (" + String(upload->totalSize) + " bytes)</a> <br><br>\r\n";
+			}
+			else
+			{
+				body += "Upload failed for "+ String(upload->filename) +" <br>\r\n";
+			}
+		}
+		else
+		{
+			body += "No uploaded data <br>\r\n";
+		}
+
+	}
+	body += "<form method='POST' action='/upload' enctype='multipart/form-data'>\r\n";
+	body += "<input type='file' name='file'>\r\n";
+	body += "<input type='submit' value='Upload'>\r\n";
+	body += "</form>\r\n";
+	body += "</body>\r\n";
+	body += "</html>\r\n";
+	response.sendString(body);
+}
+
+void UploadPageTwoFiles(HttpRequest &request, HttpResponse &response)
+{
+	String body = "<html>\r\n";
+	body += "<head>\r\n";
+	body += "<title>SMING HTTP Upload example</title>\r\n";
+	body += "</head>\r\n";
+	body += "<body><br>\r\n";
+	if(request.getRequestMethod() == RequestMethod::POST)
+	{
+		if(request.hasUpload()) {
+			Vector<HttpUpload*> uploads = request.getUploads();
+			for (int i = 0; i < uploads.size(); i++)
+			{
+				HttpUpload* upload = uploads[i];
+				if (upload->status == HTTP_UPLOAD_FINISHED) {
+					body += "Successfully uploaded <a href=\"/"+ String(upload->filename) +"\" target=\"_blank\">"+ String(upload->filename) +" (" + String(upload->totalSize) + " bytes)</a> <br><br>\r\n";
+				}
+				else
+				{
+					body += "Upload failed for "+ String(upload->filename) +" <br>\r\n";
+				}
+			}
+		}
+		else
+		{
+			body += "No uploaded data <br><br>\r\n";
+		}
+
+	}
+	body += "<form method='POST' action='/upload_two_files' enctype='multipart/form-data'>\r\n";
+	body += "<p><input type='file' name='file'></p>\r\n";
+	body += "<p><input type='file' name='file_two'></p>\r\n";
+	body += "<p><input type='submit' value='Upload'></p>\r\n";
+	body += "</form>\r\n";
+	body += "</body>\r\n";
+	body += "</html>\r\n";
+	response.sendString(body);
+}
+
+
+void UploadPageWithVars(HttpRequest &request, HttpResponse &response)
+{
+	String body = "<html>\r\n";
+	body += "<head>\r\n";
+	body += "<title>SMING HTTP Upload example</title>\r\n";
+	body += "</head>\r\n";
+	body += "<body><br>\r\n";
+	if(request.getRequestMethod() == RequestMethod::POST)
+	{
+		if(request.hasUpload()) {
+			Vector<HttpUpload*> uploads = request.getUploads();
+			HttpUpload* upload = uploads.get(0);
+			if (upload->status == HTTP_UPLOAD_FINISHED) {
+				body += "Successfully uploaded <a href=\"/"+ String(upload->filename) +"\" target=\"_blank\">"+ String(upload->filename) +" (" + String(upload->totalSize) + " bytes)</a> <br><br>\r\n";
+			}
+			else
+			{
+				body += "Upload failed for "+ String(upload->filename) +" <br>\r\n";
+			}
+		}
+		else
+		{
+			body += "No uploaded data <br><br>\r\n";
+		}
+		body += "post  var:  "+ request.getPostParameter("postvar") +" <br>\r\n";
+		body += "query var: "+ request.getQueryParameter("query") +" <br>\r\n";
+
+
+	}
+	body += "<form method='POST' action='/upload_with_vars?query=myquery' enctype='multipart/form-data'>\r\n";
+	body += "<p>post: <input type='text' name='postvar'></p>\r\n";
+	body += "<p>File: <input type='file' name='file'></p>\r\n";
+	body += "<p><input type='submit' value='Upload'></p>\r\n";
+	body += "</form>\r\n";
+	body += "</body>\r\n";
+	body += "</html>\r\n";
+	response.sendString(body);
+}
+
+void UploadHandler(HttpRequest& request, HttpUpload& upload) {
+	if(upload.status == HTTP_UPLOAD_BEGIN)
+	{
+		debugf("Got upload request for file: %s", upload.filename.c_str());
+		// we don`t need to do anything here to accept the upload
+		// if we don`t want to save the contents we would set the
+		// status to HTTP_UPLOAD_SKIP
+		//
+		// upload.status == HTTP_UPLOAD_SKIP
+
+	}
+	else if (upload.status == HTTP_UPLOAD_FINISHED)
+	{
+		debugf("Upload finished");
+	}
+}
+
+void CustomUploadPage(HttpRequest &request, HttpResponse &response)
+{
+	String body = "<html>\r\n";
+	body += "<head>\r\n";
+	body += "<title>SMING HTTP Upload custom example</title>\r\n";
+	body += "</head>\r\n";
+	body += "<body><br>\r\n";
+	if(request.getRequestMethod() == RequestMethod::POST)
+	{
+		if(request.hasUpload()) {
+			Vector<HttpUpload*> uploads = request.getUploads();
+			HttpUpload* upload = uploads.get(0);
+			if (upload->status == HTTP_UPLOAD_FINISHED) {
+				body += "Successfully uploaded <a href=\"/"+ String(upload->filename) +"\" target=\"_blank\">"+ String(upload->filename) +" (" + String(upload->totalSize) + " bytes)</a> <br><br>\r\n";
+			}
+			else
+			{
+				body += "Upload failed for "+ String(upload->filename) +" <br>\r\n";
+			}
+		}
+		else
+		{
+			body += "No uploaded data <br><br>\r\n";
+		}
+	}
+	body += "<form method='POST' action='/custom_upload' enctype='multipart/form-data'>\r\n";
+	body += "<input type='file' name='file'>\r\n";
+	body += "<input type='submit' value='Upload'>\r\n";
+	body += "</form>\r\n";
+	body += "</body>\r\n";
+	body += "</html>\r\n";
+	response.sendString(body);
+}
+
+void CustomUploadHandler(HttpRequest& request, HttpUpload& upload) {
+	if(upload.status == HTTP_UPLOAD_BEGIN)
+	{
+
+		// to initialize the custom callback, status needs
+		// to be set to HTTP_UPLOAD_WRITE_CUSTOM
+		upload.file = fileOpen(upload.filename, eFO_CreateNewAlways | eFO_WriteOnly);
+		upload.status = HTTP_UPLOAD_WRITE_CUSTOM;
+	}
+	else if(upload.status == HTTP_UPLOAD_WRITE_CUSTOM)
+	{
+		// called every time new data is available
+		// upload.bufferdata is a point to the buffer data
+		// upload.curSize is the length of the current uplod data
+
+		int res = fileWrite(upload.file, upload.bufferdata, upload.curSize);
+		if (res < 0) {
+			debugf("failed writing");
+			fileClose(upload.file);
+			fileDelete(upload.file);
+
+			// mark that the upload had an error and we should not
+			// try to write data again
+			upload.status == HTTP_UPLOAD_ERROR;
+		}
+
+	}
+	else if(upload.status == HTTP_UPLOAD_FINISHED)
+	{
+		// called when we the end of the upload data is reached
+		fileClose(upload.file);
+	}
+	else if(upload.status == HTTP_UPLOAD_ABORT)
+	{
+		// This is called when the client has a timeout
+		// or aborts the upload inbetween
+		fileClose(upload.file);
+		fileDelete(upload.file);
+
+
+	}
+}
+
+void UploadForbidden(HttpRequest &request, HttpResponse &response)
+{
+	String body = "<html>\r\n";
+	body += "<head>\r\n";
+	body += "<title>SMING HTTP Upload Forbidden example</title>\r\n";
+	body += "</head>\r\n";
+	body += "<body><br>\r\n";
+	body += "In this example the upload will fail with a BadRequest response<br><br>\r\n";
+	body += "<form method='POST' action='/upload_forbidden' enctype='multipart/form-data'>\r\n";
+	body += "<input type='file' name='file'>\r\n";
+	body += "<input type='submit' value='Upload'>\r\n";
+	body += "</form>\r\n";
+	body += "</body>\r\n";
+	body += "</html>\r\n";
+	response.sendString(body);
+}
+
+
+
+void onFile(HttpRequest &request, HttpResponse &response)
+{
+	String file = request.getPath();
+	if (file[0] == '/')	file = file.substring(1);
+	response.setCache(86400, true); // It's important to use cache for better performance.
+	response.sendFile(file);
+
+}
+
+void startServer() {
+		server.listen(80);
+		server.addPath("/", Index);
+		server.addPath("/list", List);
+		server.addPath("/upload", UploadPage, UploadHandler);
+		server.addPath("/upload_two_files", UploadPageTwoFiles, UploadHandler);
+		server.addPath("/upload_with_vars", UploadPageWithVars, UploadHandler);
+		server.addPath("/custom_upload", CustomUploadPage, CustomUploadHandler);
+		server.addPath("/upload_forbidden", UploadForbidden);
+		server.setDefaultHandler(onFile);
+}
+
+void init()
+{
+	spiffs_mount();
+	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
+	Serial.systemDebugOutput(true); // Enable debug output to serial
+
+	WifiStation.enable(false);
+	WifiAccessPoint.enable(true);
+	WifiAccessPoint.config("Sming Webserver", "", AUTH_OPEN);
+
+	// Run WEB server on system ready
+	System.onReady(startServer);
+}

--- a/samples/HttpServer_Upload/include/user_config.h
+++ b/samples/HttpServer_Upload/include/user_config.h
@@ -1,0 +1,45 @@
+#ifndef __USER_CONFIG_H__
+#define __USER_CONFIG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	// UART config
+	#define SERIAL_BAUD_RATE 115200
+
+	// ESP SDK config
+	#define LWIP_OPEN_SRC
+	#define USE_US_TIMER
+
+	// Default types
+	#define __CORRECT_ISO_CPP_STDLIB_H_PROTO
+	#include <limits.h>
+	#include <stdint.h>
+
+	// Override c_types.h include and remove buggy espconn
+	#define _C_TYPES_H_
+	#define _NO_ESPCON_
+
+	// Updated, compatible version of c_types.h
+	// Just removed types declared in <stdint.h>
+	#include <espinc/c_types_compatible.h>
+
+	// System API declarations
+	#include <esp_systemapi.h>
+
+	// C++ Support
+	#include <esp_cplusplus.h>
+	// Extended string conversion for compatibility
+	#include <stringconversion.h>
+	// Network base API
+	#include <espinc/lwip_includes.h>
+
+	// Beta boards
+	#define BOARD_ESP01
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This is the first "fully" working implementaiton for file-uploading/http-multipart-post for http server. (#552)

Currently it provides functionality to:
- upload single files 
- upload multiple files at once
- upload files with additional vars

To enable uploading for a certain path, a delegate has to be provided:
```void addPath(String path, HttpPathDelegate callback, HttpUploadDelegate uploadcallback);```

The uploadcallback function is defined as following:
```
void functionName(HttpRequest&, HttpUpload&)
```
The function has thus access to the current request in the sense of all Header and Query Paramters (as well as path) can be accessed to decide if we accept the upload (or not)

In the pathdelegate information about the uploaded files is accessible by calling:
```
if(request.hasUpload()) {
	Vector<HttpUpload*> uploads = request.getUploads();
}
```

HttpUpload is defined as
```
struct HttpUpload {
	String filename;
	String name;
	String type;
	size_t totalSize;
	size_t curSize; // size of the current data block
	char* bufferdata; //pointer to the data
	file_t file;
	HttpUploadStatus status;
};
```
after a successfull upload `curSize` and `bufferdata` will be NULL and not accessible anymore (to avoid tampering with it
`type` contains the content-type field values
`name` is the variable name defined in the form field

If we receive a http-multipart-request without a filename or if the filename is empty - the data will be treated as normal http-post parameters and is accessible via `getPostParameter` - the limit `NETWORK_MAX_HTTP_PARSING_LEN` applies to all data that is not a file.

For testing see the working examples in `samples/HttpServer_Upload`


Please test it thoroughly and provide feedback. If you encounter any issues, it would be great if you document what has lead to the issue and provide a debug log.

Do you have any suggestion/remarks? 

**Known limitations/issues:**
- when providing a filename but no content - a file with the filename but 0 size will be created  
    (it seems that chrome sends the header again when one presses go-back to the fileupload page)  
- max lenght for filenames is 31chars (current spiffs setting)  
    how should we handle this use case? how to inform the user - automatically or should the "user of the framework" take care of this in the callback? 
