### PR TITLE
Adding selective debug logging

### DIFF
--- a/Sming/SmingCore/Debug.h
+++ b/Sming/SmingCore/Debug.h
@@ -14,6 +14,48 @@
 #include "WString.h"
 #include "../Services/CommandProcessing/CommandProcessingIncludes.h"
 
+// selective debug logging extension
+#define DEBUG_INDENT_MAX                        16 // logBin max indent
+#define DEBUG_HEX_PER_LINE                      16 // logBin number of hex chars per line
+
+#define DEBUG_CLS_MAX                            2 // max num classes, scalable upto 16
+#define DEBUG_CLS_0                     0x00000000 // reserved for custom application logging
+#define DEBUG_CLS_1                     0x01000000 // reserved for Sming framework logging
+
+#define DEBUG_LVL_MAX                           32 //
+#define DEBUG_LVL_00                    0x00000000 // 0
+#define DEBUG_LVL_01                    0x00010000 // 1
+#define DEBUG_LVL_02                    0x00020000 // 2
+#define DEBUG_LVL_03                    0x00030000 // 3
+#define DEBUG_LVL_04                    0x00040000 // 4
+#define DEBUG_LVL_05                    0x00050000 // 5
+#define DEBUG_LVL_06                    0x00060000 // 6
+#define DEBUG_LVL_07                    0x00070000 // 7
+#define DEBUG_LVL_08                    0x00080000 // 8
+#define DEBUG_LVL_09                    0x00090000 // 9
+#define DEBUG_LVL_0A                    0x000A0000 // 10
+#define DEBUG_LVL_0B                    0x000B0000 // 11
+#define DEBUG_LVL_0C                    0x000C0000 // 12
+#define DEBUG_LVL_0D                    0x000D0000 // 13
+#define DEBUG_LVL_0E                    0x000E0000 // 14
+#define DEBUG_LVL_0F                    0x000F0000 // 15
+#define DEBUG_LVL_10                    0x00100000 // 16
+#define DEBUG_LVL_11                    0x00110000 // 17
+#define DEBUG_LVL_12                    0x00120000 // 18
+#define DEBUG_LVL_13                    0x00130000 // 19
+#define DEBUG_LVL_14                    0x00140000 // 20
+#define DEBUG_LVL_15                    0x00150000 // 21
+#define DEBUG_LVL_16                    0x00160000 // 22
+#define DEBUG_LVL_17                    0x00170000 // 23
+#define DEBUG_LVL_18                    0x00180000 // 24
+#define DEBUG_LVL_19                    0x00190000 // 25
+#define DEBUG_LVL_1A                    0x001A0000 // 26
+#define DEBUG_LVL_1B                    0x001B0000 // 27
+#define DEBUG_LVL_INFO                  0x001C0000 // 28 1C
+#define DEBUG_LVL_WARN                  0x001D0000 // 29 1D
+#define DEBUG_LVL_ERROR                 0x001E0000 // 30 1E
+#define DEBUG_LVL_CRIT                  0x001F0000 // 31 1F
+
 /** @brief  Delegate constructor usage: (&YourClass::method, this)
  *  @ingroup event_handlers
  */
@@ -74,15 +116,72 @@ public:
      */
 	void setDebug(Stream &reqStream);
 
+
+    /** @brief  Set debug class levels for logTxt() and logBin()
+     *  @param  cls        Debug class, DEBUG_CLS_%
+     *  @param  clsLevels  Debug levels bitmap for class, 1 bit per level
+     *  @note   Usage:     Debug.logClsLevels(DEBUG_CLS_0, 0x000017FF);
+     */
+	uint32_t           logClsLevels(uint32_t cls, uint32_t clsLevels);
+           
+    /** @brief  Get debug class levels
+     *  @param  cls        Debug class
+     *  @note   Usage:     Debug.logClsLevels();
+     */
+	uint32_t           logClsLevels(uint32_t cls);
+
+    /** @brief  Set msgId usage for logTxt() and logBin()
+     *  @param  printMsgId Debug levels for class, 32 bits
+     *  @note   Usage:     Debug.logPrintMsgId(true);
+     */
+  bool               logPrintMsgId(bool printMsgId);
+
+    /** @brief  Get msgId usage
+     *  @note   Usage:     Debug.logPrintMsgId();
+     */
+  bool               logPrintMsgId() ;
+
+    /** @brief  Log textual data if level is enabled for class
+     *  @param  msgId      Debug Class/Level/Sequence, 0xCCLLSSSS
+     *  @note              CC   = DEBUG_CLS_%
+     *  @note              LL   = DEBUG_LVL_%
+     *  @note              SSSS = 0000..FFFF, seqnr to map logging to source code 
+     *  @param  fmt        Format string with optional args
+     *  @note   Usage:     Debug.logTxt(DEBUG_CLS_0 | DEBUG_LVL_01 | 0x1234, "format %u", parm1);
+     */
+  void               logTxt(uint32_t msgId, const char* fmt, ...);
+
+    /** @brief  Log binary data if level is enabled for class
+     *  @param  msgId      Debug Class/Level/Sequence, 0xCCLLSSSS
+     *  @note              CC   = DEBUG_CLS_%
+     *  @note              LL   = DEBUG_LVL_%
+     *  @note              SSSS = 0000..FFFF, seqnr to map logging to source code 
+     *  @param  indent     Print indent for binary data, 0-16
+     *  @param  pIn        Pointer to binary data
+     *  @param  cbIn       Size of binary data
+     *  @param  fmt        Format string with optional args
+     *  @note   Usage:     Debug.logBin(DEBUG_CLS_0 | DEBUG_LVL_01 | 0x1234, 2, &byArr, sizeof(byArr), "format %u", parm1);
+     */
+  void               logBin(uint32_t msgId, uint32_t indent, const void *pIn, uint32_t cbIn, const char* fmt, ...);
+
 private:
 	bool started = false;
 	bool useDebugPrefix = true;
 	bool newDebugLine = true;
+
 	DebugOuputOptions debugOut;
 	void printPrefix();
 	void processDebugCommands(String commandLine, CommandOutput* commandOutput);
 
 	size_t write(uint8_t);  /* implementation of write for Print Class */
+
+	// selective debug logging extension
+  bool               m_printMsgId = true;
+  uint32_t           m_clsLevels[DEBUG_CLS_MAX];
+
+  void               _NibbleToHex(uint8_t nibIn, char **ppOut);
+  void               _ByteToHex(uint8_t byIn, char **ppOut);
+  void               _ByteToAsc(uint8_t byIn, char **ppOut);
 };
 
 /**	@brief	Global instance of Debug object

--- a/Sming/Wiring/Print.cpp
+++ b/Sming/Wiring/Print.cpp
@@ -200,14 +200,23 @@ size_t Print::println(const Printable &p)
 size_t Print::printf(const char *fmt, ...)
 {
 	size_t sz = 0;
-	size_t buffSize = INITIAL_PRINTF_BUFFSIZE;
-	bool retry = false;
-	do {
-		char tempBuff[buffSize];
+
 		va_list va;
 		va_start(va, fmt);
-		sz = m_vsnprintf(tempBuff,buffSize, fmt, va);
+  sz = printf(fmt, va);
 		va_end(va);
+  return sz;
+} // printf
+
+size_t Print::printf(const char *fmt, va_list va)
+{
+	size_t sz = 0;
+	size_t buffSize = INITIAL_PRINTF_BUFFSIZE;
+	bool   retry = false;
+
+	do {
+		char tempBuff[buffSize];
+		sz = m_vsnprintf(tempBuff,buffSize, fmt, va);
 		if (sz > (buffSize -1))
 		{
 			buffSize = sz + 1; // Leave room for terminating null char
@@ -222,7 +231,7 @@ size_t Print::printf(const char *fmt, ...)
 			return sz;
 		}
 	} while (retry);
-}
+} // printf
 
 // private methods
 

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -86,6 +86,7 @@ class Print
 
     // printf
     size_t printf(const char *fmt, ...);
+    size_t printf(const char *fmt, va_list va);
 
   private:
     int write_error;

--- a/samples/Basic_SelectiveLogging/Makefile
+++ b/samples/Basic_SelectiveLogging/Makefile
@@ -1,0 +1,24 @@
+#####################################################################
+#### Please don't change this file. Use Makefile-user.mk instead ####
+#####################################################################
+# Including user Makefile.
+# Should be used to set project-specific parameters
+include ./Makefile-user.mk
+
+# Important parameters check.
+# We need to make sure SMING_HOME and ESP_HOME variables are set.
+# You can use Makefile-user.mk in each project or use enviromental variables to set it globally.
+ 
+ifndef SMING_HOME
+$(error SMING_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+ifndef ESP_HOME
+$(error ESP_HOME is not set. Please configure it in Makefile-user.mk)
+endif
+
+# Include main Sming Makefile
+ifeq ($(RBOOT_ENABLED), 1)
+include $(SMING_HOME)/Makefile-rboot.mk
+else
+include $(SMING_HOME)/Makefile-project.mk
+endif

--- a/samples/Basic_SelectiveLogging/Makefile-user.mk
+++ b/samples/Basic_SelectiveLogging/Makefile-user.mk
@@ -1,0 +1,39 @@
+## Local build configuration
+## Parameters configured here will override default and ENV values.
+## Uncomment and change examples:
+
+## Add your source directories here separated by space
+# MODULES = app
+# EXTRA_INCDIR = include
+
+## ESP_HOME sets the path where ESP tools and SDK are located.
+## Windows:
+# ESP_HOME = c:/Espressif
+
+## MacOS / Linux:
+# ESP_HOME = /opt/esp-open-sdk
+
+## SMING_HOME sets the path where Sming framework is located.
+## Windows:
+# SMING_HOME = c:/tools/sming/Sming 
+
+## MacOS / Linux
+# SMING_HOME = /opt/sming/Sming
+
+## COM port parameter is reqruied to flash firmware correctly.
+## Windows: 
+# COM_PORT = COM3
+
+## MacOS / Linux:
+# COM_PORT = /dev/tty.usbserial
+
+## Com port speed
+# COM_SPEED	= 115200
+
+## Configure flash parameters (for ESP12-E and other new boards):
+# SPI_MODE = dio
+
+## SPIFFS options
+DISABLE_SPIFFS = 1
+# SPIFF_FILES = files
+

--- a/samples/Basic_SelectiveLogging/app/application.cpp
+++ b/samples/Basic_SelectiveLogging/app/application.cpp
@@ -1,0 +1,155 @@
+
+//----------------------------------------------------------------------------
+// Sample to demonstrate selective debug logging for the Sming Debug object
+//
+// For now I added 2 log classes (DEBUG_CLS_0 and DEBUG_CLS_1), where class 0
+// is intended for logging created by an application using the Sming framework,
+// and class 1 is intended for the Sming framework itself.
+//
+// 
+// 
+// Per class you have 32 log levels, they have a name and a mask like this:
+//   level 0  : name = DEBUG_LVL_00     -> mask = 0x00000001
+//   level 1  : name = DEBUG_LVL_01     -> mask = 0x00000002
+//   ...
+//   level 26 : name = DEBUG_LVL_1A     -> mask = 0x04000000
+//   level 27 : name = DEBUG_LVL_1B     -> mask = 0x08000000
+//   level 28 : name = DEBUG_LVL_INFO   -> mask = 0x10000000
+//   level 29 : name = DEBUG_LVL_WARN   -> mask = 0x20000000
+//   level 30 : name = DEBUG_LVL_ERROR  -> mask = 0x40000000
+//   level 31 : name = DEBUG_LVL_CRIT   -> mask = 0x80000000
+//
+// To enable levels for a class, you set their OR'ed mask value to the Debug
+// object using the logClsLevels(cls, clsLevels) function. 
+//
+// I.e. to enable levels 0, 1, 8 and 16 you OR their mask values like this:
+//   Debug.logClsLevels(DEBUG_CLS_0, 0x00010103)
+//
+// Use Debug.logClsLevels(cls) to read the current levels set for a class.
+//   Debug.logClsLevels(DEBUG_CLS_0)
+// 
+//
+//
+// Using logPrintMsgId(bool) you can enable/disable printing of the msgId in front
+// of the logged line(s), by default this is disabled. I.e. 
+//   Debug.logPrintMsgId(true);
+//   Debug.logPrintMsgId(false);
+//
+// Use logPrintMsgId() to obtain the current setting.
+//   Debug.logPrintMsgId();
+//
+// 
+//
+// The msgId is a 32bit value and the first parameter to logTxt() and logBin(), it
+// is composed by OR'ing the class, level and an optional sequence number like this:
+//   DEBUG_CLS_0 | DEBUG_LVL_00 | 0x0010
+//
+// Since DEBUG_CLS_0 evaluates to 0 it can be omitted.
+//
+// The level is used by logTxt() and logBin() to check whether that level is enabled
+// for the given class, only if enabled will logTxt() or logBin() generate logging.
+//
+// The sequence number can be used to identify the exact location in code that 
+// generates a certain logging line, it can vary between 0x0000 and 0xFFFF.
+// 
+//
+//
+// Using logTxt(msgId, format, ....) you can log strings as if using printf, i.e.
+//   Debug.logTxt(DEBUG_LVL_05 | 0x0000, "appOnPublish,topic=%s,msg=%s", strTopic.c_str(), strMsg.c_str());
+//
+// Might show:
+//   Dbg 1787.887 : appOnPublish,topic=astr76b32/node0/cmd/out0,msg=ontimed.5000
+//
+// Or this after Debug.logPrintMsgId(true):
+//   Dbg 1719.666 : 00050000,appOnPublish,topic=astr76b32/node0/cmd/out0,msg=ontimed.5000
+//
+// 
+//
+// Using logBin(msgId, indent, pBuf, cbBuf, format, ...) you can log a buffer of data in hex format, i.e.
+//   Debug.logBin(DEBUG_LVL_05 | 0x0000, 2, strTopic.c_str(), strTopic.length(),
+//                "appOnPublish,topic=%s,msg=%s", strTopic.c_str(), strMsg.c_str());
+//
+// Might show:
+//   Dbg 1787.894 : appOnPublish,topic=astr76b32/node0/cmd/out0,msg=ontimed.5000
+//   Dbg 1787.896 :   6173747237366233322F6E6F6465302F astr76b32/node0/
+//   Dbg 1787.902 :   636D642F6F757430                 cmd/out0
+//
+// Or this after Debug.logPrintMsgId(true):
+//   Dbg 1719.673 : 00050010,appOnPublish,topic=astr76b32/node0/cmd/out0,msg=ontimed.5000
+//   Dbg 1719.677 : 00050010,  6173747237366233322F6E6F6465302F astr76b32/node0/
+//   Dbg 1719.683 : 00050010,  636D642F6F757430                 cmd/out0
+//
+//
+//
+// Using this feature you can develop your application with the neccesary 
+// logging code embedded in the product. You can enabled logging selective to
+// help debugging during development or troubleshooting at a customer location.
+//
+// Performance or memory overhead will be very limited.
+//----------------------------------------------------------------------------
+#include <user_config.h>
+#include <SmingCore/SmingCore.h>
+#include <SmingCore/Debug.h>
+
+//----------------------------------------------------------------------------
+#define CLSLVL_APP                    DEBUG_LVL_00 // 0x0001
+#define CLSLVL_EVEN                   DEBUG_LVL_01 // 0x0002
+#define CLSLVL_ODD                    DEBUG_LVL_02 // 0x0004
+
+Timer   g_timerApp;
+int     g_nCount = 0;
+
+
+//----------------------------------------------------------------------------
+// application function 1
+//----------------------------------------------------------------------------
+void appFnEven(uint8_t* pIn, int cbIn, const char* szTitle)
+{
+  Debug.logTxt(CLSLVL_EVEN | 0x0000, "appFnEven,cbIn=%d", cbIn);
+  Debug.logBin(CLSLVL_EVEN | 0x0010, 2, pIn, cbIn, "appFnEven,title=%s", szTitle);
+  } // appFnEven
+
+//----------------------------------------------------------------------------
+// application function 2
+//----------------------------------------------------------------------------
+void appFnOdd(uint8_t* pIn, int cbIn, const char* szTitle)
+{
+  Debug.logTxt(CLSLVL_EVEN | 0x0000, "appFnOdd,cbIn=%d", cbIn);
+  Debug.logBin(CLSLVL_EVEN | 0x0010, 2, pIn, cbIn, "appFnOdd,title=%s", szTitle);
+  } // appFnOdd
+
+//----------------------------------------------------------------------------
+// application timer callback
+//----------------------------------------------------------------------------
+void appTimerCb()
+{
+  uint8_t buf[64];
+  int     n;
+   
+  // prepare buffer to log
+  Debug.logTxt(CLSLVL_APP | 0x0000, "appTimerCb");
+  g_nCount++;
+  memset(buf, (uint8_t)(g_nCount % 256), sizeof(buf));
+
+  if (g_nCount % 2)
+    appFnOdd(buf, sizeof(buf), "This is the odd call");
+  else 
+    appFnEven(buf, sizeof(buf), "This is the even call");
+
+  Debug.logTxt(CLSLVL_APP | 0x9999, "appTimerCb");
+  } // appTimerCb
+
+//----------------------------------------------------------------------------
+// main entry
+//----------------------------------------------------------------------------
+void init()
+{
+  // enable printing of msgId in front of logline
+  Debug.logPrintMsgId(true);
+
+  // set class 0 loglevels for DEBUG_LVL_00, DEBUG_LVL_01 and DEBUG_LVL_02
+  Debug.logClsLevels(DEBUG_CLS_0, 0x00000007);
+
+  // start app timer
+  g_timerApp.initializeMs(1000, appTimerCb).start();
+  } // init

--- a/samples/Basic_SelectiveLogging/include/user_config.h
+++ b/samples/Basic_SelectiveLogging/include/user_config.h
@@ -1,0 +1,45 @@
+#ifndef __USER_CONFIG_H__
+#define __USER_CONFIG_H__
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+	// UART config
+	#define SERIAL_BAUD_RATE 115200
+
+	// ESP SDK config
+	#define LWIP_OPEN_SRC
+	#define USE_US_TIMER
+
+	// Default types
+	#define __CORRECT_ISO_CPP_STDLIB_H_PROTO
+	#include <limits.h>
+	#include <stdint.h>
+
+	// Override c_types.h include and remove buggy espconn
+	#define _C_TYPES_H_
+	#define _NO_ESPCON_
+
+	// Updated, compatible version of c_types.h
+	// Just removed types declared in <stdint.h>
+	#include <espinc/c_types_compatible.h>
+
+	// System API declarations
+	#include <esp_systemapi.h>
+
+	// C++ Support
+	#include <esp_cplusplus.h>
+	// Extended string conversion for compatibility
+	#include <stringconversion.h>
+	// Network base API
+	#include <espinc/lwip_includes.h>
+
+	// Beta boards
+	#define BOARD_ESP01
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This upgrade of the debug logging subsystem allows users to apply selective debug logging.

For now I added 2 log classes (0 and 1), where class 0 is intended for logging created by an application using the Sming framework, and class 1 is intended for the Sming framework itself.

Per class you can configure 32 levels using logClsLevels(cls, clsLevels), for each level enabled in a class, you set the corresponding bit in clsLevels to 1. This can be changed at runtime, i.e. derived from configuration data, user input, ...

Using logPrintMsgId(bool) you can enable/disable printing of the msgId in front of the logline.

Using logTxt(msgId, format, ....) you can log strings as if using printf, where msgId contains cls, clsLvl (0-31) and a sequence number. If clsLvl is enabled for cls, then the text is logged, otherwise not. The sequence number can be used to link a logline to a source location to make analyzing of logging easier.

Using logBin(...) you can log a buffer of data in hex format, same behaviour as for logTxt()
