### PR TITLE
Include directories in spiffy rom

### DIFF
--- a/Sming/spiffy/spiffy.c
+++ b/Sming/spiffy/spiffy.c
@@ -177,7 +177,7 @@ int write_to_spiffs(const char *fname, u8_t *data, int size) {
 	return ret;
 }
 int add_file(const char *path, const struct stat *st,
-                const int typeflag, struct FTW *pathinfo) {
+                const int typeflag) {
 //int add_file(const char* fdir, char* fname) {
 
 	int ret = 0;
@@ -288,7 +288,7 @@ int main(int argc, char **argv) {
 				printf("Creating empty filesystem.\n");
 			} else {
 				printf("Adding files in directory '%s'.\n", folder);
-				int result = nftw(folder, add_file, USE_FDS, FTW_PHYS);
+				int result = ftw(folder, add_file, 10);
 			    if (result > 0) {
 			    	printf("Unable to open directory '%s' result code '%d'.\n", folder, result);
 					ret = EXIT_FAILURE;


### PR DESCRIPTION
According to spiffy documentation:

```
Presently, spiffs does not support directories. It produces a flat structure. Creating a file with path tmp/myfile.txt will create a file called tmp/myfile.txt instead of a myfile.txt under directory tmp.
```

spiffy don't support getting list of files in directory but is able to have files with slashes in names. There are a lot of cases where it is enough (eg separate javascript and css files on web server root). I modified spiffy.c to scan and include subdirectories.
I tested it on my esp (build and flashed on windows) and files are visible.
As I'm neither native c or c++ programmer please review my code.
