### PR TITLE
return TimeoutError when timeout occured

### DIFF
--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -98,7 +98,7 @@ err_t TcpConnection::onPoll()
 		debugf("TCP connection closed by timeout: %d (from %d)", sleep, timeOut);
 
 		close();
-		return ERR_OK;
+		return ERR_TIMEOUT;
 	}
 
 	if (tcp != NULL && getAvailableWriteSize() > 0) //(tcp->state >= SYN_SENT && tcp->state <= ESTABLISHED))


### PR DESCRIPTION
Fix for #712 

I`ve tested it with HttpClient and HttpServer and did not experience any different behavior. Any other remarks/comments when changing the return value to the proper one? 