### PR TITLE
Added access to nanosecond resolution RTC.

### DIFF
--- a/Sming/SmingCore/Platform/RTC.cpp
+++ b/Sming/SmingCore/Platform/RTC.cpp
@@ -5,23 +5,32 @@ RtcClass::RtcClass() {
 	hardwareReset = (info->reason == REASON_WDT_RST);
 }
 
-uint32_t RtcClass::getRtcSeconds() {
+
+uint64_t RtcClass::getRtcNanoseconds() {
 	RtcData rtcTime;
 	loadTime(rtcTime);
 	updateTime(rtcTime);
 	saveTime(rtcTime);
-	return (rtcTime.time / NS_PER_SECOND);
+	return rtcTime.time;
 }
 
 
+uint32_t RtcClass::getRtcSeconds() {
+	return (getRtcNanoseconds() / NS_PER_SECOND);
+}
 
-bool RtcClass::setRtcSeconds(uint32_t seconds) {
+
+bool RtcClass::setRtcNanoseconds(uint64_t nanoseconds) {
 	RtcData rtcTime;
 	loadTime(rtcTime);
 	updateTime(rtcTime);
-	uint64_t time= ((uint64_t) seconds * NS_PER_SECOND);
-	rtcTime.time = time;
+	rtcTime.time = nanoseconds;
 	return saveTime(rtcTime);
+}
+
+
+bool RtcClass::setRtcSeconds(uint32_t seconds) {
+	return setRtcNanoseconds((uint64_t)seconds * NS_PER_SECOND);
 }
 
 

--- a/Sming/SmingCore/Platform/RTC.h
+++ b/Sming/SmingCore/Platform/RTC.h
@@ -29,10 +29,21 @@ public:
      */
 	RtcClass();
 
+    /** @brief  Get nanoseconds from RTC
+     *  @retval uint64_t Quantity of nanoseconds since last RTC reset or set
+     */
+	uint64_t getRtcNanoseconds();
+
     /** @brief  Get seconds from RTC
      *  @retval uint32_t Quantity of seconds since last RTC reset or set
      */
 	uint32_t getRtcSeconds();
+
+	/** @brief  Set RTC nanoseconds
+	 *  @param  nanoseconds Value to set RTC to
+	 *  @retval bool True on success
+	 */
+	bool setRtcNanoseconds(uint64_t nanoseconds);
 
     /** @brief  Set RTC seconds
      *  @param  seconds Value to set RTC seconds to


### PR DESCRIPTION
I'm working on a clock and need sub-second resolution to the RTC. This small change allow setting/getting of the RTC in nanosecond resolution. It is fully backwards compatible.

Why nanoseconds? For my specific use-case tens of milliseconds should do it but this adds additional multiplications to the codebase. By working in nanoseconds the number of multiplications for RTC access stays the same.