### PR TITLE
Rboot: Fixed issue with final bytes < 4 not being written on the flash memory.

### DIFF
--- a/Sming/SmingCore/Network/rBootHttpUpdate.cpp
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.cpp
@@ -50,6 +50,12 @@ void rBootHttpUpdate::updateFailed() {
 	if (updateDelegate) updateDelegate(false);
 }
 
+void rBootHttpUpdate::onItemDownloadCompleted(HttpClient& client, bool successful) {
+	if(successful) {
+		rboot_write_end(&rBootWriteStatus);
+	}
+}
+
 void rBootHttpUpdate::onTimer() {
 	
 	if (TcpClient::isProcessing()) return; // Will wait
@@ -80,7 +86,7 @@ void rBootHttpUpdate::onTimer() {
 	rBootHttpUpdateItem &it = items[currentItem];
 	debugf("Download file:\r\n    (%d) %s -> %X", currentItem, it.url.c_str(), it.targetOffset);
 	rBootWriteStatus = rboot_write_init(items[currentItem].targetOffset);
-	startDownload(URL(it.url), eHCM_UserDefined, NULL);
+	startDownload(URL(it.url), eHCM_UserDefined, HttpClientCompletedDelegate(&rBootHttpUpdate::onItemDownloadCompleted, this));
 }
 
 void rBootHttpUpdate::writeRawData(pbuf* buf, int startPos) {

--- a/Sming/SmingCore/Network/rBootHttpUpdate.h
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.h
@@ -40,6 +40,7 @@ protected:
 	virtual void writeRawData(pbuf* buf, int startPos);
 	void applyUpdate();
 	void updateFailed();
+	void onItemDownloadCompleted(HttpClient& client, bool successful);
 
 protected:
 	Vector<rBootHttpUpdateItem> items;


### PR DESCRIPTION
If the size of the last downloaded item is not divisible by 4 then the remaining final bytes are not written. This commit fixes this issue.