### PR TITLE
Set the irom0 segment to its max allowed size.

### DIFF
--- a/Sming/compiler/ld/eagle.app.v6.cpp.ld
+++ b/Sming/compiler/ld/eagle.app.v6.cpp.ld
@@ -5,7 +5,7 @@ MEMORY
   dport0_0_seg :                        org = 0x3FF00000, len = 0x10
   dram0_0_seg :                         org = 0x3FFE8000, len = 0x14000
   iram1_0_seg :                         org = 0x40100000, len = 0x8000
-  irom0_0_seg :                         org = 0x40209000, len = 0x78000
+  irom0_0_seg :                         org = 0x40209000, len = (1M - 0x9000)
 }
 
 PHDRS

--- a/samples/Basic_rBoot/rom0.ld
+++ b/samples/Basic_rBoot/rom0.ld
@@ -5,7 +5,7 @@ MEMORY
   dport0_0_seg :                        org = 0x3FF00000, len = 0x10
   dram0_0_seg :                         org = 0x3FFE8000, len = 0x14000
   iram1_0_seg :                         org = 0x40100000, len = 0x8000
-  irom0_0_seg :                         org = 0x40202010, len = 0x42000
+  irom0_0_seg :                         org = 0x40202010, len = (1M - 0x2010)
 }
 
 PHDRS


### PR DESCRIPTION
The initial LD restrictions are too restrictive. Those changes to the linker script allow to use the full addressable space in ESP8266.