### PR TITLE
Fix websocket server to properly handle multi-frame tcp packets.

### DIFF
--- a/Sming/Services/cWebsocket/websocket.cpp
+++ b/Sming/Services/cWebsocket/websocket.cpp
@@ -58,7 +58,7 @@ void wsMakeFrame(const uint8_t *data, size_t dataLength,
     }
 }
 
-static size_t getPayloadLength(const uint8_t *inputFrame, size_t inputLength,
+size_t getPayloadLength(const uint8_t *inputFrame, size_t inputLength,
                                uint8_t *payloadFieldExtraBytes, wsFrameType *frameType)
 {
     size_t payloadLength = inputFrame[1] & 0x7F;

--- a/Sming/Services/cWebsocket/websocket.h
+++ b/Sming/Services/cWebsocket/websocket.h
@@ -101,4 +101,6 @@ enum wsState {
     extern wsFrameType wsParseInputFrame(uint8_t *inputFrame, size_t inputLength,
                                        uint8_t **dataPtr, size_t *dataLength);
 
+    extern size_t getPayloadLength(const uint8_t *inputFrame, size_t inputLength,
+                                   uint8_t *payloadFieldExtraBytes, wsFrameType *frameType);
 #endif	/* WEBSOCKET_H */


### PR DESCRIPTION
Little fix to handle several websocket frame packed into one tcp packet. Current implementation just process first frame and silently left rest frame(s) in the same tcp packet. Proposed fix is bit ugly, but fully working and it do not touch much code. I plan to refactor whole websocket subsystem to more consistent and to share code with work-in-progress websocket-client.
