### PR TITLE
mprintf: reduce include overhead\nproper declare symbols with C linka…

### DIFF
--- a/Sming/system/include/m_printf.h
+++ b/Sming/system/include/m_printf.h
@@ -5,12 +5,23 @@ License: MIT
 Date: 21.12.2015
 Descr: embedded very simple version of printf with float support
 */
-
 #ifndef _M_PRINTF_
 #define _M_PRINTF_
 
+#include <stdarg.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 extern int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args);
 extern int m_snprintf(char* buf, int length, const char *fmt, ...);
-extern int m_printf(const char *fmt, ...);
+extern int m_printf(char const*, ...);
+extern int m_vprintf ( const char * format, va_list arg );
+extern void m_putc(char c);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /*_M_PRINTF_*/

--- a/Sming/system/include/stringconversion.h
+++ b/Sming/system/include/stringconversion.h
@@ -14,6 +14,7 @@ extern "C" {
 
 int atoi(const char *nptr); // Already implemented
 
+extern char* ltoa_wp(long val, char* buffer, int base, int width, char pad);
 extern char* ltoa_w (long, char*, int, int width);
 extern char* ltoa (long, char*, int);
 
@@ -22,6 +23,7 @@ extern char* ultoa_w(unsigned long val, char* buffer, unsigned int base, int wid
 extern char* ultoa(unsigned long val, char* buffer, unsigned int base);
 
 #define itoa ltoa
+extern char *dtostrf_p(double floatVar, int minStringWidthIncDecimalPoint, int numDigitsAfterDecimal, char *outputBuffer, char pad);
 extern char *dtostrf(double floatVar, int minStringWidthIncDecimalPoint, int numDigitsAfterDecimal, char *outputBuffer);
 long atol(const char *nptr);
 extern long os_strtol(const char* str, char** endptr, int base);

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -7,7 +7,6 @@ Descr: embedded very simple version of printf with float support
 */
 
 #include <stdarg.h>
-//#include "../../SmingCore/SmingCore.h"
 #include "osapi.h"
 
 #define MPRINTF_BUF_SIZE 256

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -7,7 +7,8 @@ Descr: embedded very simple version of printf with float support
 */
 
 #include <stdarg.h>
-#include "../../SmingCore/SmingCore.h"
+//#include "../../SmingCore/SmingCore.h"
+#include "osapi.h"
 
 #define MPRINTF_BUF_SIZE 256
 
@@ -32,6 +33,12 @@ void setMPrintfPrinterCbc(void (*callback)(char))
 	cbc_printchar = callback;
 }
 
+void m_putc(char c)
+{
+	if (cbc_printchar)
+		cbc_printchar(c);
+}
+
 /**
  * @fn int m_snprintf(char* buf, int length, const char *fmt, ...);
  *
@@ -54,14 +61,7 @@ int m_snprintf(char* buf, int length, const char *fmt, ...)
 	return n;
 }
 
-/**
- * @fn int m_printf(const char *fmt, ...);
- *
- * @param fmt - printf compatible format string
- *
- * @retval int - number of characters written to console
- */
-int m_printf(const char *fmt, ...)
+int m_vprintf ( const char * format, va_list arg )
 {
 	if(!cbc_printchar)
 	{
@@ -69,20 +69,41 @@ int m_printf(const char *fmt, ...)
 	}
 
 	char buf[MPRINTF_BUF_SIZE], *p;
-	va_list args;
-	int n = 0;
 
-	va_start(args, fmt);
-	m_vsnprintf(buf, sizeof(buf), fmt, args);
-	va_end(args);
+	int n = 0;
+	m_vsnprintf(buf, sizeof(buf), format, arg);
 
 	p = buf;
-	while (*p)
+	while (p && n < sizeof(buf) && *p)
 	{
 		cbc_printchar(*p);
 		n++;
 		p++;
 	}
+
+	return n;
+}
+
+/**
+ * @fn int m_printf(const char *fmt, ...);
+ *
+ * @param fmt - printf compatible format string
+ *
+ * @retval int - number of characters written to console
+ */
+int m_printf(const char* fmt, ...)
+{
+	int n=0;
+
+	if(!fmt)
+		return 0;
+
+	va_list args;
+	va_start(args, fmt);
+
+	n = m_vprintf(fmt, args);
+
+	va_end(args);
 
 	return n;
 }
@@ -95,7 +116,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
 	int8_t precision, width;
 	char pad;
 
-	char tempNum[24];
+	char tempNum[40];
 
 	for (str = buf; *fmt; fmt++)
 	{
@@ -176,7 +197,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
 
 		case 'p':
 			s = ultoa((unsigned long) va_arg(args, void *), tempNum, 16);
-			while (*s)
+			while (*s && (maxLen - (uint32_t)(str - buf) > OVERFLOW_GUARD))
 				*str++ = *s++;
 			continue;
 
@@ -197,8 +218,8 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
 
 		case 'f':
 
-			s = dtostrf(va_arg(args, double), width, precision, tempNum);
-			while (*s)
+			s = dtostrf_p(va_arg(args, double), width, precision, tempNum, pad);
+			while (*s && (maxLen - (uint32_t)(str - buf) > OVERFLOW_GUARD))
 				*str++ = *s++;
 			continue;
 
@@ -213,11 +234,11 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
 		}
 
 		if (flags & SIGN)
-			s = ltoa_w(va_arg(args, int), tempNum, base, width);
+			s = ltoa_wp(va_arg(args, int), tempNum, base, width, pad);
 		else
 			s = ultoa_wp(va_arg(args, unsigned int), tempNum, base, width, pad);
 
-		while (*s)
+		while (*s && (maxLen - (uint32_t)(str - buf) > OVERFLOW_GUARD))
 			*str++ = *s++;
 	}
 

--- a/Sming/system/stringconversion.cpp
+++ b/Sming/system/stringconversion.cpp
@@ -83,7 +83,7 @@ char *dtostrf(double floatVar, int minStringWidthIncDecimalPoint, int numDigitsA
 }
 // Author zitron: http://forum.arduino.cc/index.php?topic=37391#msg276209
 // modified by ADiea: remove dependencies strcat, floor, round; reorganize+speedup code
-extern char *dtostrf_p(double floatVar, int minStringWidthIncDecimalPoint, int numDigitsAfterDecimal, char *outputBuffer, char pad)
+char *dtostrf_p(double floatVar, int minStringWidthIncDecimalPoint, int numDigitsAfterDecimal, char *outputBuffer, char pad)
 {
 	char temp[40], num[40];
 	unsigned long mult = 1, int_part;

--- a/Sming/system/stringconversion.cpp
+++ b/Sming/system/stringconversion.cpp
@@ -12,8 +12,13 @@ char* ltoa(long val, char* buffer, int base)
 
 char* ltoa_w(long val, char* buffer, int base, int width)
 {
-	int i = 34, p = 0;
-	char buf[36] = {0};
+	return ltoa_wp(val, buffer, base, width, ' ');
+}
+
+char* ltoa_wp(long val, char* buffer, int base, int width, char pad)
+{
+	int i = 38, p = 0;
+	char buf[40] = {0};
 	bool ngt = val < 0;
 	if (ngt) val = -val;
 
@@ -29,8 +34,9 @@ char* ltoa_w(long val, char* buffer, int base, int width)
 		width -= strlen(&buf[i+1]);
 		if(width > 0)
 		{
-			memset(buffer, ' ', width);
+			memset(buffer, pad, width);
 		}
+		else width = 0;
 	}
 
 	strcpy(buffer + width, &buf[i+1]);
@@ -50,8 +56,8 @@ char* ultoa_w(unsigned long val, char* buffer, unsigned int base, int width)
 }
 char* ultoa_wp(unsigned long val, char* buffer, unsigned int base, int width, char pad)
 {
-	int i = 34, p = 0;
-	char buf[36] = {0};
+	int i = 38, p = 0;
+	char buf[40] = {0};
 
 	for(; val && i ; --i, p++, val /= base)
 		buf[i] = "0123456789abcdef"[val % base];
@@ -64,17 +70,22 @@ char* ultoa_wp(unsigned long val, char* buffer, unsigned int base, int width, ch
 		{
 			memset(buffer, pad, width);
 		}
+		else width = 0;
 	}
 	strcpy(buffer + width, &buf[i+1]);
 
 	return buffer;
 }
 
-// Author zitron: http://forum.arduino.cc/index.php?topic=37391#msg276209
-// modified by ADiea: remove dependencies strcat, floor, round; reorganize+speedup code
 char *dtostrf(double floatVar, int minStringWidthIncDecimalPoint, int numDigitsAfterDecimal, char *outputBuffer)
 {
-	char temp[24], num[24];
+	return dtostrf_p(floatVar, minStringWidthIncDecimalPoint, numDigitsAfterDecimal, outputBuffer, ' ');
+}
+// Author zitron: http://forum.arduino.cc/index.php?topic=37391#msg276209
+// modified by ADiea: remove dependencies strcat, floor, round; reorganize+speedup code
+extern char *dtostrf_p(double floatVar, int minStringWidthIncDecimalPoint, int numDigitsAfterDecimal, char *outputBuffer, char pad)
+{
+	char temp[40], num[40];
 	unsigned long mult = 1, int_part;
 	int16_t i, processedFracLen = numDigitsAfterDecimal;
 
@@ -174,7 +185,7 @@ char *dtostrf(double floatVar, int minStringWidthIncDecimalPoint, int numDigitsA
 		i = minStringWidthIncDecimalPoint - strlen(num) + 1;
 		while (--i > 0)
 		{
-			*buf++ = ' ';
+			*buf++ = pad;
 		}
 
 		//Write output buffer


### PR DESCRIPTION
…ge\nfix crash when size is smaller than arg_size for %d %u\n fix padding for %d and %f\nfix buffer overflow for %d %f\n add vsnprintf equivalent \n add putch equivalent

Rebase of https://github.com/SmingHub/Sming/pull/748