### PR TITLE
Specify commit to checkout for esp-open-sdk

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -109,7 +109,7 @@ RUN useradd -d /home/espbuilder -m espbuilder && \
 	echo "espbuilder ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/espbuilder && \
 	chmod 0440 /etc/sudoers.d/espbuilder
 
-RUN cd /opt && git clone --recursive https://github.com/pfalcon/esp-open-sdk.git
+RUN cd /opt && git clone --recursive https://github.com/pfalcon/esp-open-sdk.git && cd /opt/esp-open-sdk && git checkout e8d757b1a70a5cf19df0afe23a769739c6cff343
 RUN chmod 777 -R /opt/esp-open-sdk
 
 USER espbuilder

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,7 +69,7 @@ RUN rm "node-v$NODE_VERSION-linux-x64.tar.xz" SHASUMS256.txt.asc SHASUMS256.txt
 # Install Cloud9
 # ------------------------------------------------------------------------------
 
-RUN git clone https://github.com/c9/core.git /opt/cloud9
+RUN git clone https://github.com/c9/core.git /opt/cloud9 && cd /opt/cloud9 && git checkout 32fc12bf922288d0c2b518c73aa75e19f14bed8b
 WORKDIR /opt/cloud9
 RUN scripts/install-sdk.sh
 RUN npm install
@@ -145,7 +145,7 @@ RUN wget https://github.com/themadinventor/esptool/archive/master.zip && unzip m
 # Install esptool2
 # ------------------------------------------------------------------------------
 
-RUN cd $ESP_HOME && git clone https://github.com/raburton/esptool2
+RUN cd $ESP_HOME && git clone https://github.com/raburton/esptool2 && cd $ESP_HOME/esptool2 && git checkout ec0e2c72952f4fa8242eedd307c58a479d845abe
 RUN cd $ESP_HOME/esptool2 && make
 
 ENV PATH $ESP_HOME/esptool2:$PATH


### PR DESCRIPTION
Fix esp-open-sdk git commit to checkout.

Not specifying the commit could have 3 issues:
 1. Possibly building unchecked version, which could cause difficult to catch bugs.
 2. Difficulty to reproduce identical build environment on a later time
 3. Docker caching issues when wanting to rebuild with a later esp-open-sdk version

All other git checkouts should be frozen to specific tags or commits as well, testing it currently.