### PR TITLE
Proper timeout handling for Websockets

### DIFF
--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -110,6 +110,7 @@ bool HttpServer::initWebSocket(HttpServerConnection& connection, HttpRequest& re
     if (!sock->initialize(request, response))
         return false;
 
+    connection.setTimeOut(USHRT_MAX); //Disable disconnection on connection idle (no rx/tx)
 	connection.setDisconnectionHandler(HttpServerConnectionDelegate(&HttpServer::onCloseWebSocket, this)); // auto remove on close
 	response.sendHeader(connection); // Will push header before user data
 

--- a/Sming/SmingCore/Network/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/HttpServerConnection.cpp
@@ -115,7 +115,6 @@ void HttpServerConnection::beginSendData()
 	{
 		debugf("Switched to WebSocket Protocol");
 		state = eHCS_WebSocketFrames; // Stay opened
-//		setTimeOut(USHRT_MAX);
 	}
 	else
 		state = eHCS_Sending;

--- a/Sming/SmingCore/Network/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/HttpServerConnection.cpp
@@ -115,7 +115,7 @@ void HttpServerConnection::beginSendData()
 	{
 		debugf("Switched to WebSocket Protocol");
 		state = eHCS_WebSocketFrames; // Stay opened
-		setTimeOut(USHRT_MAX);
+//		setTimeOut(USHRT_MAX);
 	}
 	else
 		state = eHCS_Sending;

--- a/Sming/SmingCore/Network/WebSocket.h
+++ b/Sming/SmingCore/Network/WebSocket.h
@@ -30,6 +30,7 @@ public:
 	void sendBinary(const uint8_t* data, int size);
 	void enableCommand();
 	void close();
+	void setTimeOut(uint16_t waitTimeOut) { if(connection) connection->setTimeOut(waitTimeOut); };
 
 protected:
 	bool initialize(HttpRequest &request, HttpResponse &response);


### PR DESCRIPTION
Current implementation of websockets lack some timeout to disconnect idle and moreover dead clients.
If client is browser there is no problec, browser itself or underlying OS send either correct websocket close
frame or at least TCP close, but if client is esp8266 or similar it can hang/freeze/go offline/etc
unexpectedly, and do not send ANY cleanup to websocket server so such connection will stay forever.
Proposed change resolve this by exposing setTimeOut to Websocket class and change of setting default timeout
for websocket client connection. Now it is possible to set desired client timeout in onConnect event of
websocket server or do nothing and keep original behaviour - no disconnection on connection idle.
+ Expose setTimeOut from HttpServerConnection to Websocket
- Remove setTimeOut(USHRT_MAX) from HttpServerConnection::beginSendData()
+ Add connection.setTimeOut(USHRT_MAX) to HttpServer::initWebSocket to preserve original behaviour