### PR TITLE
More efficient way to analyze errors.

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -134,6 +134,8 @@ ifeq ($(ENABLE_GDB), 1)
 	THIRD_PARTY_DATA += third-party/esp-gdbstub/Makefile
 	MODULES		 += third-party/esp-gdbstub
 	EXTRA_INCDIR += third-party/esp-gdbstub
+else ifneq ($(SMING_RELEASE),1)
+	MODULES += gdb
 endif
 
 # libraries used in this project, mainly provided by the SDK
@@ -147,7 +149,11 @@ endif
 
 # compiler flags using during compilation of source files. Add '-pg' for debugging
 CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL)
-ifeq ($(ENABLE_GDB), 1)
+ifeq ($(SMING_RELEASE),1)
+	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
+	#      for full list of optimization options
+	CFLAGS += -Os -DSMING_RELEASE=1
+else ifeq ($(ENABLE_GDB), 1)
 	CFLAGS += -Og -ggdb -DGDBSTUB_FREERTOS=0 -DENABLE_GDB=1
 else
 	CFLAGS += -Os -g

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -116,6 +116,8 @@ export COMPILE := gcc
 export PATH := $(ESP_HOME)/xtensa-lx106-elf/bin:$(PATH)
 XTENSA_TOOLS_ROOT := $(ESP_HOME)/xtensa-lx106-elf/bin
 
+STRIP   := $(XTENSA_TOOLS_ROOT)/xtensa-lx106-elf-strip
+
 CURRENT_DIR := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
 
 SPIFF_FILES ?= files
@@ -152,12 +154,18 @@ LIBS		= microc microgcc hal phy pp net80211 lwip wpa main $(LIBSMING) crypto pwm
 
 # compiler flags using during compilation of source files
 CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS)
-ifeq ($(ENABLE_GDB), 1)
+ifeq ($(SMING_RELEASE),1)
+	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
+	#      for full list of optimization options
+	CFLAGS += -Os -DSMING_RELEASE=1
+else ifeq ($(ENABLE_GDB), 1)
 	CFLAGS += -Og -ggdb -DGDBSTUB_FREERTOS=0 -DENABLE_GDB=1
 	MODULES		 += $(THIRD_PARTY_DIR)/gdbstub
 	EXTRA_INCDIR += $(THIRD_PARTY_DIR)/gdbstub
+	STRIP := @true
 else
 	CFLAGS += -Os -g
+	STRIP := @true
 endif
 CXXFLAGS	= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11 -felide-constructors
 
@@ -305,6 +313,8 @@ spiff_update: spiff_clean $(SPIFF_BIN_OUT)
 $(TARGET_OUT): $(APP_AR)
 	$(vecho) "LD $@"	
 	$(Q) $(LD) -L$(USER_LIBDIR) -L$(SDK_LIBDIR) $(LD_SCRIPT) $(LDFLAGS) -Wl,--start-group $(LIBS) $(APP_AR) -Wl,--end-group -o $@
+
+	$(Q) $(STRIP) $@
 
 	$(vecho) ""	
 	$(vecho) "#Memory / Section info:"	

--- a/Sming/appinit/user_main.cpp
+++ b/Sming/appinit/user_main.cpp
@@ -1,8 +1,10 @@
 #include <user_config.h>
 #include "../SmingCore/SmingCore.h"
 
-#ifdef ENABLE_GDB
-	#include "../esp-gdbstub/gdbstub.h"
+#ifndef SMING_RELEASE
+extern "C" {
+  void gdbstub_init();
+}
 #endif
 
 extern void init();
@@ -13,7 +15,11 @@ extern "C" void  __attribute__((weak)) user_init(void)
 	uart_div_modify(UART_ID_0, UART_CLK_FREQ / 115200);
 	cpp_core_initialize();
 	System.initialize();
-#ifdef ENABLE_GDB
+#ifdef SMING_RELEASE
+	// disable all debug output for release builds
+	Serial.systemDebugOutput(false);
+	system_set_os_print(0);
+#else
 	gdbstub_init();
 #endif
 	init(); // User code init

--- a/Sming/gdb/gdbstub-entry.s
+++ b/Sming/gdb/gdbstub-entry.s
@@ -1,0 +1,54 @@
+/******************************************************************************
+ * Copyright 2015 Espressif Systems
+ *
+ * Description: Assembly routines for the gdbstub
+ *
+ * License: ESPRESSIF MIT License
+ *******************************************************************************/
+
+
+#include <xtensa/config/specreg.h>
+#include <xtensa/config/core-isa.h>
+#include <xtensa/corebits.h>
+
+.global gdbstub_savedRegs
+
+	.text
+.literal_position
+
+	.text
+	.align	4
+
+/*
+The savedRegs struct:
+	uint32_t pc;
+	uint32_t ps;
+	uint32_t sar;
+	uint32_t vpri;
+	uint32_t a0;
+	uint32_t a[14]; //a2..a15
+	uint32_t litbase;
+	uint32_t sr176;
+	uint32_t sr208;
+	uint32_t a1;
+	uint32_t reason;
+	uint32_t excvaddr;
+*/
+
+	.global gdbstub_save_extra_sfrs_for_exception
+	.align 4
+//The Xtensa OS HAL does not save all the special function register things. This bit of assembly
+//fills the gdbstub_savedRegs struct with them.
+gdbstub_save_extra_sfrs_for_exception:
+	movi	a2, gdbstub_savedRegs
+	rsr		a3, LITBASE
+	s32i	a3, a2, 0x4C
+	rsr		a3, 176
+	s32i	a3, a2, 0x50
+	rsr		a3, 208
+	s32i	a3, a2, 0x54
+	rsr		a3, EXCCAUSE
+	s32i	a3, a2, 0x5C
+	rsr		a3, EXCVADDR
+	s32i	a3, a2, 0x60
+	ret

--- a/Sming/gdb/gdbstub.c
+++ b/Sming/gdb/gdbstub.c
@@ -44,6 +44,9 @@ static unsigned int getaregval(int reg) {
 static void print_stack(uint32_t start, uint32_t end) {
   uint32_t pos = 0;
   os_printf("\nStack dump:\n");
+  os_printf("To decode the stack dump call from command line:\n   python $SMING_HOME/tools/decode-stacktrace.py out/build/app.out\n");
+  os_printf("and copy & paste the text enclosed in '===='.\n");
+  os_printf("================================================================\n");
   for (pos = start; pos < end; pos += 0x10) {
     uint32_t* values = (uint32_t*)(pos);
     // rough indicator: stack frames usually have SP saved as the second word
@@ -53,6 +56,9 @@ static void print_stack(uint32_t start, uint32_t end) {
         pos, values[0], values[1], values[2], values[3], (looksLikeStackFrame)?'<':' ');
   }
   os_printf("\n");
+  os_printf("================================================================\n");
+  os_printf("To decode the stack dump call from command line:\n   python $SMING_HOME/tools/decode-stacktrace.py out/build/app.out\n");
+  os_printf("and copy & paste the text enclosed in '===='.\n");
 }
 
 void _xtos_set_exception_handler(int cause, void (exhandler)(struct XTensa_exception_frame_s *frame));

--- a/Sming/gdb/gdbstub.c
+++ b/Sming/gdb/gdbstub.c
@@ -1,0 +1,113 @@
+/******************************************************************************
+ * Copyright 2015 Espressif Systems
+ *
+ * Description: A stub to make the ESP8266 debuggable by GDB over the serial
+ * port.
+ *
+ * License: ESPRESSIF MIT License
+ *******************************************************************************/
+
+#include <user_config.h>
+#include "ets_sys.h"
+#include "eagle_soc.h"
+#include "c_types.h"
+#include "gpio.h"
+#include "xtensa/corebits.h"
+
+//From xtruntime-frames.h
+struct XTensa_exception_frame_s {
+  uint32_t pc;
+  uint32_t ps;
+  uint32_t sar;
+  uint32_t vpri;
+  uint32_t a0;
+  uint32_t a[14]; //a2..a15
+  // The following are added manually by the exception code; the HAL doesn't set these on an exception.
+  uint32_t litbase;
+  uint32_t sr176;
+  uint32_t sr208;
+  uint32_t a1;
+  uint32_t reason;
+  uint32_t excvaddr;
+};
+
+//The asm stub saves the Xtensa registers here when a debugging exception happens.
+struct XTensa_exception_frame_s gdbstub_savedRegs;
+
+//Get the value of one of the A registers
+static unsigned int getaregval(int reg) {
+  if (reg==0) return gdbstub_savedRegs.a0;
+  if (reg==1) return gdbstub_savedRegs.a1;
+  return gdbstub_savedRegs.a[reg-2];
+}
+
+static void print_stack(uint32_t start, uint32_t end) {
+  uint32_t pos = 0;
+  os_printf("\nStack dump:\n");
+  for (pos = start; pos < end; pos += 0x10) {
+    uint32_t* values = (uint32_t*)(pos);
+    // rough indicator: stack frames usually have SP saved as the second word
+    bool looksLikeStackFrame = (values[2] == pos + 0x10);
+
+    os_printf("%08lx:  %08lx %08lx %08lx %08lx %c\n",
+        pos, values[0], values[1], values[2], values[3], (looksLikeStackFrame)?'<':' ');
+  }
+  os_printf("\n");
+}
+
+void _xtos_set_exception_handler(int cause, void (exhandler)(struct XTensa_exception_frame_s *frame));
+int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
+
+// Print exception info to console
+static void printReason() {
+  int i=0;
+  //register uint32_t sp asm("a1");
+  struct XTensa_exception_frame_s *reg = &gdbstub_savedRegs;
+  os_printf("\n\n***** Fatal exception %ld\n", reg->reason);
+  os_printf("pc=0x%08lx sp=0x%08lx excvaddr=0x%08lx\n", reg->pc, reg->a1, reg->excvaddr);
+  os_printf("ps=0x%08lx sar=0x%08lx vpri=0x%08lx\n", reg->ps, reg->sar, reg->vpri);
+  for (i=0; i<16; i++) {
+    unsigned int r = getaregval(i);
+    os_printf("r%02d: 0x%08x=%10d ", i, r, r);
+    if (i%3 == 2) os_printf("\n");
+  }
+  os_printf("\n");
+  //print_stack(reg->pc, sp, 0x3fffffb0);
+  print_stack(getaregval(1), 0x3fffffb0);
+}
+
+extern void ets_wdt_disable();
+extern void ets_wdt_enable();
+
+// Non-OS exception handler. Gets called by the Xtensa HAL.
+static void gdb_exception_handler(struct XTensa_exception_frame_s *frame) {
+  //Save the extra registers the Xtensa HAL doesn't save
+  extern void gdbstub_save_extra_sfrs_for_exception();
+  gdbstub_save_extra_sfrs_for_exception();
+  //Copy registers the Xtensa HAL did save to gdbstub_savedRegs
+  os_memcpy(&gdbstub_savedRegs, frame, 19*4);
+  //Credits go to Cesanta for this trick. A1 seems to be destroyed, but because it
+  //has a fixed offset from the address of the passed frame, we can recover it.
+  //gdbstub_savedRegs.a1=(uint32_t)frame+EXCEPTION_GDB_SP_OFFSET;
+  gdbstub_savedRegs.a1=(uint32_t)frame;
+
+  ets_wdt_disable();
+  printReason();
+  ets_wdt_enable();
+  while(1) ;
+}
+
+//The OS-less SDK uses the Xtensa HAL to handle exceptions. We can use those functions to catch any
+//fatal exceptions and invoke the debugger when this happens.
+void gdbstub_init() {
+  unsigned int i;
+  int exno[]={EXCCAUSE_ILLEGAL, EXCCAUSE_SYSCALL, EXCCAUSE_INSTR_ERROR, EXCCAUSE_LOAD_STORE_ERROR,
+      EXCCAUSE_DIVIDE_BY_ZERO, EXCCAUSE_UNALIGNED, EXCCAUSE_INSTR_DATA_ERROR, EXCCAUSE_LOAD_STORE_DATA_ERROR,
+      EXCCAUSE_INSTR_ADDR_ERROR, EXCCAUSE_LOAD_STORE_ADDR_ERROR, EXCCAUSE_INSTR_PROHIBITED,
+      EXCCAUSE_LOAD_PROHIBITED, EXCCAUSE_STORE_PROHIBITED};
+  for (i=0; i<(sizeof(exno)/sizeof(exno[0])); i++) {
+    _xtos_set_exception_handler(exno[i], gdb_exception_handler);
+  }
+}
+
+//extern void gdb_init() __attribute__((weak, alias("gdbstub_init")));

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -34,7 +34,11 @@
 #endif
 
 #undef assert
+#ifdef SMING_RELEASE
+#define debugf(fmt, ...)
+#else
 #define debugf(fmt, ...) m_printf(fmt"\r\n", ##__VA_ARGS__)
+#endif
 #define assert(condition) if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__)
 #define SYSTEM_ERROR(fmt, ...) m_printf("ERROR: " fmt "\r\n", ##__VA_ARGS__)
 

--- a/tools/decode-stacktrace.py
+++ b/tools/decode-stacktrace.py
@@ -1,0 +1,53 @@
+#!/bin/sh
+########################################################
+#
+#  Stack Trace Decoder
+#  Author: Slavey Karadzhov <slav@attachix.com>
+#
+########################################################
+import shlex
+import select
+import subprocess
+import sys
+import re
+
+def usage():
+    print "Usage: \n\t%s <file.elf> [<error-stack.log>]" % sys.argv[0]
+    
+def extractAddresses(data):
+    m = re.findall("(40[0-2](\d|[a-f]){5})", data)
+    if len(m) == 0:
+        return m
+      
+    addresses = []      
+    for item in m:
+        addresses.append(item[0]) 
+            
+    return addresses  
+    
+if __name__ == "__main__":
+    if len(sys.argv)  not in range(2,4):
+        usage()
+        sys.exit(1)
+        
+    command = "xtensa-lx106-elf-addr2line -aipfC -e '%s' " % sys.argv[1]
+    pipe = subprocess.Popen(shlex.split(command), bufsize=1, stdin=subprocess.PIPE)
+    
+    if len(sys.argv) > 2:
+        data = open(sys.argv[2]).read()
+        pipe.communicate("\n".join(extractAddresses(data)))
+    else:
+        while True:
+            data = raw_input()
+            addresses = extractAddresses(data)
+            if len(addresses) == 0:
+                continue
+            
+#             print "[",addresses,"]"
+            
+            line = "\r\n".join(addresses)+"\r\n"
+#             line = line.ljust(125," ")
+            
+            pipe.stdin.write(line)
+            pipe.stdin.flush()
+            


### PR DESCRIPTION
With this new addition it will be possible to see the complete stack dump from an error and analyze it using a simple tool written in python. 

Once a fatal exception occurs SMING will try to handle it and print: something like

```bash
dhcp server start:(ip:192.168.4.1,mask:255.255.255.0,gw:192.168.4.1)
bcn 100
E:M 1610615024


***** Fatal exception 29
pc=0x4000e1c3 sp=0x3ffff900 excvaddr=0x00000018
ps=0x00000030 sar=0x00000004 vpri=0x0000000a
r00: 0x400018ac=1073748140 r01: 0x3ffff900=1073740032 r02: 0x00000018=        24 
r03: 0x00000000=         0 r04: 0x00000008=         8 r05: 0x00000018=        24 
r06: 0x3ffffab8=1073740472 r07: 0x00000000=         0 r08: 0x3fff27c8=1073686472 
r09: 0x00000000=         0 r10: 0x00000000=         0 r11: 0x00000000=         0 
r12: 0x00000018=        24 r13: 0x3ffffa88=1073740424 r14: 0x3fff2218=1073685016 
r15: 0x3ffef794=1073674132 

Stack dump:
To decode the stack dump call from command line:
   python $SMING_HOME/tools/decode-stacktrace.py out/build/app.out
and copy & paste the text enclosed in '====' 
================================================================
3ffff900:  4000e1c3 00000030 00000004 0000000a  
3ffff910:  400018ac 00000018 00000000 00000008  
3ffff920:  00000018 3ffffab8 00000000 3fff27c8  
3ffff930:  00000000 00000000 00000000 00000018  
3ffff940:  3ffffa88 3fff2218 3ffef794 0000001d  
3ffff950:  00380031 00000064 00000000 0000000a  
3ffff960:  00000000 3ffff9d0 3ffff9d0 3ffe8523  
3ffff970:  40002514 3fffdd3c 00000000 3ffeab0c  
3ffff980:  60000600 0000000a 00000008 00000000  
3ffff990:  00000000 600008f0 00000000 3ffff92a  
3ffff9a0:  00000000 00000064 00000000 3ffff933
=====
...
```

To decode that that use the recommended command (python $SMING_HOME/tools/decode-stacktrace.py out/build/app.out). Once the command is started you can paste the stack dump and as a result you will get an output like that...

```bash
3fffffa0:  000203e9 00030000 203a6100 55aa55aa0x40100cb8: pvPortMalloc at ??:?
0x40000000: ?? ??:0
0x40240000: AccessPointClass::onSystemReady() at /path-to/Sming/Sming/SmingCore/Platform/AccessPoint.cpp:174
0x40236ca0: chip_v6_unset_chanfreq at ??:?
0x4021bee2: esf_buf_alloc at ??:?
0x402211e9: ieee80211_freedom_output at ??:?
0x4021c707: ieee80211_getmgtframe at ??:?
0x40221426: ieee80211_beacon_alloc at ??:?
0x4021cd8a: ieee80211_hostap_attach at ??:?
0x4021ded8: wifi_softap_start at ??:?
0x40209914: user_rf_pre_init at ??:?
0x402098b9: user_rf_pre_init at ??:?
0x40100734: wdt_feed at ??:?
```
