### PR TITLE
Fix stability and performance of websocket server

### DIFF
--- a/Sming/SmingCore/Network/WebSocket.cpp
+++ b/Sming/SmingCore/Network/WebSocket.cpp
@@ -51,7 +51,6 @@ void WebSocket::send(const char* message, int length, wsFrameType type)
 	wsMakeFrame(nullptr, length, frameHeader, &headSize, type);
 	connection->write((char*)frameHeader, headSize, TCP_WRITE_FLAG_COPY | TCP_WRITE_FLAG_MORE);
 	connection->write(message, length, TCP_WRITE_FLAG_COPY);
-	connection->flush();
 }
 
 void WebSocket::sendString(const String& message)


### PR DESCRIPTION
By removing flush() in websocket send code we add just little more delay but stability and performance of websocket server increased.
Tested on VERY frequent sending some date via websocket from server to client (browser)
without fix data often lost and overal stability of server fall, with this fix I can send VERY frequently each second without data loss and stability loss.