### PR TITLE
Update DS18S20.cpp and .h

### DIFF
--- a/Sming/Libraries/DS18S20/ds18s20.cpp
+++ b/Sming/Libraries/DS18S20/ds18s20.cpp
@@ -150,6 +150,10 @@ void DS18S20::StartReadNext()
    {
 	   debugx("  DBG: DS18S20 reading task end");
 	   InProgress=false;
+	   if(ReadEndCallback > 0)
+	   {
+		   ReadEndCallback();
+	   }
    }
 }
 
@@ -255,3 +259,12 @@ uint8_t DS18S20::GetSensorsCount()
 
 }
 
+void DS18S20::RegisterEndCallback(void (*Callback)())
+{
+	ReadEndCallback = Callback;
+}
+
+void DS18S20::UnRegisterCallback()
+{
+	ReadEndCallback = 0;
+}


### PR DESCRIPTION
Added callback on end of conversion.
in DS18S20.h File
public section:

	void RegisterEndCallback(void (*)()); //End conversion "interrupt" function register
	void UnRegisterCallback(); //Delete "interrupt" [end conversion]
private

void (*ReadEndCallback)() = 0;

file DS18s20.h in separate pull... 