### PR TITLE
Add callback to end of temperature conversion.

### DIFF
--- a/Sming/Libraries/DS18S20/ds18s20.cpp
+++ b/Sming/Libraries/DS18S20/ds18s20.cpp
@@ -256,7 +256,6 @@ uint64_t DS18S20::GetSensorID(uint8_t index)
 uint8_t DS18S20::GetSensorsCount()
 {
 		  return numberOf;
-
 }
 
 void DS18S20::RegisterEndCallback(void (*Callback)())

--- a/Sming/Libraries/DS18S20/ds18s20.cpp
+++ b/Sming/Libraries/DS18S20/ds18s20.cpp
@@ -150,6 +150,10 @@ void DS18S20::StartReadNext()
    {
 	   debugx("  DBG: DS18S20 reading task end");
 	   InProgress=false;
+	   if(ReadEndCallback > 0) //If callback set, execute function
+	   {
+		   ReadEndCallback();
+	   }
    }
 }
 
@@ -253,5 +257,15 @@ uint8_t DS18S20::GetSensorsCount()
 {
 		  return numberOf;
 
+}
+
+void DS18S20::RegisterEndCallback(void (*Callback)())
+{
+	ReadEndCallback = Callback;
+}
+
+void DS18S20::UnRegisterCallback()
+{
+	ReadEndCallback = 0;
 }
 

--- a/Sming/Libraries/DS18S20/ds18s20.h
+++ b/Sming/Libraries/DS18S20/ds18s20.h
@@ -28,7 +28,9 @@ class DS18S20
 public:
 	DS18S20();
 	void Init(uint8_t);			//call for OneWire init
-	void StartMeasure();        //Start measurement result after 1.2 seconds * number of sensors
+	void StartMeasure();                    //Start measurement result after 1.2 seconds * number of sensors
+	void RegisterEndCallback(void (*)());   //Add function called of conversion end - "interrupt" function of end conversion
+	void UnRegisterCallback();              //Unset conversion end function
 	float GetCelsius(uint8_t);
 	float GetFahrenheit(uint8_t);
 	bool IsValidTemperature(uint8_t);


### PR DESCRIPTION
`void StartMeasure();` --Only added spaces 2 comment (Git edit = del -> add) i no delete any function. 

This library working correctly on my device ~8 month.

I used 2 temperature sensor send to Thingspeak every 30s.

Used:

```
void sendData()
{
     /*New read temperature data processing*/
}

ReadTemp.RegisterEndCallback(sendData);
```
Edit or add new Sample to DS18S20 library? 