### PR TITLE
operator== to compare web sockets

### DIFF
--- a/Sming/SmingCore/Network/WebSocket.h
+++ b/Sming/SmingCore/Network/WebSocket.h
@@ -32,6 +32,8 @@ public:
 	void close();
 	void setTimeOut(uint16_t waitTimeOut) { if(connection) connection->setTimeOut(waitTimeOut); };
 
+	bool operator==(const WebSocket &other) const { return this->connection == other.connection;};
+
 protected:
 	bool initialize(HttpRequest &request, HttpResponse &response);
 	bool is(HttpServerConnection* conn) { return connection == conn; };


### PR DESCRIPTION
in some web socket applications it is useful to relay an incoming message from a client to all other clients.

Without possibility to compare the sender with the clients list this is difficult.

Also the operator== is missing in the method
WebSocketsList.removeElement(const WebSocket & obj)