### PR TITLE
spiffs_mount() added in ScreenTFT_ILI9340-ILI9341 sample

### DIFF
--- a/samples/ScreenTFT_ILI9340-ILI9341/app/application.cpp
+++ b/samples/ScreenTFT_ILI9340-ILI9341/app/application.cpp
@@ -85,6 +85,10 @@ void init()
 	//WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(false);
 	WifiAccessPoint.enable(false);
+	
+	spiffs_mount();
+	Serial.println("FileSystem mounted.");
+
 	//	delay(2000);
 	Serial.println("Display start");
 


### PR DESCRIPTION
Added **spiffs_mount()** to enable the file system and be able to read BMP
files.