### PR TITLE
Allow compilation of custom LWIP

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,3 +24,6 @@
 	path = Sming/third-party/umm_malloc
 	url = https://github.com/rhempel/umm_malloc.git
 	ignore = dirty
+[submodule "Sming/third-party/esp-open-lwip"]
+	path = Sming/third-party/esp-open-lwip
+	url = https://github.com/pfalcon/esp-open-lwip.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,5 +44,4 @@ script:
   - make -C $SMING_HOME/../samples/Basic_Blink clean
   - make Basic_Blink ENABLE_CUSTOM_HEAP=1
   - make clean samples-clean
-  - make ENABLE_CUSTOM_LWIP=1 
-  - make samples ENABLE_CUSTOM_LWIP=1
+  - if [ "$SDK_VERSION" == "1.5.0" ]; then make ENABLE_CUSTOM_LWIP=1; make samples ENABLE_CUSTOM_LWIP=1; fi 

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,6 @@ script:
   - make ENABLE_CUSTOM_HEAP=1
   - make -C $SMING_HOME/../samples/Basic_Blink clean
   - make Basic_Blink ENABLE_CUSTOM_HEAP=1
+  - make clean samples-clean
+  - make ENABLE_CUSTOM_LWIP=1 
+  - make samples ENABLE_CUSTOM_LWIP=1

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -150,10 +150,18 @@ ifeq ($(ENABLE_CUSTOM_HEAP), 1)
 	CUSTOM_TARGETS += $(USER_LIBDIR)/libmainmm.a
 endif
 
+# => Open Source LWIP
+LIBLWIP = lwip
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+	THIRD_PARTY_DATA += third-party/esp-open-lwip/Makefile.open
+	EXTRA_INCDIR += third-party/esp-open-lwip/include
+	CUSTOM_TARGETS += $(USER_LIBDIR)/liblwip_open.a
+	LIBLWIP = lwip_open
+endif
+
 # libraries used in this project, mainly provided by the SDK
 USER_LIBDIR = compiler/lib
-LIBS		= microc microgcc hal phy pp net80211 lwip wpa main
-
+LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa main
 ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	THIRD_PARTY_DATA += third-party/pwm/pwm.c
 	LIBS += pwm
@@ -295,6 +303,13 @@ $(USER_LIBDIR)/libmainmm.a: $(addprefix $(SDK_LIBDIR)/,libmain.a)
 	$(Q) cp $^ $@ 
 	$(Q) $(AR) -d $@ mem_manager.o
 endif
+
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+$(USER_LIBDIR)/liblwip_open.a: third-party/esp-open-lwip/Makefile.open
+	$(Q) $(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open
+	$(Q) cp third-party/esp-open-lwip/liblwip_open.a $@
+endif
+
 
 spiffy: spiffy/spiffy
 

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -152,6 +152,7 @@ endif
 
 # => Open Source LWIP
 LIBLWIP = lwip
+ENABLE_ESPCONN ?= 1
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 	THIRD_PARTY_DATA += third-party/esp-open-lwip/Makefile.open
 	EXTRA_INCDIR += third-party/esp-open-lwip/include
@@ -306,8 +307,7 @@ endif
 
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 $(USER_LIBDIR)/liblwip_open.a: third-party/esp-open-lwip/Makefile.open
-	$(Q) $(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open
-	$(Q) cp third-party/esp-open-lwip/liblwip_open.a $@
+	$(Q) $(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open ENABLE_ESPCONN=$(ENABLE_ESPCONN) USER_LIBDIR=$(SMING_HOME)/$(USER_LIBDIR)/
 endif
 
 

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -146,7 +146,12 @@ endif
 # define your custom directories in the project's own Makefile before including this one
 MODULES      ?= app     # default to app if not set by user
 EXTRA_INCDIR ?= include # default to include if not set by user
-EXTRA_INCDIR += $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SMING_HOME)/Services/SpifFS $(SDK_BASE)/../include $(THIRD_PARTY_DIR)/rboot $(THIRD_PARTY_DIR)/rboot/appcode $(THIRD_PARTY_DIR)/spiffs/src
+
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+	LWIP_INCDIR = $(SMING_HOME)/third-party/esp-open-lwip	
+endif
+
+EXTRA_INCDIR += $(SMING_HOME)/include $(SMING_HOME)/ $(LWIP_INCDIR) $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SMING_HOME)/Services/SpifFS $(SDK_BASE)/../include $(THIRD_PARTY_DIR)/rboot $(THIRD_PARTY_DIR)/rboot/appcode $(THIRD_PARTY_DIR)/spiffs/src
 
 ENABLE_CUSTOM_HEAP ?= 0
  
@@ -155,9 +160,14 @@ ifeq ($(ENABLE_CUSTOM_HEAP),1)
 	LIBMAIN = mainmm
 endif
 
+LIBLWIP = lwip
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+	LIBLWIP = lwip_open
+endif
+
 # libraries used in this project, mainly provided by the SDK
 USER_LIBDIR = $(SMING_HOME)/compiler/lib/
-LIBS		= microc microgcc hal phy pp net80211 lwip wpa $(LIBMAIN) $(LIBSMING) crypto pwm smartconfig $(EXTRA_LIBS)
+LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa $(LIBMAIN) $(LIBSMING) crypto pwm smartconfig $(EXTRA_LIBS)
 
 # compiler flags using during compilation of source files
 CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS)
@@ -188,6 +198,11 @@ ifeq ($(ENABLE_SSL),1)
 	CUSTOM_TARGETS += $(USER_LIBDIR)/lib$(LIBSMING).a include/ssl/private_key.h
 	CFLAGS += $(AXTLS_FLAGS)  
 	CXXFLAGS += $(AXTLS_FLAGS)	
+endif
+
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+	CUSTOM_TARGETS += $(USER_LIBDIR)/liblwip_open.a
+#	EXTRA_INCDIR += third-party/esp-open-lwip/include
 endif
 
 # we will use global WiFi settings from Eclipse Environment Variables, if possible
@@ -364,6 +379,11 @@ include/ssl/private_key.h:
 ifeq ($(ENABLE_CUSTOM_PWM), 1)
 $(USER_LIBDIR)/libpwm.a:
 	$(Q) $(MAKE) -C $(SMING_HOME) compiler/lib/libpwm.a ENABLE_CUSTOM_PWM=1
+endif
+
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+$(USER_LIBDIR)/liblwip_open.a:
+	$(Q) $(MAKE) -C $(SMING_HOME) compiler/lib/liblwip_open.a ENABLE_CUSTOM_LWIP=1
 endif
 
 checkdirs: $(BUILD_DIR) $(FW_BASE) $(CUSTOM_TARGETS)

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -148,7 +148,12 @@ endif
 MODULES      ?= app     # default to app if not set by user
 MODULES      += $(THIRD_PARTY_DIR)/rboot/appcode
 EXTRA_INCDIR ?= include # default to include if not set by user
-EXTRA_INCDIR += $(SMING_HOME)/include $(SMING_HOME)/ $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SMING_HOME)/Services/SpifFS $(SDK_BASE)/../include $(THIRD_PARTY_DIR)/rboot $(THIRD_PARTY_DIR)/rboot/appcode $(THIRD_PARTY_DIR)/spiffs/src
+
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+	LWIP_INCDIR = $(SMING_HOME)/third-party/esp-open-lwip	
+endif
+
+EXTRA_INCDIR += $(SMING_HOME)/include $(SMING_HOME)/ $(LWIP_INCDIR) $(SMING_HOME)/system/include $(SMING_HOME)/Wiring $(SMING_HOME)/Libraries $(SMING_HOME)/SmingCore $(SMING_HOME)/Services/SpifFS $(SDK_BASE)/../include $(THIRD_PARTY_DIR)/rboot $(THIRD_PARTY_DIR)/rboot/appcode $(THIRD_PARTY_DIR)/spiffs/src
 
 USER_LIBDIR  = $(SMING_HOME)/compiler/lib/
 
@@ -194,7 +199,12 @@ else
 endif
 # libraries used in this project, mainly provided by the SDK
 
-LIBS		= microc microgcc hal phy pp net80211 lwip wpa $(LIBMAIN) $(LIBSMING) crypto pwm smartconfig $(EXTRA_LIBS)
+LIBLWIP = lwip
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+	LIBLWIP = lwip_open
+endif
+
+LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa $(LIBMAIN) $(LIBSMING) crypto pwm smartconfig $(EXTRA_LIBS)
 
 # SSL support using axTLS
 ifeq ($(ENABLE_SSL),1)
@@ -209,6 +219,11 @@ ifeq ($(ENABLE_SSL),1)
 	CFLAGS += $(AXTLS_FLAGS)  
 	CXXFLAGS += $(AXTLS_FLAGS)	
 endif
+
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+	EXTRA_INCDIR += third-party/esp-open-lwip/include
+endif
+
 
 # we will use global WiFi settings from Eclipse Environment Variables, if possible
 WIFI_SSID ?= ""

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -1,0 +1,39 @@
+diff --git a/include/user_config.h b/include/user_config.h
+index e69de29..1db5073 100644
+--- a/include/user_config.h
++++ b/include/user_config.h
+@@ -0,0 +1,34 @@
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++typedef signed short        sint16_t;
++
++void *ets_bzero(void *block, size_t size);
++bool ets_post(uint32_t prio, ETSSignal sig, ETSParam par);
++void ets_task(ETSTask task, uint32_t prio, ETSEvent * queue, uint8 qlen);
++
++void system_pp_recycle_rx_pkt(void *eb);
++
++#ifndef MEMLEAK_DEBUG
++	extern void *pvPortMalloc( size_t xWantedSize );
++	extern void vPortFree( void *pv );
++	extern void *pvPortZalloc(size_t size);
++#else
++	extern void *pvPortMalloc(size_t xWantedSize, const char *file, uint32 line);
++	extern void *pvPortZalloc(size_t xWantedSize, const char *file, uint32 line);
++	extern void vPortFree(void *ptr, const char *file, uint32 line);
++
++	extern void pvPortFree(void *ptr);
++	extern void *vPortMalloc(size_t xWantedSize);
++#endif /*MEMLEAK_DEBUG*/
++
++
++	extern void *pvPortCalloc(unsigned int n, unsigned int count);
++	extern void *pvPortRealloc(void * p, size_t size);
++	extern size_t xPortGetFreeHeapSize(void);
++//	extern void prvHeapInit(void) ICACHE_FLASH_ATTR ;
++
++#ifdef __cplusplus
++}
++#endif

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -37,3 +37,33 @@ index e69de29..1db5073 100644
 +#ifdef __cplusplus
 +}
 +#endif
+diff --git a/Makefile.open b/Makefile.open
+index 1bc584f..493275b 100644
+--- a/Makefile.open
++++ b/Makefile.open
+@@ -36,11 +36,21 @@ lwip/core/ipv4/ip.o \
+ lwip/core/ipv4/ip_frag.o \
+ lwip/netif/etharp.o \
+ \
+-lwip/app/dhcpserver.o \
+-\
+-espconn_dummy.o \
++lwip/app/dhcpserver.o
++
++
++ifneq ($(ENABLE_ESPCONN),1)
++    OBJS += espconn_dummy.o
++else
++    OBJS += lwip/app/espconn.o \
++lwip/app/espconn_tcp.o \
++lwip/app/espconn_udp.o \
++lwip/app/espconn_mdns.o \
++lwip/core/mdns.o
++
++endif
+ 
+-LIB = liblwip_open.a
++LIB = $(USER_LIBDIR)liblwip_open.a
+ 
+ all: $(LIB)
+ 


### PR DESCRIPTION
This feature allows Sming users to compile their custom LWIP library based on the open-sourced Espressif LWIP version for SDK 1.5.

There are some catches:
* Custom LWIP compilation will work for users of esp-open-sdk 1.4 BUT not for esp-alt-sdk 1.4 (a patch is proposed and waits for comment/approval: https://github.com/kireevco/esp-alt-sdk/pull/30)
* By default LWIP compiles with `espconn` methods in it. They are needed by smartconfig and probably other closed-source libraries. If you don't use smartconfig you can compile liblwip_open with the following commands:

```
cd $SMING_HOME
rm compiler/lib/liblwip_open.a
make compiler/lib/liblwip_open.a ENABLE_CUSTOM_LWIP=1 ENABLE_ESPCONN=0
```

Related to #874, #515 and #313. 