### PR TITLE
StationClass: add return value to connect() and disconnect()

### DIFF
--- a/Sming/SmingCore/Platform/Station.cpp
+++ b/Sming/SmingCore/Platform/Station.cpp
@@ -100,14 +100,14 @@ bool StationClass::config(String ssid, String password, bool autoConnectOnStartu
 	return true;
 }
 
-void StationClass::connect()
+bool StationClass::connect()
 {
-	wifi_station_connect();
+	return wifi_station_connect();
 }
 
-void StationClass::disconnect()
+bool StationClass::disconnect()
 {
-	wifi_station_disconnect();
+	return wifi_station_disconnect();
 }
 
 bool StationClass::isConnected()

--- a/Sming/SmingCore/Platform/Station.h
+++ b/Sming/SmingCore/Platform/Station.h
@@ -104,11 +104,11 @@ public:
 
 	/**	@brief	Connect WiFi station to network
 	 */
-	void connect();
+	bool connect();
 
 	/**	@brief	Disconnect WiFi station from network
 	 */
-	void disconnect();
+	bool disconnect();
 
 	/**	@brief	Get WiFi station connectoin status
 	 *	@retval	bool True if connected.


### PR DESCRIPTION
According to the SDK documentation both functions return true on success and false on failure (see #858). 
