### PR TITLE
Reduce TcpConnection heap usage on builds with SSL disabled

### DIFF
--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -61,11 +61,11 @@ public:
 
 	void reset(); // Reset current status, data and etc.
 
+#ifdef ENABLE_SSL
 	using TcpClient::addSslOptions;
 	using TcpClient::setSslFingerprint;
 	using TcpClient::setSslClientKeyCert;
 	using TcpClient::freeSslClientKeyCert;
-#ifdef ENABLE_SSL
 	using TcpClient::getSsl;
 #endif
 

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -49,11 +49,11 @@ public:
 	bool subscribe(String topic);
 	bool unsubscribe(String topic);
 
+#ifdef ENABLE_SSL
 	using TcpClient::addSslOptions;
 	using TcpClient::setSslFingerprint;
 	using TcpClient::setSslClientKeyCert;
 	using TcpClient::freeSslClientKeyCert;
-#ifdef ENABLE_SSL
 	using TcpClient::getSsl;
 #endif
 

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -32,10 +32,12 @@ TcpConnection::~TcpConnection()
 	autoSelfDestruct = false;
 	close();
 
+#ifdef ENABLE_SSL
 	if(sslFingerprint) {
 		delete[] sslFingerprint;
 	}
 	freeSslClientKeyCert();
+#endif
 	debugf("~TCP connection");
 }
 
@@ -47,9 +49,9 @@ bool TcpConnection::connect(String server, int port, boolean useSsl /* = false *
 	ip_addr_t addr;
 
 	this->useSsl = useSsl;
+#ifdef ENABLE_SSL
 	this->sslOptions |= sslOptions;
 
-#ifdef ENABLE_SSL
 	if(ssl_ext == NULL) {
 		ssl_ext = ssl_ext_new();
 		ssl_ext->host_name = (char *)malloc(server.length() + 1);
@@ -80,9 +82,10 @@ bool TcpConnection::connect(String server, int port, boolean useSsl /* = false *
 
 bool TcpConnection::connect(IPAddress addr, uint16_t port, boolean useSsl /* = false */, uint32_t sslOptions /* = 0 */)
 {
-
+#ifdef ENABLE_SSL
 	this->useSsl = useSsl;
 	this->sslOptions |= sslOptions;
+#endif
 
 	return internalTcpConnect(addr, port);
 }
@@ -630,6 +633,7 @@ void TcpConnection::staticDnsResponse(const char *name, ip_addr_t *ipaddr, void 
 	delete dlook;
 }
 
+#ifdef ENABLE_SSL
 void TcpConnection::addSslOptions(uint32_t sslOptions) {
 	this->sslOptions |= sslOptions;
 }
@@ -697,7 +701,6 @@ void TcpConnection::freeSslClientKeyCert() {
 	clientKeyCert.certificateLength = 0;
 }
 
-#ifdef ENABLE_SSL
 SSL* TcpConnection::getSsl() {
 	return ssl;
 }

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -70,6 +70,7 @@ public:
 	IPAddress getRemoteIp()  { return (tcp == NULL) ? INADDR_NONE : IPAddress(tcp->remote_ip);};
 	uint16_t getRemotePort() { return (tcp == NULL) ? 0 : tcp->remote_port; };
 
+#ifdef ENABLE_SSL
 	void addSslOptions(uint32_t sslOptions);
 
 	/**
@@ -101,7 +102,6 @@ public:
 	 */
 	void freeSslClientKeyCert();
 
-#ifdef ENABLE_SSL
 	SSL* getSsl();
 #endif
 
@@ -137,13 +137,13 @@ protected:
 	SSL *ssl = nullptr;
 	SSLCTX *sslContext = nullptr;
 	SSL_EXTENSIONS *ssl_ext=NULL;
-#endif
-	boolean useSsl = false;
 	uint8_t *sslFingerprint=null;
 	boolean sslConnected = false;
 	uint32_t sslOptions=0;
 	SSLKeyCertPair clientKeyCert;
 	boolean freeClientKeyCert = false;
+#endif
+	boolean useSsl = false;
 };
 
 #endif /* _SMING_CORE_TCPCONNECTION_H_ */

--- a/Sming/SmingCore/Network/WebsocketClient.h
+++ b/Sming/SmingCore/Network/WebsocketClient.h
@@ -104,11 +104,11 @@ public:
 	  *  @retval Returnt websocket client mode
 	  */
 
+#ifdef ENABLE_SSL
 	using TcpClient::addSslOptions;
 	using TcpClient::setSslFingerprint;
 	using TcpClient::setSslClientKeyCert;
 	using TcpClient::freeSslClientKeyCert;
-#ifdef ENABLE_SSL
 	using TcpClient::getSsl;
 #endif
 

--- a/Sming/SmingCore/Network/rBootHttpUpdate.h
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.h
@@ -35,11 +35,11 @@ public:
 	void setCallback(otaUpdateDelegate reqUpdateDelegate);
 	void setDelegate(otaUpdateDelegate reqUpdateDelegate);
 
+#ifdef ENABLE_SSL
 	using HttpClient::addSslOptions;
 	using HttpClient::setSslFingerprint;
 	using HttpClient::setSslClientKeyCert;
 	using HttpClient::freeSslClientKeyCert;
-#ifdef ENABLE_SSL
 	using HttpClient::getSsl;
 #endif
 


### PR DESCRIPTION
On issue #830, I described the problem: even when ENABLE_SSL is not defined, the TcpConnection class still contains some members related to SSL that are completely useless and wasted about 18 bytes of heap per connection.

My changes basically consist on moving the position of the `#ifdef`s so that all of the SSL stuff is disabled when Sming is compiled without SSL support.

It was really simple to do this, which makes me worried: am I missing the reason why it wasn't done like this from the beginning? My code seems to still work fine...