### PR TITLE
Add custom userdata to websocket obj

### DIFF
--- a/Sming/SmingCore/Network/WebSocket.cpp
+++ b/Sming/SmingCore/Network/WebSocket.cpp
@@ -75,3 +75,13 @@ void WebSocket::close()
 {
 	connection->close();
 }
+
+void WebSocket::setUserData(void* userData)
+{
+	m_pUserData = userData;
+}
+
+void* WebSocket::getUserData()
+{
+	return m_pUserData;
+}

--- a/Sming/SmingCore/Network/WebSocket.cpp
+++ b/Sming/SmingCore/Network/WebSocket.cpp
@@ -76,9 +76,9 @@ void WebSocket::close()
 	connection->close();
 }
 
-void WebSocket::setUserData(void* _userData)
+void WebSocket::setUserData(void* userData)
 {
-	userData = _userData;
+	this->userData = userData;
 }
 
 void* WebSocket::getUserData()

--- a/Sming/SmingCore/Network/WebSocket.cpp
+++ b/Sming/SmingCore/Network/WebSocket.cpp
@@ -75,13 +75,3 @@ void WebSocket::close()
 {
 	connection->close();
 }
-
-void WebSocket::setUserData(void* userData)
-{
-	m_pUserData = userData;
-}
-
-void* WebSocket::getUserData()
-{
-	return m_pUserData;
-}

--- a/Sming/SmingCore/Network/WebSocket.cpp
+++ b/Sming/SmingCore/Network/WebSocket.cpp
@@ -75,3 +75,13 @@ void WebSocket::close()
 {
 	connection->close();
 }
+
+void WebSocket::setUserData(void* _userData)
+{
+	userData = _userData;
+}
+
+void* WebSocket::getUserData()
+{
+	return userData;
+}

--- a/Sming/SmingCore/Network/WebSocket.h
+++ b/Sming/SmingCore/Network/WebSocket.h
@@ -68,6 +68,16 @@ public:
 	 */
 	bool operator==(const WebSocket &other) const { return this->connection == other.connection;};
 
+	/** @brief  Store user dtaa pointer for this socket(connection)
+	 *  @param  _userData Pointer to user defined data
+	 */
+	void setUserData(void* _userData);
+
+	/** @brief  Get user data pointer for this socket(connection)
+	 *  @return  Pointer to user defined data
+	 */
+	void *getUserData();
+
 protected:
 	bool initialize(HttpRequest &request, HttpResponse &response);
 	bool is(HttpServerConnection* conn) { return connection == conn; };
@@ -75,6 +85,7 @@ protected:
 private:
 	HttpServerConnection* connection;
 	CommandExecutor* commandExecutor = nullptr;
+	void* userData = nullptr;
 };
 
 #endif /* SMINGCORE_NETWORK_WEBSOCKET_H_ */

--- a/Sming/SmingCore/Network/WebSocket.h
+++ b/Sming/SmingCore/Network/WebSocket.h
@@ -22,20 +22,51 @@ class WebSocket
 {
 	friend class HttpServer;
 public:
+	/** @brief  Object class constructor
+	 *  @param conn Pointer to HttpServer connection object that this webSocket will use
+	 */
 	WebSocket(HttpServerConnection* conn);
-	~WebSocket();
 
+	/** @brief  Virtual object class destructor
+	 */
+	virtual ~WebSocket();
+
+	/** @brief  Send data to other peer
+	 *  @param message Pointer to buffer to send
+	 *  @param length Length of buffer to send
+	 *  @param type Frametype of the message to be sent. Default is text frame.
+	 */
 	virtual void send(const char* message, int length, wsFrameType type = WS_TEXT_FRAME);
+
+	/** @brief  Send a string to other peer
+	 *  @param message String object holdiong the message to send
+	 */
 	void sendString(const String& message);
+
+	/** @brief  Send binary data to other peer
+	 *  @param data Pointer to buffer to send
+	 *  @param size Length of buffer to send
+	 */
 	void sendBinary(const uint8_t* data, int size);
+
+	/** @brief  Enable command processing
+	 */
 	void enableCommand();
+
+	/** @brief  Close webSocket connection
+	 */
 	void close();
+
+	/** @brief  Set TCP connection timeout
+	 *  @param  waitTimeOut TCP timeout
+	 */
 	void setTimeOut(uint16_t waitTimeOut) { if(connection) connection->setTimeOut(waitTimeOut); };
 
+	/** @brief  Test if two sockets are the same
+	 *  @param  other The other websocket
+	 *  @return true if the two webSockets are defining the same connection
+	 */
 	bool operator==(const WebSocket &other) const { return this->connection == other.connection;};
-
-	void setUserData(void* userData);
-	void *getUserData();
 
 protected:
 	bool initialize(HttpRequest &request, HttpResponse &response);
@@ -44,7 +75,6 @@ protected:
 private:
 	HttpServerConnection* connection;
 	CommandExecutor* commandExecutor = nullptr;
-	void* m_pUserData = nullptr;
 };
 
 #endif /* SMINGCORE_NETWORK_WEBSOCKET_H_ */

--- a/Sming/SmingCore/Network/WebSocket.h
+++ b/Sming/SmingCore/Network/WebSocket.h
@@ -34,6 +34,9 @@ public:
 
 	bool operator==(const WebSocket &other) const { return this->connection == other.connection;};
 
+	void setUserData(void* userData);
+	void *getUserData();
+
 protected:
 	bool initialize(HttpRequest &request, HttpResponse &response);
 	bool is(HttpServerConnection* conn) { return connection == conn; };
@@ -41,6 +44,7 @@ protected:
 private:
 	HttpServerConnection* connection;
 	CommandExecutor* commandExecutor = nullptr;
+	void* m_pUserData = nullptr;
 };
 
 #endif /* SMINGCORE_NETWORK_WEBSOCKET_H_ */

--- a/Sming/SmingCore/Network/WebSocket.h
+++ b/Sming/SmingCore/Network/WebSocket.h
@@ -39,7 +39,7 @@ public:
 	virtual void send(const char* message, int length, wsFrameType type = WS_TEXT_FRAME);
 
 	/** @brief  Send a string to other peer
-	 *  @param message String object holdiong the message to send
+	 *  @param message String object holding the message to send
 	 */
 	void sendString(const String& message);
 
@@ -63,15 +63,15 @@ public:
 	void setTimeOut(uint16_t waitTimeOut) { if(connection) connection->setTimeOut(waitTimeOut); };
 
 	/** @brief  Test if two sockets are the same
-	 *  @param  other The other websocket
+	 *  @param  other The other webSocket
 	 *  @return true if the two webSockets are defining the same connection
 	 */
 	bool operator==(const WebSocket &other) const { return this->connection == other.connection;};
 
-	/** @brief  Store user dtaa pointer for this socket(connection)
-	 *  @param  _userData Pointer to user defined data
+	/** @brief  Store user data pointer for this socket(connection)
+	 *  @param  userData Pointer to user defined data
 	 */
-	void setUserData(void* _userData);
+	void setUserData(void* userData);
 
 	/** @brief  Get user data pointer for this socket(connection)
 	 *  @return  Pointer to user defined data

--- a/samples/HttpServer_WebSockets/app/CUserData.cpp
+++ b/samples/HttpServer_WebSockets/app/CUserData.cpp
@@ -1,0 +1,61 @@
+#include "CUserData.h"
+
+//Simplified container modelling a user session
+CUserData::CUserData(const char* uName, const char* uData):userName(uName), userData(uData)
+{
+
+}
+CUserData::~CUserData()
+{
+	logOut();
+}
+
+void CUserData::addSession(WebSocket& connection)
+{
+	activeWebSockets.addElement(&connection);
+	connection.setUserData((void*)this);
+}
+
+void CUserData::removeSession(WebSocket& connection)
+{
+	for(int i=0; i < activeWebSockets.count(); i++)
+	{
+		if(connection == *(activeWebSockets[i]))
+		{
+			activeWebSockets[i]->setUserData(nullptr);
+			activeWebSockets.remove(i);
+			Serial.println("Removed user session");
+			return;
+		}
+	}
+}
+
+void CUserData::printMessage(WebSocket& connection,const String &msg)
+{
+	int i=0;
+	for(; i < activeWebSockets.count(); i++)
+	{
+		if(connection == *(activeWebSockets[i]))
+		{
+			break;
+		}
+	}
+
+	if(i < activeWebSockets.count())
+	{
+		Serial.print("Received msg on connection ");
+		Serial.print(i);
+		Serial.print(" :");
+		Serial.print(msg);
+	}
+}
+
+void CUserData::logOut()
+{
+	for(int i=0; i < activeWebSockets.count(); i++)
+	{
+		activeWebSockets[i]->setUserData(nullptr);
+	}
+
+	activeWebSockets.removeAllElements();
+}

--- a/samples/HttpServer_WebSockets/include/CUserData.h
+++ b/samples/HttpServer_WebSockets/include/CUserData.h
@@ -1,0 +1,23 @@
+#ifndef C_USER_DATA_H_SAMPLE
+#define C_USER_DATA_H_SAMPLE
+
+#include <user_config.h>
+#include <SmingCore/SmingCore.h>
+
+//Simplified container modelling a user session
+class CUserData
+{
+public:
+	CUserData(const char* uName, const char* uData);
+	~CUserData();
+	void addSession(WebSocket& connection);
+	void removeSession(WebSocket& connection);
+	void printMessage(WebSocket& connection,const String &msg);
+	void logOut();
+private:
+	String userName;
+	String userData;
+	Vector<WebSocket*> activeWebSockets;
+};
+
+#endif /*C_USER_DATA_H_SAMPLE*/


### PR DESCRIPTION
Sometimes we need extra information(defined in the application) to be stored for every websocket for purpose of connection reusing. This defines the possibility to store a void* that is treated as application intends.