### PR TITLE
rBootHttpUpdate: Hooks added for signed and/or encrypted OTA

### DIFF
--- a/Sming/SmingCore/Network/rBootHttpUpdate.cpp
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.cpp
@@ -60,7 +60,10 @@ void rBootHttpUpdate::onTimer() {
 	if (TcpClient::getConnectionState() == eTCS_Successful) {
 
 		//  always call writeEnd()
-		if (!writeEnd()) writeError = 1;
+		if (!writeEnd()) {
+			debugf("final checks failed!");
+            writeError = 1;
+        }    
 		
 		if (!isSuccessful()) {
 			updateFailed();

--- a/Sming/SmingCore/Network/rBootHttpUpdate.cpp
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.cpp
@@ -62,8 +62,8 @@ void rBootHttpUpdate::onTimer() {
 		//  always call writeEnd()
 		if (!writeEnd()) {
 			debugf("final checks failed!");
-            writeError = 1;
-        }    
+			writeError = 1;
+		}    
 		
 		if (!isSuccessful()) {
 			updateFailed();

--- a/Sming/SmingCore/Network/rBootHttpUpdate.h
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.h
@@ -24,7 +24,7 @@ struct rBootHttpUpdateItem {
 	int size;
 };
 
-class rBootHttpUpdate: private HttpClient {
+class rBootHttpUpdate: protected HttpClient {
 
 public:
 	rBootHttpUpdate();
@@ -58,9 +58,9 @@ protected:
 	uint8 romSlot;
 	otaUpdateDelegate updateDelegate;
 
-    virtual void writeInit();
-    virtual bool writeFlash(const u8 *data, u16 size);
-    virtual bool writeEnd();
+	virtual void writeInit();
+	virtual bool writeFlash(const u8 *data, u16 size);
+	virtual bool writeEnd();
 };
 
 #endif /* SMINGCORE_NETWORK_RBOOTHTTPUPDATE_H_ */

--- a/Sming/SmingCore/Network/rBootHttpUpdate.h
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.h
@@ -50,10 +50,6 @@ protected:
 	void updateFailed();
 	void onItemDownloadCompleted(HttpClient& client, bool successful);
 
-    virtual void writeInit();
-    virtual bool writeFlash(const u8 *data, u16 size);
-    virtual bool writeEnd();
-
 protected:
 	Vector<rBootHttpUpdateItem> items;
 	Timer timer;
@@ -61,6 +57,10 @@ protected:
 	rboot_write_status rBootWriteStatus;
 	uint8 romSlot;
 	otaUpdateDelegate updateDelegate;
+
+    virtual void writeInit();
+    virtual bool writeFlash(const u8 *data, u16 size);
+    virtual bool writeEnd();
 };
 
 #endif /* SMINGCORE_NETWORK_RBOOTHTTPUPDATE_H_ */

--- a/Sming/SmingCore/Network/rBootHttpUpdate.h
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.h
@@ -50,6 +50,10 @@ protected:
 	void updateFailed();
 	void onItemDownloadCompleted(HttpClient& client, bool successful);
 
+    virtual void writeInit();
+    virtual bool writeFlash(const u8 *data, u16 size);
+    virtual bool writeEnd();
+
 protected:
 	Vector<rBootHttpUpdateItem> items;
 	Timer timer;


### PR DESCRIPTION
_rboot_write_init()_, _rboot_write_flash()_ and _rboot_write_end()_ moved to virtual methods. This allows a subclass to implement hooks to download signed or encrypted firmware files. 

Hope I got it right ;-)