### PR TITLE
HardwareSerial refactoring

### DIFF
--- a/Sming/SmingCore/Digital.cpp
+++ b/Sming/SmingCore/Digital.cpp
@@ -7,52 +7,58 @@
 
 #include "../SmingCore/Digital.h"
 #include "../Wiring/WiringFrameworkIncludes.h"
+#include "espinc/peri.h"
+
+uint8_t esp8266_gpioToFn[16] = {0x34, 0x18, 0x38, 0x14, 0x3C, 0x40, 0x1C, 0x20, 0x24, 0x28, 0x2C, 0x30, 0x04, 0x08, 0x0C, 0x10};
 
 void pinMode(uint16_t pin, uint8_t mode)
 {
-	if (pin < 16)
-	{
-		// Set as GPIO
-		PIN_FUNC_SELECT((EspDigitalPins[pin].mux), (EspDigitalPins[pin].gpioFunc));
-
-		// Switch to Input or Output
-		if (mode == INPUT || mode == INPUT_PULLUP)
-			GPIO_REG_WRITE(GPIO_ENABLE_W1TC_ADDRESS, (1<<pin));
-		else
-			GPIO_REG_WRITE(GPIO_ENABLE_W1TS_ADDRESS, (1<<pin));
-	}
-	else if (pin == 16)
-	{
-		if (mode == INPUT  || mode == INPUT_PULLUP)
-		{
-		    WRITE_PERI_REG(PAD_XPD_DCDC_CONF,
-		                   (READ_PERI_REG(PAD_XPD_DCDC_CONF) & 0xffffffbc) | (uint32)0x1); 		// mux configuration for XPD_DCDC and rtc_gpio0 connection
-
-		    WRITE_PERI_REG(RTC_GPIO_CONF,
-		                   (READ_PERI_REG(RTC_GPIO_CONF) & (uint32)0xfffffffe) | (uint32)0x0);	//mux configuration for out enable
-
-		    WRITE_PERI_REG(RTC_GPIO_ENABLE,
-		                   READ_PERI_REG(RTC_GPIO_ENABLE) & (uint32)0xfffffffe);				//out disable
-		}
-		else
-		{
-			WRITE_PERI_REG(PAD_XPD_DCDC_CONF,
-						   (READ_PERI_REG(PAD_XPD_DCDC_CONF) & 0xffffffbc) | (uint32)0x1); 		// mux configuration for XPD_DCDC to output rtc_gpio0
-
-			WRITE_PERI_REG(RTC_GPIO_CONF,
-						   (READ_PERI_REG(RTC_GPIO_CONF) & (uint32)0xfffffffe) | (uint32)0x0);	//mux configuration for out enable
-
-			WRITE_PERI_REG(RTC_GPIO_ENABLE,
-						   (READ_PERI_REG(RTC_GPIO_ENABLE) & (uint32)0xfffffffe) | (uint32)0x1); //out enable
-		}
-	} else
-		SYSTEM_ERROR("No pin %d, can't set mode", pin); // NO PIN!
-
-	//Decide to enable or disable the pullup
-	if (mode == INPUT_PULLUP)
-	{
-		pullup(pin);
-	}
+  if(pin < 16){
+    if(mode == SPECIAL){
+      GPC(pin) = (GPC(pin) & (0xF << GPCI)); //SOURCE(GPIO) | DRIVER(NORMAL) | INT_TYPE(UNCHANGED) | WAKEUP_ENABLE(DISABLED)
+      GPEC = (1 << pin); //Disable
+      GPF(pin) = GPFFS(GPFFS_BUS(pin));//Set mode to BUS (RX0, TX0, TX1, SPI, HSPI or CLK depending in the pin)
+      if(pin == 3) GPF(pin) |= (1 << GPFPU);//enable pullup on RX
+    } else if(mode & FUNCTION_0){
+      GPC(pin) = (GPC(pin) & (0xF << GPCI)); //SOURCE(GPIO) | DRIVER(NORMAL) | INT_TYPE(UNCHANGED) | WAKEUP_ENABLE(DISABLED)
+      GPEC = (1 << pin); //Disable
+      GPF(pin) = GPFFS((mode >> 4) & 0x07);
+      if(pin == 13 && mode == FUNCTION_4) GPF(pin) |= (1 << GPFPU);//enable pullup on RX
+    }  else if(mode == OUTPUT || mode == OUTPUT_OPEN_DRAIN){
+      GPF(pin) = GPFFS(GPFFS_GPIO(pin));//Set mode to GPIO
+      GPC(pin) = (GPC(pin) & (0xF << GPCI)); //SOURCE(GPIO) | DRIVER(NORMAL) | INT_TYPE(UNCHANGED) | WAKEUP_ENABLE(DISABLED)
+      if(mode == OUTPUT_OPEN_DRAIN) GPC(pin) |= (1 << GPCD);
+      GPES = (1 << pin); //Enable
+    } else if(mode == INPUT || mode == INPUT_PULLUP){
+      GPF(pin) = GPFFS(GPFFS_GPIO(pin));//Set mode to GPIO
+      GPEC = (1 << pin); //Disable
+      GPC(pin) = (GPC(pin) & (0xF << GPCI)) | (1 << GPCD); //SOURCE(GPIO) | DRIVER(OPEN_DRAIN) | INT_TYPE(UNCHANGED) | WAKEUP_ENABLE(DISABLED)
+      if(mode == INPUT_PULLUP) {
+          GPF(pin) |= (1 << GPFPU);  // Enable  Pullup
+      }
+    } else if(mode == WAKEUP_PULLUP || mode == WAKEUP_PULLDOWN){
+      GPF(pin) = GPFFS(GPFFS_GPIO(pin));//Set mode to GPIO
+      GPEC = (1 << pin); //Disable
+      if(mode == WAKEUP_PULLUP) {
+          GPF(pin) |= (1 << GPFPU);  // Enable  Pullup
+          GPC(pin) = (1 << GPCD) | (4 << GPCI) | (1 << GPCWE); //SOURCE(GPIO) | DRIVER(OPEN_DRAIN) | INT_TYPE(LOW) | WAKEUP_ENABLE(ENABLED)
+      } else {
+          GPF(pin) |= (1 << GPFPD);  // Enable  Pulldown
+          GPC(pin) = (1 << GPCD) | (5 << GPCI) | (1 << GPCWE); //SOURCE(GPIO) | DRIVER(OPEN_DRAIN) | INT_TYPE(HIGH) | WAKEUP_ENABLE(ENABLED)
+      }
+    }
+  } else if(pin == 16){
+    GPF16 = GP16FFS(GPFFS_GPIO(pin));//Set mode to GPIO
+    GPC16 = 0;
+    if(mode == INPUT || mode == INPUT_PULLDOWN_16){
+      if(mode == INPUT_PULLDOWN_16){
+        GPF16 |= (1 << GP16FPD);//Enable Pulldown
+      }
+      GP16E &= ~1;
+    } else if(mode == OUTPUT){
+      GP16E |= 1;
+    }
+  }
 }
 
 //Detect if pin is input

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -14,252 +14,224 @@
 #include "../SmingCore/Clock.h"
 #include "../SmingCore/Interrupts.h"
 
-// UartDev is defined and initialized in ROM code.
-extern UartDevice UartDev;
-
 //set m_printf callback
-extern void setMPrintfPrinterCbc(void (*callback)(char));
+//extern void setMPrintfPrinterCbc(void (*callback)(char));
 
 // StreamDataAvailableDelegate HardwareSerial::HWSDelegates[2];
 
 HWSerialMemberData HardwareSerial::memberData[NUMBER_UARTS];
 
 HardwareSerial::HardwareSerial(const int uartPort)
-	: uart(uartPort)
+	: uartNr(uartPort), rxSize(256)
 {
-	resetCallback();
 	// Start Serial task
 	serialQueue = (os_event_t *)malloc(sizeof(os_event_t) * SERIAL_QUEUE_LEN);
 	system_os_task(delegateTask,USER_TASK_PRIO_0,serialQueue,SERIAL_QUEUE_LEN);
 }
 
-void HardwareSerial::begin(const uint32_t baud/* = 9600*/)
+HardwareSerial::~HardwareSerial()
 {
-	//TODO: Move to params!
-	UartDev.baut_rate = (UartBautRate)baud;
-	UartDev.parity = NONE_BITS;
-	UartDev.exist_parity = STICK_PARITY_DIS;
-	UartDev.stop_bits = ONE_STOP_BIT;
-	UartDev.data_bits = EIGHT_BITS;
-
-	ETS_UART_INTR_ATTACH((void*)uart0_rx_intr_handler,  &(UartDev.rcv_buff));
-	PIN_PULLUP_DIS(PERIPHS_IO_MUX_U0TXD_U);
-	PIN_FUNC_SELECT(PERIPHS_IO_MUX_U0TXD_U, FUNC_U0TXD);
-
-	uart_div_modify(uart, UART_CLK_FREQ / (UartDev.baut_rate));
-
-	WRITE_PERI_REG(UART_CONF0(uart),    UartDev.exist_parity
-				   | UartDev.parity
-				   | (UartDev.stop_bits << UART_STOP_BIT_NUM_S)
-				   | (UartDev.data_bits << UART_BIT_NUM_S));
-
-
-	//clear rx and tx fifo,not ready
-	SET_PERI_REG_MASK(UART_CONF0(uart), UART_RXFIFO_RST | UART_TXFIFO_RST);
-	CLEAR_PERI_REG_MASK(UART_CONF0(uart), UART_RXFIFO_RST | UART_TXFIFO_RST);
-
-	//set rx fifo trigger
-	WRITE_PERI_REG(UART_CONF1(uart), (UartDev.rcv_buff.TrigLvl & UART_RXFIFO_FULL_THRHD) << UART_RXFIFO_FULL_THRHD_S);
-
-	//clear all interrupt
-	WRITE_PERI_REG(UART_INT_CLR(uart), 0xffff);
-	//enable rx_interrupt
-	SET_PERI_REG_MASK(UART_INT_ENA(uart), UART_RXFIFO_FULL_INT_ENA);
-
-	ETS_UART_INTR_ENABLE();
-	delay(10);
-	Serial.println("\r\n"); // after SPAM :)
+	if(serialQueue != nullptr) {
+		free(serialQueue);
+		serialQueue = nullptr;
+	}
 }
 
-size_t HardwareSerial::write(uint8_t oneChar)
+void HardwareSerial::begin(const uint32_t baud, SerialConfig config, SerialMode mode, uint8_t  txPin)
 {
-	//if (oneChar == '\0') return 0;
+    end();
+    uart = uart_init(uartNr, baud, (int) config, (int) mode,  txPin, rxSize);
+    resetCallback();
+}
 
-	uart_tx_one_char(oneChar);
+void HardwareSerial::end()
+{
+    if(uart_get_debug() == uartNr) {
+        uart_set_debug(UART_NO);
+    }
 
-	return 1;
+    if (uart) {
+        uart_uninit(uart);
+        uart = NULL;
+    }
+}
+
+size_t HardwareSerial::setRxBufferSize(size_t size){
+    if(uart) {
+        rxSize = uart_resize_rx_buffer(uart, size);
+    } else {
+        rxSize = size;
+    }
+    return rxSize;
+}
+
+void HardwareSerial::swap(uint8_t tx_pin)
+{
+    if(!uart) {
+        return;
+    }
+    uart_swap(uart, tx_pin);
+}
+
+void HardwareSerial::setTx(uint8_t tx_pin)
+{
+    if(!uart) {
+        return;
+    }
+    uart_set_tx(uart, tx_pin);
+}
+
+void HardwareSerial::pins(uint8_t tx, uint8_t rx)
+{
+    if(!uart) {
+        return;
+    }
+    uart_set_pins(uart, tx, rx);
+}
+
+bool HardwareSerial::isTxEnabled(void)
+{
+    return uart && uart_tx_enabled(uart);
+}
+
+bool HardwareSerial::isRxEnabled(void)
+{
+    return uart && uart_rx_enabled(uart);
 }
 
 int HardwareSerial::available()
 {
-	RcvMsgBuff &rxBuf = UartDev.rcv_buff;
-	if (rxBuf.pWritePos != rxBuf.pReadPos)
-	{
-		if (rxBuf.pWritePos > rxBuf.pReadPos)
-			return rxBuf.pWritePos - rxBuf.pReadPos;
-		else
-			return (((uint32_t)rxBuf.pRcvMsgBuff + RX_BUFF_SIZE) - (uint32_t)UartDev.rcv_buff.pReadPos) + (uint32_t)rxBuf.pWritePos;
-	}
-	else
+	int result = static_cast<int>(uart_rx_available(uart));
+	return result;
+}
+
+size_t HardwareSerial::write(uint8_t oneChar)
+{
+	if(!uart || !uart_tx_enabled(uart)) {
 		return 0;
+	}
+
+	uart_write_char(uart, oneChar);
+	return 1;
 }
 
 int HardwareSerial::read()
 {
-	if (available() == 0)
-		return -1;
-
-	noInterrupts();
-	RcvMsgBuff &rxBuf = UartDev.rcv_buff;
-	char res = *(rxBuf.pReadPos);
-	rxBuf.pReadPos++;
-
-	if (rxBuf.pReadPos >= (rxBuf.pRcvMsgBuff + RX_BUFF_SIZE))
-		rxBuf.pReadPos = rxBuf.pRcvMsgBuff ;
-
-	interrupts();
-	return res;
+	return uart_read_char(uart);
 }
 
 int HardwareSerial::readMemoryBlock(char* buf, int max_len)
 {
-	RcvMsgBuff &rxBuf = UartDev.rcv_buff;
-	int num = 0;
+	if (uart !=0 && uart_rx_enabled(uart)) {
+		int size;
+		char c;
+		for(int i=0;i<max_len; i++) {
+			c = read();
+			if (c == -1) {
+				break;
+			}
 
-	noInterrupts();
-	if (rxBuf.pWritePos != rxBuf.pReadPos) {
-		while ((rxBuf.pWritePos != rxBuf.pReadPos) && (max_len-- > 0)) {
-			*buf = *rxBuf.pReadPos;		// Read data from Buffer
-			num++;						// Increase counter of read bytes
-			buf++;						// Increase Buffer pointer
-
-			// Set pointer to next data word in ring buffer
-			rxBuf.pReadPos++;
-			if (rxBuf.pReadPos >= (rxBuf.pRcvMsgBuff + RX_BUFF_SIZE))
-				rxBuf.pReadPos = rxBuf.pRcvMsgBuff ;
+			// @TODO: Check this section...
+			buf[i] = c;
 		}
+		return size;
 	}
-	interrupts();
-
-	return num;
+	return -1;
 }
 
 int HardwareSerial::peek()
 {
-	if (available() == 0)
-		return -1;
-
-	noInterrupts();
-	RcvMsgBuff &rxBuf = UartDev.rcv_buff;
-	char res = *(rxBuf.pReadPos);
-	interrupts();
-	return res;
+	return uart_peek_char(uart);
 }
 
 void HardwareSerial::flush()
 {
+	if(!uart || !uart_tx_enabled(uart)) {
+		return;
+	}
+
+	uart_wait_tx_empty(uart);
 }
 
 
-/*void HardwareSerial::printf(const char *fmt, ...)
-{
-	// Doesn't work :(
-	va_list va;
-	va_start(va, fmt);
-	ets_uart_printf(fmt, va);
-	va_end(va);
-}*/
-
 void HardwareSerial::systemDebugOutput(bool enabled)
 {
-	if (uart == UART_ID_0)
-		setMPrintfPrinterCbc(enabled ? uart_tx_one_char : NULL);
-	//else
-	//	os_install_putc1(enabled ? (void *)uart1_tx_one_char : NULL); //TODO: Debug serial
+	if(!uart) {
+		return;
+	}
+
+	if(enabled) {
+		if(uart_tx_enabled(uart)) {
+			uart_set_debug(uartNr);
+		} else {
+			uart_set_debug(UART_NO);
+		}
+	} else {
+		// disable debug for this interface
+		if(uart_get_debug() == uartNr) {
+			uart_set_debug(UART_NO);
+		}
+	}
+}
+
+void HardwareSerial::callbackHandler(uart_t *uart) {
+	if(uart == NULL) {
+		return;
+	}
+
+	uint8_t receivedChar;
+	while ((receivedChar = uart_read_char(uart)) != -1) {
+		if ((memberData[UART_ID_0].HWSDelegate) || (memberData[UART_ID_0].commandExecutor)) {
+			uint32 serialQueueParameter;
+			uint16 cc;
+			//    	  cc = (pRxBuff->pWritePos < pRxBuff->pReadPos) ? ((pRxBuff->pWritePos + RX_BUFF_SIZE) - pRxBuff->pReadPos)
+			//      													: (pRxBuff->pWritePos - pRxBuff->pReadPos);
+			cc = (uart->rx_buffer->wpos < uart->rx_buffer->rpos) ?
+					((uart->rx_buffer->wpos + uart->rx_buffer->size)
+							- uart->rx_buffer->rpos) :
+					(uart->rx_buffer->wpos - uart->rx_buffer->rpos);
+			serialQueueParameter = (cc * 256) + receivedChar; // can be done by bitlogic, avoid casting to ETSParam
+
+			if (memberData[UART_ID_0].HWSDelegate) {
+				system_os_post(USER_TASK_PRIO_0, SERIAL_SIGNAL_DELEGATE, serialQueueParameter);
+			}
+			if (memberData[UART_ID_0].commandExecutor) {
+				system_os_post(USER_TASK_PRIO_0, SERIAL_SIGNAL_COMMAND, serialQueueParameter);
+			}
+		}
+	}
 }
 
 void HardwareSerial::setCallback(StreamDataReceivedDelegate reqDelegate, bool useSerialRxBuffer /* = true */)
 {
-	memberData[uart].HWSDelegate = reqDelegate;
-	memberData[uart].useRxBuff = useSerialRxBuffer;
+	uart->callback = callbackHandler;
+
+	memberData[uartNr].HWSDelegate = reqDelegate;
+	memberData[uartNr].useRxBuff = useSerialRxBuffer;
 }
 
 void HardwareSerial::resetCallback()
 {
-	memberData[uart].HWSDelegate = nullptr;
-	memberData[uart].useRxBuff = true;
+	memberData[uartNr].HWSDelegate = nullptr;
+	memberData[uartNr].useRxBuff = true;
+
+	uart->callback = 0;
 }
 
 void HardwareSerial::commandProcessing(bool reqEnable)
 {
 	if (reqEnable)
 	{
-		if (!memberData[uart].commandExecutor)
+		if (!memberData[uartNr].commandExecutor)
 		{
-			memberData[uart].commandExecutor = new CommandExecutor(&Serial);
+			memberData[uartNr].commandExecutor = new CommandExecutor(&Serial);
 		}
 	}
 	else
 	{
-		delete memberData[uart].commandExecutor;
-		memberData[uart].commandExecutor = nullptr;
+		delete memberData[uartNr].commandExecutor;
+		memberData[uartNr].commandExecutor = nullptr;
 	}
-}
-
-
-void HardwareSerial::uart0_rx_intr_handler(void *para)
-{
-    /* uart0 and uart1 intr combine togther, when interrupt occur, see reg 0x3ff20020, bit2, bit0 represents
-     * uart1 and uart0 respectively
-     */
-    RcvMsgBuff *pRxBuff = (RcvMsgBuff *)para;
-    uint8 RcvChar;
-
-    if (UART_RXFIFO_FULL_INT_ST != (READ_PERI_REG(UART_INT_ST(UART_ID_0)) & UART_RXFIFO_FULL_INT_ST))
-        return;
-
-    WRITE_PERI_REG(UART_INT_CLR(UART_ID_0), UART_RXFIFO_FULL_INT_CLR);
-
-    while (READ_PERI_REG(UART_STATUS(UART_ID_0)) & (UART_RXFIFO_CNT << UART_RXFIFO_CNT_S))
-    {
-        RcvChar = READ_PERI_REG(UART_FIFO(UART_ID_0)) & 0xFF;
-
-        /* you can add your handle code below.*/
-      if (memberData[UART_ID_0].useRxBuff)
-      {
-        *(pRxBuff->pWritePos) = RcvChar;
-
-        // insert here for get one command line from uart
-        if (RcvChar == '\n' )
-            pRxBuff->BuffState = WRITE_OVER;
-
-        pRxBuff->pWritePos++;
-
-        if (pRxBuff->pWritePos == (pRxBuff->pRcvMsgBuff + RX_BUFF_SIZE))
-        {
-            // overflow ...we may need more error handle here.
-        	pRxBuff->pWritePos = pRxBuff->pRcvMsgBuff;
-        }
-
-        if (pRxBuff->pWritePos == pRxBuff->pReadPos)
-        {   // Prevent readbuffer overflow
-			if (pRxBuff->pReadPos == (pRxBuff->pRcvMsgBuff + RX_BUFF_SIZE))
-			{
-				pRxBuff->pReadPos = pRxBuff->pRcvMsgBuff ;
-			} else {
-				pRxBuff->pReadPos++;
-			}
-		}
-      }
-
-      if ((memberData[UART_ID_0].HWSDelegate) || (memberData[UART_ID_0].commandExecutor))
-      {
-    	  uint32 serialQueueParameter;
-    	  uint16 cc;
-    	  cc = (pRxBuff->pWritePos < pRxBuff->pReadPos) ? ((pRxBuff->pWritePos + RX_BUFF_SIZE) - pRxBuff->pReadPos)
-      													: (pRxBuff->pWritePos - pRxBuff->pReadPos);
-    	  serialQueueParameter = (cc * 256) + RcvChar; // can be done by bitlogic, avoid casting to ETSParam
-
-          if (memberData[UART_ID_0].HWSDelegate)
-		  {
-        	  system_os_post(USER_TASK_PRIO_0, SERIAL_SIGNAL_DELEGATE, serialQueueParameter);
-		  }
-          if (memberData[UART_ID_0].commandExecutor)
-      	  {
-        	  system_os_post(USER_TASK_PRIO_0, SERIAL_SIGNAL_COMMAND, serialQueueParameter);
-      	  }
-      }
-    }
 }
 
 void HardwareSerial::delegateTask (os_event_t *inputEvent)
@@ -290,7 +262,11 @@ void HardwareSerial::delegateTask (os_event_t *inputEvent)
 	}
 }
 
-
+int HardwareSerial::baudRate(void)
+{
+    // Null pointer on _uart is checked by SDK
+    return uart_get_baudrate(uart);
+}
 
 
 HardwareSerial Serial(UART_ID_0);

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -18,6 +18,9 @@ HWSerialMemberData HardwareSerial::memberData[NUMBER_UARTS];
 os_event_t *HardwareSerial::serialQueue = nullptr;
 bool HardwareSerial::init = false;
 
+//set m_printf callback
+extern void setMPrintfPrinterCbc(void (*callback)(uart_t *, char), uart_t *uart);
+
 HardwareSerial::HardwareSerial(const int uartPort)
 	: uartNr(uartPort), rxSize(256)
 {
@@ -157,13 +160,16 @@ void HardwareSerial::systemDebugOutput(bool enabled)
 	if(enabled) {
 		if(uart_tx_enabled(uart)) {
 			uart_set_debug(uartNr);
+			setMPrintfPrinterCbc(uart_write_char, uart);
 		} else {
 			uart_set_debug(UART_NO);
+			setMPrintfPrinterCbc(NULL, NULL);
 		}
 	} else {
 		// disable debug for this interface
 		if(uart_get_debug() == uartNr) {
 			uart_set_debug(UART_NO);
+			setMPrintfPrinterCbc(NULL, NULL);
 		}
 	}
 }

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -289,5 +289,10 @@ int HardwareSerial::baudRate(void)
     return uart_get_baudrate(uart);
 }
 
+HardwareSerial::operator bool() const
+{
+    return uart != 0;
+}
+
 
 HardwareSerial Serial(UART_ID_0);

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -54,6 +54,9 @@ void HardwareSerial::end()
         uart_uninit(uart);
         uart = NULL;
     }
+    else {
+    	uart_detach(uartNr);
+    }
 }
 
 size_t HardwareSerial::setRxBufferSize(size_t size){

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -96,11 +96,26 @@ public:
 		begin(baud, SERIAL_8N1, SERIAL_FULL, 1);
 	}
 
+	/**
+	 * @brief Initialise and set its configuration.
+	 * @param SerialConfig can be 5, 6, 7, 8 data bits, odd (O),
+	 * 					   even (E), and no (N) parity, and 1 or 2 stop bits.
+	 * 		  			   To set the desired mode, call  Serial.begin(baudrate, SERIAL_8N1),
+	 * 		  			   Serial.begin(baudrate, SERIAL_6E2), etc.
+	 */
 	void begin(const uint32_t baud, SerialConfig config)
 	{
 		begin(baud, config, SERIAL_FULL, 1);
 	}
 
+	/**
+	 * @brief Initialise, set its configuration and mode.
+	 * @param SerialConfig can be 5, 6, 7, 8 data bits, odd (O),
+	 * 					   even (E), and no (N) parity, and 1 or 2 stop bits.
+	 * 		  			   To set the desired mode, call  Serial.begin(baudrate, SERIAL_8N1),
+	 * 		  			   Serial.begin(baudrate, SERIAL_6E2), etc.
+	 * @param SerialMode specifies if the UART supports receiving (RX), transmitting (TX) or both (FULL) operations
+	 */
 	void begin(const uint32_t baud, SerialConfig config, SerialMode mode)
 	{
 		begin(baud, config, mode, 1);
@@ -195,8 +210,22 @@ public:
 	 */
 	void resetCallback();
 
+	/**
+	 * @brief  Checks if the current UART can transmit(print) information
+	 * @retval bool true if transmitting is allowed
+	 */
 	bool isTxEnabled(void);
+
+	/**
+	 * @brief  Checks if the current UART can receive information
+	 * @retval bool true if receiving is allowed
+	 */
 	bool isRxEnabled(void);
+
+	/**
+	 * @brief Get the current baud rate
+	 * @retval int baud rate
+	 */
 	int baudRate(void);
 
 private:
@@ -220,10 +249,13 @@ private:
 };
 
 /**	@brief	Global instance of serial port UART0
- *	@note	Use Serial.<i>function</i> to access serial functions
+ *  @note	Use Serial.<i>function</i> to access serial functions
  *	@note	Example:
  *  @code   Serial.begin(115200);
 	@endcode
+	@note   Serial uses UART0, which is mapped to pins GPIO1 (TX) and GPIO3 (RX).
+	@note   Serial may be remapped to GPIO15 (TX) and GPIO13 (RX) by calling Serial.swap() after Serial.begin.
+	@note   Calling swap again maps UART0 back to GPIO1 and GPIO3.
 */
 extern HardwareSerial Serial;
 

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -187,8 +187,9 @@ public:
 	/** @brief  Set handler for received data
 	 *  @param  reqCallback Function to handle received data
 	 *  @param  useSerialRxBuffer True to use the built-in serial receive buffer
+	 *  @retval bool Returns true if the callback was set correctly
 	 */
-	void setCallback(StreamDataReceivedDelegate reqCallback, bool useSerialRxBuffer = true);
+	bool setCallback(StreamDataReceivedDelegate reqCallback, bool useSerialRxBuffer = true);
 
 	/** @brief  Remove handler for received data
 	 */

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -123,25 +123,49 @@ public:
 
 	void begin(const uint32_t baud, SerialConfig config, SerialMode mode, uint8_t txPin);
 
+	/*
+	 * @brief De-inits the current UART if it is already used
+	 */
 	void end();
 
+	/*
+	 * @brief Sets receiving buffer size
+	 * @param size_t requested size
+	 * @retval size_t actual size
+	 */
 	size_t setRxBufferSize(size_t size);
 
+	/*
+	 * @brief Toggle between use of GPIO13/GPIO15 or GPIO3/GPIO(1/2) as RX and TX
+	 * @note UART0 uses pins GPIO1 (TX) and GPIO3 (RX). It may be swapped to GPIO15 (TX) and GPIO13 (RX) by calling .swap() after .begin. C
+	 * @note Calling swap again maps UART0 back to GPIO1 and GPIO3.
+	 */
 	void swap()
 	{
 		swap(1);
 	}
-	void swap(uint8_t tx_pin);    //toggle between use of GPIO13/GPIO15 or GPIO3/GPIO(1/2) as RX and TX
 
 	/*
-	 * Toggle between use of GPIO1 and GPIO2 as TX on UART 0.
-	 * Note: UART 1 can't be used if GPIO2 is used with UART 0!
+	 * @brief Toggle between use of GPIO13/GPIO15 or GPIO3/GPIO(1/2) as RX and TX
+	 * @param uint8_t Pin number.
+	 */
+	void swap(uint8_t tx_pin);
+
+	/*
+	 * @brief Toggle between use of GPIO1 and GPIO2 as TX on UART 0.
+	 * @note: UART 1 can't be used if GPIO2 is used with UART 0!
+	 * @note: If UART1 is not used and UART0 is not swapped - TX for UART0 can be mapped to GPIO2 by calling .setTx(2) after
+	 * 		  .begin or directly with .begin(baud, config, mode, 2).
+	 *
 	 */
 	void setTx(uint8_t tx_pin);
 
 	/*
-	 * UART 0 possible options are (1, 3), (2, 3) or (15, 13)
-	 * UART 1 allows only TX on 2 if UART 0 is not (2, 3)
+	 * @brief Sets the transmission and receiving PINS
+	 * @param uint8_t tx Transmission pin number
+	 * @param uint8_t rx Receiving pin number
+	 * @note UART 0 possible options are (1, 3), (2, 3) or (15, 13)
+	 * @note UART 1 allows only TX on 2 if UART 0 is not (2, 3)
 	 */
 	void pins(uint8_t tx, uint8_t rx);
 
@@ -172,8 +196,6 @@ public:
 
 	/** @brief  Clear the serial port receive buffer
  	 *  @note   All received data is removed from the serial port buffer
- 	 *  @warning This function is not implemented!!!
- 	 *  @todo   Implement Serial::flush()
 	 */
 	void flush();
 
@@ -185,7 +207,6 @@ public:
 
 	using Stream::write;
 
-	//void printf(const char *fmt, ...);
 	/** @brief  Configure serial port for system debug output
 	 *  @param  enabled True to enable this port for system debug output
 	 *  @note   If enabled, port will issue system debug messages
@@ -256,7 +277,7 @@ private:
  *  @code   Serial.begin(115200);
 	@endcode
 	@note   Serial uses UART0, which is mapped to pins GPIO1 (TX) and GPIO3 (RX).
-	@note   Serial may be remapped to GPIO15 (TX) and GPIO13 (RX) by calling Serial.swap() after Serial.begin.
+	@note   Serial may be swapped to GPIO15 (TX) and GPIO13 (RX) by calling Serial.swap() after Serial.begin.
 	@note   Calling swap again maps UART0 back to GPIO1 and GPIO3.
 */
 extern HardwareSerial Serial;

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -235,7 +235,9 @@ private:
 	uart_t* uart = nullptr;
 	size_t rxSize;
 
-	os_event_t * serialQueue = nullptr;
+	static os_event_t *serialQueue;
+
+	static bool init;
 
 	/** @brief  Interrupt handler for UART0 receive events
 	 * @param uart_t* pointer to UART structure

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -249,6 +249,11 @@ public:
 	 */
 	int baudRate(void);
 
+	/**
+	 * @brief Operator that returns true if the uart structure is set
+	 */
+	operator bool() const;
+
 private:
 	int uartNr;
 	static HWSerialMemberData memberData[NUMBER_UARTS];

--- a/Sming/Wiring/WConstants.h
+++ b/Sming/Wiring/WConstants.h
@@ -40,10 +40,20 @@
 #define HIGH     0x1
 //#define HIGH     0xFF
 
-#define INPUT        0x0
-#define OUTPUT       0x1
-#define INPUT_PULLUP 0x2 //defined in Arduino > 100
-//#define OUTPUT   0xFF
+//GPIO FUNCTIONS
+#define INPUT             0x00
+#define INPUT_PULLUP      0x02
+#define INPUT_PULLDOWN_16 0x04 // PULLDOWN only possible for pin16
+#define OUTPUT            0x01
+#define OUTPUT_OPEN_DRAIN 0x03
+#define WAKEUP_PULLUP     0x05
+#define WAKEUP_PULLDOWN   0x07
+#define SPECIAL           0xF8 //defaults to the usable BUSes uart0rx/tx uart1tx and hspi
+#define FUNCTION_0        0x08
+#define FUNCTION_1        0x18
+#define FUNCTION_2        0x28
+#define FUNCTION_3        0x38
+#define FUNCTION_4        0x48
 
 #define CHANGE   32 // to avoid conflict with HIGH value
 #define FALLING  2

--- a/Sming/system/include/espinc/uart.h
+++ b/Sming/system/include/espinc/uart.h
@@ -1,96 +1,167 @@
-#ifndef UART_APP_H
-#define UART_APP_H
+/*
+ uart.h - UART HAL
 
-#include "../espinc/uart_register.h"
+ Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
 
-#define RX_BUFF_SIZE    0x100
-#define TX_BUFF_SIZE    100
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
 
-typedef enum {
-    FIVE_BITS = 0x0,
-    SIX_BITS = 0x1,
-    SEVEN_BITS = 0x2,
-    EIGHT_BITS = 0x3
-} UartBitsNum4Char;
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
 
-typedef enum {
-    ONE_STOP_BIT             = 0,
-    ONE_HALF_STOP_BIT        = BIT2,
-    TWO_STOP_BIT             = BIT2
-} UartStopBitsNum;
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
-typedef enum {
-    NONE_BITS = 0,
-    ODD_BITS   = 0,
-    EVEN_BITS = BIT4
-} UartParityMode;
+*/
+#ifndef ESP_UART_H
+#define ESP_UART_H
 
-typedef enum {
-    STICK_PARITY_DIS   = 0,
-    STICK_PARITY_EN    = BIT3 | BIT5
-} UartExistParity;
+#include <stdint.h>
+#include <stdbool.h>
+#include <stddef.h>
 
-typedef enum {
-    BIT_RATE_9600     = 9600,
-    BIT_RATE_19200   = 19200,
-    BIT_RATE_38400   = 38400,
-    BIT_RATE_57600   = 57600,
-    BIT_RATE_74880   = 74880,
-    BIT_RATE_115200 = 115200,
-    BIT_RATE_230400 = 230400,
-    BIT_RATE_460800 = 460800,
-    BIT_RATE_921600 = 921600
-} UartBautRate;
-
-typedef enum {
-    NONE_CTRL,
-    HARDWARE_CTRL,
-    XON_XOFF_CTRL
-} UartFlowCtrl;
-
-typedef enum {
-    EMPTY,
-    UNDER_WRITE,
-    WRITE_OVER
-} RcvMsgBuffState;
-
-typedef struct {
-    uint32     RcvBuffSize;
-    uint8     *pRcvMsgBuff;
-    uint8     *pWritePos;
-    uint8     *pReadPos;
-    uint8      TrigLvl; //JLU: may need to pad
-    RcvMsgBuffState  BuffState;
-} RcvMsgBuff;
-
-typedef struct {
-    uint32   TrxBuffSize;
-    uint8   *pTrxBuff;
-} TrxMsgBuff;
-
-typedef enum {
-    BAUD_RATE_DET,
-    WAIT_SYNC_FRM,
-    SRCH_MSG_HEAD,
-    RCV_MSG_BODY,
-    RCV_ESC_CHAR,
-} RcvMsgState;
-
-typedef struct {
-    UartBautRate 	     baut_rate;
-    UartBitsNum4Char  data_bits;
-    UartExistParity      exist_parity;
-    UartParityMode 	    parity;    // chip size in byte
-    UartStopBitsNum   stop_bits;
-    UartFlowCtrl         flow_ctrl;
-    RcvMsgBuff          rcv_buff;
-    TrxMsgBuff           trx_buff;
-    RcvMsgState        rcv_state;
-    int                      received;
-    int                      buff_uart_no;  //indicate which uart use tx/rx buffer
-} UartDevice;
-
-void uart_init(UartBautRate uart0_br, UartBautRate uart1_br);
-
+#if defined (__cplusplus)
+extern "C" {
 #endif
 
+#define UART0    0
+#define UART1    1
+#define UART_NO -1
+
+// Options for `config` argument of uart_init
+#define UART_NB_BIT_MASK      0B00001100
+#define UART_NB_BIT_5         0B00000000
+#define UART_NB_BIT_6         0B00000100
+#define UART_NB_BIT_7         0B00001000
+#define UART_NB_BIT_8         0B00001100
+
+#define UART_PARITY_MASK      0B00000011
+#define UART_PARITY_NONE      0B00000000
+#define UART_PARITY_EVEN      0B00000010
+#define UART_PARITY_ODD       0B00000011
+
+#define UART_NB_STOP_BIT_MASK 0B00110000
+#define UART_NB_STOP_BIT_0    0B00000000
+#define UART_NB_STOP_BIT_1    0B00010000
+#define UART_NB_STOP_BIT_15   0B00100000
+#define UART_NB_STOP_BIT_2    0B00110000
+
+#define UART_5N1 ( UART_NB_BIT_5 | UART_PARITY_NONE | UART_NB_STOP_BIT_1 )
+#define UART_6N1 ( UART_NB_BIT_6 | UART_PARITY_NONE | UART_NB_STOP_BIT_1 )
+#define UART_7N1 ( UART_NB_BIT_7 | UART_PARITY_NONE | UART_NB_STOP_BIT_1 )
+#define UART_8N1 ( UART_NB_BIT_8 | UART_PARITY_NONE | UART_NB_STOP_BIT_1 )
+#define UART_5N2 ( UART_NB_BIT_5 | UART_PARITY_NONE | UART_NB_STOP_BIT_2 )
+#define UART_6N2 ( UART_NB_BIT_6 | UART_PARITY_NONE | UART_NB_STOP_BIT_2 )
+#define UART_7N2 ( UART_NB_BIT_7 | UART_PARITY_NONE | UART_NB_STOP_BIT_2 )
+#define UART_8N2 ( UART_NB_BIT_8 | UART_PARITY_NONE | UART_NB_STOP_BIT_2 )
+#define UART_5E1 ( UART_NB_BIT_5 | UART_PARITY_EVEN | UART_NB_STOP_BIT_1 )
+#define UART_6E1 ( UART_NB_BIT_6 | UART_PARITY_EVEN | UART_NB_STOP_BIT_1 )
+#define UART_7E1 ( UART_NB_BIT_7 | UART_PARITY_EVEN | UART_NB_STOP_BIT_1 )
+#define UART_8E1 ( UART_NB_BIT_8 | UART_PARITY_EVEN | UART_NB_STOP_BIT_1 )
+#define UART_5E2 ( UART_NB_BIT_5 | UART_PARITY_EVEN | UART_NB_STOP_BIT_2 )
+#define UART_6E2 ( UART_NB_BIT_6 | UART_PARITY_EVEN | UART_NB_STOP_BIT_2 )
+#define UART_7E2 ( UART_NB_BIT_7 | UART_PARITY_EVEN | UART_NB_STOP_BIT_2 )
+#define UART_8E2 ( UART_NB_BIT_8 | UART_PARITY_EVEN | UART_NB_STOP_BIT_2 )
+#define UART_5O1 ( UART_NB_BIT_5 | UART_PARITY_ODD  | UART_NB_STOP_BIT_1 )
+#define UART_6O1 ( UART_NB_BIT_6 | UART_PARITY_ODD  | UART_NB_STOP_BIT_1 )
+#define UART_7O1 ( UART_NB_BIT_7 | UART_PARITY_ODD  | UART_NB_STOP_BIT_1 )
+#define UART_8O1 ( UART_NB_BIT_8 | UART_PARITY_ODD  | UART_NB_STOP_BIT_1 )
+#define UART_5O2 ( UART_NB_BIT_5 | UART_PARITY_ODD  | UART_NB_STOP_BIT_2 )
+#define UART_6O2 ( UART_NB_BIT_6 | UART_PARITY_ODD  | UART_NB_STOP_BIT_2 )
+#define UART_7O2 ( UART_NB_BIT_7 | UART_PARITY_ODD  | UART_NB_STOP_BIT_2 )
+#define UART_8O2 ( UART_NB_BIT_8 | UART_PARITY_ODD  | UART_NB_STOP_BIT_2 )
+
+/*
+#define UART_5N1 0x10
+#define UART_6N1 0x14
+#define UART_7N1 0x18
+#define UART_8N1 0x1c
+#define UART_5N2 0x30
+#define UART_6N2 0x34
+#define UART_7N2 0x38
+#define UART_8N2 0x3c
+#define UART_5E1 0x12
+#define UART_6E1 0x16
+#define UART_7E1 0x1a
+#define UART_8E1 0x1e
+#define UART_5E2 0x32
+#define UART_6E2 0x36
+#define UART_7E2 0x3a
+#define UART_8E2 0x3e
+#define UART_5O1 0x13
+#define UART_6O1 0x17
+#define UART_7O1 0x1b
+#define UART_8O1 0x1f
+#define UART_5O2 0x33
+#define UART_6O2 0x37
+#define UART_7O2 0x3b
+#define UART_8O2 0x3f
+*/
+
+// Options for `mode` argument of uart_init
+#define UART_FULL     0
+#define UART_RX_ONLY  1
+#define UART_TX_ONLY  2
+
+#define UART_TX_FIFO_SIZE 0x80
+
+struct uart_rx_buffer_ {
+    size_t size;
+    size_t rpos;
+    size_t wpos;
+    uint8_t * buffer;
+};
+
+struct uart_;
+
+struct uart_ {
+    int uart_nr;
+    int baud_rate;
+    bool rx_enabled;
+    bool tx_enabled;
+    uint8_t rx_pin;
+    uint8_t tx_pin;
+    struct uart_rx_buffer_ * rx_buffer;
+    void (*callback)(struct uart_* arg);
+};
+
+typedef struct uart_ uart_t;
+
+uart_t* uart_init(int uart_nr, int baudrate, int config, int mode, int tx_pin, size_t rx_size);
+void uart_uninit(uart_t* uart);
+
+void uart_swap(uart_t* uart, int tx_pin);
+void uart_set_tx(uart_t* uart, int tx_pin);
+void uart_set_pins(uart_t* uart, int tx, int rx);
+bool uart_tx_enabled(uart_t* uart);
+bool uart_rx_enabled(uart_t* uart);
+
+void uart_set_baudrate(uart_t* uart, int baud_rate);
+int uart_get_baudrate(uart_t* uart);
+
+size_t uart_resize_rx_buffer(uart_t* uart, size_t new_size);
+
+void uart_write_char(uart_t* uart, char c);
+void uart_write(uart_t* uart, const char* buf, size_t size);
+int uart_read_char(uart_t* uart);
+int uart_peek_char(uart_t* uart);
+size_t uart_rx_available(uart_t* uart);
+size_t uart_tx_free(uart_t* uart);
+void uart_wait_tx_empty(uart_t* uart);
+void uart_flush(uart_t* uart);
+
+void uart_set_debug(int uart_nr);
+int uart_get_debug();
+
+
+#if defined (__cplusplus)
+} // extern "C"
+#endif
+
+#endif // ESP_UART_H

--- a/Sming/system/include/espinc/uart.h
+++ b/Sming/system/include/espinc/uart.h
@@ -77,33 +77,6 @@ extern "C" {
 #define UART_7O2 ( UART_NB_BIT_7 | UART_PARITY_ODD  | UART_NB_STOP_BIT_2 )
 #define UART_8O2 ( UART_NB_BIT_8 | UART_PARITY_ODD  | UART_NB_STOP_BIT_2 )
 
-/*
-#define UART_5N1 0x10
-#define UART_6N1 0x14
-#define UART_7N1 0x18
-#define UART_8N1 0x1c
-#define UART_5N2 0x30
-#define UART_6N2 0x34
-#define UART_7N2 0x38
-#define UART_8N2 0x3c
-#define UART_5E1 0x12
-#define UART_6E1 0x16
-#define UART_7E1 0x1a
-#define UART_8E1 0x1e
-#define UART_5E2 0x32
-#define UART_6E2 0x36
-#define UART_7E2 0x3a
-#define UART_8E2 0x3e
-#define UART_5O1 0x13
-#define UART_6O1 0x17
-#define UART_7O1 0x1b
-#define UART_8O1 0x1f
-#define UART_5O2 0x33
-#define UART_6O2 0x37
-#define UART_7O2 0x3b
-#define UART_8O2 0x3f
-*/
-
 // Options for `mode` argument of uart_init
 #define UART_FULL     0
 #define UART_RX_ONLY  1

--- a/Sming/system/include/espinc/uart.h
+++ b/Sming/system/include/espinc/uart.h
@@ -158,6 +158,7 @@ void uart_flush(uart_t* uart);
 
 void uart_set_debug(int uart_nr);
 int uart_get_debug();
+void uart_detach(int uart_nr);
 
 
 #if defined (__cplusplus)

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -13,7 +13,12 @@ Descr: embedded very simple version of printf with float support
 
 #define OVERFLOW_GUARD 24
 
-void (*cbc_printchar)(char ch) = uart_tx_one_char;
+static void defaultPrintChar(uart_t *uart, char c) {
+	return uart_tx_one_char(c);
+}
+
+void (*cbc_printchar)(uart_t *, char) = defaultPrintChar;
+uart_t *cbc_printchar_uart = NULL;
 
 #define SIGN    	(1<<1)	/* Unsigned/signed long */
 
@@ -29,15 +34,16 @@ static int skip_atoi(const char **s)
 	return i;
 }
 
-void setMPrintfPrinterCbc(void (*callback)(char))
+void setMPrintfPrinterCbc(void (*callback)(uart_t *, char), uart_t *uart)
 {
 	cbc_printchar = callback;
+	cbc_printchar_uart = uart;
 }
 
 void m_putc(char c)
 {
 	if (cbc_printchar)
-		cbc_printchar(c);
+		cbc_printchar(cbc_printchar_uart, c);
 }
 
 /**
@@ -77,7 +83,7 @@ int m_vprintf ( const char * format, va_list arg )
 	p = buf;
 	while (p && n < sizeof(buf) && *p)
 	{
-		cbc_printchar(*p);
+		cbc_printchar(cbc_printchar_uart, *p);
 		n++;
 		p++;
 	}

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -510,3 +510,11 @@ int uart_get_debug()
 {
     return s_uart_debug_nr;
 }
+
+void uart_detach(int uart_nr) {
+	ETS_UART_INTR_DISABLE();
+	USC1(uart_nr) = 0;
+	USIC(uart_nr) = 0xffff;
+	USIE(uart_nr) = 0;
+	ETS_UART_INTR_ATTACH(NULL, NULL);
+}

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -1,0 +1,512 @@
+/*
+ uart.cpp - esp8266 UART HAL
+
+ Copyright (c) 2014 Ivan Grokhotkov. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+ */
+
+
+/**
+ *  UART GPIOs
+ *
+ * UART0 TX: 1 or 2
+ * UART0 RX: 3
+ *
+ * UART0 SWAP TX: 15
+ * UART0 SWAP RX: 13
+ *
+ *
+ * UART1 TX: 7 (NC) or 2
+ * UART1 RX: 8 (NC)
+ *
+ * UART1 SWAP TX: 11 (NC)
+ * UART1 SWAP RX: 6 (NC)
+ *
+ * NC = Not Connected to Module Pads --> No Access
+ *
+ */
+#include "Arduino.h"
+#include "esp_systemapi.h"
+#include "espinc/uart.h"
+#include "espinc/peri.h"
+#include <user_interface.h>
+
+static int s_uart_debug_nr = UART0;
+
+size_t uart_resize_rx_buffer(uart_t* uart, size_t new_size)
+{
+    if(uart == NULL || !uart->rx_enabled) {
+        return 0;
+    }
+    if(uart->rx_buffer->size == new_size) {
+        return uart->rx_buffer->size;
+    }
+    uint8_t * new_buf = (uint8_t*)malloc(new_size);
+    if(!new_buf) {
+        return uart->rx_buffer->size;
+    }
+    size_t new_wpos = 0;
+    ETS_UART_INTR_DISABLE();
+    while(uart_rx_available(uart) && new_wpos < new_size) {
+        new_buf[new_wpos++] = uart_read_char(uart);
+    }
+    uint8_t * old_buf = uart->rx_buffer->buffer;
+    uart->rx_buffer->rpos = 0;
+    uart->rx_buffer->wpos = new_wpos;
+    uart->rx_buffer->size = new_size;
+    uart->rx_buffer->buffer = new_buf;
+    free(old_buf);
+    ETS_UART_INTR_ENABLE();
+    return uart->rx_buffer->size;
+}
+
+int uart_peek_char(uart_t* uart)
+{
+    if(uart == NULL || !uart->rx_enabled) {
+        return -1;
+    }
+    if (!uart_rx_available(uart)) {
+        return -1;
+    }
+    return uart->rx_buffer->buffer[uart->rx_buffer->rpos];
+}
+
+int uart_read_char(uart_t* uart)
+{
+    int data = uart_peek_char(uart);
+    if(data != -1) {
+        uart->rx_buffer->rpos = (uart->rx_buffer->rpos + 1) % uart->rx_buffer->size;
+    }
+    return data;
+}
+
+size_t uart_rx_available(uart_t* uart)
+{
+    if(uart == NULL || !uart->rx_enabled) {
+        return 0;
+    }
+    if(uart->rx_buffer->wpos < uart->rx_buffer->rpos) {
+      return (uart->rx_buffer->wpos + uart->rx_buffer->size) - uart->rx_buffer->rpos;
+    }
+    return uart->rx_buffer->wpos - uart->rx_buffer->rpos;
+}
+
+
+void IRAM_ATTR uart_isr(void * arg)
+{
+    uart_t* uart = (uart_t*)arg;
+    if(uart == NULL || !uart->rx_enabled) {
+        USIC(uart->uart_nr) = USIS(uart->uart_nr);
+        ETS_UART_INTR_DISABLE();
+        return;
+    }
+    if(USIS(uart->uart_nr) & ((1 << UIFF) | (1 << UITO))){
+        while((USS(uart->uart_nr) >> USRXC) & 0x7F){
+            uint8_t data = USF(uart->uart_nr);
+            size_t nextPos = (uart->rx_buffer->wpos + 1) % uart->rx_buffer->size;
+            if(nextPos != uart->rx_buffer->rpos) {
+                uart->rx_buffer->buffer[uart->rx_buffer->wpos] = data;
+                uart->rx_buffer->wpos = nextPos;
+            }
+        }
+    }
+    USIC(uart->uart_nr) = USIS(uart->uart_nr);
+    if(uart->callback) {
+    	uart->callback(uart);
+    }
+}
+
+void uart_start_isr(uart_t* uart)
+{
+    if(uart == NULL || !uart->rx_enabled) {
+        return;
+    }
+    USC1(uart->uart_nr) = (127 << UCFFT) | (0x02 << UCTOT) | (1 <<UCTOE );
+    USIC(uart->uart_nr) = 0xffff;
+    USIE(uart->uart_nr) = (1 << UIFF) | (1 << UIFR) | (1 << UITO);
+//    ETS_UART_INTR_ATTACH(uart_isr,  (void *)uart);
+    ETS_UART_INTR_ATTACH((void *)uart_isr,  (void *)uart);
+    ETS_UART_INTR_ENABLE();
+}
+
+void uart_stop_isr(uart_t* uart)
+{
+    if(uart == NULL || !uart->rx_enabled) {
+        return;
+    }
+    ETS_UART_INTR_DISABLE();
+    USC1(uart->uart_nr) = 0;
+    USIC(uart->uart_nr) = 0xffff;
+    USIE(uart->uart_nr) = 0;
+    ETS_UART_INTR_ATTACH(NULL, NULL);
+}
+
+
+void uart_write_char(uart_t* uart, char c)
+{
+    if(uart == NULL || !uart->tx_enabled) {
+        return;
+    }
+    while((USS(uart->uart_nr) >> USTXC) >= 0x7f);
+    USF(uart->uart_nr) = c;
+}
+
+void uart_write(uart_t* uart, const char* buf, size_t size)
+{
+    if(uart == NULL || !uart->tx_enabled) {
+        return;
+    }
+    while(size--) {
+        uart_write_char(uart, *buf++);
+    }
+}
+
+size_t uart_tx_free(uart_t* uart)
+{
+    if(uart == NULL || !uart->tx_enabled) {
+        return 0;
+    }
+    return UART_TX_FIFO_SIZE - ((USS(uart->uart_nr) >> USTXC) & 0xff);
+}
+
+void uart_wait_tx_empty(uart_t* uart)
+{
+    if(uart == NULL || !uart->tx_enabled) {
+        return;
+    }
+    while(((USS(uart->uart_nr) >> USTXC) & 0xff) > 0) {
+        delay(0);
+    }
+}
+
+void uart_flush(uart_t* uart)
+{
+    if(uart == NULL) {
+        return;
+    }
+
+    uint32_t tmp = 0x00000000;
+    if(uart->rx_enabled) {
+        tmp |= (1 << UCRXRST);
+        ETS_UART_INTR_DISABLE();
+        uart->rx_buffer->rpos = 0;
+        uart->rx_buffer->wpos = 0;
+        ETS_UART_INTR_ENABLE();
+    }
+
+    if(uart->tx_enabled) {
+        tmp |= (1 << UCTXRST);
+    }
+
+    USC0(uart->uart_nr) |= (tmp);
+    USC0(uart->uart_nr) &= ~(tmp);
+}
+
+void uart_set_baudrate(uart_t* uart, int baud_rate)
+{
+    if(uart == NULL) {
+        return;
+    }
+    uart->baud_rate = baud_rate;
+    USD(uart->uart_nr) = (ESP8266_CLOCK / uart->baud_rate);
+}
+
+int uart_get_baudrate(uart_t* uart)
+{
+    if(uart == NULL) {
+        return 0;
+    }
+    return uart->baud_rate;
+}
+
+uart_t* uart_init(int uart_nr, int baudrate, int config, int mode, int tx_pin, size_t rx_size)
+{
+    uart_t* uart = (uart_t*) malloc(sizeof(uart_t));
+    if(uart == NULL) {
+        return NULL;
+    }
+
+    uart->uart_nr = uart_nr;
+
+    switch(uart->uart_nr) {
+    case UART0:
+        ETS_UART_INTR_DISABLE();
+        ETS_UART_INTR_ATTACH(NULL, NULL);
+        uart->rx_enabled = (mode != UART_TX_ONLY);
+        uart->tx_enabled = (mode != UART_RX_ONLY);
+        uart->rx_pin = (uart->rx_enabled)?3:255;
+        if(uart->rx_enabled) {
+            struct uart_rx_buffer_ * rx_buffer = (struct uart_rx_buffer_ *)malloc(sizeof(struct uart_rx_buffer_));
+            if(rx_buffer == NULL) {
+              free(uart);
+              return NULL;
+            }
+            rx_buffer->size = rx_size;//var this
+            rx_buffer->rpos = 0;
+            rx_buffer->wpos = 0;
+            rx_buffer->buffer = (uint8_t *)malloc(rx_buffer->size);
+            if(rx_buffer->buffer == NULL) {
+              free(rx_buffer);
+              free(uart);
+              return NULL;
+            }
+            uart->rx_buffer = rx_buffer;
+            pinMode(uart->rx_pin, SPECIAL);
+        }
+        if(uart->tx_enabled) {
+            if (tx_pin == 2) {
+                uart->tx_pin = 2;
+                pinMode(uart->tx_pin, FUNCTION_4);
+            } else {
+                uart->tx_pin = 1;
+                pinMode(uart->tx_pin, FUNCTION_0);
+            }
+        } else {
+            uart->tx_pin = 255;
+        }
+        IOSWAP &= ~(1 << IOSWAPU0);
+        break;
+    case UART1:
+        // Note: uart_interrupt_handler does not support RX on UART 1.
+        uart->rx_enabled = false;
+        uart->tx_enabled = (mode != UART_RX_ONLY);
+        uart->rx_pin = 255;
+        uart->tx_pin = (uart->tx_enabled)?2:255;  // GPIO7 as TX not possible! See GPIO pins used by UART
+        if(uart->tx_enabled) {
+            pinMode(uart->tx_pin, SPECIAL);
+        }
+        break;
+    case UART_NO:
+    default:
+        // big fail!
+        free(uart);
+        return NULL;
+    }
+
+    uart_set_baudrate(uart, baudrate);
+    USC0(uart->uart_nr) = config;
+    uart_flush(uart);
+    USC1(uart->uart_nr) = 0;
+    USIC(uart->uart_nr) = 0xffff;
+    USIE(uart->uart_nr) = 0;
+    if(uart->uart_nr == UART0 && uart->rx_enabled) {
+        uart_start_isr(uart);
+    }
+
+    return uart;
+}
+
+void uart_uninit(uart_t* uart)
+{
+    if(uart == NULL) {
+        return;
+    }
+
+    switch(uart->rx_pin) {
+    case 3:
+        pinMode(3, INPUT);
+        break;
+    case 13:
+        pinMode(13, INPUT);
+        break;
+    }
+
+    switch(uart->tx_pin) {
+    case 1:
+        pinMode(1, INPUT);
+        break;
+    case 2:
+        pinMode(2, INPUT);
+        break;
+    case 15:
+        pinMode(15, INPUT);
+        break;
+    }
+
+    if(uart->rx_enabled){
+        free(uart->rx_buffer->buffer);
+        free(uart->rx_buffer);
+        uart_stop_isr(uart);
+    }
+    free(uart);
+}
+
+void uart_swap(uart_t* uart, int tx_pin)
+{
+    if(uart == NULL) {
+        return;
+    }
+    switch(uart->uart_nr) {
+    case UART0:
+        if(((uart->tx_pin == 1 || uart->tx_pin == 2) && uart->tx_enabled) || (uart->rx_pin == 3 && uart->rx_enabled)) {
+            if(uart->tx_enabled) { //TX
+                pinMode(uart->tx_pin, INPUT);
+                uart->tx_pin = 15;
+            }
+            if(uart->rx_enabled) { //RX
+                pinMode(uart->rx_pin, INPUT);
+                uart->rx_pin = 13;
+            }
+            if(uart->tx_enabled) {
+                pinMode(uart->tx_pin, FUNCTION_4);    //TX
+            }
+            if(uart->rx_enabled) {
+                pinMode(uart->rx_pin, FUNCTION_4);    //RX
+            }
+            IOSWAP |= (1 << IOSWAPU0);
+        } else {
+            if(uart->tx_enabled) { //TX
+                pinMode(uart->tx_pin, INPUT);
+                uart->tx_pin = (tx_pin == 2)?2:1;
+            }
+            if(uart->rx_enabled) { //RX
+                pinMode(uart->rx_pin, INPUT);
+                uart->rx_pin = 3;
+            }
+            if(uart->tx_enabled) {
+                pinMode(uart->tx_pin, (tx_pin == 2)?FUNCTION_4:SPECIAL);    //TX
+            }
+            if(uart->rx_enabled) {
+                pinMode(3, SPECIAL);    //RX
+            }
+            IOSWAP &= ~(1 << IOSWAPU0);
+        }
+
+        break;
+    case UART1:
+        // Currently no swap possible! See GPIO pins used by UART
+        break;
+    default:
+        break;
+    }
+}
+
+void uart_set_tx(uart_t* uart, int tx_pin)
+{
+    if(uart == NULL) {
+        return;
+    }
+    switch(uart->uart_nr) {
+    case UART0:
+        if(uart->tx_enabled) {
+            if (uart->tx_pin == 1 && tx_pin == 2) {
+                pinMode(uart->tx_pin, INPUT);
+                uart->tx_pin = 2;
+                pinMode(uart->tx_pin, FUNCTION_4);
+            } else if (uart->tx_pin == 2 && tx_pin != 2) {
+                pinMode(uart->tx_pin, INPUT);
+                uart->tx_pin = 1;
+                pinMode(uart->tx_pin, SPECIAL);
+            }
+        }
+
+        break;
+    case UART1:
+        // GPIO7 as TX not possible! See GPIO pins used by UART
+        break;
+    default:
+        break;
+    }
+}
+
+void uart_set_pins(uart_t* uart, int tx, int rx)
+{
+    if(uart == NULL) {
+        return;
+    }
+
+    if(uart->uart_nr == UART0) { // Only UART0 allows pin changes
+        if(uart->tx_enabled && uart->tx_pin != tx) {
+            if( rx == 13 && tx == 15) {
+                uart_swap(uart, 15);
+            } else if (rx == 3 && (tx == 1 || tx == 2)) {
+                if (uart->rx_pin != rx) {
+                    uart_swap(uart, tx);
+                } else {
+                    uart_set_tx(uart, tx);
+                }
+            }
+        }
+        if(uart->rx_enabled && uart->rx_pin != rx && rx == 13 && tx == 15) {
+            uart_swap(uart, 15);
+        }
+    }
+}
+
+
+bool uart_tx_enabled(uart_t* uart)
+{
+    if(uart == NULL) {
+        return false;
+    }
+    return uart->tx_enabled;
+}
+
+bool uart_rx_enabled(uart_t* uart)
+{
+    if(uart == NULL) {
+        return false;
+    }
+    return uart->rx_enabled;
+}
+
+
+static void uart_ignore_char(char c)
+{
+}
+
+static void uart0_write_char(char c)
+{
+    while(((USS(0) >> USTXC) & 0xff) >= 0x7F) {
+        delay(0);
+    }
+    USF(0) = c;
+}
+
+static void uart1_write_char(char c)
+{
+    while(((USS(1) >> USTXC) & 0xff) >= 0x7F) {
+        delay(0);
+    }
+    USF(1) = c;
+}
+
+void uart_set_debug(int uart_nr)
+{
+    s_uart_debug_nr = uart_nr;
+    switch(s_uart_debug_nr) {
+    case UART0:
+        system_set_os_print(1);
+        ets_install_putc1((void *) &uart0_write_char);
+        break;
+    case UART1:
+        system_set_os_print(1);
+        ets_install_putc1((void *) &uart1_write_char);
+        break;
+    case UART_NO:
+    default:
+        system_set_os_print(0);
+        ets_install_putc1((void *) &uart_ignore_char);
+        break;
+    }
+}
+
+int uart_get_debug()
+{
+    return s_uart_debug_nr;
+}

--- a/samples/Basic_Serial/app/application.cpp
+++ b/samples/Basic_Serial/app/application.cpp
@@ -73,6 +73,20 @@ void init()
 {
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 
+	/**
+	 * Serial1 uses UART1, TX pin is GPIO2.
+	 * UART1 can not be used to receive data because normally
+	 * it's RX pin is occupied for flash chip connection.
+	 */
+	HardwareSerial Serial1(UART1);
+	Serial1.begin(SERIAL_BAUD_RATE);
+
+	/*
+	 * The line below redirect debug output to UART1
+	 */
+	Serial1.systemDebugOutput(true);
+	Serial1.printf("====Debug Information=====\n");
+
 	procTimer.initializeMs(2000, sayHello).start();
 
 	testPrintf();
@@ -81,6 +95,8 @@ void init()
 	//  * Option 1
 	//	Set Serial Callback to global routine:
 	//	   Serial.setCallback(onDataCallback);
+	// If you want to test local echo set the following callback
+	//	   Serial.setCallback(echoCallback);
 
 	// 	* Option 2
 	//  Instantiate hwsDelegateDemo which includes Serial Delegate class

--- a/samples/Basic_Serial/app/application.cpp
+++ b/samples/Basic_Serial/app/application.cpp
@@ -73,10 +73,17 @@ void init()
 {
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 
+	debugf("\n(DEBUG) message printed on UART0\n");
+
 	/**
 	 * Serial1 uses UART1, TX pin is GPIO2.
 	 * UART1 can not be used to receive data because normally
 	 * it's RX pin is occupied for flash chip connection.
+	 *
+	 * If you have a spare serial to USB converter do the following to see the
+	 * messages printed on UART1:
+	 * - connect converter GND to esp8266 GND
+	 * - connect converter RX to esp8266 GPIO2
 	 */
 	HardwareSerial Serial1(UART1);
 	Serial1.begin(SERIAL_BAUD_RATE);
@@ -86,6 +93,8 @@ void init()
 	 */
 	Serial1.systemDebugOutput(true);
 	Serial1.printf("====Debug Information=====\n");
+
+	debugf("(DEBUG) message printed on UART1\n"); // You should see the debug message in UART1 only.
 
 	procTimer.initializeMs(2000, sayHello).start();
 

--- a/samples/Basic_Serial/include/SerialReadingDelegateDemo.h
+++ b/samples/Basic_Serial/include/SerialReadingDelegateDemo.h
@@ -7,6 +7,11 @@ void onDataCallback(Stream& stream, char arrivedChar, unsigned short availableCh
 	Serial.printf("Char: %d, Count: %d\n", (uint8_t)arrivedChar, availableCharsCount);
 }
 
+void echoCallback(Stream& stream, char arrivedChar, unsigned short availableCharsCount)
+{
+	stream.write(arrivedChar);
+}
+
 //*** Example of class callback processing
 class SerialReadingDelegateDemo
 {

--- a/samples/Basic_Serial/include/SerialReadingDelegateDemo.h
+++ b/samples/Basic_Serial/include/SerialReadingDelegateDemo.h
@@ -4,6 +4,7 @@
 //*** Example of global callback routine
 void onDataCallback(Stream& stream, char arrivedChar, unsigned short availableCharsCount)
 {
+	Serial.printf("Char: %d, Count: %d\n", (uint8_t)arrivedChar, availableCharsCount);
 }
 
 //*** Example of class callback processing


### PR DESCRIPTION
The old code was causing constant stopping and starting of interrupts leading to bad performance.
It was not possible to use UART1 for debug output.
it was not possible to change / specify UART configuration or rx buffer size.

The new code, "borrowed" from esp8266/Arduino and adapted for Sming  addresses those issues. In addition it allows to address up to 256 uarts and attach callbacks for received data.