### PR TITLE
Make NetUtils::debugPrintTcpList() static

### DIFF
--- a/Sming/SmingCore/Network/NetUtils.h
+++ b/Sming/SmingCore/Network/NetUtils.h
@@ -31,7 +31,7 @@ public:
 	static bool FixNetworkRouting();
 
 	// Debug
-	void debugPrintTcpList();
+	static void debugPrintTcpList();
 
 private:
 	static bool ipClientRoutingFixed;


### PR DESCRIPTION
Useful function for debugging TCP connections status from application code. 
No need to have object instance, make it static.