### PR TITLE
Reverted the previous commit (434ef0d60420940ede75bf895736a22bd8549f2…

### DIFF
--- a/Sming/Services/SpifFS/spiffs_config.h
+++ b/Sming/Services/SpifFS/spiffs_config.h
@@ -15,15 +15,13 @@
 #ifdef __ets__
 #include <user_config.h>
 #include "../system/flashmem.h"
-#include <stdint.h>
 #else
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stddef.h>
 #include <ctype.h>
-typedef   signed           int intptr_t;
-typedef unsigned           int uintptr_t;
+#include <stdint.h>
 typedef signed int s32_t;
 typedef unsigned int u32_t;
 typedef signed short s16_t;


### PR DESCRIPTION
…3) because it broke the build

with esp-alt-sdk and esp-open-sdk on Linux and Mac OS X.
If there is a problem with the Windows built an issue needs to be provided with information before breaking the build process for other platforms.