### PR TITLE
Make default debug uart speed configurable.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ a [custom PWM library](https://github.com/StefanBruens/ESP8266_new_pwm) will be 
 - Custom Heap Allocation: If your application is experiencing heap fragmentation then you can try the Umm Malloc heap allocation. To enable it compile
 Sming with ENABLE_CUSTOM_HEAP=1. In order to use it in your sample/application make sure to compile the sample with ENABLE_CUSTOM_HEAP=1. Avoid enabling
 your custom heap allocation AND -mforce-l32 compiler flag.
-
+- Custom serial baud rate: By default serial debug interface baud is 115200. You can set COM_SPEED_SERIAL to alter that for ex: COM_SPEED_SERIAL=921600
 
 You can find more information about compilation and flashing process by reading esp8266.com forum discussion thread.
 

--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ a [custom PWM library](https://github.com/StefanBruens/ESP8266_new_pwm) will be 
 - Custom Heap Allocation: If your application is experiencing heap fragmentation then you can try the Umm Malloc heap allocation. To enable it compile
 Sming with ENABLE_CUSTOM_HEAP=1. In order to use it in your sample/application make sure to compile the sample with ENABLE_CUSTOM_HEAP=1. Avoid enabling
 your custom heap allocation AND -mforce-l32 compiler flag.
-- Custom serial baud rate: By default serial debug interface baud is 115200. You can set COM_SPEED_SERIAL to alter that for ex: COM_SPEED_SERIAL=921600
+- Custom serial baud rate: The default serial baud rate is 115200. If you want to change it to a higher baud rate you can recompile Sming and your application changing the COM_SPEED_SERIAL directive. For example COM_SPEED_SERIAL=921600
 
 You can find more information about compilation and flashing process by reading esp8266.com forum discussion thread.
 

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -99,6 +99,16 @@ export COMPILE := gcc
 export PATH := $(ESP_HOME)/xtensa-lx106-elf/bin:$(PATH)
 XTENSA_TOOLS_ROOT := $(ESP_HOME)/xtensa-lx106-elf/bin
 
+## COM port parameters
+# Default COM port speed (generic)
+COM_SPEED ?= 115200
+
+# Default COM port speed (used for flashing)
+COM_SPEED_ESPTOOL ?= $(COM_SPEED)
+
+# Default COM port speed (used in code)
+COM_SPEED_SERIAL  ?= $(COM_SPEED)
+
 # Sming Framework Path
 SMF = $(SMING_HOME)
 

--- a/Sming/appinit/user_main.cpp
+++ b/Sming/appinit/user_main.cpp
@@ -29,7 +29,6 @@ extern "C" void  __attribute__((weak)) user_init(void)
 extern "C" void __attribute__((weak)) user_rf_pre_init(void)
 {
 	uart_div_modify(UART_ID_0, UART_CLK_FREQ / SERIAL_BAUD_RATE);
-
 	// RTC startup fix, author pvvx
     volatile uint32 * ptr_reg_rtc_ram = (volatile uint32 *)0x60001000;
     if((ptr_reg_rtc_ram[24] >> 16) > 4) {

--- a/Sming/appinit/user_main.cpp
+++ b/Sming/appinit/user_main.cpp
@@ -12,7 +12,7 @@ extern void init();
 extern "C" void  __attribute__((weak)) user_init(void)
 {
 	system_timer_reinit();
-	uart_div_modify(UART_ID_0, UART_CLK_FREQ / 115200);
+
 	cpp_core_initialize();
 	System.initialize();
 #ifdef SMING_RELEASE
@@ -28,6 +28,8 @@ extern "C" void  __attribute__((weak)) user_init(void)
 // For compatibility with SDK v1.1
 extern "C" void __attribute__((weak)) user_rf_pre_init(void)
 {
+	uart_div_modify(UART_ID_0, UART_CLK_FREQ / SERIAL_BAUD_RATE);
+
 	// RTC startup fix, author pvvx
     volatile uint32 * ptr_reg_rtc_ram = (volatile uint32 *)0x60001000;
     if((ptr_reg_rtc_ram[24] >> 16) > 4) {

--- a/Sming/include/user_config.h
+++ b/Sming/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Accelerometer_MMA7455/include/user_config.h
+++ b/samples/Accelerometer_MMA7455/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Arducam/include/user_config.h
+++ b/samples/Arducam/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_APA102/include/user_config.h
+++ b/samples/Basic_APA102/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_AirUpdate/include/user_config.h
+++ b/samples/Basic_AirUpdate/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_Blink/include/user_config.h
+++ b/samples/Basic_Blink/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_Capsense/include/user_config.h
+++ b/samples/Basic_Capsense/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_Delegates/include/user_config.h
+++ b/samples/Basic_Delegates/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_HwPWM/include/user_config.h
+++ b/samples/Basic_HwPWM/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_Interrupts/include/user_config.h
+++ b/samples/Basic_Interrupts/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_Neopixel/include/user_config.h
+++ b/samples/Basic_Neopixel/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_PWM/include/user_config.h
+++ b/samples/Basic_PWM/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_ProgMem/include/user_config.h
+++ b/samples/Basic_ProgMem/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_ScannerI2C/include/user_config.h
+++ b/samples/Basic_ScannerI2C/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_Serial/include/user_config.h
+++ b/samples/Basic_Serial/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_Servo/include/user_config.h
+++ b/samples/Basic_Servo/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_SmartConfig/include/user_config.h
+++ b/samples/Basic_SmartConfig/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_Ssl/include/user_config.h
+++ b/samples/Basic_Ssl/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_WebSkeletonApp/include/user_config.h
+++ b/samples/Basic_WebSkeletonApp/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_WiFi/include/user_config.h
+++ b/samples/Basic_WiFi/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Basic_rBoot/include/user_config.h
+++ b/samples/Basic_rBoot/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/CommandProcessing_Debug/include/user_config.h
+++ b/samples/CommandProcessing_Debug/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Compass_HMC5883L/include/user_config.h
+++ b/samples/Compass_HMC5883L/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/DNSCaptivePortal/include/user_config.h
+++ b/samples/DNSCaptivePortal/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/DS3232RTC_NTP_Setter/include/user_config.h
+++ b/samples/DS3232RTC_NTP_Setter/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Echo_Ssl/include/user_config.h
+++ b/samples/Echo_Ssl/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/FtpServer_Files/include/user_config.h
+++ b/samples/FtpServer_Files/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Gesture_APDS-9960/include/user_config.h
+++ b/samples/Gesture_APDS-9960/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/HttpClient_Instapush/include/user_config.h
+++ b/samples/HttpClient_Instapush/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/HttpClient_ThingSpeak/include/user_config.h
+++ b/samples/HttpClient_ThingSpeak/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/HttpServer_AJAX/include/user_config.h
+++ b/samples/HttpServer_AJAX/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/HttpServer_Bootstrap/include/user_config.h
+++ b/samples/HttpServer_Bootstrap/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/HttpServer_ConfigNetwork/include/user_config.h
+++ b/samples/HttpServer_ConfigNetwork/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/HttpServer_WebSockets/include/user_config.h
+++ b/samples/HttpServer_WebSockets/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Humidity_DHT22/include/user_config.h
+++ b/samples/Humidity_DHT22/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Humidity_SI7021/include/user_config.h
+++ b/samples/Humidity_SI7021/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/IR_lib/include/user_config.h
+++ b/samples/IR_lib/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/LED_WS2812/include/user_config.h
+++ b/samples/LED_WS2812/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Light_BH1750/include/user_config.h
+++ b/samples/Light_BH1750/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/LiquidCrystal_44780/include/user_config.h
+++ b/samples/LiquidCrystal_44780/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/MeteoControl/include/user_config.h
+++ b/samples/MeteoControl/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/MeteoControl_mqtt/include/user_config.h
+++ b/samples/MeteoControl_mqtt/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/MqttClient_Hello/include/user_config.h
+++ b/samples/MqttClient_Hello/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/PortExpander_MCP23017/include/user_config.h
+++ b/samples/PortExpander_MCP23017/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/PortExpander_MCP23S17/include/user_config.h
+++ b/samples/PortExpander_MCP23S17/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Pressure_BMP180/include/user_config.h
+++ b/samples/Pressure_BMP180/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Radio_RCSwitch/include/user_config.h
+++ b/samples/Radio_RCSwitch/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Radio_nRF24L01/include/user_config.h
+++ b/samples/Radio_nRF24L01/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Radio_si4432/include/user_config.h
+++ b/samples/Radio_si4432/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/SDCard/include/user_config.h
+++ b/samples/SDCard/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/ScreenLCD_5110/include/user_config.h
+++ b/samples/ScreenLCD_5110/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/ScreenOLED_SSD1306/include/user_config.h
+++ b/samples/ScreenOLED_SSD1306/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/ScreenTFT_ILI9163C/include/user_config.h
+++ b/samples/ScreenTFT_ILI9163C/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/ScreenTFT_ILI9340-ILI9341/include/user_config.h
+++ b/samples/ScreenTFT_ILI9340-ILI9341/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/ScreenTFT_ST7735/include/user_config.h
+++ b/samples/ScreenTFT_ST7735/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/SystemClock_NTP/include/user_config.h
+++ b/samples/SystemClock_NTP/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/TcpClient_NarodMon/include/user_config.h
+++ b/samples/TcpClient_NarodMon/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Telnet_TCPServer_TCPClient/include/user_config.h
+++ b/samples/Telnet_TCPServer_TCPClient/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Temperature_DS1820/include/user_config.h
+++ b/samples/Temperature_DS1820/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/UdpServer_Echo/include/user_config.h
+++ b/samples/UdpServer_Echo/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/UdpServer_mDNS/include/user_config.h
+++ b/samples/UdpServer_mDNS/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Ultrasonic_HCSR04/include/user_config.h
+++ b/samples/Ultrasonic_HCSR04/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/samples/Websocket_Client/include/user_config.h
+++ b/samples/Websocket_Client/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC


### PR DESCRIPTION
For debug purposes it's better to use a bigger baudrate such as 921600.

