### PR TITLE
fix lwip windows

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,7 +51,7 @@ a [custom PWM library](https://github.com/StefanBruens/ESP8266_new_pwm) will be 
 - Custom Heap Allocation: If your application is experiencing heap fragmentation then you can try the Umm Malloc heap allocation. To enable it compile
 Sming with ENABLE_CUSTOM_HEAP=1. In order to use it in your sample/application make sure to compile the sample with ENABLE_CUSTOM_HEAP=1. Avoid enabling
 your custom heap allocation AND -mforce-l32 compiler flag.
-
+- Custom serial baud rate: By default serial debug interface baud is 115200. You can set COM_SPEED_SERIAL to alter that for ex: COM_SPEED_SERIAL=921600
 
 You can find more information about compilation and flashing process by reading esp8266.com forum discussion thread.
 

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -258,9 +258,11 @@ V ?= $(VERBOSE)
 ifeq ("$(V)","1")
 Q :=
 vecho := @true
+MAKE_QUIET :=
 else
 Q := @
 vecho := @echo
+MAKE_QUIET := --quiet
 endif
 
 vpath %.c $(SRC_DIR)
@@ -299,19 +301,24 @@ endif
 
 ifeq ($(ENABLE_SSL), 1)
 $(USER_LIBDIR)/libaxtls.a:
-	$(Q) $(MAKE) -C third-party/axtls-8266 -e V=$(V) BIN_DIR="$(SMING_HOME)/$(USER_LIBDIR)"
+	$(vecho) "Building SSL..."
+	$(Q) $(MAKE) -C third-party/axtls-8266 -e $(MAKE_QUIET) V=$(V) BIN_DIR="$(SMING_HOME)/$(USER_LIBDIR)"
+	$(vecho) "...done"
 endif
 
 ifeq ($(ENABLE_CUSTOM_HEAP), 1)
 $(USER_LIBDIR)/libmainmm.a: $(addprefix $(SDK_LIBDIR)/,libmain.a)
-	$(vecho) "Enabling custom heap implementation"
+	$(vecho) "Building custom heap implementation"
 	$(Q) cp $^ $@ 
 	$(Q) $(AR) -d $@ mem_manager.o
+	$(vecho) "...done"
 endif
 
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 $(USER_LIBDIR)/liblwip_%.a: third-party/esp-open-lwip/Makefile.open
-	$(Q) $(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open ENABLE_ESPCONN=$(ENABLE_ESPCONN) USER_LIBDIR=$(SMING_HOME)/$(USER_LIBDIR)/
+	$(vecho) "Building custom LWIP"
+	$(Q) $(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open $(MAKE_QUIET) V=$(V) ENABLE_ESPCONN=$(ENABLE_ESPCONN) SDK_BASE="$(SDK_BASE)" USER_LIBDIR="$(SMING_HOME)/$(USER_LIBDIR)/" all
+	$(vecho) "...done"
 endif
 
 spiffy: spiffy/spiffy
@@ -334,6 +341,7 @@ endif
 	$(vecho) "Done"
 
 checkdirs: $(THIRD_PARTY_DATA) $(BUILD_DIR) $(FW_BASE) $(CUSTOM_TARGETS)
+	$(vecho) Building Sming...
 
 $(BUILD_DIR):
 	$(Q) mkdir -p $@
@@ -345,12 +353,20 @@ $(FW_BASE):
 rebuild: clean all
 
 clean:
+	$(vecho) "Cleaning SMING..."
 	$(Q) rm -f $(APP_AR)
 	$(Q) rm -f $(TARGET_OUT)
 	$(Q) rm -rf $(BUILD_DIR)
 	$(Q) rm -rf $(BUILD_BASE)
 	$(Q) rm -rf $(FW_BASE)
+
+ifeq ($(ENABLE_CUSTOM_LWIP), 1)
+	$(vecho) "Cleaning LWIP..."
+	$(Q) $(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open clean ENABLE_ESPCONN=$(ENABLE_ESPCONN) USER_LIBDIR="$(SMING_HOME)/$(USER_LIBDIR)/"
+endif
+
 ifeq ($(ENABLE_SSL), 1)
+	$(vecho) "Cleaning SSL..."
 	$(Q) -$(MAKE) --no-print-directory -C third-party/axtls-8266 clean -e V=$(V) BIN_DIR="$(SMING_HOME)/$(USER_LIBDIR)"
 else
 	$(Q) $(MAKE) --no-print-directory -C spiffy clean V=$(V)

--- a/Sming/appinit/user_main.cpp
+++ b/Sming/appinit/user_main.cpp
@@ -12,7 +12,7 @@ extern void init();
 extern "C" void  __attribute__((weak)) user_init(void)
 {
 	system_timer_reinit();
-	uart_div_modify(UART_ID_0, UART_CLK_FREQ / 115200);
+
 	cpp_core_initialize();
 	System.initialize();
 #ifdef SMING_RELEASE
@@ -28,6 +28,8 @@ extern "C" void  __attribute__((weak)) user_init(void)
 // For compatibility with SDK v1.1
 extern "C" void __attribute__((weak)) user_rf_pre_init(void)
 {
+	uart_div_modify(UART_ID_0, UART_CLK_FREQ / SERIAL_BAUD_RATE);
+
 	// RTC startup fix, author pvvx
     volatile uint32 * ptr_reg_rtc_ram = (volatile uint32 *)0x60001000;
     if((ptr_reg_rtc_ram[24] >> 16) > 4) {

--- a/Sming/include/user_config.h
+++ b/Sming/include/user_config.h
@@ -6,7 +6,7 @@ extern "C" {
 #endif
 
 	// UART config
-	#define SERIAL_BAUD_RATE 115200
+	#define SERIAL_BAUD_RATE COM_SPEED_SERIAL
 
 	// ESP SDK config
 	#define LWIP_OPEN_SRC

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -90,14 +90,12 @@ index 1bc584f..5db5467 100644
  $(LIB): $(OBJS)
  	$(AR) rcs $@ $^
 diff --git a/include/arch/cc.h b/include/arch/cc.h
-index ff03b30..f755330 100644
+index ff03b30..932c73d 100644
 --- a/include/arch/cc.h
 +++ b/include/arch/cc.h
-@@ -37,9 +37,27 @@
- //#include <string.h>
+@@ -38,8 +38,25 @@
  #include "c_types.h"
  #include "ets_sys.h"
-+
  #include "osapi.h"
 +#include <stdarg.h>
 +
@@ -121,87 +119,12 @@ index ff03b30..f755330 100644
  //#define LWIP_PROVIDE_ERRNO
  
  #if (1)
-diff --git a/lwip/app/dhcpserver.c b/lwip/app/dhcpserver.c
-index ddb5984..b7055c9 100644
---- a/lwip/app/dhcpserver.c
-+++ b/lwip/app/dhcpserver.c
-@@ -13,6 +13,8 @@
+@@ -56,6 +73,7 @@ typedef signed     short   s16_t;
+ typedef unsigned   long    u32_t;
+ typedef signed     long    s32_t;
+ typedef unsigned long   mem_ptr_t;
++typedef signed short        sint16_t;
  
- #include "user_interface.h"
- 
-+extern int wifi_softap_set_station_info(uint8_t * chaddr, struct ip_addr *ip);
-+
- #ifdef MEMLEAK_DEBUG
- static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
- #endif
-diff --git a/lwip/core/dhcp.c b/lwip/core/dhcp.c
-index 342543e..5596cbf 100644
---- a/lwip/core/dhcp.c
-+++ b/lwip/core/dhcp.c
-@@ -84,6 +84,8 @@
- 
- #include <string.h>
- 
-+extern void system_station_got_ip_set(ip_addr_t * ip_addr, ip_addr_t *sn_mask, ip_addr_t *gw_addr);
-+
- #ifdef MEMLEAK_DEBUG
- static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
- #endif
-diff --git a/lwip/core/ipv4/ip_addr.c b/lwip/core/ipv4/ip_addr.c
-index 81db807..06f4d0d 100644
---- a/lwip/core/ipv4/ip_addr.c
-+++ b/lwip/core/ipv4/ip_addr.c
-@@ -40,6 +40,8 @@
- #include "lwip/ip_addr.h"
- #include "lwip/netif.h"
- 
-+extern int isdigit ( int c );
-+
- /* used by IP_ADDR_ANY and IP_ADDR_BROADCAST in ip_addr.h */
- const ip_addr_t ip_addr_any ICACHE_RODATA_ATTR = { IPADDR_ANY };
- const ip_addr_t ip_addr_broadcast ICACHE_RODATA_ATTR = { IPADDR_BROADCAST };
-diff --git a/lwip/core/tcp.c b/lwip/core/tcp.c
-index ee50ceb..929801c 100644
---- a/lwip/core/tcp.c
-+++ b/lwip/core/tcp.c
-@@ -638,13 +638,9 @@ tcp_new_port(void)
-   static u16_t port = TCP_LOCAL_PORT_RANGE_START;
-   
-  again:
--//  if (++port >= TCP_LOCAL_PORT_RANGE_END) {
--//    port = TCP_LOCAL_PORT_RANGE_START;
--//  }
--  port = os_random();
--  port %= TCP_LOCAL_PORT_RANGE_END;
--  if (port < TCP_LOCAL_PORT_RANGE_START)
--	  port += TCP_LOCAL_PORT_RANGE_START;
-+
-+  port = TCP_LOCAL_PORT_RANGE_START + os_random()%(TCP_LOCAL_PORT_RANGE_END - TCP_LOCAL_PORT_RANGE_START);
-+
-   /* Check all PCB lists. */
-   for (i = 0; i < NUM_TCP_PCB_LISTS; i++) {  
-     for(pcb = *tcp_pcb_lists[i]; pcb != NULL; pcb = pcb->next) {
-@@ -1424,9 +1420,13 @@ tcp_pcb_purge(struct tcp_pcb *pcb)
-     }
-     if (pcb->unsent != NULL) {
-       LWIP_DEBUGF(TCP_DEBUG, ("tcp_pcb_purge: not all data sent\n"));
-+      tcp_segs_free(pcb->unsent);
-+      pcb->unsent = NULL;
-     }
-     if (pcb->unacked != NULL) {
-       LWIP_DEBUGF(TCP_DEBUG, ("tcp_pcb_purge: data left on ->unacked\n"));
-+      tcp_segs_free(pcb->unacked);
-+      pcb->unacked = NULL;
-     }
- #if TCP_QUEUE_OOSEQ
-     if (pcb->ooseq != NULL) {
-@@ -1440,9 +1440,6 @@ tcp_pcb_purge(struct tcp_pcb *pcb)
-        queue if it fires */
-     pcb->rtime = -1;
- 
--    tcp_segs_free(pcb->unsent);
--    tcp_segs_free(pcb->unacked);
--    pcb->unacked = pcb->unsent = NULL;
- #if TCP_OVERSIZE
-     pcb->unsent_oversize = 0;
- #endif /* TCP_OVERSIZE */
+ #define S16_F "d"
+ #define U16_F "d"
+

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -1,8 +1,11 @@
 diff --git a/include/user_config.h b/include/user_config.h
-index e69de29..1db5073 100644
+index e69de29..3a85c8c 100644
 --- a/include/user_config.h
 +++ b/include/user_config.h
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,39 @@
++#ifndef _USER_CONFIG_LWIP_
++#define _USER_CONFIG_LWIP_
++
 +#ifdef __cplusplus
 +extern "C" {
 +#endif
@@ -37,20 +40,24 @@ index e69de29..1db5073 100644
 +#ifdef __cplusplus
 +}
 +#endif
++
++#endif /*_USER_CONFIG_LWIP_*/
 diff --git a/Makefile.open b/Makefile.open
-index 1bc584f..df7b6e8 100644
+index 1bc584f..5db5467 100644
 --- a/Makefile.open
 +++ b/Makefile.open
-@@ -2,7 +2,7 @@ CC = xtensa-lx106-elf-gcc
+@@ -2,7 +2,9 @@ CC = xtensa-lx106-elf-gcc
  AR = xtensa-lx106-elf-ar
  DEFS = -DLWIP_OPEN_SRC -DPBUF_RSV_FOR_WLAN -DEBUF_LWIP -DICACHE_FLASH
  COPT = -Os
 -CFLAGS = $(DEFS) $(COPT) -Iinclude -Wl,-EL -mlongcalls -mtext-section-literals $(CFLAGS_EXTRA)
-+CFLAGS = $(DEFS) $(COPT) -Iinclude -I$(ESP_HOME)/sdk/include/ -Wl,-EL -mlongcalls -mtext-section-literals $(CFLAGS_EXTRA)
++
++CFLAGS = $(DEFS) $(COPT) -Iinclude -I$(SDK_BASE)/include -Wl,-EL -mlongcalls -mtext-section-literals $(CFLAGS_EXTRA)
++
  # Install prefix of esp-open-sdk toolchain
  PREFIX = ~/toolchain/xtensa-lx106-elf
  
-@@ -36,11 +36,24 @@ lwip/core/ipv4/ip.o \
+@@ -36,14 +38,26 @@ lwip/core/ipv4/ip.o \
  lwip/core/ipv4/ip_frag.o \
  lwip/netif/etharp.o \
  \
@@ -58,8 +65,10 @@ index 1bc584f..df7b6e8 100644
 -\
 -espconn_dummy.o \
 +lwip/app/dhcpserver.o
-+
-+
+ 
+-LIB = liblwip_open.a
+ 
+-all: $(LIB)
 +ifneq ($(ENABLE_ESPCONN),1)
 +    OBJS += espconn_dummy.o
 +else
@@ -68,14 +77,131 @@ index 1bc584f..df7b6e8 100644
 +lwip/app/espconn_udp.o \
 +lwip/app/espconn_mdns.o \
 +lwip/core/mdns.o
-+
-+endif
  
--LIB = liblwip_open.a
++endif
++
 +LIB = $(USER_LIBDIR)liblwip_open.a
 +ifeq ($(ENABLE_ESPCONN),1)
 +    LIB = $(USER_LIBDIR)liblwip_full.a
 +endif
++
++all: $(LIB)
  
- all: $(LIB)
+ $(LIB): $(OBJS)
+ 	$(AR) rcs $@ $^
+diff --git a/include/arch/cc.h b/include/arch/cc.h
+index ff03b30..f755330 100644
+--- a/include/arch/cc.h
++++ b/include/arch/cc.h
+@@ -37,9 +37,27 @@
+ //#include <string.h>
+ #include "c_types.h"
+ #include "ets_sys.h"
++
+ #include "osapi.h"
++#include <stdarg.h>
++
+ #define EFAULT 14
  
++//Extra symbols to avoid implicit declaration warnings
++extern void *ets_memset(void *s, int c, size_t n);
++extern void ets_memcpy(void*, const void*, uint32);
++
++extern size_t ets_strlen(const char *s);
++extern int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
++extern int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
++extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
++extern void ets_timer_disarm(ETSTimer *a);
++extern void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *pfunction, void *parg);
++extern uint32 r_rand(void);
++extern int ets_memcmp(const void *s1, const void *s2, size_t n);
++
++struct netif * eagle_lwip_getif(uint8 index);
++
+ //#define LWIP_PROVIDE_ERRNO
+ 
+ #if (1)
+diff --git a/lwip/app/dhcpserver.c b/lwip/app/dhcpserver.c
+index ddb5984..b7055c9 100644
+--- a/lwip/app/dhcpserver.c
++++ b/lwip/app/dhcpserver.c
+@@ -13,6 +13,8 @@
+ 
+ #include "user_interface.h"
+ 
++extern int wifi_softap_set_station_info(uint8_t * chaddr, struct ip_addr *ip);
++
+ #ifdef MEMLEAK_DEBUG
+ static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
+ #endif
+diff --git a/lwip/core/dhcp.c b/lwip/core/dhcp.c
+index 342543e..5596cbf 100644
+--- a/lwip/core/dhcp.c
++++ b/lwip/core/dhcp.c
+@@ -84,6 +84,8 @@
+ 
+ #include <string.h>
+ 
++extern void system_station_got_ip_set(ip_addr_t * ip_addr, ip_addr_t *sn_mask, ip_addr_t *gw_addr);
++
+ #ifdef MEMLEAK_DEBUG
+ static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
+ #endif
+diff --git a/lwip/core/ipv4/ip_addr.c b/lwip/core/ipv4/ip_addr.c
+index 81db807..06f4d0d 100644
+--- a/lwip/core/ipv4/ip_addr.c
++++ b/lwip/core/ipv4/ip_addr.c
+@@ -40,6 +40,8 @@
+ #include "lwip/ip_addr.h"
+ #include "lwip/netif.h"
+ 
++extern int isdigit ( int c );
++
+ /* used by IP_ADDR_ANY and IP_ADDR_BROADCAST in ip_addr.h */
+ const ip_addr_t ip_addr_any ICACHE_RODATA_ATTR = { IPADDR_ANY };
+ const ip_addr_t ip_addr_broadcast ICACHE_RODATA_ATTR = { IPADDR_BROADCAST };
+diff --git a/lwip/core/tcp.c b/lwip/core/tcp.c
+index ee50ceb..929801c 100644
+--- a/lwip/core/tcp.c
++++ b/lwip/core/tcp.c
+@@ -638,13 +638,9 @@ tcp_new_port(void)
+   static u16_t port = TCP_LOCAL_PORT_RANGE_START;
+   
+  again:
+-//  if (++port >= TCP_LOCAL_PORT_RANGE_END) {
+-//    port = TCP_LOCAL_PORT_RANGE_START;
+-//  }
+-  port = os_random();
+-  port %= TCP_LOCAL_PORT_RANGE_END;
+-  if (port < TCP_LOCAL_PORT_RANGE_START)
+-	  port += TCP_LOCAL_PORT_RANGE_START;
++
++  port = TCP_LOCAL_PORT_RANGE_START + os_random()%(TCP_LOCAL_PORT_RANGE_END - TCP_LOCAL_PORT_RANGE_START);
++
+   /* Check all PCB lists. */
+   for (i = 0; i < NUM_TCP_PCB_LISTS; i++) {  
+     for(pcb = *tcp_pcb_lists[i]; pcb != NULL; pcb = pcb->next) {
+@@ -1424,9 +1420,13 @@ tcp_pcb_purge(struct tcp_pcb *pcb)
+     }
+     if (pcb->unsent != NULL) {
+       LWIP_DEBUGF(TCP_DEBUG, ("tcp_pcb_purge: not all data sent\n"));
++      tcp_segs_free(pcb->unsent);
++      pcb->unsent = NULL;
+     }
+     if (pcb->unacked != NULL) {
+       LWIP_DEBUGF(TCP_DEBUG, ("tcp_pcb_purge: data left on ->unacked\n"));
++      tcp_segs_free(pcb->unacked);
++      pcb->unacked = NULL;
+     }
+ #if TCP_QUEUE_OOSEQ
+     if (pcb->ooseq != NULL) {
+@@ -1440,9 +1440,6 @@ tcp_pcb_purge(struct tcp_pcb *pcb)
+        queue if it fires */
+     pcb->rtime = -1;
+ 
+-    tcp_segs_free(pcb->unsent);
+-    tcp_segs_free(pcb->unacked);
+-    pcb->unacked = pcb->unsent = NULL;
+ #if TCP_OVERSIZE
+     pcb->unsent_oversize = 0;
+ #endif /* TCP_OVERSIZE */


### PR DESCRIPTION
Custom LWIP was not building on windows because make call did not specify target all result was: nothing to do

Lwip patch also contains pull requests [tcp fixes](https://github.com/pfalcon/esp-open-lwip/pull/5) and [fix warnings](https://github.com/pfalcon/esp-open-lwip/pull/6)

Also small cosmetisations, fixed excessive printing when VERBOSE=0 is passed to make.

Please also test on Linux/BSD and give feedback it does not break anything