### PR TITLE
Added directives to define location of rboot roms.

### DIFF
--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -12,6 +12,19 @@
 RBOOT_BIG_FLASH  ?= 1
 RBOOT_TWO_ROMS   ?= 0
 RBOOT_RTC_ENABLED ?= 0
+RBOOT_GPIO_ENABLED ?= 0
+
+### ROM Addresses ###
+# The parameter below specifies the location of the second rom.
+# This parameter is used only when RBOOT_BIG_FLASH = 1 
+# BOOT_ROM1_ADDR = 0x200000
+
+# The parameter below specifies the location of the GPIO ROM.
+# This parameter is used only when RBOOT_GPIO_ENABLED = 1
+# If you use two SPIFFS make sure that this address is minimum
+# RBOOT_SPIFFS_1 + SPIFF_SIZE 
+# BOOT_ROM2_ADDR = 0x310000
+
 RBOOT_ROM_0      ?= rom0
 RBOOT_ROM_1      ?= rom1
 RBOOT_SPIFFS_0   ?= 0x100000
@@ -332,6 +345,9 @@ export RBOOT_BIG_FLASH
 export RBOOT_BUILD_BASE
 export RBOOT_FW_BASE
 export RBOOT_RTC_ENABLED
+export RBOOT_GPIO_ENABLED
+export RBOOT_ROM1_ADDR
+export RBOOT_ROM2_ADDR
 export SPI_SIZE
 export SPI_MODE
 export SPI_SPEED
@@ -349,6 +365,10 @@ endif
 ifeq ($(RBOOT_RTC_ENABLED),1)
 	# enable the temporary switch to rom feature
 	CFLAGS += -DBOOT_RTC_ENABLED
+endif
+
+ifeq ($(RBOOT_GPIO_ENABLED),1)
+	CFLAGS += -DBOOT_GPIO_ENABLED
 endif
 
 INCDIR	:= $(addprefix -I,$(SRC_DIR))
@@ -381,7 +401,7 @@ endef
 all: $(USER_LIBDIR)/lib$(LIBSMING).a checkdirs $(LIBMAIN_DST) $(RBOOT_BIN) $(RBOOT_ROM_0) $(RBOOT_ROM_1) $(SPIFF_BIN_OUT) $(FW_FILE_1) $(FW_FILE_2) 
 
 $(RBOOT_BIN):
-	$(MAKE) -C $(THIRD_PARTY_DIR)/rboot
+	$(MAKE) -C $(THIRD_PARTY_DIR)/rboot RBOOT_GPIO_ENABLED=$(RBOOT_GPIO_ENABLED)
 
 $(LIBMAIN_DST): $(LIBMAIN_SRC)
 	@echo "OC $@"

--- a/Sming/third-party/.patches/rboot.patch
+++ b/Sming/third-party/.patches/rboot.patch
@@ -1,0 +1,47 @@
+diff --git a/Makefile b/Makefile
+index ca234de..08b0fba 100644
+--- a/Makefile
++++ b/Makefile
+@@ -55,6 +55,12 @@ endif
+ ifeq ($(RBOOT_IROM_CHKSUM),1)
+ 	CFLAGS += -DBOOT_IROM_CHKSUM
+ endif
++ifneq ($(RBOOT_ROM1_ADDR),)
++	CFLAGS += -DBOOT_ROM1_ADDR=$(RBOOT_ROM1_ADDR)
++endif
++ifneq ($(RBOOT_ROM2_ADDR),)
++	CFLAGS += -DBOOT_ROM2_ADDR=$(RBOOT_ROM2_ADDR)
++endif
+ ifneq ($(RBOOT_EXTRA_INCDIR),)
+ 	CFLAGS += $(addprefix -I,$(RBOOT_EXTRA_INCDIR))
+ endif
+diff --git a/rboot.c b/rboot.c
+index 6e10a2f..7ac60a8 100644
+--- a/rboot.c
++++ b/rboot.c
+@@ -250,7 +250,25 @@ static uint8 calc_chksum(uint8 *start, uint8 *end) {
+ static uint8 default_config(rboot_config *romconf, uint32 flashsize) {
+ 	romconf->count = 2;
+ 	romconf->roms[0] = SECTOR_SIZE * (BOOT_CONFIG_SECTOR + 1);
++
++#ifdef BOOT_ROM1_ADDR
++	romconf->roms[1] = BOOT_ROM1_ADDR;
++#else
+ 	romconf->roms[1] = (flashsize / 2) + (SECTOR_SIZE * (BOOT_CONFIG_SECTOR + 1));
++#endif
++
++#if defined(BOOT_BIG_FLASH) && defined(BOOT_GPIO_ENABLED)
++	if(flashsize > 0x200000) {
++		romconf->count += 1;
++#ifdef BOOT_ROM2_ADDR
++		romconf->roms[2] = BOOT_ROM2_ADDR;
++#else
++		romconf->roms[2] = 0x310000;
++#endif
++		romconf->gpio_rom = 2;
++	}
++#endif
++
+ #ifdef BOOT_GPIO_ENABLED
+ 	romconf->mode = MODE_GPIO_ROM;
+ #endif


### PR DESCRIPTION
Better access to the (R)BOOT_GPIO_ENABLED directives in Sming.
Added option to enable factory-default rom activated by the desired GPIO (RST by default).