### PR TITLE
Make the custom PWM to be really selectable.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -45,7 +45,7 @@ Sming - Open Source framework for high efficiency WiFi SoC ESP8266 native develo
 - [ESPtool2] (https://github.com/raburton/esptool2) esptool2 
 
 ## Optional features
-- Custom PWM: If Sming is compiled with ENABLE_CUSTOM_PWM=1 then instead of using the Espressif SDK pwm library
+- Custom PWM: If you want to use the open PWM implementation then compile your application with ENABLE_CUSTOM_PWM=1. There is no need to recompile the Sming library.
 a [custom PWM library](https://github.com/StefanBruens/ESP8266_new_pwm) will be used.
 - SSL: The SSL support is not built-in by default to conserve resources. If you want to enable it then take a look at the [Readme](https://github.com/SmingHub/Sming/blob/develop/samples/Basic_Ssl/README.md) in the Basic_Ssl samples.
 - Custom Heap Allocation: If your application is experiencing heap fragmentation then you can try the Umm Malloc heap allocation. To enable it compile

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -169,7 +169,6 @@ USER_LIBDIR = compiler/lib
 LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa main
 ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	THIRD_PARTY_DATA += third-party/pwm/pwm.c
-	LIBS += pwm
 endif
 
 # compiler flags using during compilation of source files. Add '-pg' for debugging

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -292,7 +292,7 @@ endef
 all: checkdirs $(APP_AR) spiffy
 
 ifeq ($(ENABLE_CUSTOM_PWM), 1)	
-$(USER_LIBDIR)/libpwm.a: third-party/pwm/pwm.c
+$(USER_LIBDIR)/libpwm_open.a: third-party/pwm/pwm.c
 	$(Q) $(CC) $(INCDIR) $(MODULE_INCDIR) $(EXTRA_INCDIR) $(SDK_INCDIR) $(CFLAGS)  -c $< -o $(dir $<)/pwm.o
 	$(Q) $(AR) rcs $@ $(dir $<)/pwm.o
 endif 

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -171,9 +171,15 @@ ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 	CUSTOM_TARGETS += $(USER_LIBDIR)/lib$(LIBLWIP).a 
 endif
 
+LIBPWM = pwm
+ifeq ($(ENABLE_CUSTOM_PWM), 1)
+	LIBPWM = pwm_open
+	CUSTOM_TARGETS += $(USER_LIBDIR)/lib$(LIBPWM).a
+endif
+
 # libraries used in this project, mainly provided by the SDK
 USER_LIBDIR = $(SMING_HOME)/compiler/lib/
-LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa $(LIBMAIN) $(LIBSMING) crypto pwm smartconfig $(EXTRA_LIBS)
+LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa $(LIBMAIN) $(LIBSMING) crypto $(LIBPWM) smartconfig $(EXTRA_LIBS)
 
 # compiler flags using during compilation of source files
 CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS)
@@ -300,12 +306,6 @@ INCDIR	:= $(addprefix -I,$(SRC_DIR))
 EXTRA_INCDIR	:= $(addprefix -I,$(EXTRA_INCDIR))
 MODULE_INCDIR	:= $(addsuffix /include,$(INCDIR))
 
-CUSTOM_TARGETS ?=
-
-ifeq ($(ENABLE_CUSTOM_PWM), 1)
-	CUSTOM_TARGETS += $(USER_LIBDIR)/libpwm.a
-endif
-
 V ?= $(VERBOSE)
 ifeq ("$(V)","1")
 Q :=
@@ -378,8 +378,8 @@ include/ssl/private_key.h:
 	$(Q) AXDIR=$(CURRENT_DIR)/include/ssl/  $(THIRD_PARTY_DIR)/axtls-8266/tools/make_certs.sh 
 
 ifeq ($(ENABLE_CUSTOM_PWM), 1)
-$(USER_LIBDIR)/libpwm.a:
-	$(Q) $(MAKE) -C $(SMING_HOME) compiler/lib/libpwm.a ENABLE_CUSTOM_PWM=1
+$(USER_LIBDIR)/libpwm_open.a:
+	$(Q) $(MAKE) -C $(SMING_HOME) compiler/lib/libpwm_open.a ENABLE_CUSTOM_PWM=1
 endif
 
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -210,7 +210,13 @@ ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 	CUSTOM_TARGETS += $(USER_LIBDIR)/lib$(LIBLWIP).a
 endif
 
-LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa $(LIBMAIN) $(LIBSMING) crypto pwm smartconfig $(EXTRA_LIBS)
+LIBPWM = pwm
+ifeq ($(ENABLE_CUSTOM_PWM), 1)
+	LIBPWM = pwm_open
+	CUSTOM_TARGETS += $(USER_LIBDIR)/lib$(LIBPWM).a
+endif
+
+LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa $(LIBMAIN) $(LIBSMING) crypto $(LIBPWM) smartconfig $(EXTRA_LIBS)
 
 # SSL support using axTLS
 ifeq ($(ENABLE_SSL),1)
@@ -423,8 +429,8 @@ include/ssl/private_key.h:
 	$(Q) AXDIR=$(CURRENT_DIR)/include/ssl/  $(THIRD_PARTY_DIR)/axtls-8266/tools/make_certs.sh 
 	
 ifeq ($(ENABLE_CUSTOM_PWM), 1)
-$(USER_LIBDIR)/libpwm.a:
-	$(Q) $(MAKE) -C $(SMING_HOME) compiler/lib/libpwm.a ENABLE_CUSTOM_PWM=1
+$(USER_LIBDIR)/libpwm_open.a:
+	$(Q) $(MAKE) -C $(SMING_HOME) compiler/lib/libpwm_open.a ENABLE_CUSTOM_PWM=1
 endif
 
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)


### PR DESCRIPTION
Until now if the custom PWM was compiled it would be used in all projects, no matter the compile directives.