### PR TITLE
Fix lwip compilation on windows

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -310,7 +310,7 @@ endif
 
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 $(USER_LIBDIR)/liblwip_%.a: third-party/esp-open-lwip/Makefile.open
-	$(Q) $(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open ENABLE_ESPCONN=$(ENABLE_ESPCONN) USER_LIBDIR=$(SMING_HOME)/$(USER_LIBDIR)/
+	$(Q) $(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open ENABLE_ESPCONN=$(ENABLE_ESPCONN) SDK_BASE="$(SDK_BASE)" USER_LIBDIR="$(SMING_HOME)/$(USER_LIBDIR)/" all
 endif
 
 spiffy: spiffy/spiffy

--- a/Sming/Makefile-windows.mk
+++ b/Sming/Makefile-windows.mk
@@ -13,4 +13,4 @@ ESPTOOL		 ?= $(SDK_TOOLS)/esptool.exe
 KILL_TERM    ?= taskkill.exe -f -im Terminal.exe || exit 0
 GET_FILESIZE ?= stat --printf="%s"
 TERMINAL     ?= $(SDK_TOOLS)/Terminal.exe $(COM_PORT) $(COM_SPEED_SERIAL)
-MEMANALYZER  ?= $(SDK_TOOLS)/memanalyzer.exe $(OBJDUMP).exe
+MEMANALYZER  ?= $(SDK_TOOLS)/ESP8266/memanalyzer.exe $(OBJDUMP).exe

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -1,8 +1,11 @@
 diff --git a/include/user_config.h b/include/user_config.h
-index e69de29..1db5073 100644
+index e69de29..3a85c8c 100644
 --- a/include/user_config.h
 +++ b/include/user_config.h
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,39 @@
++#ifndef _USER_CONFIG_LWIP_
++#define _USER_CONFIG_LWIP_
++
 +#ifdef __cplusplus
 +extern "C" {
 +#endif
@@ -37,20 +40,24 @@ index e69de29..1db5073 100644
 +#ifdef __cplusplus
 +}
 +#endif
++
++#endif /*_USER_CONFIG_LWIP_*/
 diff --git a/Makefile.open b/Makefile.open
-index 1bc584f..df7b6e8 100644
+index 1bc584f..5db5467 100644
 --- a/Makefile.open
 +++ b/Makefile.open
-@@ -2,7 +2,7 @@ CC = xtensa-lx106-elf-gcc
+@@ -2,7 +2,9 @@ CC = xtensa-lx106-elf-gcc
  AR = xtensa-lx106-elf-ar
  DEFS = -DLWIP_OPEN_SRC -DPBUF_RSV_FOR_WLAN -DEBUF_LWIP -DICACHE_FLASH
  COPT = -Os
 -CFLAGS = $(DEFS) $(COPT) -Iinclude -Wl,-EL -mlongcalls -mtext-section-literals $(CFLAGS_EXTRA)
-+CFLAGS = $(DEFS) $(COPT) -Iinclude -I$(ESP_HOME)/sdk/include/ -Wl,-EL -mlongcalls -mtext-section-literals $(CFLAGS_EXTRA)
++
++CFLAGS = $(DEFS) $(COPT) -Iinclude -I$(SDK_BASE)/include -Wl,-EL -mlongcalls -mtext-section-literals $(CFLAGS_EXTRA)
++
  # Install prefix of esp-open-sdk toolchain
  PREFIX = ~/toolchain/xtensa-lx106-elf
  
-@@ -36,11 +36,24 @@ lwip/core/ipv4/ip.o \
+@@ -36,14 +38,26 @@ lwip/core/ipv4/ip.o \
  lwip/core/ipv4/ip_frag.o \
  lwip/netif/etharp.o \
  \
@@ -58,8 +65,10 @@ index 1bc584f..df7b6e8 100644
 -\
 -espconn_dummy.o \
 +lwip/app/dhcpserver.o
-+
-+
+ 
+-LIB = liblwip_open.a
+ 
+-all: $(LIB)
 +ifneq ($(ENABLE_ESPCONN),1)
 +    OBJS += espconn_dummy.o
 +else
@@ -68,14 +77,54 @@ index 1bc584f..df7b6e8 100644
 +lwip/app/espconn_udp.o \
 +lwip/app/espconn_mdns.o \
 +lwip/core/mdns.o
-+
-+endif
  
--LIB = liblwip_open.a
++endif
++
 +LIB = $(USER_LIBDIR)liblwip_open.a
 +ifeq ($(ENABLE_ESPCONN),1)
 +    LIB = $(USER_LIBDIR)liblwip_full.a
 +endif
++
++all: $(LIB)
  
- all: $(LIB)
+ $(LIB): $(OBJS)
+ 	$(AR) rcs $@ $^
+diff --git a/include/arch/cc.h b/include/arch/cc.h
+index ff03b30..932c73d 100644
+--- a/include/arch/cc.h
++++ b/include/arch/cc.h
+@@ -38,8 +38,25 @@
+ #include "c_types.h"
+ #include "ets_sys.h"
+ #include "osapi.h"
++#include <stdarg.h>
++
+ #define EFAULT 14
  
++//Extra symbols to avoid implicit declaration warnings
++extern void *ets_memset(void *s, int c, size_t n);
++extern void ets_memcpy(void*, const void*, uint32);
++
++extern size_t ets_strlen(const char *s);
++extern int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
++extern int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
++extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
++extern void ets_timer_disarm(ETSTimer *a);
++extern void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *pfunction, void *parg);
++extern uint32 r_rand(void);
++extern int ets_memcmp(const void *s1, const void *s2, size_t n);
++
++struct netif * eagle_lwip_getif(uint8 index);
++
+ //#define LWIP_PROVIDE_ERRNO
+ 
+ #if (1)
+@@ -56,6 +73,7 @@ typedef signed     short   s16_t;
+ typedef unsigned   long    u32_t;
+ typedef signed     long    s32_t;
+ typedef unsigned long   mem_ptr_t;
++typedef signed short        sint16_t;
+ 
+ #define S16_F "d"
+ #define U16_F "d"
+


### PR DESCRIPTION
On windows lwip compilation is skipped because target all is not specified. 