### PR TITLE
Initialize default baud rate.

### DIFF
--- a/Sming/appinit/user_main.cpp
+++ b/Sming/appinit/user_main.cpp
@@ -12,6 +12,7 @@ extern void init();
 extern "C" void  __attribute__((weak)) user_init(void)
 {
 	system_timer_reinit();
+	uart_div_modify(UART_ID_0, UART_CLK_FREQ / SERIAL_BAUD_RATE);
 	cpp_core_initialize();
 	System.initialize();
 #ifdef SMING_RELEASE


### PR DESCRIPTION
If the weak function `user_rf_pre_init` is not used we need to be able to define the default baud rate.
Fixes issues with PR #903.