### PR TITLE
Use custom LWIP by default

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -57,16 +57,11 @@ n/a = The selected SDK is not available on that OS
 - [ESPtool2](https://github.com/raburton/esptool2) esptool2 
 
 ## Optional features
-- Custom PWM: If you want to use the open PWM implementation then compile your application with ENABLE_CUSTOM_PWM=1. There is no need to recompile the Sming library.
-a [custom PWM library](https://github.com/StefanBruens/ESP8266_new_pwm) will be used.
-- SSL: The SSL support is not built-in by default to conserve resources. If you want to enable it then take a look at the [Readme](https://github.com/SmingHub/Sming/blob/develop/samples/Basic_Ssl/README.md) in the Basic_Ssl samples.
-- Custom Heap Allocation: If your application is experiencing heap fragmentation then you can try the Umm Malloc heap allocation. To enable it compile
-Sming with ENABLE_CUSTOM_HEAP=1. In order to use it in your sample/application make sure to compile the sample with ENABLE_CUSTOM_HEAP=1. Avoid enabling
-your custom heap allocation AND -mforce-l32 compiler flag.
-- Custom LWIP: If you want to recompile the IP stack and add features like IPv4 forwarding you can do this by compiling Sming with
-ENABLE_CUSTOM_LWIP=1. Remember to add the same option when compiling your application. If the application requires the use of some of the
-espconn_* functions add also the ENABLE_ESPCONN=1 directive. See `Makefile-user.mk` from the [Basic_SmartConfig](https://github.com/SmingHub/Sming/blob/develop/samples/Basic_SmartConfig/Makefile-user.mk#L41) application for examples.
-- Custom serial baud rate: The default serial baud rate is 115200. If you want to change it to a higher baud rate you can recompile Sming and your application changing the COM_SPEED_SERIAL directive. For example COM_SPEED_SERIAL=921600
+- Custom LWIP:(default:ON) By default we are using custom compiled LWIP stack instead of the binary one provided from Espressif. This is increasing the free memory and decreasing the space on the flash. All espconn_* functions are turned off by default. If your application requires the use of some of the espconn_* functions then add the ENABLE_ESPCONN=1 directive. See `Makefile-user.mk` from the [Basic_SmartConfig](https://github.com/SmingHub/Sming/blob/develop/samples/Basic_SmartConfig/Makefile-user.mk#L41) application for examples. If you would like to use the binary LWIP then you should turn off the custom LWIP compilation by providing ENABLE_CUSTOM_LWIP=0.
+- SSL:(default:off) The SSL support is not built-in by default to conserve resources. If you want to enable it then take a look at the [Readme](https://github.com/SmingHub/Sming/blob/develop/samples/Basic_Ssl/README.md) in the Basic_Ssl samples.
+- Custom PWM:(default:off) If you want to use the [open PWM implementation](https://github.com/StefanBruens/ESP8266_new_pwm) then compile your application with ENABLE_CUSTOM_PWM=1. There is no need to recompile the Sming library.
+- Custom serial baud rate: (default:off) The default serial baud rate is 115200. If you want to change it to a higher baud rate you can recompile Sming and your application changing the COM_SPEED_SERIAL directive. For example COM_SPEED_SERIAL=921600
+- Custom Heap Allocation:(default:off) If your application is experiencing heap fragmentation then you can try the Umm Malloc heap allocation. To enable it compile Sming with ENABLE_CUSTOM_HEAP=1. In order to use it in your sample/application make sure to compile the sample with ENABLE_CUSTOM_HEAP=1. Avoid enabling your custom heap allocation AND -mforce-l32 compiler flag.
 
 You can find more information about compilation and flashing process by reading esp8266.com forum discussion thread.
 

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -162,6 +162,7 @@ endif
 
 # => Open Source LWIP
 LIBLWIP = lwip
+ENABLE_CUSTOM_LWIP ?= 1
 ENABLE_ESPCONN ?= 0
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 	THIRD_PARTY_DATA += third-party/esp-open-lwip/Makefile.open

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -160,6 +160,7 @@ endif
 MODULES      ?= app     # default to app if not set by user
 EXTRA_INCDIR ?= include # default to include if not set by user
 
+ENABLE_CUSTOM_LWIP ?= 1
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 	LWIP_INCDIR = $(SMING_HOME)/third-party/esp-open-lwip	
 endif

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -166,6 +166,7 @@ MODULES      ?= app     # default to app if not set by user
 MODULES      += $(THIRD_PARTY_DIR)/rboot/appcode
 EXTRA_INCDIR ?= include # default to include if not set by user
 
+ENABLE_CUSTOM_LWIP ?= 1
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 	LWIP_INCDIR = $(SMING_HOME)/third-party/esp-open-lwip	
 endif

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -128,3 +128,16 @@ index ff03b30..932c73d 100644
  #define S16_F "d"
  #define U16_F "d"
 
+diff --git a/include/lwipopts.h b/include/lwipopts.h
+index eaa8dd6..6a08192 100644
+--- a/include/lwipopts.h
++++ b/include/lwipopts.h
+@@ -953,7 +953,7 @@
+  * an upper limit on the MSS advertised by the remote host.
+  */
+ #ifndef TCP_MSS
+-#define TCP_MSS                         1460
++#define TCP_MSS                        1390 
+ #endif
+ #endif
+ 


### PR DESCRIPTION
Set the compilation to use custom LWIP by default. This will help us have some more free heap bytes, example: Basic_rBoot with SDK 2.0

with the binary LWIP
```
SDK: v2.0.0(5a875ba)
Free Heap: 44480
```

with the custom LWiP
```
SDK: v2.0.0(5a875ba)
Free Heap: 44856
```

and smaller ROM, size wise,

with binary LWIP
```
291152  out/firmware/rom0.bin
```
with custom LWIP
```
279152 out/firmware/rom0.bin
```

If accepted this PR should be merged AFTER [that PR](https://github.com/SmingHub/Sming/pull/927)