### PR TITLE
Fix debug messages when rBoot is enabled

### DIFF
--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -184,6 +184,8 @@ ENABLE_CUSTOM_HEAP ?= 0
 LIBMAIN = main
 LIBMAIN_SRC = $(addprefix $(SDK_LIBDIR)/,libmain.a)
 
+USER_LIBDIR = $(SMING_HOME)/compiler/lib/
+
 ifeq ($(ENABLE_CUSTOM_HEAP),1)
 	LIBMAIN = mainmm
 	LIBMAIN_SRC := $(USER_LIBDIR)lib$(LIBMAIN).a
@@ -197,7 +199,6 @@ ifeq ($(RBOOT_BIG_FLASH),1)
 else
 	LIBMAIN_DST = $()
 endif
-# libraries used in this project, mainly provided by the SDK
 
 LIBLWIP = lwip
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
@@ -215,7 +216,6 @@ ifeq ($(ENABLE_CUSTOM_PWM), 1)
 endif
 
 # libraries used in this project, mainly provided by the SDK
-USER_LIBDIR = $(SMING_HOME)/compiler/lib/
 LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa $(LIBMAIN) $(LIBSMING) crypto $(LIBPWM) smartconfig $(EXTRA_LIBS)
 
 # compiler flags using during compilation of source files

--- a/samples/Basic_rBoot/rom0.ld
+++ b/samples/Basic_rBoot/rom0.ld
@@ -158,10 +158,10 @@ SECTIONS
   .irom0.text : ALIGN(4)
   {
     _irom0_text_start = ABSOLUTE(.);
-    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text)
-	out/build/app_app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-  *libsming.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-  *libsmingssl.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
+    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.debug.*)
+	out/build/app_app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
+  *libsming.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
+  *libsmingssl.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
     _irom0_text_end = ABSOLUTE(.);
 	_flash_code_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr


### PR DESCRIPTION
Apparently, the people in charge of #927 forgot to apply the changes necessary for things to work on ROMs compiled with rBoot in mind. This resulted in all Sming debug messages appearing as garbage on such ROMs:

![garbage debug messages](https://cloud.githubusercontent.com/assets/984584/22864632/237e742c-f14d-11e6-88e0-22434f5385e3.png)

This pull request fixes the issue by applying the necessary changes to the rBoot-specific Makefile and also to the example rBoot linker script.

In addition, I changed some things in the rBoot-specific Makefile to make it more similar to the common one. I did not port the new memory information output as it seemed to require quite a bit more effort than my time allowed, and I guess that can be postponed to a later pull request...

This has been tested and confirmed to work for my projects only. I can't guarantee that other configurations will still work, but I don't see why not.