### PR TITLE
Add ability to specify CC & LD for building spiffy utility per platform

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -340,7 +340,7 @@ spiffy: spiffy/spiffy
 
 spiffy/spiffy:
 	$(vecho) "Making spiffy utility"
-	$(Q) $(MAKE) --no-print-directory -C spiffy V=$(V)
+	$(Q) $(MAKE) --no-print-directory -C spiffy CC=$(SPIFFY_CC) LD=$(SPIFFY_LD) V=$(V)
 	$(vecho) "Done"
 
 $(APP_AR): $(OBJ)

--- a/Sming/Makefile-bsd.mk
+++ b/Sming/Makefile-bsd.mk
@@ -14,3 +14,7 @@ KILL_TERM    ?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 GET_FILESIZE ?= stat -f "%-15z"
 TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
 MEMANALYZER  ?= $(OBJDUMP) -h -j .data -j .rodata -j .bss -j .text -j .irom0.text
+
+SPIFFY_CC ?= clang
+SPIFFY_LD ?= clang
+

--- a/Sming/Makefile-linux.mk
+++ b/Sming/Makefile-linux.mk
@@ -14,3 +14,6 @@ KILL_TERM    ?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 GET_FILESIZE ?= stat --printf="%s"
 TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
 MEMANALYZER  ?= $(OBJDUMP) -h -j .data -j .rodata -j .bss -j .text -j .irom0.text
+
+SPIFFY_CC ?= gcc
+SPIFFY_LD ?= gcc

--- a/Sming/Makefile-macos.mk
+++ b/Sming/Makefile-macos.mk
@@ -14,3 +14,6 @@ KILL_TERM    ?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 GET_FILESIZE ?= stat -L -f%z
 TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
 MEMANALYZER  ?= $(OBJDUMP) -h -j .data -j .rodata -j .bss -j .text -j .irom0.text
+
+SPIFFY_CC ?= gcc
+SPIFFY_LD ?= gcc

--- a/Sming/Makefile-windows.mk
+++ b/Sming/Makefile-windows.mk
@@ -14,3 +14,6 @@ KILL_TERM    ?= taskkill.exe -f -im Terminal.exe || exit 0
 GET_FILESIZE ?= stat --printf="%s"
 TERMINAL     ?= $(SDK_TOOLS)/Terminal.exe $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
 MEMANALYZER  ?= $(SDK_TOOLS)/ESP8266/memanalyzer.exe $(OBJDUMP).exe
+
+SPIFFY_CC ?= gcc
+SPIFFY_LD ?= gcc

--- a/Sming/spiffy/Makefile
+++ b/Sming/spiffy/Makefile
@@ -2,8 +2,6 @@
 # Makefile for spiffy
 #
 
-CC := gcc
-LD := gcc
 
 INCDIR := -I../Services/SpifFS -I../third-party/spiffs/src
 CFLAGS := -O2 -Wall -Wno-unused-value


### PR DESCRIPTION
Add SPIFFY_CC and SPIFFY_LD in Makefile-[platform].mk to specify CC an LD to use for build and link spiffy

For example on recent FreeBSD some problem arise with gcc but all goes just fine with clang as CC & LD to build/link spiffy