### PR TITLE
TcpClient: setReceiveCallback and setCompleteCallback

### DIFF
--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -180,7 +180,7 @@ void TcpClient::pushAsyncPart()
 		delete stream; // Free memory now!
 		stream = NULL;
 	}
-} 
+}
 
 err_t TcpClient::onSent(uint16_t len)
 {
@@ -199,7 +199,7 @@ err_t TcpClient::onSent(uint16_t len)
 
 	return ERR_OK;
 }
- 
+
 void TcpClient::onError(err_t err)
 {
 	state = eTCS_Failed;

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -180,7 +180,7 @@ void TcpClient::pushAsyncPart()
 		delete stream; // Free memory now!
 		stream = NULL;
 	}
-}
+} 
 
 err_t TcpClient::onSent(uint16_t len)
 {
@@ -199,7 +199,7 @@ err_t TcpClient::onSent(uint16_t len)
 
 	return ERR_OK;
 }
-
+ 
 void TcpClient::onError(err_t err)
 {
 	state = eTCS_Failed;
@@ -219,6 +219,11 @@ void TcpClient::onFinished(TcpClientState finishState)
 
 	if (completed)
 		completed(*this, state == eTCS_Successful);
+}
+
+void TcpClient::setReceiveDelegate(TcpClientDataDelegate receiveCb)
+{
+	receive = receiveCb;
 }
 
 void TcpClient::setCompleteDelegate(TcpClientCompleteDelegate completeCb)

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -51,17 +51,17 @@ public:
 	 *	@param	receiveCb callback delegate or NULL
 	 */
 	void setReceiveDelegate(TcpClientDataDelegate receiveCb = NULL);
- 
+
 	/**	@brief	Set or clear the callback for connection close
 	 *	@param	completeCb callback delegate or NULL
 	 */
 	void setCompleteDelegate(TcpClientCompleteDelegate completeCb = NULL);
-	
+
 	bool send(const char* data, uint16_t len, bool forceCloseAfterSent = false);
 	bool sendString(String data, bool forceCloseAfterSent = false);
 	__forceinline bool isProcessing()  { return state == eTCS_Connected || state == eTCS_Connecting; }
 	__forceinline TcpClientState getConnectionState() { return state; }
-	
+
 protected:
 	virtual err_t onConnected(err_t err);
 	virtual err_t onReceive(pbuf *buf);

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -47,13 +47,21 @@ public:
 	virtual bool connect(IPAddress addr, uint16_t port, boolean useSsl = false, uint32_t sslOptions = 0);
 	virtual void close();
 
+	/**	@brief	Set or clear the callback for received data
+	 *	@param	receiveCb callback delegate or NULL
+	 */
+	void setReceiveDelegate(TcpClientDataDelegate receiveCb = NULL);
+ 
+	/**	@brief	Set or clear the callback for connection close
+	 *	@param	completeCb callback delegate or NULL
+	 */
 	void setCompleteDelegate(TcpClientCompleteDelegate completeCb = NULL);
 	
 	bool send(const char* data, uint16_t len, bool forceCloseAfterSent = false);
 	bool sendString(String data, bool forceCloseAfterSent = false);
 	__forceinline bool isProcessing()  { return state == eTCS_Connected || state == eTCS_Connecting; }
 	__forceinline TcpClientState getConnectionState() { return state; }
-
+	
 protected:
 	virtual err_t onConnected(err_t err);
 	virtual err_t onReceive(pbuf *buf);


### PR DESCRIPTION
Sometimes it is desirable to change the callbacks for TcpClient later. For example, this allows to setup a TcpServer with separate processing for each client like this:

    
    class CliTcp {
        public:
            CliTcp(TcpClient *client) {
                _client = client;
                client->setReceiveCallback( TcpClientDataDelegate(&CliTcp::_on_receive, this) );
                client->setCompleteCallback( TcpClientCompleteDelegate(&CliTcp::_on_complete, this) );
            }
    
            ...
    
        private:
            bool _on_receive(TcpClient&, char *data, int size) {
                ...
            }
    
            //  self destruct on close
            void _on_complete(TcpClient& client, bool) {
                client.setReceiveCallback( 0 );
                client.setCompleteCallback( 0 );
                delete this;
            }
            
            TcpClient *_client;
    };
    
    static void _on_connect(TcpClient* client) {
        new CliTcp(client);
    }
     
    void telnet_init() {
        auto srv = new TcpServer(_on_connect, 0, 0);
        srv->listen(TELNET_PORT);
    }  

This approach seems cleaner to me than using a local lookup table (like TelnetServer does to identify the first and only client).