### PR TITLE
Support for setting custom host CC and LD.

### DIFF
--- a/Sming/spiffy/Makefile
+++ b/Sming/spiffy/Makefile
@@ -2,8 +2,8 @@
 # Makefile for spiffy
 #
 
-CC := gcc
-LD := gcc
+HOST_CC ?= gcc
+HOST_LD ?= gcc
 
 INCDIR := -I../Services/SpifFS -I../third-party/spiffs/src
 CFLAGS := -O2 -Wall -Wno-unused-value
@@ -20,19 +20,19 @@ all: spiffy
 
 %.o: ../Services/SpifFS/%.c
 	$(vecho) "CC $<"
-	$(Q) $(CC) $(CFLAGS) $(INCDIR) -c $< -o $@
+	$(Q) $(HOST_CC) $(CFLAGS) $(INCDIR) -c $< -o $@
 	
 %.o: ../third-party/spiffs/src/%.c
 	$(vecho) "CC $<"
-	$(Q) $(CC) $(CFLAGS) $(INCDIR) -c $< -o $@
+	$(Q) $(HOST_CC) $(CFLAGS) $(INCDIR) -c $< -o $@
 
 spiffy.o: spiffy.c
 	$(vecho) "CC $<"
-	$(Q) $(CC) $(CFLAGS) $(INCDIR) -c $< -o $@
+	$(Q) $(HOST_CC) $(CFLAGS) $(INCDIR) -c $< -o $@
 
 spiffy: spiffy.o spiffs_cache.o spiffs_nucleus.o spiffs_hydrogen.o spiffs_gc.o spiffs_check.o
 	$(vecho) "LD $@"
-	$(Q) $(LD) -o $@ $^
+	$(Q) $(HOST_LD) -o $@ $^
 
 clean:
 	$(Q) rm -f *.o


### PR DESCRIPTION
If there is a need for a custom host compiler and linker, then it can be set with HOST_CC=<you-preferred-compiler>. For example:

```
cd $SMING_HOME
make HOST_CC=clang V=1
```