### PR TITLE
Revert "Fix SystemClockClass::setTime to work accordingly to timezone settings"

### DIFF
--- a/Sming/SmingCore/SystemClock.cpp
+++ b/Sming/SmingCore/SystemClock.cpp
@@ -21,7 +21,7 @@ DateTime SystemClockClass::now(TimeZone timeType /* = eTZ_Local */)
 void SystemClockClass::setTime(time_t time, TimeZone timeType /* = eTZ_Local */)
 {
 	bool timeSet =
-	(timeType == eTZ_Local) ?	RTC.setRtcSeconds((time + (timezoneDiff * SECS_PER_HOUR))) : RTC.setRtcSeconds(time);
+	(timeType == eTZ_UTC) ?	RTC.setRtcSeconds((time + (timezoneDiff * SECS_PER_HOUR))) : RTC.setRtcSeconds(time);
 	debugf("time updated? %d", timeSet);
 	status = eSCS_Set;
 }


### PR DESCRIPTION
Reverts SmingHub/Sming#949
removing changes made without the need
