### PR TITLE
UdpConnection: Changed sendStringTo to pass the data by reference.

### DIFF
--- a/Sming/SmingCore/Network/UdpConnection.cpp
+++ b/Sming/SmingCore/Network/UdpConnection.cpp
@@ -79,7 +79,7 @@ void UdpConnection::sendString(const char* data)
 	send(data, strlen(data));
 }
 
-void UdpConnection::sendString(const String data)
+void UdpConnection::sendString(const String& data)
 {
 	sendString(data.c_str());
 }
@@ -97,7 +97,7 @@ void UdpConnection::sendStringTo(IPAddress remoteIP, uint16_t remotePort, const 
 	sendTo(remoteIP, remotePort, data, strlen(data));
 }
 
-void UdpConnection::sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String data)
+void UdpConnection::sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String& data)
 {
 	sendStringTo(remoteIP, remotePort, data.c_str());
 }

--- a/Sming/SmingCore/Network/UdpConnection.h
+++ b/Sming/SmingCore/Network/UdpConnection.h
@@ -31,11 +31,11 @@ public:
 	// After connect(..)
 	virtual void send(const char* data, int length);
 	void sendString(const char* data);
-	void sendString(const String data);
+	void sendString(const String& data);
 
 	virtual void sendTo(IPAddress remoteIP, uint16_t remotePort, const char* data, int length);
 	void sendStringTo(IPAddress remoteIP, uint16_t remotePort, const char* data);
-	void sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String data);
+	void sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String& data);
 
 protected:
 	virtual void onReceive(pbuf *buf, IPAddress remoteIP, uint16_t remotePort);


### PR DESCRIPTION
Reported in #335.