### PR TITLE
LWIP: Ported fix for incorrect subnet mask.

### DIFF
--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -167,4 +167,49 @@ index af6e360..6d8cabd 100644
  #endif
  #else
  #ifndef mem_free
+ diff --git a/lwip/app/dhcpserver.c b/lwip/app/dhcpserver.c
+index ddb5984..fb677c6 100644
+--- a/lwip/app/dhcpserver.c
++++ b/lwip/app/dhcpserver.c
+@@ -133,21 +133,16 @@ static uint8_t* ICACHE_FLASH_ATTR add_offer_options(uint8_t *optptr)
  
+         ipadd.addr = *( (uint32_t *) &server_address);
+ 
+-#ifdef USE_CLASS_B_NET
+-        *optptr++ = DHCP_OPTION_SUBNET_MASK;
+-        *optptr++ = 4;  //length
+-        *optptr++ = 255;
+-        *optptr++ = 240;	
+-        *optptr++ = 0;
+-        *optptr++ = 0;
+-#else
++        struct ip_info if_ip;
++        os_bzero(&if_ip, sizeof(struct ip_info));
++        wifi_get_ip_info(SOFTAP_IF, &if_ip);
++
+         *optptr++ = DHCP_OPTION_SUBNET_MASK;
+-        *optptr++ = 4;  
+-        *optptr++ = 255;
+-        *optptr++ = 255;	
+-        *optptr++ = 255;
+-        *optptr++ = 0;
+-#endif
++        *optptr++ = 4;
++        *optptr++ = ip4_addr1( &if_ip.netmask);
++        *optptr++ = ip4_addr2( &if_ip.netmask);
++        *optptr++ = ip4_addr3( &if_ip.netmask);
++        *optptr++ = ip4_addr4( &if_ip.netmask);
+ 
+         *optptr++ = DHCP_OPTION_LEASE_TIME;
+         *optptr++ = 4;  
+@@ -164,10 +159,6 @@ static uint8_t* ICACHE_FLASH_ATTR add_offer_options(uint8_t *optptr)
+         *optptr++ = ip4_addr4( &ipadd);
+ 
+         if (dhcps_router_enabled(offer)){
+-        	struct ip_info if_ip;
+-			os_bzero(&if_ip, sizeof(struct ip_info));
+-			wifi_get_ip_info(SOFTAP_IF, &if_ip);
+-
+ 			*optptr++ = DHCP_OPTION_ROUTER;
+ 			*optptr++ = 4;
+ 			*optptr++ = ip4_addr1( &if_ip.gw);


### PR DESCRIPTION
See: https://github.com/esp8266/Arduino/commit/cc84a64793d3ac02c93f332b72b164c6a5b074a9
Set DHCP subnet correctly for softAP.
Removes hard coded subnet of 255.255.255.0 and fetches the correct subnet from wifi_get_ip_info()