### PR TITLE
Eclipse code autocompletion for "String" type

### DIFF
--- a/Sming/.cproject
+++ b/Sming/.cproject
@@ -34,6 +34,9 @@
 									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
 									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/SmingCore&quot;"/>
 								</option>
+								<option id="gnu.cpp.compiler.option.preprocessor.def.1931827600" name="Defined symbols (-D)" superClass="gnu.cpp.compiler.option.preprocessor.def" useByScannerDiscovery="false" valueType="definedSymbols">
+									<listOptionValue builtIn="false" value="ARDUINO=106"/>
+								</option>
 								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1606285752" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
 							</tool>
 							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.413198192" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>


### PR DESCRIPTION
We already have "-DARDUINO=106" in Makefile, but Eclipse didn't know about that and can't make code suggestions right:

Sming\Sming\Services\ArduinoJson\include\ArduinoJson\Arduino\String.hpp:
```C++
#if !defined(ARDUINO) && !defined(SMING_VERSION)

#include <string>
typedef std::string String;

#else

#include <WString.h>

#endif
```

This parameter in project resolve issue.