### PR TITLE
[Fixes #994] unify delegate class name styles

### DIFF
--- a/Sming/SmingCore/Network/rBootHttpUpdate.cpp
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.cpp
@@ -35,11 +35,11 @@ void rBootHttpUpdate::switchToRom(uint8 romSlot) {
 	this->romSlot = romSlot;
 }
 
-void rBootHttpUpdate::setCallback(otaUpdateDelegate reqUpdateDelegate) {
+void rBootHttpUpdate::setCallback(OtaUpdateDelegate reqUpdateDelegate) {
 	setDelegate(reqUpdateDelegate);
 }
 
-void rBootHttpUpdate::setDelegate(otaUpdateDelegate reqUpdateDelegate) {
+void rBootHttpUpdate::setDelegate(OtaUpdateDelegate reqUpdateDelegate) {
 	this->updateDelegate = reqUpdateDelegate;
 }
 

--- a/Sming/SmingCore/Network/rBootHttpUpdate.h
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.h
@@ -18,7 +18,7 @@
 class rBootHttpUpdate;
 
 //typedef void (*otaCallback)(bool result);
-typedef Delegate<void(rBootHttpUpdate& client, bool result)> otaUpdateDelegate;
+typedef Delegate<void(rBootHttpUpdate& client, bool result)> OtaUpdateDelegate;
 
 struct rBootHttpUpdateItem {
 	String url;
@@ -34,8 +34,8 @@ public:
 	void addItem(int offset, String firmwareFileUrl);
 	void start();
 	void switchToRom(uint8 romSlot);
-	void setCallback(otaUpdateDelegate reqUpdateDelegate);
-	void setDelegate(otaUpdateDelegate reqUpdateDelegate);
+	void setCallback(OtaUpdateDelegate reqUpdateDelegate);
+	void setDelegate(OtaUpdateDelegate reqUpdateDelegate);
 
 
 	// Expose request and response header information
@@ -66,7 +66,7 @@ protected:
 	int currentItem;
 	rboot_write_status rBootWriteStatus;
 	uint8 romSlot;
-	otaUpdateDelegate updateDelegate;
+	OtaUpdateDelegate updateDelegate;
 
 	virtual void writeInit();
 	virtual bool writeFlash(const u8 *data, u16 size);

--- a/Sming/SmingCore/Platform/WifiEvents.cpp
+++ b/Sming/SmingCore/Platform/WifiEvents.cpp
@@ -14,37 +14,37 @@ WifiEventsClass::WifiEventsClass()
 	wifi_set_event_handler_cb(staticWifiEventHandler);
 }
 
-void WifiEventsClass::onStationConnect(onStationConnectDelegate delegateFunction)
+void WifiEventsClass::onStationConnect(StationConnectDelegate delegateFunction)
 {
 	onSTAConnect = delegateFunction;
 }
 
-void WifiEventsClass::onStationDisconnect(onStationDisconnectDelegate delegateFunction)
+void WifiEventsClass::onStationDisconnect(StationDisconnectDelegate delegateFunction)
 {
 	onSTADisconnect = delegateFunction;
 }
 
-void WifiEventsClass::onStationAuthModeChange(onStationAuthModeChangeDelegate delegateFunction)
+void WifiEventsClass::onStationAuthModeChange(StationAuthModeChangeDelegate delegateFunction)
 {
 	onSTAAuthModeChange = delegateFunction;
 }
 
-void WifiEventsClass::onStationGotIP(onStationGotIPDelegate delegateFunction)
+void WifiEventsClass::onStationGotIP(StationGotIPDelegate delegateFunction)
 {
 	onSTAGotIP = delegateFunction;
 }
 
-void WifiEventsClass::onAccessPointConnect(onAccessPointConnectDelegate delegateFunction)
+void WifiEventsClass::onAccessPointConnect(AccessPointConnectDelegate delegateFunction)
 {
 	onSOFTAPConnect = delegateFunction;
 }
 
-void WifiEventsClass::onAccessPointDisconnect(onAccessPointDisconnectDelegate delegateFunction)
+void WifiEventsClass::onAccessPointDisconnect(AccessPointDisconnectDelegate delegateFunction)
 {
 	onSOFTAPDisconnect = delegateFunction;
 }
 
-void WifiEventsClass::onAccessPointProbeReqRecved(onAccessPointProbeReqRecvedDelegate delegateFunction)
+void WifiEventsClass::onAccessPointProbeReqRecved(AccessPointProbeReqRecvedDelegate delegateFunction)
 {
 	onSOFTAPProbeReqRecved = delegateFunction;
 }

--- a/Sming/SmingCore/Platform/WifiEvents.h
+++ b/Sming/SmingCore/Platform/WifiEvents.h
@@ -13,38 +13,38 @@
 #include "../../Wiring/IPAddress.h"
 
 //Define WifiEvents Delegates types
-typedef Delegate<void(String, uint8_t, uint8_t[6], uint8_t)> onStationConnectDelegate;
-typedef Delegate<void(String, uint8_t, uint8_t[6], uint8_t)> onStationDisconnectDelegate;
-typedef Delegate<void(uint8_t, uint8_t)> onStationAuthModeChangeDelegate;
-typedef Delegate<void(IPAddress, IPAddress, IPAddress)> onStationGotIPDelegate;
-typedef Delegate<void(uint8_t[6], uint8_t)> onAccessPointConnectDelegate;
-typedef Delegate<void(uint8_t[6], uint8_t)> onAccessPointDisconnectDelegate;
-typedef Delegate<void(int16_t, uint8_t[6])> onAccessPointProbeReqRecvedDelegate;
+typedef Delegate<void(String, uint8_t, uint8_t[6], uint8_t)> StationConnectDelegate;
+typedef Delegate<void(String, uint8_t, uint8_t[6], uint8_t)> StationDisconnectDelegate;
+typedef Delegate<void(uint8_t, uint8_t)> StationAuthModeChangeDelegate;
+typedef Delegate<void(IPAddress, IPAddress, IPAddress)> StationGotIPDelegate;
+typedef Delegate<void(uint8_t[6], uint8_t)> AccessPointConnectDelegate;
+typedef Delegate<void(uint8_t[6], uint8_t)> AccessPointDisconnectDelegate;
+typedef Delegate<void(int16_t, uint8_t[6])> AccessPointProbeReqRecvedDelegate;
 
 class WifiEventsClass
 {
 public:
 	WifiEventsClass();
 
-	void onStationConnect(onStationConnectDelegate delegateFunction);
-	void onStationDisconnect(onStationDisconnectDelegate delegateFunction);
-	void onStationAuthModeChange(onStationAuthModeChangeDelegate delegateFunction);
-	void onStationGotIP(onStationGotIPDelegate delegateFunction);
-	void onAccessPointConnect(onAccessPointConnectDelegate delegateFunction);
-	void onAccessPointDisconnect(onAccessPointDisconnectDelegate delegateFunction);
-	void onAccessPointProbeReqRecved(onAccessPointProbeReqRecvedDelegate delegateFunction);
+	void onStationConnect(StationConnectDelegate delegateFunction);
+	void onStationDisconnect(StationDisconnectDelegate delegateFunction);
+	void onStationAuthModeChange(StationAuthModeChangeDelegate delegateFunction);
+	void onStationGotIP(StationGotIPDelegate delegateFunction);
+	void onAccessPointConnect(AccessPointConnectDelegate delegateFunction);
+	void onAccessPointDisconnect(AccessPointDisconnectDelegate delegateFunction);
+	void onAccessPointProbeReqRecved(AccessPointProbeReqRecvedDelegate delegateFunction);
 
 private:
 	static void staticWifiEventHandler(System_Event_t *evt);
 	void WifiEventHandler(System_Event_t *evt);
 
-	onStationConnectDelegate onSTAConnect = nullptr;
-	onStationDisconnectDelegate onSTADisconnect = nullptr;
-	onStationAuthModeChangeDelegate onSTAAuthModeChange = nullptr;
-	onStationGotIPDelegate onSTAGotIP = nullptr;
-	onAccessPointConnectDelegate onSOFTAPConnect = nullptr;
-	onAccessPointDisconnectDelegate onSOFTAPDisconnect = nullptr;
-	onAccessPointProbeReqRecvedDelegate onSOFTAPProbeReqRecved = nullptr;
+	StationConnectDelegate onSTAConnect = nullptr;
+	StationDisconnectDelegate onSTADisconnect = nullptr;
+	StationAuthModeChangeDelegate onSTAAuthModeChange = nullptr;
+	StationGotIPDelegate onSTAGotIP = nullptr;
+	AccessPointConnectDelegate onSOFTAPConnect = nullptr;
+	AccessPointDisconnectDelegate onSOFTAPDisconnect = nullptr;
+	AccessPointProbeReqRecvedDelegate onSOFTAPProbeReqRecved = nullptr;
 };
 
 


### PR DESCRIPTION
Both samples that use `WifiEvents` compile, flash and run fine - these are `Websocket_Client` and `Basic_WebSkeletonApp`. There are no samples that use rBoot OTA update and I was not able to test this code on live system.

This change will break user code that uses `WifiEvents` and creates delegate instances directly. Code that relies on internal delegates created in `WifiEvents` class is not affected.