### PR TITLE
Make WifiStation.enable(false) disable waitConnection's timer

### DIFF
--- a/Sming/SmingCore/Platform/Station.cpp
+++ b/Sming/SmingCore/Platform/Station.cpp
@@ -33,7 +33,10 @@ void StationClass::enable(bool enabled, bool save)
 		mode = wifi_get_opmode_default() & ~STATION_MODE;
 	else
 		mode = wifi_get_opmode() & ~STATION_MODE;
-	if (enabled) mode |= STATION_MODE;
+	if (enabled)
+		mode |= STATION_MODE;
+	else if (connectionTimer)
+		delete connectionTimer;
 	if (save)
 		wifi_set_opmode(mode);
 	else


### PR DESCRIPTION
Disabling WifiStation did not prevent a delegate installed via a call to
waitConnection() from being called after the timeout.