### PR TITLE
Removes full path from filenames in Doxygen config

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -140,7 +140,7 @@ INLINE_INHERITED_MEMB  = YES
 # shortest path that makes the file name unique will be used
 # The default value is: YES.
 
-FULL_PATH_NAMES        = YES
+FULL_PATH_NAMES        = NO
 
 # The STRIP_FROM_PATH tag can be used to strip a user-defined part of the path.
 # Stripping is only done if one of the specified strings matches the left-hand


### PR DESCRIPTION
API documentation has been generated by Doxygen with the absolute file paths of each source / header file shown in the html docs. This is undesirable as it does not align with each user's own file system and may provide private or other information about the build machine. This is currently an issue with the manual builds of api docs that are pushed to https://sminghub.github.io. This change removes full path configuration for Doxygen.