### PR TITLE
HardwarePWM: Fix period unit in comments to uS instead of nS

### DIFF
--- a/Sming/SmingCore/HardwarePWM.cpp
+++ b/Sming/SmingCore/HardwarePWM.cpp
@@ -3,7 +3,7 @@
  * Original Author: https://github.com/hrsavla
  *
  * This HardwarePWM library enables Sming framework user to use ESP SDK PWM API
- * Period of PWM is fixed to 1000ms / Frequency = 1khz
+ * Period of PWM is fixed to 1000us / Frequency = 1khz
  * Duty at 100% = 22222. Duty at 0% = 0
  * You can use function setPeriod() to change frequency/period.
  * Calculate the max duty as per the formulae give in ESP8266 SDK
@@ -11,6 +11,9 @@
  *
  * PWM can be generated on upto 8 pins (ie All pins except pin 16)
  * Created on August 17, 2015, 2:27 PM
+ *
+ * See also ESP8266 Technical Reference, Chapter 12:
+ * http://espressif.com/sites/default/files/documentation/esp8266-technical_reference_en.pdf
  */
 
 #include "Clock.h"

--- a/samples/Basic_HwPWM/app/application.cpp
+++ b/samples/Basic_HwPWM/app/application.cpp
@@ -3,7 +3,7 @@
  * Original Author: https://github.com/hrsavla
  *
  * This HardwarePWM library enables Sming framework user to use ESP SDK PWM API
- * Period of PWM is fixed to 1000ms / Frequency = 1khz
+ * Period of PWM is fixed to 1000us / Frequency = 1khz
  * Duty at 100% = 22222. Duty at 0% = 0
  * You can use function setPeriod() to change frequency/period.
  * Calculate the Duty as per the formulae give in ESP8266 SDK
@@ -11,6 +11,9 @@
  *
  * PWM can be generated on upto 8 pins (ie All pins except pin 16)
  * Created on August 17, 2015, 2:27 PM
+ *
+ * See also ESP8266 Technical Reference, Chapter 12:
+ * http://espressif.com/sites/default/files/documentation/esp8266-technical_reference_en.pdf
  */
 #include <user_config.h>
 #include <SmingCore/SmingCore.h>


### PR DESCRIPTION
1000 ms are 1000 * 0,001s = 1s which gives a frequency of 1/1 = 1 Hz
instead of 1 KHz. Now either the period or the frequency is wrong. Turns
out it's the period as the ESP8266 Technical Reference associates
1000 uS with 1 KHz.