### PR TITLE
Do not strip last digit from current meminfo size section

### DIFF
--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -382,7 +382,7 @@ $(TARGET_OUT): $(APP_AR)
 	$(Q) $(MEMANALYZER) $@ > $(FW_MEMINFO_NEW)
 	
 	$(Q) if [ -f "$(FW_MEMINFO_NEW)" -a -f "$(FW_MEMINFO_OLD)" ]; then \
-	  awk -F "|" 'FILENAME == "$(FW_MEMINFO_OLD)" { arr[$$1]=$$5 } FILENAME == "$(FW_MEMINFO_NEW)" { if (arr[$$1] != $$5){printf "%s%s%+d%s", substr($$0, 1, length($$0) - 1)," (",$$5 - arr[$$1],")\n" } else {print $$0} }' $(FW_MEMINFO_OLD) $(FW_MEMINFO_NEW); \
+	  awk -F "|" 'FILENAME == "$(FW_MEMINFO_OLD)" { arr[$$1]=$$5 } FILENAME == "$(FW_MEMINFO_NEW)" { if (arr[$$1] != $$5){printf "%s (%+d)\n", $$0,$$5 - arr[$$1] } else {printf "%s\n", $$0} }' $(FW_MEMINFO_OLD) $(FW_MEMINFO_NEW); \
 	elif [ -f "$(FW_MEMINFO_NEW)" ]; then \
 	  cat $(FW_MEMINFO_NEW); \
 	fi


### PR DESCRIPTION
`substr($$0, 1, length($$0) - 1)` is stripping last digit from current meminfo section size line cause it doesn't contains \n at the end.