### PR TITLE
Fix i2c master by properly setup SDA pin as INPUT_PULLUP

### DIFF
--- a/Sming/Wiring/I2cMaster.cpp
+++ b/Sming/Wiring/I2cMaster.cpp
@@ -54,7 +54,7 @@ uint8_t SoftI2cMaster::read(uint8_t last) {
   uint8_t b = 0;
   // make sure pull-up enabled
   digitalWrite(sdaPin_, HIGH);
-  pinMode(sdaPin_, INPUT);
+  pinMode(sdaPin_, INPUT_PULLUP);
   // read byte
   for (uint8_t i = 0; i < 8; i++) {
     // don't change this loop unless you verify the change with a scope
@@ -130,7 +130,7 @@ bool SoftI2cMaster::write(uint8_t data) {
     digitalWrite(sclPin_, LOW);
   }
   // get Ack or Nak
-  pinMode(sdaPin_, INPUT);
+  pinMode(sdaPin_, INPUT_PULLUP);
   // enable pullup
   digitalWrite(sdaPin_, HIGH);
   digitalWrite(sclPin_, HIGH);


### PR DESCRIPTION
Fixes issue with some i2c setup where INPUT_PULLUP is mandatory (missing SDA/SCL pull up resistors).
There is new version of pinMode after Sming 3.1.0, so to be consistent with old behavior, SDA pin MUST be INPUT_PULLUP, not only INPUT and digitalWrite(SDA, HIGH). This was tested with MCP23017 as both input and output port expander connected to esp8266 without SDA/SCL resistors.