### PR TITLE
[Fixes #1065] Copy terminating null byte in strcpy_P

### DIFF
--- a/Sming/Wiring/FakePgmSpace.cpp
+++ b/Sming/Wiring/FakePgmSpace.cpp
@@ -31,8 +31,7 @@ extern "C" size_t strlen_P(const char * src_P)
 
 extern "C" char *strcpy_P(char * dest, const char * src_P)
 {
-	int len = strlen_P(src_P);
-	memcpy_P(dest, src_P, len);
+	for (char *p = dest; *p = pgm_read_byte(src_P++); p++) ;
 	return dest;
 }
 


### PR DESCRIPTION
So it behaves exactly as regular `strcpy`. Thanks @tius2000 for working fix in code.

This is related to #1048 as well and fixes 2 of 3 failing tests.