### PR TITLE
WifiStation.waitConnection is marked as obsolete and will be removed …

### DIFF
--- a/Sming/SmingCore/Platform/Station.h
+++ b/Sming/SmingCore/Platform/Station.h
@@ -219,6 +219,10 @@ public:
 	 *	@param	successfulConnected Function to call when WiFi station connects to network
 	 *	@param	secondsTimeOut Quantity of seconds to wait for connection
 	 *	@param	connectionNotEstablished Function to call if WiFi station fails to connect to network
+	 *
+	 *	@deprecated This method is deprecated and will be removed in the next versions. Use WifiEvents instead.
+	 *				For an example of WifiEvents take a look at the Basic_Wifi sample code.
+	 *
 	 */
 	void waitConnection(ConnectionDelegate successfulConnected, int secondsTimeOut, ConnectionDelegate connectionNotEstablished);
 

--- a/samples/Basic_WiFi/app/application.cpp
+++ b/samples/Basic_WiFi/app/application.cpp
@@ -28,17 +28,17 @@ void listNetworks(bool succeeded, BssList list)
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(IPAddress ip, IPAddress mask, IPAddress gateway)
 {
 	debugf("I'm CONNECTED");
-	Serial.println(WifiStation.getIP().toString());
+	Serial.println(ip.toString());
 }
 
-// Will be called when WiFi station timeout was reached
-void connectFail()
+// Will be called when WiFi station was disconnected
+void connectFail(String ssid, uint8_t ssidLength, uint8_t *bssid, uint8_t reason)
 {
-	debugf("I'm NOT CONNECTED!");
-	WifiStation.waitConnection(connectOk, 10, connectFail); // Repeat and check again
+	// The different reason codes can be found in user_interface.h. in your SDK.
+	debugf("Disconnected from %s. Reason: %d", ssid.c_str(), reason);
 }
 
 // Will be called when WiFi hardware and software initialization was finished
@@ -76,6 +76,9 @@ void init()
 	// Print available access points
 	WifiStation.startScan(listNetworks); // In Sming we can start network scan from init method without additional code
 
-	// Run our method when station was connected to AP (or not connected)
-	WifiStation.waitConnection(connectOk, 30, connectFail); // We recommend 20+ seconds at start
+	// Set callback that should be triggered when we have assigned IP
+	WifiEvents.onStationGotIP(connectOk);
+
+	// Set callback that should be triggered if we are disconnected or connection attempt failed
+	WifiEvents.onStationDisconnect(connectFail);
 }


### PR DESCRIPTION
…in coming versions.

Use WifiEvents instead.
The Basic_Wifi example is changed and should be used as a starting point for the migration of your own code.