### PR TITLE
[Rel #1071] more samples converted to WifiEvents

### DIFF
--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -257,9 +257,14 @@ void StartServers()
 
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
+}
+
+// Will be called when station is fully operational
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
 	StartServers();
 }
 
@@ -280,8 +285,8 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiAccessPoint.enable(false);
 
-	// Run our method when station was connected to AP
-	WifiStation.waitConnection(connectOk);
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationGotIP(&gotIP);
 
 	// setup the ArduCAM
 	initCam();

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -256,12 +256,6 @@ void StartServers()
 }
 
 
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-}
-
 // Will be called when station is fully operational
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
@@ -285,7 +279,6 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiAccessPoint.enable(false);
 
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationGotIP(gotIP);
 
 	// setup the ArduCAM

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -285,8 +285,8 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiAccessPoint.enable(false);
 
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationGotIP(gotIP);
 
 	// setup the ArduCAM
 	initCam();

--- a/samples/Basic_AirUpdate/app/application.cpp
+++ b/samples/Basic_AirUpdate/app/application.cpp
@@ -20,7 +20,7 @@ void IRAM_ATTR interruptHandler()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	Serial.println("I'm CONNECTED");
 
@@ -44,5 +44,5 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/Basic_AirUpdate/app/application.cpp
+++ b/samples/Basic_AirUpdate/app/application.cpp
@@ -44,5 +44,5 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationConnect(connectOk);
 }

--- a/samples/Basic_AirUpdate/app/application.cpp
+++ b/samples/Basic_AirUpdate/app/application.cpp
@@ -20,7 +20,7 @@ void IRAM_ATTR interruptHandler()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
 
@@ -44,5 +44,5 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiStation.waitConnection(connectOk);
+	WifiEvents.onStationConnect(&connectOk);
 }

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -192,9 +192,9 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
-	WifiEvents.onStationConnect(&connect_Ok);
-	WifiEvents.onStationDisconnect(&connect_Fail);
-	WifiEvents.onStationGotIP(&got_IP);
+	WifiEvents.onStationConnect(connect_Ok);
+	WifiEvents.onStationDisconnect(connect_Fail);
+	WifiEvents.onStationGotIP(got_IP);
 
 
 

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -158,19 +158,23 @@ void StartDemo() {
 
 
 // Will be called when WiFi station was connected to AP
-void connect_Ok()
+void connect_Ok(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
-	Serial.print("I'm CONNECTED - ");
-	Serial.println(WifiStation.getIP().toString());
+	Serial.println("I'm CONNECTED");
+}
 
+void got_IP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
+	Serial.printf("IP: %s\n", ip.toString().c_str());
 	//You can put here other job like web,tcp etc.
 }
 
 // Will be called when WiFi station timeout was reached
-void connect_Fail()
+void connect_Fail(String SSID, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	Serial.println("I'm NOT CONNECTED!");
-	WifiStation.waitConnection(connect_Ok, 10, connect_Fail); // Repeat and check again
+	WifiStation.disconnect();
+	WifiStation.connect();
 }
 
 void init()
@@ -188,7 +192,9 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
-	WifiStation.waitConnection(connect_Ok, 20, connect_Fail);
+	WifiEvents.onStationConnect(&connect_Ok);
+	WifiEvents.onStationDisconnect(&connect_Fail);
+	WifiEvents.onStationGotIP(&got_IP);
 
 
 

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -157,19 +157,13 @@ void StartDemo() {
 
 
 
-// Will be called when WiFi station was connected to AP
-void connect_Ok(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-}
-
 void got_IP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	Serial.printf("IP: %s\n", ip.toString().c_str());
 	//You can put here other job like web,tcp etc.
 }
 
-// Will be called when WiFi station timeout was reached
+// Will be called when WiFi station loses connection
 void connect_Fail(String SSID, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	Serial.println("I'm NOT CONNECTED!");
@@ -190,7 +184,6 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
-	WifiEvents.onStationConnect(connect_Ok);
 	WifiEvents.onStationDisconnect(connect_Fail);
 	WifiEvents.onStationGotIP(got_IP);
 

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -173,8 +173,6 @@ void got_IP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 void connect_Fail(String SSID, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	Serial.println("I'm NOT CONNECTED!");
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void init()

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -88,7 +88,7 @@ void onDownload(HttpClient& client, bool success)
 	}
 }
 
-void connectOk()
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	const uint8_t googleSha1Fingerprint[] = { 0x07, 0xf0, 0xb0, 0x8d, 0x41, 0xfb, 0xee, 0x6b, 0x34, 0xfb,
 			                                  0x9a, 0xd0, 0x9a, 0xa7, 0x73, 0xab, 0xcc, 0x8b, 0xb2, 0x64 };
@@ -98,7 +98,7 @@ void connectOk()
 			0x65, 0x09, 0x62, 0x37, 0xeb, 0x75, 0x92, 0xaa, 0x10, 0x03, 0xe7, 0x99, 0x01, 0x9d, 0x9f, 0x0c
 	};
 
-	debugf("Connected. Got IP: %s", WifiStation.getIP().toString().c_str());
+	debugf("Connected. Got IP: %s", ip.toString().c_str());
 	downloadClient.addSslOptions(SSL_SERVER_VERIFY_LATER);
 
 	/*
@@ -115,10 +115,11 @@ void connectOk()
 	downloadClient.downloadString("https://www.google.com/", onDownload);
 }
 
-void connectFail()
+void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.waitConnection(connectOk, 10, connectFail); // Repeat and check again
+	WifiStation.disconnect();
+	WifiStation.connect();
 }
 
 void init()
@@ -131,6 +132,6 @@ void init()
 	WifiStation.enable(true);
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
 
-	// Run our method when station was connected to AP (or not connected)
-	WifiStation.waitConnection(connectOk, 30, connectFail); // We recommend 20+ seconds at start
+	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationDisconnect(&connectFail);
 }

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -132,6 +132,6 @@ void init()
 	WifiStation.enable(true);
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
 
-	WifiEvents.onStationGotIP(&gotIP);
-	WifiEvents.onStationDisconnect(&connectFail);
+	WifiEvents.onStationGotIP(gotIP);
+	WifiEvents.onStationDisconnect(connectFail);
 }

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -118,8 +118,6 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void init()

--- a/samples/Basic_WebSkeletonApp/app/application.cpp
+++ b/samples/Basic_WebSkeletonApp/app/application.cpp
@@ -22,8 +22,8 @@ void init()
 	ActiveConfig = loadConfig();
 
 	// Attach Wifi events handlers
-	WifiEvents.onStationDisconnect(STADisconnect);
-	WifiEvents.onStationGotIP(STAGotIP);
+	WifiEvents.onStationDisconnect(&STADisconnect);
+	WifiEvents.onStationGotIP(&STAGotIP);
 
 	startWebServer();
 

--- a/samples/Basic_WebSkeletonApp/app/application.cpp
+++ b/samples/Basic_WebSkeletonApp/app/application.cpp
@@ -22,8 +22,8 @@ void init()
 	ActiveConfig = loadConfig();
 
 	// Attach Wifi events handlers
-	WifiEvents.onStationDisconnect(&STADisconnect);
-	WifiEvents.onStationGotIP(&STAGotIP);
+	WifiEvents.onStationDisconnect(STADisconnect);
+	WifiEvents.onStationGotIP(STAGotIP);
 
 	startWebServer();
 

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -110,13 +110,6 @@ void startExampleApplicationCommand()
 	commandHandler.registerCommand(CommandDelegate("example","Example Command from Class","Application",processApplicationCommands));
 }
 
-
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-}
-
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	StartServers();
@@ -141,6 +134,5 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -141,6 +141,6 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -112,9 +112,13 @@ void startExampleApplicationCommand()
 
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
+}
+
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
 	StartServers();
 
 	startExampleApplicationCommand();
@@ -137,5 +141,6 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiStation.waitConnection(connectOk);
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/DS3232RTC_NTP_Setter/app/application.cpp
+++ b/samples/DS3232RTC_NTP_Setter/app/application.cpp
@@ -41,8 +41,6 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void init()

--- a/samples/DS3232RTC_NTP_Setter/app/application.cpp
+++ b/samples/DS3232RTC_NTP_Setter/app/application.cpp
@@ -58,8 +58,8 @@ void init()
 	// Station - WiFi client
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
 	WifiStation.enable(true);
-	WifiEvents.onStationGotIP(&gotIP);
-	WifiEvents.onStationDisconnect(&connectFail);
+	WifiEvents.onStationGotIP(gotIP);
+	WifiEvents.onStationDisconnect(connectFail);
 
 	// set timezone hourly difference to UTC
 	SystemClock.setTimeZone(2); // GMT+2

--- a/samples/DS3232RTC_NTP_Setter/app/application.cpp
+++ b/samples/DS3232RTC_NTP_Setter/app/application.cpp
@@ -33,15 +33,16 @@ void onNtpReceive(NtpClient& client, time_t timestamp) {
 	Serial.printf("Time synchronized: %s\n", SystemClock.getSystemTimeString().c_str());
 }
 
-void connectOk()
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	ntpClient.requestTime();
 }
 
-void connectFail()
+void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.waitConnection(connectOk, 10, connectFail); // Repeat and check again
+	WifiStation.disconnect();
+	WifiStation.connect();
 }
 
 void init()
@@ -52,14 +53,13 @@ void init()
 //Uncomment proper line, or set right pins by hand
 	Wire.pins(0, 2); //Change to your SCL - 0,SDA - 2 GPIO pin number
 //	Wire.pins(5, 4); //Change to your SCL - 5,SDA - 4 GPIO pin number
-        Wire.begin();
+	Wire.begin();
 
-	// Run our method when station was connected to AP (or not connected)
-	WifiStation.waitConnection(connectOk, 30, connectFail); // We recommend 20+ seconds at start
-	
 	// Station - WiFi client
-	WifiStation.enable(true);
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
+	WifiStation.enable(true);
+	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationDisconnect(&connectFail);
 
 	// set timezone hourly difference to UTC
 	SystemClock.setTimeZone(2); // GMT+2

--- a/samples/Echo_Ssl/app/application.cpp
+++ b/samples/Echo_Ssl/app/application.cpp
@@ -109,11 +109,6 @@ bool onReceive(TcpClient& tcpClient, char *data, int size) {
 	return tcpClient.send(data, size);
 }
 
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	debugf("Connected.");
-}
-
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
@@ -137,7 +132,6 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationDisconnect(connectFail);
 	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/Echo_Ssl/app/application.cpp
+++ b/samples/Echo_Ssl/app/application.cpp
@@ -117,8 +117,6 @@ void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)

--- a/samples/Echo_Ssl/app/application.cpp
+++ b/samples/Echo_Ssl/app/application.cpp
@@ -139,7 +139,7 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -47,7 +47,7 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -9,12 +9,6 @@
 
 FTPServer ftp;
 
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("\r\nI'm CONNECTED");
-}
-
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	Serial.printf("IP: %s\n", ip.toString().c_str());
@@ -47,7 +41,6 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationDisconnect(connectFail);
 	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -10,11 +10,14 @@
 FTPServer ftp;
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
-	Serial.println("\r\nI'm CONNECTED:");
-	Serial.println(WifiStation.getIP().toString());
+	Serial.println("\r\nI'm CONNECTED");
+}
 
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
+	Serial.printf("IP: %s\n", ip.toString().c_str());
 	// Start FTP server
 	ftp.listen(21);
 	ftp.addUser("me", "123"); // FTP account
@@ -22,7 +25,7 @@ void connectOk()
 }
 
 // Will be called when WiFi station timeout was reached
-void connectFail()
+void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	Serial.println("I'm NOT CONNECTED. Need help!!! :(");
 
@@ -44,5 +47,7 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiStation.waitConnection(connectOk, 20, connectFail); // We recommend 20+ seconds for connection timeout at start
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationDisconnect(&connectFail);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/HttpClient_Instapush/app/application.cpp
+++ b/samples/HttpClient_Instapush/app/application.cpp
@@ -84,7 +84,7 @@ void publishMessage()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
 
@@ -104,5 +104,5 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiStation.waitConnection(connectOk);
+	WifiEvents.onStationConnect(&connectOk);
 }

--- a/samples/HttpClient_Instapush/app/application.cpp
+++ b/samples/HttpClient_Instapush/app/application.cpp
@@ -84,7 +84,7 @@ void publishMessage()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	Serial.println("I'm CONNECTED");
 
@@ -104,5 +104,5 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/HttpClient_Instapush/app/application.cpp
+++ b/samples/HttpClient_Instapush/app/application.cpp
@@ -104,5 +104,5 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationConnect(connectOk);
 }

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -39,12 +39,6 @@ void sendData()
 	thingSpeak.downloadString("http://api.thingspeak.com/update?key=7XXUJWCWYTMXKN3L&field1=" + String(sensorValue), onDataSent);
 }
 
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-}
-
 // Will be called when WiFi station timeout was reached
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
@@ -75,7 +69,6 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationDisconnect(connectFail);
 	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -75,7 +75,7 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -40,24 +40,27 @@ void sendData()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
-
-	// Start send data loop
-	procTimer.initializeMs(25 * 1000, sendData).start(); // every 25 seconds
 }
 
 // Will be called when WiFi station timeout was reached
-void connectFail()
+void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	Serial.println("I'm NOT CONNECTED. Need help :(");
 
 	// Start soft access point
-	WifiAccessPoint.enable(true);
 	WifiAccessPoint.config("CONFIG ME PLEEEEASE...", "", AUTH_OPEN);
+	WifiAccessPoint.enable(true);
 
 	// .. some you code for configuration ..
+}
+
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
+	// Start send data loop
+	procTimer.initializeMs(25 * 1000, sendData).start(); // every 25 seconds
 }
 
 void init()
@@ -72,5 +75,7 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiStation.waitConnection(connectOk, 20, connectFail); // We recommend 20+ seconds for connection timeout at start
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationDisconnect(&connectFail);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -101,12 +101,6 @@ void startFTP()
 	ftp.addUser("me", "123"); // FTP account
 }
 
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-}
-
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	startFTP();
@@ -131,6 +125,5 @@ void init()
 	}
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -131,6 +131,6 @@ void init()
 	}
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -102,10 +102,13 @@ void startFTP()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
+}
 
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
 	startFTP();
 	startWebServer();
 }
@@ -128,5 +131,6 @@ void init()
 	}
 
 	// Run our method when station was connected to AP
-	WifiStation.waitConnection(connectOk);
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -87,10 +87,13 @@ void downloadContentFiles()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
+}
 
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
 	if (!fileExist("index.html") || !fileExist("bootstrap.css.gz") || !fileExist("jquery.js.gz"))
 	{
 		// Download server content at first
@@ -116,7 +119,8 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiStation.waitConnection(connectOk);
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationGotIP(&gotIP);
 
 	//Change CPU freq. to 160MHZ
 	System.setCpuFrequency(eCF_160MHz);

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -86,12 +86,6 @@ void downloadContentFiles()
 	}
 }
 
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-}
-
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	if (!fileExist("index.html") || !fileExist("bootstrap.css.gz") || !fileExist("jquery.js.gz"))
@@ -119,7 +113,6 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationGotIP(gotIP);
 
 	//Change CPU freq. to 160MHZ

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -119,8 +119,8 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationGotIP(gotIP);
 
 	//Change CPU freq. to 160MHZ
 	System.setCpuFrequency(eCF_160MHz);

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -102,12 +102,7 @@ void startWebServer()
 	Serial.println("==============================\r\n");
 }
 
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-}
-
+// Will be called when WiFi station becomes fully operational
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	startWebServer();
@@ -125,6 +120,5 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -103,10 +103,13 @@ void startWebServer()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
+}
 
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
 	startWebServer();
 }
 
@@ -122,5 +125,6 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiStation.waitConnection(connectOk);
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -125,6 +125,6 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/LED_YeelightBulb/app/application.cpp
+++ b/samples/LED_YeelightBulb/app/application.cpp
@@ -27,7 +27,7 @@ void blink()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	debugf("I'm CONNECTED");
 
@@ -44,5 +44,5 @@ void init()
 	WifiStation.enable(true);
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
 
-	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/LED_YeelightBulb/app/application.cpp
+++ b/samples/LED_YeelightBulb/app/application.cpp
@@ -44,5 +44,5 @@ void init()
 	WifiStation.enable(true);
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
 
-	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationConnect(connectOk);
 }

--- a/samples/LED_YeelightBulb/app/application.cpp
+++ b/samples/LED_YeelightBulb/app/application.cpp
@@ -27,7 +27,7 @@ void blink()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	debugf("I'm CONNECTED");
 
@@ -44,5 +44,5 @@ void init()
 	WifiStation.enable(true);
 	WifiStation.config(WIFI_SSID, WIFI_PWD); // Put you SSID and Password here
 
-	WifiStation.waitConnection(connectOk);
+	WifiEvents.onStationConnect(&connectOk);
 }

--- a/samples/MeteoControl/app/application.cpp
+++ b/samples/MeteoControl/app/application.cpp
@@ -58,9 +58,9 @@ void init()
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
 
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 
 	procTimer.initializeMs(5000, process).start();
 	process();

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -30,9 +30,9 @@ void init()
 	//WifiStation.setIP(ESP_IP);
 	WifiAccessPoint.enable(false);
 	WDT.enable(false);	//disable watchdog
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 }
 
 // Publish our message

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -8,7 +8,6 @@
 
 Timer publishTimer;
 
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel);
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason);
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway);
 
@@ -30,7 +29,6 @@ void init()
 	//WifiStation.setIP(ESP_IP);
 	WifiAccessPoint.enable(false);
 	WDT.enable(false);	//disable watchdog
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationDisconnect(connectFail);
 	WifiEvents.onStationGotIP(gotIP);
 }
@@ -58,12 +56,6 @@ void startMqttClient()
 	mqtt.connect(CLIENT, LOG, PASS);
 	Serial.print("\rConnected to MQTT server\n");
 	mqtt.subscribe(SUB_TOPIC);
-}
-
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	debugf("connected");	
 }
 
 // Will be called when WiFi station timeout was reached

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -71,9 +71,6 @@ void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason
 {
 	debugf("connection FAILED");
 	Serial.println("NOT CONNECTED");
-
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -128,7 +128,7 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -94,23 +94,26 @@ void startMqttClient()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
+}
 
+// Will be called when WiFi station timeout was reached
+void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
+{
+	Serial.println("I'm NOT CONNECTED. Need help :(");
+
+	// .. some you code for device configuration ..
+}
+
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
 	// Run MQTT client
 	startMqttClient();
 
 	// Start publishing loop
 	procTimer.initializeMs(20 * 1000, publishMessage).start(); // every 20 seconds
-}
-
-// Will be called when WiFi station timeout was reached
-void connectFail()
-{
-	Serial.println("I'm NOT CONNECTED. Need help :(");
-
-	// .. some you code for device configuration ..
 }
 
 void init()
@@ -125,5 +128,7 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiStation.waitConnection(connectOk, 20, connectFail); // We recommend 20+ seconds for connection timeout at start
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationDisconnect(&connectFail);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -93,12 +93,6 @@ void startMqttClient()
 	mqtt->subscribe("main/status/#");
 }
 
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-}
-
 // Will be called when WiFi station timeout was reached
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
@@ -128,7 +122,6 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP (or not connected)
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationDisconnect(connectFail);
 	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/ScreenOLED_SSD1306/app/application.cpp
+++ b/samples/ScreenOLED_SSD1306/app/application.cpp
@@ -30,19 +30,23 @@ Adafruit_SSD1306 display(-1); // reset Pin required but later ignored if set to 
 Timer DemoTimer;
 
 // Will be called when WiFi station was connected to AP
-void connect_Ok()
+void connect_Ok(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
-	Serial.print("WiFi : I'm CONNECTED - ");
-	Serial.println(WifiStation.getIP().toString());
-
-	//You can put here other job like web,tcp, send other info to display etc.
+	Serial.println("WiFi : I'm CONNECTED");
 }
 
-// Will be called when WiFi station timeout was reached
-void connect_Fail()
+// Will be called when WiFi station loses connection
+void connect_Fail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	Serial.println("WiFi: I'm NOT CONNECTED!");
-	WifiStation.waitConnection(connect_Ok, 10, connect_Fail); // Repeat and check again
+	WifiStation.disconnect();
+	WifiStation.connect();
+}
+
+void got_IP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
+	Serial.print("Got IP: ");
+	Serial.println(ip.toString());
 }
 
 
@@ -90,7 +94,9 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
-	WifiStation.waitConnection(connect_Ok, 20, connect_Fail);
+	WifiEvents.onStationConnect(&connect_Ok);
+	WifiEvents.onStationDisconnect(&connect_Fail);
+	WifiEvents.onStationGotIP(&got_IP);
 
 	Serial.println("Display: start");
 

--- a/samples/ScreenOLED_SSD1306/app/application.cpp
+++ b/samples/ScreenOLED_SSD1306/app/application.cpp
@@ -29,12 +29,6 @@ Adafruit_SSD1306 display(-1); // reset Pin required but later ignored if set to 
 
 Timer DemoTimer;
 
-// Will be called when WiFi station was connected to AP
-void connect_Ok(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("WiFi : I'm CONNECTED");
-}
-
 // Will be called when WiFi station loses connection
 void connect_Fail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
@@ -71,7 +65,7 @@ void Demo2()
 
 void Demo1()
 {
-        Serial.println("Display: circle");
+	Serial.println("Display: circle");
 	// Clear the buffer.
 	display.clearDisplay();
 	// draw a circle, 10 pixel radius
@@ -92,7 +86,6 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
-	WifiEvents.onStationConnect(connect_Ok);
 	WifiEvents.onStationDisconnect(connect_Fail);
 	WifiEvents.onStationGotIP(got_IP);
 

--- a/samples/ScreenOLED_SSD1306/app/application.cpp
+++ b/samples/ScreenOLED_SSD1306/app/application.cpp
@@ -94,9 +94,9 @@ void init()
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
-	WifiEvents.onStationConnect(&connect_Ok);
-	WifiEvents.onStationDisconnect(&connect_Fail);
-	WifiEvents.onStationGotIP(&got_IP);
+	WifiEvents.onStationConnect(connect_Ok);
+	WifiEvents.onStationDisconnect(connect_Fail);
+	WifiEvents.onStationGotIP(got_IP);
 
 	Serial.println("Display: start");
 

--- a/samples/ScreenOLED_SSD1306/app/application.cpp
+++ b/samples/ScreenOLED_SSD1306/app/application.cpp
@@ -39,8 +39,6 @@ void connect_Ok(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel
 void connect_Fail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	Serial.println("WiFi: I'm NOT CONNECTED!");
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void got_IP(IPAddress ip, IPAddress netmask, IPAddress gateway)

--- a/samples/SystemClock_NTP/app/application.cpp
+++ b/samples/SystemClock_NTP/app/application.cpp
@@ -112,6 +112,6 @@ void init()
 
 	printTimer.initializeMs(1000, onPrintSystemTime).start();
 	
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/SystemClock_NTP/app/application.cpp
+++ b/samples/SystemClock_NTP/app/application.cpp
@@ -64,8 +64,15 @@ void onNtpReceive(NtpClient& client, time_t timestamp) {
 	Serial.println(SystemClock.getSystemTimeString());
 }
 
-// Will be called when WiFi station was connected to AP
-void connectOk()
+// Will be called when WiFi station timeout was reached
+void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
+{
+	debugf("I'm NOT CONNECTED!");
+	WifiStation.disconnect();
+	WifiStation.connect();
+}
+
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 // Set specific parameters if started by option 1 or 2
 	// Set client to do automatic time requests every 60 seconds.
@@ -84,14 +91,6 @@ void connectOk()
 
 //	When using Delegate Callback Option 2
 	demo = new ntpClientDemo();
-
-}
-
-// Will be called when WiFi station timeout was reached
-void connectFail()
-{
-	debugf("I'm NOT CONNECTED!");
-	WifiStation.waitConnection(connectOk, 10, connectFail); // Repeat and check again
 }
 
 
@@ -113,6 +112,6 @@ void init()
 
 	printTimer.initializeMs(1000, onPrintSystemTime).start();
 	
-	// Run our method when station was connected to AP (or not connected)
-	WifiStation.waitConnection(connectOk, 30, connectFail); // We recommend 20+ seconds at start
+	WifiEvents.onStationDisconnect(&connectFail);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/SystemClock_NTP/app/application.cpp
+++ b/samples/SystemClock_NTP/app/application.cpp
@@ -68,8 +68,6 @@ void onNtpReceive(NtpClient& client, time_t timestamp) {
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)

--- a/samples/TcpClient_NarodMon/app/application.cpp
+++ b/samples/TcpClient_NarodMon/app/application.cpp
@@ -121,7 +121,7 @@ void init()
 	 * connectFail будет вызвана, если подключиться не получится
 	 * 30 - таймаут подключения (сек)
 	 */
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/TcpClient_NarodMon/app/application.cpp
+++ b/samples/TcpClient_NarodMon/app/application.cpp
@@ -90,9 +90,6 @@ void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason
 {
 	// Если подключение к роутеру не удалось, выводим сообщение
 	debugf("I'm NOT CONNECTED!");
-	// И пробуем еще раз
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)

--- a/samples/TcpClient_NarodMon/app/application.cpp
+++ b/samples/TcpClient_NarodMon/app/application.cpp
@@ -70,7 +70,7 @@ void sendData()
 }
 
 // Когда удачно подключились к роутеру
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	// debug msg
 	debugf("I'm CONNECTED to WiFi");
@@ -84,19 +84,23 @@ void connectOk()
 		mac = mac.substring(0, i) + "-" + mac.substring(i++);
 
 	debugf("mac: %s", mac.c_str());
-
-	// вызываем по таймеру функцию sendData
-	procTimer.initializeMs(6 * 60 * 1000, sendData).start(); // каждые 6 минут
-	// ну и заодно сразу после запуска вызываем, чтобы не ждать 6 минут первый раз
-	sendData();
 }
 
-void connectFail()
+void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	// Если подключение к роутеру не удалось, выводим сообщение
 	debugf("I'm NOT CONNECTED!");
 	// И пробуем еще раз
-	WifiStation.waitConnection(connectOk, 10, connectFail);
+	WifiStation.disconnect();
+	WifiStation.connect();
+}
+
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
+	// вызываем по таймеру функцию sendData
+	procTimer.initializeMs(6 * 60 * 1000, sendData).start(); // каждые 6 минут
+	// ну и заодно сразу после запуска вызываем, чтобы не ждать 6 минут первый раз
+	sendData();
 }
 
 void init()
@@ -117,5 +121,7 @@ void init()
 	 * connectFail будет вызвана, если подключиться не получится
 	 * 30 - таймаут подключения (сек)
 	 */
-	WifiStation.waitConnection(connectOk, 30, connectFail);
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationDisconnect(&connectFail);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/Telnet_TCPServer_TCPClient/app/application.cpp
+++ b/samples/Telnet_TCPServer_TCPClient/app/application.cpp
@@ -124,8 +124,6 @@ void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)

--- a/samples/Telnet_TCPServer_TCPClient/app/application.cpp
+++ b/samples/Telnet_TCPServer_TCPClient/app/application.cpp
@@ -116,16 +116,21 @@ void startServers()
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
-	startServers();
 }
 
-void connectFail()
+void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.waitConnection(connectOk, 10, connectFail);
+	WifiStation.disconnect();
+	WifiStation.connect();
+}
+
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
+	startServers();
 }
 
 void init()
@@ -138,7 +143,9 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiStation.waitConnection(connectOk, 30, connectFail);
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationDisconnect(&connectFail);
+	WifiEvents.onStationGotIP(&gotIP);
 	Debug.setDebug(Serial);
 	Debug.initCommand();
 	Debug.start();

--- a/samples/Telnet_TCPServer_TCPClient/app/application.cpp
+++ b/samples/Telnet_TCPServer_TCPClient/app/application.cpp
@@ -143,9 +143,9 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 	Debug.setDebug(Serial);
 	Debug.initCommand();
 	Debug.start();

--- a/samples/Telnet_TCPServer_TCPClient/app/application.cpp
+++ b/samples/Telnet_TCPServer_TCPClient/app/application.cpp
@@ -115,12 +115,6 @@ void startServers()
 	commandHandler.registerCommand(CommandDelegate("application","This command is defined by the application\r\n","testGroup", applicationCommand));
 }
 
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-}
-
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
@@ -141,7 +135,6 @@ void init()
 	WifiAccessPoint.enable(false);
 
 	// Run our method when station was connected to AP
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationDisconnect(connectFail);
 	WifiEvents.onStationGotIP(gotIP);
 	Debug.setDebug(Serial);

--- a/samples/UdpServer_Echo/app/application.cpp
+++ b/samples/UdpServer_Echo/app/application.cpp
@@ -28,7 +28,7 @@ void onReceive(UdpConnection& connection, char *data, int size, IPAddress remote
 	udp.sendStringTo(remoteIP, EchoPort, text);
 }
 
-void onConnected()
+void gotIP(IPAddress ip, IPAddress gateway, IPAddress netmask)
 {
 	udp.listen(EchoPort);
 
@@ -46,5 +46,5 @@ void init()
 	Serial.systemDebugOutput(true);
 
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
-	WifiStation.waitConnection(onConnected);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/UdpServer_Echo/app/application.cpp
+++ b/samples/UdpServer_Echo/app/application.cpp
@@ -46,5 +46,5 @@ void init()
 	Serial.systemDebugOutput(true);
 
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -120,7 +120,7 @@ void init()
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
 
-	WifiEvents.onStationConnect(&connectOk);
-	WifiEvents.onStationDisconnect(&connectFail);
-	WifiEvents.onStationGotIP(&gotIP);
+	WifiEvents.onStationConnect(connectOk);
+	WifiEvents.onStationDisconnect(connectFail);
+	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -89,15 +89,6 @@ void startWebServer()
 	Serial.println("==============================\r\n");
 }
 
-
-// Will be called when WiFi station was connected to AP
-void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
-{
-	Serial.println("I'm CONNECTED");
-	if (!fileExist("index.html"))
-			fileSetContent("index.html", "<h3>Congrats !! You are Connected to your ESP module with mDNS address test.local</h3>");
-}
-
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
@@ -105,6 +96,8 @@ void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
+	if (!fileExist("index.html"))
+		fileSetContent("index.html", "<h3>Congrats !! You are Connected to your ESP module with mDNS address test.local</h3>");
 	startWebServer();
 	startmDNS();  // Start mDNS "Advertise" of your hostname "test.local" for this example
 }
@@ -118,7 +111,6 @@ void init()
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
 
-	WifiEvents.onStationConnect(connectOk);
 	WifiEvents.onStationDisconnect(connectFail);
 	WifiEvents.onStationGotIP(gotIP);
 }

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -101,8 +101,6 @@ void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -91,20 +91,24 @@ void startWebServer()
 
 
 // Will be called when WiFi station was connected to AP
-void connectOk()
+void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 {
 	Serial.println("I'm CONNECTED");
 	if (!fileExist("index.html"))
 			fileSetContent("index.html", "<h3>Congrats !! You are Connected to your ESP module with mDNS address test.local</h3>");
-
-
-	startWebServer();
-	startmDNS();  // Start mDNS "Advertise" of your hostname "test.local" for this example
 }
-void connectFail()
+
+void connectFail(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	debugf("I'm NOT CONNECTED!");
-	WifiStation.waitConnection(connectOk, 10, connectFail);
+	WifiStation.disconnect();
+	WifiStation.connect();
+}
+
+void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+{
+	startWebServer();
+	startmDNS();  // Start mDNS "Advertise" of your hostname "test.local" for this example
 }
 
 void init()
@@ -112,15 +116,11 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
-
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);
 
-
-	WifiStation.waitConnection(connectOk, 30, connectFail);
-
-
-	// Run our method when station was connected to AP
-	WifiStation.waitConnection(connectOk);
+	WifiEvents.onStationConnect(&connectOk);
+	WifiEvents.onStationDisconnect(&connectFail);
+	WifiEvents.onStationGotIP(&gotIP);
 }

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -153,9 +153,6 @@ void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway)
 void STADisconnect(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t reason)
 {
 	Serial.printf("DISCONNECT - SSID: %s, REASON: %d\n", ssid.c_str(), reason);
-
-	WifiStation.disconnect();
-	WifiStation.connect();
 }
 
 void init()

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -167,6 +167,6 @@ void init()
     WifiStation.config(WIFI_SSID, WIFI_PWD);
     WifiStation.enable(true);
 
-    WifiEvents.onStationGotIP(&STAGotIP);
-    WifiEvents.onStationDisconnect(&STADisconnect);
+    WifiEvents.onStationGotIP(STAGotIP);
+    WifiEvents.onStationDisconnect(STADisconnect);
 }


### PR DESCRIPTION
This is related to PR #1071 - all samples are converted to use `WifiEvents`. The PR is massive, but all network related examples have been converted.