### PR TITLE
Revert "Fix i2c master by properly setup SDA pin as INPUT_PULLUP"

### DIFF
--- a/Sming/Wiring/I2cMaster.cpp
+++ b/Sming/Wiring/I2cMaster.cpp
@@ -54,7 +54,7 @@ uint8_t SoftI2cMaster::read(uint8_t last) {
   uint8_t b = 0;
   // make sure pull-up enabled
   digitalWrite(sdaPin_, HIGH);
-  pinMode(sdaPin_, INPUT_PULLUP);
+  pinMode(sdaPin_, INPUT);
   // read byte
   for (uint8_t i = 0; i < 8; i++) {
     // don't change this loop unless you verify the change with a scope
@@ -130,7 +130,7 @@ bool SoftI2cMaster::write(uint8_t data) {
     digitalWrite(sclPin_, LOW);
   }
   // get Ack or Nak
-  pinMode(sdaPin_, INPUT_PULLUP);
+  pinMode(sdaPin_, INPUT);
   // enable pullup
   digitalWrite(sdaPin_, HIGH);
   digitalWrite(sclPin_, HIGH);


### PR DESCRIPTION
Reverts SmingHub/Sming#1060

In some of my tests that commit caused instability during uart reading/writing operations. For the moment a better fix will be to document that behaviour instead of always setting the INPUT_PULLUP.