### PR TITLE
Do not make so many copies of String when requesting MAC address

### DIFF
--- a/Sming/SmingCore/Platform/AccessPoint.cpp
+++ b/Sming/SmingCore/Platform/AccessPoint.cpp
@@ -142,15 +142,11 @@ bool AccessPointClass::setIP(IPAddress address)
 
 String AccessPointClass::getMAC()
 {
-	String mac;
 	uint8 hwaddr[6] = {0};
 	wifi_get_macaddr(SOFTAP_IF, hwaddr);
-	for (int i = 0; i < 6; i++)
-	{
-		if (hwaddr[i] < 0x10) mac += "0";
-		mac += String(hwaddr[i], HEX);
-	}
-	return mac;
+	char buf[20];
+	sprintf(buf, "%02x%02x%02x%02x%02x%02x", hwaddr[0], hwaddr[1], hwaddr[2], hwaddr[3], hwaddr[4], hwaddr[5]);
+	return String(buf);
 }
 
 String AccessPointClass::getSSID()

--- a/Sming/SmingCore/Platform/Station.cpp
+++ b/Sming/SmingCore/Platform/Station.cpp
@@ -161,15 +161,11 @@ IPAddress StationClass::getIP()
 
 String StationClass::getMAC()
 {
-	String mac;
 	uint8 hwaddr[6] = {0};
 	wifi_get_macaddr(STATION_IF, hwaddr);
-	for (int i = 0; i < 6; i++)
-	{
-		if (hwaddr[i] < 0x10) mac += "0";
-		mac += String(hwaddr[i], HEX);
-	}
-	return mac;
+	char buf[20];
+	sprintf(buf, "%02x%02x%02x%02x%02x%02x", hwaddr[0], hwaddr[1], hwaddr[2], hwaddr[3], hwaddr[4], hwaddr[5]);
+	return String(buf);
 }
 
 IPAddress StationClass::getNetworkBroadcast()


### PR DESCRIPTION
Current code in Station.cpp and AccessPoint.cpp 6 times concatenates String object, effectively making copies that are later discarded. This change saves >320 bytes flash and 16 bytes RAM.