### PR TITLE
Fix mixed AP/STA in debug messages

### DIFF
--- a/Sming/SmingCore/Platform/AccessPoint.cpp
+++ b/Sming/SmingCore/Platform/AccessPoint.cpp
@@ -158,7 +158,7 @@ String AccessPointClass::getSSID()
 	softap_config config = {0};
 	if (!wifi_softap_get_config(&config))
 	{
-		debugf("Can't read station configuration!");
+		debugf("Can't read AP configuration!");
 		return "";
 	}
 	debugf("SSID: %s", (char*)config.ssid);
@@ -170,7 +170,7 @@ String AccessPointClass::getPassword()
 	softap_config config = {0};
 	if (!wifi_softap_get_config(&config))
 	{
-		debugf("Can't read station configuration!");
+		debugf("Can't read AP configuration!");
 		return "";
 	}
 	debugf("Pass: %s", (char*)config.password);

--- a/Sming/SmingCore/Platform/Station.cpp
+++ b/Sming/SmingCore/Platform/Station.cpp
@@ -218,10 +218,10 @@ bool StationClass::setIP(IPAddress address, IPAddress netmask, IPAddress gateway
 	ipinfo.netmask = netmask;
 	ipinfo.gw = gateway;
 	if (wifi_set_ip_info(STATION_IF, &ipinfo))
-		debugf("AP IP succesfully updated");
+		debugf("Station IP succesfully updated");
 	else
 	{
-		debugf("AP IP can't be updated");
+		debugf("Station IP can't be updated");
 		enableDHCP(true);
 	}
 	wifi_station_connect();


### PR DESCRIPTION
AP and STA are mixed in debug messages in both Station.cpp and AccessPoint.cpp