### PR TITLE
fix error SPI mode

### DIFF
--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -292,14 +292,14 @@ void SPIClass::prepare(SPISettings mySettings) {
  */
 void SPIClass::spi_mode(uint8 mode){
 
-	uint8 spi_cpha = mode & 0xF0;
-	uint8 spi_cpol = mode & 0x0F;
+	uint8 spi_cpha = mode & 0x0F;
+	uint8 spi_cpol = mode & 0xF0;
 
 #ifdef SPI_DEBUG
 	debugf("SPIClass::spi_mode(mode %x) spi_cpha %X,spi_cpol %X)", mode, spi_cpha, spi_cpol);
 #endif
 
-	if(spi_cpha) {
+	if(spi_cpha == spi_cpol) {
 		CLEAR_PERI_REG_MASK(SPI_USER(SPI_NO), SPI_CK_OUT_EDGE);
 	} else {
 		SET_PERI_REG_MASK(SPI_USER(SPI_NO), SPI_CK_OUT_EDGE);
@@ -495,9 +495,3 @@ void SPIClass::setFrequency(int freq) {
 	}
 
 }
-
-
-
-
-
-


### PR DESCRIPTION
I using SPI hardware simultaneously for SD Card (SPI_MODE0) and accelerometer (SPI_MODE3), in Sming 2.x and both running fine. This month I upgraded to Sming to 3.1.2 and the SD Card comms error but the accelerometer running just fine.

I suspected this happens after fix by this pull request https://github.com/SmingHub/Sming/pull/710 where `SPI_CK_OUT_EDGE` value preserved and prior to that fix, the value always 0, and my SD Card and accelerometer strangely always working. After digging the codebase I found multiple bugs related to hardware SPI, first one in SPI settings class:

SPI mode to CPHA and CPOL value:

| CPHA | CPOL | SPI MODE |
|------|------|----------|
| 0    | 0    | 0        |
| 1    | 0    | 1        |
| 0    | 1    | 2        |
| 1    | 1    | 3        |

definition of `SPI_MODE` value:

| defined macro | value defined by SPISettings class | value expected by SPI class |
|---------------|------------------------------------|-----------------------------|
| `SPI_MODE0`   | `0x00`                             | `0x00`                      |
| `SPI_MODE1`   | `0x0F`                             | `0xF0`                      |
| `SPI_MODE2`   | `0xF0`                             | `0x0F`                      |
| `SPI_MODE3`   | `0xFF`                             | `0xFF`                      |

Note that `SPI_MODE0` and `SPI_MODE3` which I use are not affected, but we still need to fix this. Even after value in SPI Settings adjusted to SPI class, the SD Card still not working. After looking to some repository and espressif sdk example, I found out that setting value mapped in `spi_mode` function are wrong, here's the table:

| Intended mode | Supplied Value | `SPI_CK_OUT_EDGE` | `SPI_IDLE_EDGE` | Actual mode |
|---------------|----------------|-------------------|-----------------|-------------|
| `SPI_MODE0`   | 0x00           | 1                 | 0               | SPI Mode 1  |
| `SPI_MODE1`   | 0xF0           | 0                 | 0               | SPI Mode 0  |
| `SPI_MODE2`   | 0x0F           | 1                 | 1               | SPI Mode 2  |
| `SPI_MODE3`   | 0xFF           | 0                 | 1               | SPI Mode 3  |

This explains why my accelerometer (SPI Mode 3) are still working, while the SD Card fail. It also explains why prior to https://github.com/SmingHub/Sming/pull/710 my code was working because `SPI_CK_OUT_EDGE` always = 0, and accidentally correct for `SPI_MODE0` and `SPI_MODE3`.