### PR TITLE
[Rel #1076] C string version of `connect()` method

### DIFF
--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -53,6 +53,14 @@ TcpClient::~TcpClient()
 	}
 }
 
+bool TcpClient::connect(const char * server, int port, boolean useSsl /* = false */, uint32_t sslOptions /* = 0 */)
+{
+	if (isProcessing()) return false;
+
+	state = eTCS_Connecting;
+	return TcpConnection::connect(server, port, useSsl, sslOptions);
+}
+
 bool TcpClient::connect(String server, int port, boolean useSsl /* = false */, uint32_t sslOptions /* = 0 */)
 {
 	if (isProcessing()) return false;

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -63,10 +63,7 @@ bool TcpClient::connect(const char * server, int port, boolean useSsl /* = false
 
 bool TcpClient::connect(String server, int port, boolean useSsl /* = false */, uint32_t sslOptions /* = 0 */)
 {
-	if (isProcessing()) return false;
-
-	state = eTCS_Connecting;
-	return TcpConnection::connect(server.c_str(), port, useSsl, sslOptions);
+	return TcpClient::connect(server.c_str(), port, useSsl, sslOptions);
 }
 
 bool TcpClient::connect(IPAddress addr, uint16_t port, boolean useSsl /* = false */, uint32_t sslOptions /* = 0 */)

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -44,6 +44,7 @@ public:
 
 public:
 	virtual bool connect(String server, int port, boolean useSsl = false, uint32_t sslOptions = 0);
+	virtual bool connect(const char * server, int port, boolean useSsl = false, uint32_t sslOptions = 0);
 	virtual bool connect(IPAddress addr, uint16_t port, boolean useSsl = false, uint32_t sslOptions = 0);
 	virtual void close();
 


### PR DESCRIPTION
I did not touch existing `connect()` that takes `String` but it calls `TcpConnection::connect()` with C string as argument already.