### PR TITLE
[Rel #1076] make `String` arg in constructor a const reference

### DIFF
--- a/Sming/SmingCore/Network/URL.cpp
+++ b/Sming/SmingCore/Network/URL.cpp
@@ -14,7 +14,7 @@ URL::URL()
 	Port = 80;
 }
 
-URL::URL(String urlString)
+URL::URL(const String& urlString)
 {
 	int len = urlString.length();
 	if (len == 0)

--- a/Sming/SmingCore/Network/URL.h
+++ b/Sming/SmingCore/Network/URL.h
@@ -18,7 +18,7 @@ class URL
 {
 public:
 	URL();
-	URL(String urlString);
+	URL(const String& urlString);
 
 	inline String toString() { return Protocol + "://" + Host + (Port != 0 ? ":" + String(Port) : "") + getPathWithQuery(); }
 	inline String getPathWithQuery() { if (Path.length() + Query.length() > 0) return Path + Query; else return "/"; }


### PR DESCRIPTION
This prevents making unneccessary copy of `String` object that is not changed anywhere in code.