### PR TITLE
PROGMEM methods for Print.cpp

### DIFF
--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -26,6 +26,8 @@
 
 #define INITIAL_PRINTF_BUFFSIZE 128
 
+#undef printf_P
+
 class String;
 
 class Print
@@ -85,8 +87,15 @@ class Print
     size_t println(const String &s);
 
     // printf
-    size_t printf(const char *fmt, ...);
+	size_t	vprintf(const char *, va_list va);
+    size_t 	printf(const char *fmt, ...);
 
+	// progmem
+	size_t	write_P(const char* data, size_t size);
+	size_t	write_P(const char* data);
+	size_t	printf_P(const char* data, ...);
+	size_t	vprintf_P(const char *, va_list va);
+	
   private:
     int write_error;
     size_t printNumber(unsigned long, uint8_t);

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -33,7 +33,7 @@ class String;
 class Print
 {
   public:
-	Print() : write_error(0) {}
+    Print() : write_error(0) {}
   
     int getWriteError() { return write_error; }
     void clearWriteError() { setWriteError(0); }
@@ -87,15 +87,15 @@ class Print
     size_t println(const String &s);
 
     // printf
-	size_t	vprintf(const char *, va_list va);
-    size_t 	printf(const char *fmt, ...);
+    size_t  vprintf(const char *, va_list va);
+    size_t  printf(const char *fmt, ...);
 
-	// progmem
-	size_t	write_P(const char* data, size_t size);
-	size_t	write_P(const char* data);
-	size_t	printf_P(const char* data, ...);
-	size_t	vprintf_P(const char *, va_list va);
-	
+    // progmem
+    size_t  write_P(const char* data, size_t size);
+    size_t  write_P(const char* data);
+    size_t  printf_P(const char* data, ...);
+    size_t  vprintf_P(const char *, va_list va);
+    
   private:
     int write_error;
     size_t printNumber(unsigned long, uint8_t);


### PR DESCRIPTION
* missing PROGMEM methods for class Print added
* dynamic stack allocation for _printf_ moved to new method _vprintf_ 

However, I have no idea how to fix the conflict with the new macro _printf_P_ in FakePgmSpace.h :-(

(see #1067)