### PR TITLE
m_printf: PROGMEM support added

### DIFF
--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -116,7 +116,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
 	};
 
 	while (*fmt) {
-		//	copy verbatim text
+		//	copy verbatim text 
 		if (*fmt != '%')  {
 			add(*fmt++);
 			continue;
@@ -124,29 +124,25 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
 		fmt++;
 
 		const char*	s;							// source for string copy
-		char	tempNum[40];					// buffer for number conversion
-
+		char 	tempNum[40];					// buffer for number conversion
+		
 		//	reset attributes to defaults
 		bool	minus		= 0;
-		uint8_t	base		= 10;
-		int8_t	precision	= -1;
-		int8_t	width		= 0;
-		char	pad			= ' ';
-
-		//	process flags
-	DO_FLAGS:
-		switch (*fmt) {
-			case '-':
-				minus = 1;
-
-			case '+':
-			case ' ':
-			case '#':
-				fmt++;
-				goto DO_FLAGS;
+		uint8_t	base 		= 10;
+		int8_t	precision 	= -1;
+		int8_t	width 		= 0;
+		char	pad 		= ' ';
+		
+		while (char f = *fmt) {
+			if (f == '-')			minus = 1;
+			else if (f == '+')		;			// ignored
+			else if (f == ' ')		;			// ignored
+			else if (f == '#')		;			// ignored
+			else 					break;
+			fmt++;
 		}
 
-		//	process padding
+		//	process padding 
 		if (*fmt == '0') {
 			pad = '0';
 			fmt++;
@@ -157,21 +153,21 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
 			width = skip_atoi(&fmt);
 		}
 
-		//	process precision
+		// 	process precision
 		if( *fmt == '.' ) {
 			fmt++;
 			if ( is_digit(*fmt) ) precision = skip_atoi(&fmt);
 		}
-
-		//	ignore length
+		
+		//	ignore length 
 		while (*fmt == 'l' || *fmt == 'h' || *fmt == 'L') fmt++;
-
-		//	process type
+		
+		//	process type	
 		switch (char f = *fmt++) {
 			case '%':
 				add('%');
 				continue;
-
+			
 			case 'c':
 				add( (unsigned char) va_arg(args, int) );
 				continue;
@@ -185,23 +181,23 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
 
 				int padding = width - len;
 				while (!minus && padding-- > 0) add(' ');
-				while (len--)					add(*s++);
-				while (minus && padding-- > 0)	add(' ');
+				while (len--) 					add(*s++);
+				while (minus && padding-- > 0) 	add(' ');
 				continue;
-			}
+			}    
 
 			case 'p':
 				s = ultoa((unsigned long) va_arg(args, void *), tempNum, 16);
-				goto COPY;
+				break;
 
 			case 'd':
 			case 'i':
 				s = ltoa_wp(va_arg(args, int), tempNum, base, width, pad);
-				goto COPY;
+				break;
 
 			case 'f':
 				s = dtostrf_p(va_arg(args, double), width, precision, tempNum, pad);
-				goto COPY;
+				break;
 
 			case 'o':
 				base = 8;
@@ -210,21 +206,22 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
 			case 'x':
 			case 'X':
 				base = 16;
-				goto UNSIGNED;
 
 			case 'u':
 			UNSIGNED:
 				s = ultoa_wp(va_arg(args, unsigned int), tempNum, base, width, pad);
-
-			COPY:
-				while (*s) add(*s++);
-				break;
+				break;	
 
 			default:
 				add('%');
 				add(f);
+				continue;
 		}
+		
+		//	copy string to target
+		while (*s) add(*s++);
 	}
 	*buf = 0;
 	return size;
 }
+

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -11,8 +11,6 @@ Descr: embedded very simple version of printf with float support
 
 #define MPRINTF_BUF_SIZE 256
 
-#define OVERFLOW_GUARD 24
-
 static void defaultPrintChar(uart_t *uart, char c) {
 	return uart_tx_one_char(c);
 }
@@ -20,11 +18,7 @@ static void defaultPrintChar(uart_t *uart, char c) {
 void (*cbc_printchar)(uart_t *, char) = defaultPrintChar;
 uart_t *cbc_printchar_uart = NULL;
 
-#define SIGN    	(1<<1)	/* Unsigned/signed long */
-
 #define is_digit(c) ((c) >= '0' && (c) <= '9')
-
-#define MIN(a, b)   ( (a) < (b) ? (a) : (b) )
 
 static int skip_atoi(const char **s)
 {
@@ -115,145 +109,122 @@ int m_printf(const char* fmt, ...)
 	return n;
 }
 
-int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
-{
-	int i, base, flags;
-	char *str;
-	const char *s;
-	int8_t precision, width;
-	char pad;
+int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
+	size_t size = 0;
+	auto add = [&](char c) {
+		if (++size < maxLen) *buf++ = c;
+	};
 
-	char tempNum[40];
-
-	for (str = buf; *fmt; fmt++)
-	{
-		if(maxLen - (uint32_t)(str - buf) < OVERFLOW_GUARD)
-		{
-			*str++ = '(';
-			*str++ = '.';
-			*str++ = '.';
-			*str++ = '.';
-			*str++ = ')';
-
-			//mark end of string
-			*str = '\0';
-
-			//return maximum buffer len, so caller can detect not_enough_space
-			return maxLen;
-		}
-
-		if (*fmt != '%')
-		{
-			*str++ = *fmt;
+	while (*fmt) {
+		//	copy verbatim text
+		if (*fmt != '%')  {
+			add(*fmt++);
 			continue;
 		}
+		fmt++;
 
-		flags = 0;
-		fmt++; // This skips first '%'
+		const char*	s;							// source for string copy
+		char	tempNum[40];					// buffer for number conversion
 
-		//reset attributes to defaults
-		precision = -1;
-		width = 0;
-		pad = ' ';
-		base = 10;
-        bool minus = 0;
+		//	reset attributes to defaults
+		bool	minus		= 0;
+		uint8_t	base		= 10;
+		int8_t	precision	= -1;
+		int8_t	width		= 0;
+		char	pad			= ' ';
 
-		do
-		{
-            if ('-' == *fmt) minus = 1, fmt++;
-            
-			//skip width and flags data - not supported
-			while ('+' == *fmt || '#' == *fmt || '*' == *fmt || 'l' == *fmt)
+		//	process flags
+	DO_FLAGS:
+		switch (*fmt) {
+			case '-':
+				minus = 1;
+
+			case '+':
+			case ' ':
+			case '#':
 				fmt++;
+				goto DO_FLAGS;
+		}
 
-			if (is_digit(*fmt)) {
-				if (*fmt == '0') {
-					pad = '0';
-					fmt++;
-				}
-				width = skip_atoi(&fmt);
+		//	process padding
+		if (*fmt == '0') {
+			pad = '0';
+			fmt++;
+		}
+
+		//	process width ('*' is not supported yet)
+		if ( is_digit(*fmt) ) {
+			width = skip_atoi(&fmt);
+		}
+
+		//	process precision
+		if( *fmt == '.' ) {
+			fmt++;
+			if ( is_digit(*fmt) ) precision = skip_atoi(&fmt);
+		}
+
+		//	ignore length
+		while (*fmt == 'l' || *fmt == 'h' || *fmt == 'L') fmt++;
+
+		//	process type
+		switch (char f = *fmt++) {
+			case '%':
+				add('%');
+				continue;
+
+			case 'c':
+				add( (unsigned char) va_arg(args, int) );
+				continue;
+
+			case 's': {
+				s = va_arg(args, char *);
+
+				if (!s) s = "(null)";
+				size_t len = strlen(s);
+				if (len > precision) len = precision;
+
+				int padding = width - len;
+				while (!minus && padding-- > 0) add(' ');
+				while (len--)					add(*s++);
+				while (minus && padding-- > 0)	add(' ');
+				continue;
 			}
 
-			if('.' == *fmt)
-			{
-				fmt++;
-				if (is_digit(*fmt))
-					precision = skip_atoi(&fmt);
-			}
-			else
+			case 'p':
+				s = ultoa((unsigned long) va_arg(args, void *), tempNum, 16);
+				goto COPY;
+
+			case 'd':
+			case 'i':
+				s = ltoa_wp(va_arg(args, int), tempNum, base, width, pad);
+				goto COPY;
+
+			case 'f':
+				s = dtostrf_p(va_arg(args, double), width, precision, tempNum, pad);
+				goto COPY;
+
+			case 'o':
+				base = 8;
+				goto UNSIGNED;
+
+			case 'x':
+			case 'X':
+				base = 16;
+				goto UNSIGNED;
+
+			case 'u':
+			UNSIGNED:
+				s = ultoa_wp(va_arg(args, unsigned int), tempNum, base, width, pad);
+
+			COPY:
+				while (*s) add(*s++);
 				break;
-		}while(1);
 
-		switch (*fmt)
-		{
-		case 'c':
-			*str++ = (unsigned char) va_arg(args, int);
-			continue;
-
-		case 's': {
-			s = va_arg(args, char *);
-
-			if (!s) s = "(null)";
-            size_t len = strlen(s);
-            len     = MIN( len,   precision );
-            len     = MIN( len,   maxLen - size_t(str - buf) - OVERFLOW_GUARD);
-            width   = MIN( width, maxLen - size_t(str - buf) - OVERFLOW_GUARD);
-
-            int padding = width - len;
-            while (!minus && padding-- > 0) *str++ = ' ';
-            while (len--) *str++ = *s++;
-            while (minus && padding-- > 0) *str++ = ' ';
-
-			continue;
-        }    
-
-		case 'p':
-			s = ultoa((unsigned long) va_arg(args, void *), tempNum, 16);
-			while (*s && (maxLen - (uint32_t)(str - buf) > OVERFLOW_GUARD))
-				*str++ = *s++;
-			continue;
-
-		case 'o':
-			base = 8;
-			break;
-
-		case 'x':
-		case 'X':
-			base = 16;
-			break;
-
-		case 'd':
-		case 'i':
-			flags |= SIGN;
-		case 'u':
-			break;
-
-		case 'f':
-
-			s = dtostrf_p(va_arg(args, double), width, precision, tempNum, pad);
-			while (*s && (maxLen - (uint32_t)(str - buf) > OVERFLOW_GUARD))
-				*str++ = *s++;
-			continue;
-
-		default:
-			if (*fmt != '%')
-				*str++ = '%';
-			if (*fmt)
-				*str++ = *fmt;
-			else
-				--fmt;
-			continue;
+			default:
+				add('%');
+				add(f);
 		}
-
-		if (flags & SIGN)
-			s = ltoa_wp(va_arg(args, int), tempNum, base, width, pad);
-		else
-			s = ultoa_wp(va_arg(args, unsigned int), tempNum, base, width, pad);
-
-		while (*s && (maxLen - (uint32_t)(str - buf) > OVERFLOW_GUARD))
-			*str++ = *s++;
 	}
-
-	*str = '\0';
-	return str - buf;
+	*buf = 0;
+	return size;
 }

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -128,7 +128,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
 
         //  reset attributes to defaults
         bool    minus       = 0;
-        uint8_t base        = 10;
+        uint8_t ubase       = 0;
         int8_t  precision   = -1;
         int8_t  width       = 0;
         char    pad         = ' ';
@@ -177,7 +177,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
 
                 if (!s) s = "(null)";
                 size_t len = strlen(s);
-                if (len > precision) len = precision;
+                len     = MIN( len,   precision );
 
                 int padding = width - len;
                 while (!minus && padding-- > 0) add(' ');
@@ -192,7 +192,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
 
             case 'd':
             case 'i':
-                s = ltoa_wp(va_arg(args, int), tempNum, base, width, pad);
+                s = ltoa_wp(va_arg(args, int), tempNum, 10, width, pad);
                 break;
 
             case 'f':
@@ -200,16 +200,16 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
                 break;
 
             case 'o':
-                base = 8;
-                goto UNSIGNED;
+                ubase = 8;
+                break;
 
             case 'x':
             case 'X':
-                base = 16;
+                ubase = 16;
+                break;
 
             case 'u':
-            UNSIGNED:
-                s = ultoa_wp(va_arg(args, unsigned int), tempNum, base, width, pad);
+                ubase = 10;
                 break;
 
             default:
@@ -218,10 +218,12 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
                 continue;
         }
 
+        //  format unsigned numbers
+        if (ubase) s = ultoa_wp(va_arg(args, unsigned int), tempNum, ubase, width, pad);
+
         //  copy string to target
         while (*s) add(*s++);
     }
     *buf = 0;
     return size;
 }
-

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -12,7 +12,7 @@ Descr: embedded very simple version of printf with float support
 #define MPRINTF_BUF_SIZE 256
 
 static void defaultPrintChar(uart_t *uart, char c) {
-    return uart_tx_one_char(c);
+	return uart_tx_one_char(c);
 }
 
 void (*cbc_printchar)(uart_t *, char) = defaultPrintChar;
@@ -22,22 +22,22 @@ uart_t *cbc_printchar_uart = NULL;
 
 static int skip_atoi(const char **s)
 {
-    int i = 0;
-    while (is_digit(**s))
-        i = i * 10 + *((*s)++) - '0';
-    return i;
+	int i = 0;
+	while (is_digit(**s))
+		i = i * 10 + *((*s)++) - '0';
+	return i;
 }
 
 void setMPrintfPrinterCbc(void (*callback)(uart_t *, char), uart_t *uart)
 {
-    cbc_printchar = callback;
-    cbc_printchar_uart = uart;
+	cbc_printchar = callback;
+	cbc_printchar_uart = uart;
 }
 
 void m_putc(char c)
 {
-    if (cbc_printchar)
-        cbc_printchar(cbc_printchar_uart, c);
+	if (cbc_printchar)
+		cbc_printchar(cbc_printchar_uart, c);
 }
 
 /**
@@ -51,38 +51,38 @@ void m_putc(char c)
  */
 int m_snprintf(char* buf, int length, const char *fmt, ...)
 {
-    char *p;
-    va_list args;
-    int n = 0;
+	char *p;
+	va_list args;
+	int n = 0;
 
-    va_start(args, fmt);
-    n = m_vsnprintf(buf, length, fmt, args);
-    va_end(args);
+	va_start(args, fmt);
+	n = m_vsnprintf(buf, length, fmt, args);
+	va_end(args);
 
-    return n;
+	return n;
 }
 
 int m_vprintf ( const char * format, va_list arg )
 {
-    if(!cbc_printchar)
-    {
-        return 0;
-    }
+	if(!cbc_printchar)
+	{
+		return 0;
+	}
 
-    char buf[MPRINTF_BUF_SIZE], *p;
+	char buf[MPRINTF_BUF_SIZE], *p;
 
-    int n = 0;
-    m_vsnprintf(buf, sizeof(buf), format, arg);
+	int n = 0;
+	m_vsnprintf(buf, sizeof(buf), format, arg);
 
-    p = buf;
-    while (p && n < sizeof(buf) && *p)
-    {
-        cbc_printchar(cbc_printchar_uart, *p);
-        n++;
-        p++;
-    }
+	p = buf;
+	while (p && n < sizeof(buf) && *p)
+	{
+		cbc_printchar(cbc_printchar_uart, *p);
+		n++;
+		p++;
+	}
 
-    return n;
+	return n;
 }
 
 /**
@@ -94,22 +94,23 @@ int m_vprintf ( const char * format, va_list arg )
  */
 int m_printf(const char* fmt, ...)
 {
-    int n=0;
+	int n=0;
 
-    if(!fmt)
-        return 0;
+	if(!fmt)
+		return 0;
 
-    va_list args;
-    va_start(args, fmt);
+	va_list args;
+	va_start(args, fmt);
 
-    n = m_vprintf(fmt, args);
+	n = m_vprintf(fmt, args);
 
-    va_end(args);
+	va_end(args);
 
-    return n;
+	return n;
 }
 
-int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
+int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
+{
     size_t size = 0;
     auto add = [&](char c) {
         if (++size < maxLen) *buf++ = c;

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -177,7 +177,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
 
                 if (!s) s = "(null)";
                 size_t len = strlen(s);
-                len     = MIN( len,   precision );
+                if (len > precision) len = precision;
 
                 int padding = width - len;
                 while (!minus && padding-- > 0) add(' ');

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -12,7 +12,7 @@ Descr: embedded very simple version of printf with float support
 #define MPRINTF_BUF_SIZE 256
 
 static void defaultPrintChar(uart_t *uart, char c) {
-	return uart_tx_one_char(c);
+    return uart_tx_one_char(c);
 }
 
 void (*cbc_printchar)(uart_t *, char) = defaultPrintChar;
@@ -22,22 +22,22 @@ uart_t *cbc_printchar_uart = NULL;
 
 static int skip_atoi(const char **s)
 {
-	int i = 0;
-	while (is_digit(**s))
-		i = i * 10 + *((*s)++) - '0';
-	return i;
+    int i = 0;
+    while (is_digit(**s))
+        i = i * 10 + *((*s)++) - '0';
+    return i;
 }
 
 void setMPrintfPrinterCbc(void (*callback)(uart_t *, char), uart_t *uart)
 {
-	cbc_printchar = callback;
-	cbc_printchar_uart = uart;
+    cbc_printchar = callback;
+    cbc_printchar_uart = uart;
 }
 
 void m_putc(char c)
 {
-	if (cbc_printchar)
-		cbc_printchar(cbc_printchar_uart, c);
+    if (cbc_printchar)
+        cbc_printchar(cbc_printchar_uart, c);
 }
 
 /**
@@ -51,38 +51,38 @@ void m_putc(char c)
  */
 int m_snprintf(char* buf, int length, const char *fmt, ...)
 {
-	char *p;
-	va_list args;
-	int n = 0;
+    char *p;
+    va_list args;
+    int n = 0;
 
-	va_start(args, fmt);
-	n = m_vsnprintf(buf, length, fmt, args);
-	va_end(args);
+    va_start(args, fmt);
+    n = m_vsnprintf(buf, length, fmt, args);
+    va_end(args);
 
-	return n;
+    return n;
 }
 
 int m_vprintf ( const char * format, va_list arg )
 {
-	if(!cbc_printchar)
-	{
-		return 0;
-	}
+    if(!cbc_printchar)
+    {
+        return 0;
+    }
 
-	char buf[MPRINTF_BUF_SIZE], *p;
+    char buf[MPRINTF_BUF_SIZE], *p;
 
-	int n = 0;
-	m_vsnprintf(buf, sizeof(buf), format, arg);
+    int n = 0;
+    m_vsnprintf(buf, sizeof(buf), format, arg);
 
-	p = buf;
-	while (p && n < sizeof(buf) && *p)
-	{
-		cbc_printchar(cbc_printchar_uart, *p);
-		n++;
-		p++;
-	}
+    p = buf;
+    while (p && n < sizeof(buf) && *p)
+    {
+        cbc_printchar(cbc_printchar_uart, *p);
+        n++;
+        p++;
+    }
 
-	return n;
+    return n;
 }
 
 /**
@@ -94,134 +94,134 @@ int m_vprintf ( const char * format, va_list arg )
  */
 int m_printf(const char* fmt, ...)
 {
-	int n=0;
+    int n=0;
 
-	if(!fmt)
-		return 0;
+    if(!fmt)
+        return 0;
 
-	va_list args;
-	va_start(args, fmt);
+    va_list args;
+    va_start(args, fmt);
 
-	n = m_vprintf(fmt, args);
+    n = m_vprintf(fmt, args);
 
-	va_end(args);
+    va_end(args);
 
-	return n;
+    return n;
 }
 
 int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args) {
-	size_t size = 0;
-	auto add = [&](char c) {
-		if (++size < maxLen) *buf++ = c;
-	};
+    size_t size = 0;
+    auto add = [&](char c) {
+        if (++size < maxLen) *buf++ = c;
+    };
 
-	while (*fmt) {
-		//	copy verbatim text 
-		if (*fmt != '%')  {
-			add(*fmt++);
-			continue;
-		}
-		fmt++;
+    while (*fmt) {
+        //  copy verbatim text
+        if (*fmt != '%')  {
+            add(*fmt++);
+            continue;
+        }
+        fmt++;
 
-		const char*	s;							// source for string copy
-		char 	tempNum[40];					// buffer for number conversion
-		
-		//	reset attributes to defaults
-		bool	minus		= 0;
-		uint8_t	base 		= 10;
-		int8_t	precision 	= -1;
-		int8_t	width 		= 0;
-		char	pad 		= ' ';
-		
-		while (char f = *fmt) {
-			if (f == '-')			minus = 1;
-			else if (f == '+')		;			// ignored
-			else if (f == ' ')		;			// ignored
-			else if (f == '#')		;			// ignored
-			else 					break;
-			fmt++;
-		}
+        const char* s;                          // source for string copy
+        char    tempNum[40];                    // buffer for number conversion
 
-		//	process padding 
-		if (*fmt == '0') {
-			pad = '0';
-			fmt++;
-		}
+        //  reset attributes to defaults
+        bool    minus       = 0;
+        uint8_t base        = 10;
+        int8_t  precision   = -1;
+        int8_t  width       = 0;
+        char    pad         = ' ';
 
-		//	process width ('*' is not supported yet)
-		if ( is_digit(*fmt) ) {
-			width = skip_atoi(&fmt);
-		}
+        while (char f = *fmt) {
+            if (f == '-')           minus = 1;
+            else if (f == '+')      ;           // ignored
+            else if (f == ' ')      ;           // ignored
+            else if (f == '#')      ;           // ignored
+            else                    break;
+            fmt++;
+        }
 
-		// 	process precision
-		if( *fmt == '.' ) {
-			fmt++;
-			if ( is_digit(*fmt) ) precision = skip_atoi(&fmt);
-		}
-		
-		//	ignore length 
-		while (*fmt == 'l' || *fmt == 'h' || *fmt == 'L') fmt++;
-		
-		//	process type	
-		switch (char f = *fmt++) {
-			case '%':
-				add('%');
-				continue;
-			
-			case 'c':
-				add( (unsigned char) va_arg(args, int) );
-				continue;
+        //  process padding
+        if (*fmt == '0') {
+            pad = '0';
+            fmt++;
+        }
 
-			case 's': {
-				s = va_arg(args, char *);
+        //  process width ('*' is not supported yet)
+        if ( is_digit(*fmt) ) {
+            width = skip_atoi(&fmt);
+        }
 
-				if (!s) s = "(null)";
-				size_t len = strlen(s);
-				if (len > precision) len = precision;
+        //  process precision
+        if( *fmt == '.' ) {
+            fmt++;
+            if ( is_digit(*fmt) ) precision = skip_atoi(&fmt);
+        }
 
-				int padding = width - len;
-				while (!minus && padding-- > 0) add(' ');
-				while (len--) 					add(*s++);
-				while (minus && padding-- > 0) 	add(' ');
-				continue;
-			}    
+        //  ignore length
+        while (*fmt == 'l' || *fmt == 'h' || *fmt == 'L') fmt++;
 
-			case 'p':
-				s = ultoa((unsigned long) va_arg(args, void *), tempNum, 16);
-				break;
+        //  process type
+        switch (char f = *fmt++) {
+            case '%':
+                add('%');
+                continue;
 
-			case 'd':
-			case 'i':
-				s = ltoa_wp(va_arg(args, int), tempNum, base, width, pad);
-				break;
+            case 'c':
+                add( (unsigned char) va_arg(args, int) );
+                continue;
 
-			case 'f':
-				s = dtostrf_p(va_arg(args, double), width, precision, tempNum, pad);
-				break;
+            case 's': {
+                s = va_arg(args, char *);
 
-			case 'o':
-				base = 8;
-				goto UNSIGNED;
+                if (!s) s = "(null)";
+                size_t len = strlen(s);
+                if (len > precision) len = precision;
 
-			case 'x':
-			case 'X':
-				base = 16;
+                int padding = width - len;
+                while (!minus && padding-- > 0) add(' ');
+                while (len--)                   add(*s++);
+                while (minus && padding-- > 0)  add(' ');
+                continue;
+            }
 
-			case 'u':
-			UNSIGNED:
-				s = ultoa_wp(va_arg(args, unsigned int), tempNum, base, width, pad);
-				break;	
+            case 'p':
+                s = ultoa((unsigned long) va_arg(args, void *), tempNum, 16);
+                break;
 
-			default:
-				add('%');
-				add(f);
-				continue;
-		}
-		
-		//	copy string to target
-		while (*s) add(*s++);
-	}
-	*buf = 0;
-	return size;
+            case 'd':
+            case 'i':
+                s = ltoa_wp(va_arg(args, int), tempNum, base, width, pad);
+                break;
+
+            case 'f':
+                s = dtostrf_p(va_arg(args, double), width, precision, tempNum, pad);
+                break;
+
+            case 'o':
+                base = 8;
+                goto UNSIGNED;
+
+            case 'x':
+            case 'X':
+                base = 16;
+
+            case 'u':
+            UNSIGNED:
+                s = ultoa_wp(va_arg(args, unsigned int), tempNum, base, width, pad);
+                break;
+
+            default:
+                add('%');
+                add(f);
+                continue;
+        }
+
+        //  copy string to target
+        while (*s) add(*s++);
+    }
+    *buf = 0;
+    return size;
 }
 


### PR DESCRIPTION
(moved from #1077 to a new PR)

* support for format and data strings in PROGMEM added
* format specifier '%S' added for compatibility (behaves like '%s)
* _m_vprintf_ now allocates less memory on the stack unless it is actually required

There is no longer a need for separate *_P methods, this should make it easier to solve the conflicts created by the macro _printf_P_ in FakePgmSpace.h.

_Q: If you read every byte using pgm_read_byte that will cause overhead. Is that really needed in a very core component? What are the advantages?_

You a right, this will make every call to *printf a tiny bit slower. The code size is almost identical. I see the following advantages:

- it will reduce total flash size and complexity as a many additional methods are no longer needed
- all classes and methods using _m_printf_ will benefit immediately
- life will be much easier for users as they do not need to care which method to call and which format specifier to use
- format strings should go to flashmem anyway to reduce ram size 
- it is faster and uses less memory than the existing implementation for format strings in flashmem
- printf is mostly used for serial output where execution speed does not matter that much
- for time critical operations direct c string manipulation should be used instead of the printf functions

IMHO the main advantage is that it eliminated a major pitfall for users working with progmem.
