### PR TITLE
Mount spiffs or file operations on index.html fail miserably

### DIFF
--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -107,6 +107,8 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
+	spiffs_mount();
+
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(true);
 	WifiAccessPoint.enable(false);


### PR DESCRIPTION
The code later tries to access file `index.html` and fails with `open errno -10024` (fileExists) and `write errno -10024` (fileSetContent) if spiffs is not mounted.