### PR TITLE
DriverPWM(aka software PWM) is deprecated and will be removed in …

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -196,6 +196,7 @@ endif
 
 # libraries used in this project, mainly provided by the SDK
 LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa main
+# WARNING: In the next versions ENABLE_CUSTOM_PWM will be set to 1 by default
 ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	THIRD_PARTY_DATA += third-party/pwm/pwm.c
 endif

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -196,6 +196,7 @@ ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 endif
 
 LIBPWM = pwm
+# WARNING: In the next versions ENABLE_CUSTOM_PWM will be set to 1 by default
 ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	LIBPWM = pwm_open
 	CUSTOM_TARGETS += $(USER_LIBDIR)/lib$(LIBPWM).a

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -244,6 +244,7 @@ ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 endif
 
 LIBPWM = pwm
+# WARNING: In the next versions ENABLE_CUSTOM_PWM will be set to 1 by default
 ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	LIBPWM = pwm_open
 	CUSTOM_TARGETS += $(USER_LIBDIR)/lib$(LIBPWM).a

--- a/Sming/SmingCore/DriverPWM.h
+++ b/Sming/SmingCore/DriverPWM.h
@@ -20,7 +20,10 @@
 
 class ChannelPWM;
 
-/// Pulse width modulator driver class
+/**
+ * @brief Pulse width modulator driver class
+ * @deprecated DriverPWM is deprecated and will be removed in the near future. Use HardwarePWM instead.
+ */
 class DriverPWM
 {
 public:

--- a/samples/Basic_PWM/app/application.cpp
+++ b/samples/Basic_PWM/app/application.cpp
@@ -1,6 +1,15 @@
 #include <user_config.h>
 #include <SmingCore/SmingCore.h>
 
+
+/**
+ * WARNING:
+ *
+ * DriverPWM is deprecated and will be removed in the near future. Use HardwarePWM instead.
+ * For an example with HardwarePWM take a look at samples/Basic_HwPWM
+ *
+ */
+
 #define LED_PIN 12 // GPIO12
 
 DriverPWM ledPWM;


### PR DESCRIPTION
…the next versions.

HardwarePWM will use by default Stefan Bruens PWM library in the next versions.

Related to #1057.