### PR TITLE
Copy file content buffer using explicit size parameter to String constructor

### DIFF
--- a/Sming/SmingCore/FileSystem.cpp
+++ b/Sming/SmingCore/FileSystem.cpp
@@ -171,7 +171,7 @@ String fileGetContent(const String fileName)
 	buffer[size] = 0;
 	fileRead(file, buffer, size);
 	fileClose(file);
-	String res = buffer;
+	String res(buffer, size);
 	delete[] buffer;
 	return res;
 }


### PR DESCRIPTION
Fixes the issue in FileSystem.fileGetContent() where a file buffer is only read into a String until the first null byte, making it impossible to use binary files.

See Sming issue #1104 