### PR TITLE
Multiple improvements to the TCP handling.

### DIFF
--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -13,10 +13,6 @@
 #include "../Wiring/WString.h"
 #include "../Wiring/IPAddress.h"
 
-#ifdef ENABLE_SSL
-#include "../Clock.h"
-#endif
-
 TcpConnection::TcpConnection(bool autoDestruct) : autoSelfDestruct(autoDestruct), sleep(0), canSend(true), timeOut(70)
 {
 
@@ -428,7 +424,21 @@ err_t TcpConnection::staticOnConnected(void *arg, tcp_pcb *tcp, err_t err)
 				}
 			}
 
-			con->ssl = ssl_client_new(con->sslContext, clientfd, NULL, 0, con->ssl_ext);
+			debugf("SSL: Session Id Length: %d", (con->sslSessionId != NULL ? con->sslSessionId->length: 0));
+			if(con->sslSessionId != NULL &&  con->sslSessionId->length > 0) {
+				debugf("-----BEGIN SSL SESSION PARAMETERS-----");
+				for (int i = 0; i <  con->sslSessionId->length; i++) {
+					m_printf("%02x", con->sslSessionId->value[i]);
+				}
+
+				debugf("\n-----END SSL SESSION PARAMETERS-----");
+			}
+
+			con->ssl = ssl_client_new(con->sslContext, clientfd,
+									 	 (con->sslSessionId != NULL ? con->sslSessionId->value : NULL),
+										 (con->sslSessionId != NULL ? con->sslSessionId->length: 0),
+										 con->ssl_ext
+									 );
 			if(ssl_handshake_status(con->ssl)!=SSL_OK) {
 				debugf("SSL: handshake is in progress...");
 				return SSL_OK;
@@ -438,6 +448,14 @@ err_t TcpConnection::staticOnConnected(void *arg, tcp_pcb *tcp, err_t err)
 			debugf("SSL: Switching back 80 MHz");
 			System.setCpuFrequency(eCF_80MHz);
 #endif
+			if(con->sslSessionId) {
+				if(con->sslSessionId->value == NULL) {
+					con->sslSessionId->value = new uint8_t[SSL_SESSION_ID_SIZE];
+				}
+				memcpy((void *)con->sslSessionId->value, (void *)con->ssl->session_id, con->ssl->sess_id_size);
+				con->sslSessionId->length = con->ssl->sess_id_size;
+			}
+
 		}
 	}
 #endif
@@ -525,20 +543,39 @@ err_t TcpConnection::staticOnReceive(void *arg, tcp_pcb *tcp, pbuf *p, err_t err
 				debugf("SSL: Switching back to 80 MHz");
 				System.setCpuFrequency(eCF_80MHz); // Preserve some CPU cycles
 #endif
-				if(con->sslFingerprint.certSha1 && ssl_match_fingerprint(con->ssl, con->sslFingerprint.certSha1) != SSL_OK) {
-					debugf("SSL: Certificate fingerprint does not match!");
+
+				bool hasError = false;
+				do {
+					if(con->sslFingerprint.certSha1 && ssl_match_fingerprint(con->ssl, con->sslFingerprint.certSha1) != SSL_OK) {
+						debugf("SSL: Certificate fingerprint does not match!");
+						hasError = true;
+						break;
+					}
+
+					if(con->sslFingerprint.pkSha256 && ssl_match_spki_sha256(con->ssl, con->sslFingerprint.pkSha256) != SSL_OK) {
+						debugf("SSL: Certificate PK fingerprint does not match!");
+						hasError = true;
+						break;
+					}
+				} while(0);
+
+				if(con->freeFingerprints) {
+					con->freeSslFingerprints();
+				}
+
+				if(hasError) {
 					con->close();
 					closeTcpConnection(tcp);
 
 					return ERR_ABRT;
 				}
 
-				if(con->sslFingerprint.pkSha256 && ssl_match_spki_sha256(con->ssl, con->sslFingerprint.pkSha256) != SSL_OK) {
-					debugf("SSL: Certificate PK fingerprint does not match!");
-					con->close();
-					closeTcpConnection(tcp);
-
-					return ERR_ABRT;
+				if(con->sslSessionId) {
+					if(con->sslSessionId->value == NULL) {
+						con->sslSessionId->value = new uint8_t[SSL_SESSION_ID_SIZE];
+					}
+					memcpy((void *)con->sslSessionId->value, (void *)con->ssl->session_id, con->ssl->sess_id_size);
+					con->sslSessionId->length = con->ssl->sess_id_size;
 				}
 
 				err_t res = con->onConnected(err);
@@ -652,7 +689,7 @@ void TcpConnection::addSslOptions(uint32_t sslOptions) {
 	this->sslOptions |= sslOptions;
 }
 
-bool TcpConnection::pinCertificate(const uint8_t *fingerprint, SslFingerprintType type) {
+bool TcpConnection::pinCertificate(const uint8_t *fingerprint, SslFingerprintType type, bool freeAfterHandshake /* = false */) {
 	int length = 0;
 	uint8_t *localStore;
 
@@ -673,6 +710,7 @@ bool TcpConnection::pinCertificate(const uint8_t *fingerprint, SslFingerprintTyp
 		return false;
 	}
 
+	freeFingerprints = freeAfterHandshake;
 
 	if(localStore) {
 		delete[] localStore;
@@ -694,6 +732,12 @@ bool TcpConnection::pinCertificate(const uint8_t *fingerprint, SslFingerprintTyp
 	}
 
 
+	return true;
+}
+
+bool TcpConnection::pinCertificate(SSLFingerprints fingerprints, bool freeAfterHandshake /* = false */) {
+	sslFingerprint = fingerprints;
+	freeFingerprints = freeAfterHandshake;
 	return true;
 }
 
@@ -727,6 +771,13 @@ bool TcpConnection::setSslClientKeyCert(const uint8_t *key, int keyLength,
 	return true;
 }
 
+bool TcpConnection::setSslClientKeyCert(SSLKeyCertPair clientKeyCert, bool freeAfterHandshake /* = false */) {
+	this->clientKeyCert = clientKeyCert;
+	freeClientKeyCert = freeAfterHandshake;
+
+	return true;
+}
+
 void TcpConnection::freeSslClientKeyCert() {
 	if(clientKeyCert.key) {
 		delete[] clientKeyCert.key;
@@ -745,6 +796,17 @@ void TcpConnection::freeSslClientKeyCert() {
 
 	clientKeyCert.keyLength = 0;
 	clientKeyCert.certificateLength = 0;
+}
+
+void TcpConnection::freeSslFingerprints() {
+	if(sslFingerprint.certSha1) {
+		delete[] sslFingerprint.certSha1;
+		sslFingerprint.certSha1 = NULL;
+	}
+	if(sslFingerprint.pkSha256) {
+		delete[] sslFingerprint.pkSha256;
+		sslFingerprint.pkSha256 = NULL;
+	}
 }
 
 SSL* TcpConnection::getSsl() {

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -10,6 +10,7 @@
 
 #ifdef ENABLE_SSL
 #include "../../axtls-8266/compat/lwipr_compat.h"
+#include "../Clock.h"
 #endif
 
 #include "../Wiring/WiringFrameworkDependencies.h"
@@ -40,7 +41,6 @@ enum SslFingerprintType {
 					//    Only when the private key used to generate the certificate is used then that fingerprint
 };
 
-
 typedef struct {
 	uint8_t* certSha1 = NULL; // << certificate SHA1 fingerprint
 	uint8_t* pkSha256 = NULL; // << public key SHA256 fingerprint
@@ -54,15 +54,23 @@ typedef struct {
 	int certificateLength = 0;
 } SSLKeyCertPair;
 
+typedef struct {
+	uint8_t *value = NULL;
+	int length = 0;
+} SSLSessionId;
+
 #endif
 
 struct pbuf;
 class String;
 class IDataSourceStream;
 class IPAddress;
+class TcpServer;
 
 class TcpConnection
 {
+	friend class TcpServer;
+
 public:
 	TcpConnection(bool autoDestruct);
 	TcpConnection(tcp_pcb* connection, bool autoDestruct);
@@ -92,7 +100,9 @@ public:
 	/**
 	 * @brief Sets the SHA1 certificate finger print.
 	 * 		  The latter will be used after successful handshake to check against the fingerprint of the other side.
+	 *
 	 * @deprecated This method will be removed in future releases. Use pinCertificate instead.
+	 *
 	 * @param const uint8_t *data
 	 * @param int length
 	 * @return bool  true of success, false or failure
@@ -122,10 +132,24 @@ public:
 	 * 			Disadvantages: The hash needs to be updated every time the remote server updates its certificate
 	 * @return bool  true of success, false or failure
 	 */
-	bool pinCertificate(const uint8_t *fingerprint, SslFingerprintType type);
+	bool pinCertificate(const uint8_t *fingerprint, SslFingerprintType type, bool freeAfterHandshake = false);
+
+	/**
+	 * @brief   Requires(pins) the remote SSL certificate to match certain fingerprints
+	 *
+	 * @note  The data inside the fingerprints parameter is passed by reference
+	 *
+	 * @param SSLFingerprints - passes the certificate fingerprints by reference.
+	 *
+	 * @return bool  true of success, false or failure
+	 */
+	bool pinCertificate(SSLFingerprints fingerprints, bool freeAfterHandshake = false);
 
 	/**
 	 * @brief Sets client private key, certificate and password from memory
+	 *
+	 * @note  This method makes copy of the data.
+	 *
 	 * @param const uint8_t *keyData
 	 * @param int keyLength
 	 * @param const uint8_t *certificateData
@@ -140,9 +164,26 @@ public:
 							 const char *keyPassword = NULL, bool freeAfterHandshake = false);
 
 	/**
+	* @brief Sets client private key, certificate and password from memory
+	*
+	* @note  This method passes the certificate key chain by reference
+	*
+	* @param SSLKeyCertPair
+	* @param bool freeAfterHandshake
+	*
+	* @return bool  true of success, false or failure
+	*/
+	bool setSslClientKeyCert(SSLKeyCertPair clientKeyCert, bool freeAfterHandshake = false);
+
+	/**
 	 * @brief Frees the memory used for the client key and certificate pair
 	 */
 	void freeSslClientKeyCert();
+
+	/**
+	 * @brief Frees the memory used for SSL fingerprinting
+	 */
+	void freeSslFingerprints();
 
 	SSL* getSsl();
 #endif
@@ -184,6 +225,8 @@ protected:
 	uint32_t sslOptions=0;
 	SSLKeyCertPair clientKeyCert;
 	bool freeClientKeyCert = false;
+	bool freeFingerprints = false;
+	SSLSessionId* sslSessionId = NULL;
 #endif
 	bool useSsl = false;
 };

--- a/Sming/SmingCore/Network/TcpServer.h
+++ b/Sming/SmingCore/Network/TcpServer.h
@@ -22,8 +22,15 @@ public:
 	virtual ~TcpServer();
 
 public:
-	virtual bool listen(int port);
+	virtual bool listen(int port, bool useSsl = false);
 	void setTimeOut(uint16_t waitTimeOut);
+
+#ifdef ENABLE_SSL
+	/**
+	 * @brief Adds SSL support and specifies the server certificate and private key.
+	 */
+	void setServerKeyCert(SSLKeyCertPair serverKeyCert);
+#endif
 
 protected:
 	// Overload this method in your derived class!
@@ -39,6 +46,13 @@ protected:
 public:
 	static int16_t totalConnections;
 	uint16_t activeClients = 0;
+
+protected:
+	int minHeapSize = 6500;
+
+#ifdef ENABLE_SSL
+	int sslSessionCacheSize = 50;
+#endif
 
 private:
 	uint16_t timeOut;


### PR DESCRIPTION
TcpClient::onReceive
  - The data is processed without intermediate buffers.
  - Errors are reported as expected.

TcpConnection
  - Added support for SSL session resumption
  - Added convenience methods to set SSL session id and SSL fingerprints

TcpServer
  - Added support for using SSL on the server side
  !Notice: Due to memory limitations of the device it might handle only one SSL connection at a time!
  - Added setting for minimumHeapSize needed before the server starts rejecting new client connections