### PR TITLE
Fixed the JsonStream length.

### DIFF
--- a/Sming/SmingCore/DataSourceStream.cpp
+++ b/Sming/SmingCore/DataSourceStream.cpp
@@ -341,8 +341,8 @@ uint16_t JsonObjectStream::readMemoryBlock(char* data, int bufSize)
 
 int JsonObjectStream::length()
 {
-	if (rootNode != JsonObject::invalid()) {
-		return -1;
+	if (rootNode == JsonObject::invalid()) {
+		return 0;
 	}
 
 	return rootNode.measureLength();


### PR DESCRIPTION
Helps the http clients to figure out the size of the response stream without waiting for connection close.