### PR TITLE
HttpServer body parsers

### DIFF
--- a/Sming/SmingCore/Network/Http/HttpBodyParser.cpp
+++ b/Sming/SmingCore/Network/Http/HttpBodyParser.cpp
@@ -1,0 +1,97 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HttpBodyParser
+ *
+ * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
+ *
+ ****/
+
+#include "HttpBodyParser.h"
+#include "../WebHelpers/escape.h"
+
+void formUrlParser(HttpRequest& request, const char *at, int length)
+{
+	FormUrlParserState* state = (FormUrlParserState*)request.args;
+
+	if(length == -1) {
+		if(state != NULL) {
+			delete state;
+		}
+		state = new FormUrlParserState;
+		request.args = (void *)state;
+		return;
+	}
+
+	if(length == -2) {
+		int maxLength = 0;
+		for(int i=0; i<request.postParams.count(); i++) {
+			int kLength = request.postParams.keyAt(i).length();
+			int vLength = request.postParams.valueAt(i).length();
+			if(maxLength < vLength || maxLength < kLength) {
+				maxLength = (kLength < vLength ? vLength : kLength);
+			}
+		}
+
+		char* buffer = new char[maxLength + 1];
+		for(int i=0, max = request.postParams.count(); i< max; i++) {
+			String key = request.postParams.keyAt(i);
+			String value = request.postParams.valueAt(i);
+
+			uri_unescape(buffer, maxLength, key.c_str(), key.length());
+			String newKey = buffer;
+
+			if(newKey != key) {
+				request.postParams.remove(key);
+			}
+
+			uri_unescape(buffer, maxLength, value.c_str(), value.length());
+			request.postParams[newKey] = buffer;
+		}
+		delete[] buffer;
+
+		if(state != NULL) {
+			delete state;
+			request.args = NULL;
+		}
+
+		return;
+	}
+
+	if(state == NULL) {
+		debugf("Invalid request argument");
+		return;
+	}
+
+	String data = String(at, length);
+
+	while(data.length()) {
+		int pos = data.indexOf(state->searchChar);
+		if(pos == -1) {
+			if(state->searchChar == '=') {
+				state->postName += data;
+			}
+			else {
+				request.postParams[state->postName] += data;
+			}
+
+			return;
+		}
+
+		String buf = data.substring(0, pos);
+		if(state->searchChar == '=') {
+			state->postName += buf;
+			state->searchChar = '&';
+		}
+		else {
+			request.postParams[state->postName] += buf;
+			state->searchChar = '=';
+			state->postName = "";
+		}
+
+		data = data.substring(pos + 1);
+	}
+}

--- a/Sming/SmingCore/Network/Http/HttpBodyParser.h
+++ b/Sming/SmingCore/Network/Http/HttpBodyParser.h
@@ -1,0 +1,46 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HttpBodyParser
+ *
+ * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
+ *
+ ****/
+
+#ifndef _SMING_CORE_HTTP_BODY_PARSER_H_
+#define _SMING_CORE_HTTP_BODY_PARSER_H_
+
+#include "HttpCommon.h"
+#include "HttpRequest.h"
+
+typedef Delegate<void(HttpRequest&, const char *at, int length)> HttpBodyParserDelegate;
+typedef HashMap <String, HttpBodyParserDelegate> BodyParsers;
+
+typedef struct {
+	char searchChar = '=';
+	String postName = "";
+} FormUrlParserState;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Parses application/x-www-form-urlencoded body data
+ * @param HttpRequest&
+ * @param const *char
+ * @param int length Negative lengths are used to specify special cases
+ * 				-1 - start of incoming data
+ * 				-2 - end of incoming data
+ */
+void formUrlParser(HttpRequest& request, const char *at, int length);
+
+#ifdef __cplusplus
+}
+#endif
+
+
+#endif /* _SMING_CORE_HTTP_BODY_PARSER_H_ */

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -133,6 +133,8 @@ public:
 
 	int retries = 0; // how many times the request should be send again...
 
+	void *args = NULL; // Used to store data that should be valid during a single request
+
 protected:
 	RequestHeadersCompletedDelegate headersCompletedDelegate;
 	RequestBodyDelegate requestBodyDelegate;

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.h
@@ -3,6 +3,11 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HttpServerConnection
+ *
+ * Modified: 2017 - Slavey Karadzhov <slav@attachix.com>
+ *
  ****/
 
 #ifndef _SMING_CORE_HTTPSERVERCONNECTION_H_
@@ -15,6 +20,7 @@
 
 #include "HttpResource.h"
 #include "HttpRequest.h"
+#include "HttpBodyParser.h"
 
 #ifndef HTTP_SERVER_EXPOSE_NAME
 #define HTTP_SERVER_EXPOSE_NAME 1
@@ -42,12 +48,11 @@ public:
 	virtual ~HttpServerConnection();
 
 	void setResourceTree(ResourceTree* resourceTree);
+	void setBodyParsers(BodyParsers* bodyParsers);
 
 	void send();
 
 	using TcpClient::send;
-
-//	virtual void close();
 
 protected:
 	virtual err_t onReceive(pbuf *buf);
@@ -91,6 +96,9 @@ private:
 	bool lastWasValue = true;
 	String lastData = "";
 	String currentField  = "";
+
+	BodyParsers* bodyParsers;
+	HttpBodyParserDelegate bodyParser;
 };
 
 #endif /* _SMING_CORE_HTTPSERVERCONNECTION_H_ */

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -31,6 +31,11 @@ void HttpServer::configure(HttpServerSettings settings) {
 	if(settings.minHeapSize != -1 && settings.minHeapSize > -1) {
 		minHeapSize = settings.minHeapSize;
 	}
+
+	if(settings.useDefaultBodyParsers) {
+		setBodyParser(ContentType::toString(MIME_FORM_URL_ENCODED), formUrlParser);
+	}
+
 	setTimeOut(settings.keepAliveSeconds);
 #ifdef ENABLE_SSL
 	sslSessionCacheSize = settings.sslSessionCacheSize;
@@ -46,10 +51,16 @@ HttpServer::~HttpServer()
 	}
 }
 
+void HttpServer::setBodyParser(const String& contentType, HttpBodyParserDelegate parser)
+{
+	bodyParsers[contentType] = parser;
+}
+
 TcpConnection* HttpServer::createClient(tcp_pcb *clientTcp)
 {
 	HttpServerConnection* con = new HttpServerConnection(clientTcp);
 	con->setResourceTree(&resourceTree);
+	con->setBodyParsers(&bodyParsers);
 	con->setCompleteDelegate(TcpClientCompleteDelegate(&HttpServer::onConnectionClose, this));
 
 	totalConnections++;

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -21,12 +21,14 @@
 #include "Http/HttpRequest.h"
 #include "Http/HttpResource.h"
 #include "Http/HttpServerConnection.h"
+#include "Http/HttpBodyParser.h"
 
 typedef struct {
 	int maxActiveConnections = 10; // << the maximum number of concurrent requests..
 	int keepAliveSeconds = 5; // << the default seconds to keep the connection alive before closing it
 	int minHeapSize = -1; // << defines the min heap size that is required to accept connection.
 					      //  -1 - means use server default
+	bool useDefaultBodyParsers = 1; // << if the default body parsers,  as form-url-encoded, should be used
 #ifdef ENABLE_SSL
 	int sslSessionCacheSize = 10; // << number of SSL session ids to cache. Setting this to 0 will disable SSL session resumption.
 #endif
@@ -45,6 +47,8 @@ public:
 	 * @brief Allows changing the server configuration
 	 */
 	void configure(HttpServerSettings settings);
+
+	void setBodyParser(const String& contentType, HttpBodyParserDelegate parser);
 
 	/**
 	 * @param String path URL path.
@@ -71,6 +75,7 @@ protected:
 private:
 	HttpServerSettings settings;
 	ResourceTree resourceTree;
+	BodyParsers bodyParsers;
 };
 
 #endif /* _SMING_CORE_HTTPSERVER_H_ */


### PR DESCRIPTION
HttpServer:
+ Added infrastructure for body parsers.
+ Form-url-encoded is default body parser for HttpServer, that can be disabled with configuration setting, if needed.

Fixes #1115