### PR TITLE
add Timer::loop() for better class derivation from Timer class

### DIFF
--- a/Sming/SmingCore/Timer.cpp
+++ b/Sming/SmingCore/Timer.cpp
@@ -181,13 +181,13 @@ void Timer::processing(void *arg)
 					ptimer->stop();
 			}
 		}
-      ptimer->loop();
+		ptimer->tick();
 	}
 
 }
 
 
-void Timer::loop()
+void Timer::tick()
 {
 	if (callback)
 	{
@@ -197,7 +197,7 @@ void Timer::loop()
 	{
 		delegate_func();
 	}
-   else{
-      stop();
-   }
+	else{
+		stop();
+	}
 }

--- a/Sming/SmingCore/Timer.cpp
+++ b/Sming/SmingCore/Timer.cpp
@@ -48,8 +48,7 @@ void Timer::start(bool repeating/* = true*/)
 {
 	this->repeating = repeating;
 	stop();
-	if(interval == 0 || (!callback && !delegate_func)) 
-		return;
+	if (interval == 0) return;
 	
 	ets_timer_setfn(&timer, (os_timer_func_t *)processing, this);	
 	if (interval > 10000) 
@@ -182,15 +181,23 @@ void Timer::processing(void *arg)
 					ptimer->stop();
 			}
 		}
-
-		if (ptimer->callback)
-		{
-			ptimer->callback();
-		}
-		else if (ptimer->delegate_func)
-		{
-			ptimer->delegate_func();
-		}
+      ptimer->loop();
 	}
 
+}
+
+
+void Timer::loop()
+{
+	if (callback)
+	{
+		callback();
+	}
+	else if (delegate_func)
+	{
+		delegate_func();
+	}
+   else{
+      stop();
+   }
 }

--- a/Sming/SmingCore/Timer.h
+++ b/Sming/SmingCore/Timer.h
@@ -134,7 +134,7 @@ protected:
      *  @note   Can be override in class derivations. If overwriten,
      *          no classic other callbacks are working.
      */
-    virtual void loop();
+    virtual void tick();
     /** @} */
 
 private:

--- a/Sming/SmingCore/Timer.h
+++ b/Sming/SmingCore/Timer.h
@@ -126,11 +126,16 @@ public:
      */
     void IRAM_ATTR setCallback(TimerDelegate delegateFunction);
 
-    /** @} */
 
 protected:
     static void IRAM_ATTR processing(void *arg);
 
+    /** @brief  virtual timer loop() method
+     *  @note   Can be override in class derivations. If overwriten,
+     *          no classic other callbacks are working.
+     */
+    virtual void loop();
+    /** @} */
 
 private:
     os_timer_t timer;
@@ -144,6 +149,8 @@ private:
     // was added to allow for longer timer intervals.
     uint16_t long_intvl_cntr = 0;
     uint16_t long_intvl_cntr_lim = 0;
+
+
 };
 
 #endif /* _SMING_CORE_Timer_H_ */


### PR DESCRIPTION
Derivations from Timer class can not add own loop methods. With this patch, you can create own derivations from Timer and place direct your own loop method.
