### PR TITLE
WDT-friendly `delay` function

### DIFF
--- a/Sming/SmingCore/Clock.cpp
+++ b/Sming/SmingCore/Clock.cpp
@@ -8,6 +8,8 @@
 #include "../SmingCore/Clock.h"
 #include "../Wiring/WiringFrameworkIncludes.h"
 
+#define MAX_SAFE_DELAY 1000
+
 unsigned long millis(void)
 {
 	return system_get_time() / 1000UL;
@@ -20,7 +22,18 @@ unsigned long micros(void)
 
 void delay(uint32_t time)
 {
-	os_delay_us(time * 1000);
+	int quotient = time / MAX_SAFE_DELAY;
+	int remainder = time % MAX_SAFE_DELAY;
+	for(int i=0, max = quotient + 1; i < max ; i++) {
+		if(i == quotient) {
+			os_delay_us(remainder * 1000);
+		}
+		else {
+			os_delay_us(MAX_SAFE_DELAY * 1000);
+		}
+
+		system_soft_wdt_feed ();
+	}
 }
 
 void delayMicroseconds(uint32_t time)


### PR DESCRIPTION
Changed the delay function to call wdt_reset for intervals that are bigger than the max-safe-delay period.