### PR TITLE
WsConnection: declared broadcast as static so that it can be called a…

### DIFF
--- a/Sming/SmingCore/Network/Http/Websocket/WebSocketConnection.h
+++ b/Sming/SmingCore/Network/Http/Websocket/WebSocketConnection.h
@@ -39,7 +39,7 @@ public:
 	bool initialize(HttpRequest &request, HttpResponse &response);
 
 	virtual void send(const char* message, int length, wsFrameType type = WS_TEXT_FRAME);
-	void broadcast(const char* message, int length, wsFrameType type = WS_TEXT_FRAME);
+	static void broadcast(const char* message, int length, wsFrameType type = WS_TEXT_FRAME);
 
 	void sendString(const String& message);
 	void sendBinary(const uint8_t* data, int size);


### PR DESCRIPTION
…nywhere in the application.