### PR TITLE
HttpServer: Fixes and tuning 

### DIFF
--- a/Sming/SmingCore/DataSourceStream.h
+++ b/Sming/SmingCore/DataSourceStream.h
@@ -244,6 +244,12 @@ public:
      */
 	inline TemplateVariables& variables() { return templateData; }
 
+	/**
+	 * @brief Return the total length of the stream
+	 * @retval int -1 is returned when the size cannot be determined
+	 */
+	int length() { return -1; }
+
 private:
 	TemplateVariables templateData;
 	TemplateExpandState state;

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -239,6 +239,16 @@ HttpRequest* HttpRequest::onRequestComplete(RequestCompletedDelegate delegateFun
 	return this;
 }
 
+void HttpRequest::reset()
+{
+	headers.clear();
+	postParams.clear();
+	if(queryParams != NULL) {
+		delete queryParams;
+		queryParams = NULL;
+	}
+}
+
 #ifndef SMING_RELEASE
 String HttpRequest::toString() {
 	String content = "";

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -116,6 +116,8 @@ public:
 	HttpRequest* onBody(RequestBodyDelegate delegateFunction);
 	HttpRequest* onRequestComplete(RequestCompletedDelegate delegateFunction);
 
+	void reset();
+
 #ifndef SMING_RELEASE
 	/**
 	 * @brief Tries to present a readable version of the current request values

--- a/Sming/SmingCore/Network/Http/HttpResponse.cpp
+++ b/Sming/SmingCore/Network/Http/HttpResponse.cpp
@@ -180,3 +180,11 @@ bool HttpResponse::sendDataStream( IDataSourceStream * newDataStream , String re
     return true;
 }
 
+void HttpResponse::reset()
+{
+	headers.clear();
+	if(stream != NULL) {
+		delete stream;
+		stream = NULL;
+	}
+}

--- a/Sming/SmingCore/Network/Http/HttpResponse.h
+++ b/Sming/SmingCore/Network/Http/HttpResponse.h
@@ -81,6 +81,8 @@ public:
 	// Send Datastream, can be called with Classes derived from
 	bool sendDataStream( IDataSourceStream * newDataStream , String reqContentType = "" );
 
+	void reset();
+
 public:
 	int code;
 	HttpHeaders headers;

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
@@ -173,6 +173,11 @@ int HttpServerConnection::staticOnHeadersComplete(http_parser* parser)
 	int error = 0;
 	connection->request.setHeaders(connection->requestHeaders);
 
+	connection->lastWasValue = true;
+	connection->lastData = "";
+	connection->currentField  = "";
+	connection->requestHeaders.clear();
+
 	if(connection->resource != NULL && connection->resource->onHeadersComplete) {
 		error = connection->resource->onHeadersComplete(*connection, connection->request, connection->response);
 	}
@@ -404,6 +409,11 @@ void HttpServerConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 
 	if(state == eHCS_Sent && response.headers["Connection"] == "close") {
 		setTimeOut(1); // decrease the timeout to 1 tick
+	}
+
+	if(state == eHCS_Sent) {
+		response.reset();
+		request.reset();
 	}
 
 	TcpClient::onReadyToSendData(sourceEvent);

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.h
@@ -97,7 +97,7 @@ private:
 	String lastData = "";
 	String currentField  = "";
 
-	BodyParsers* bodyParsers;
+	BodyParsers* bodyParsers = NULL;
 	HttpBodyParserDelegate bodyParser;
 };
 

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -17,7 +17,7 @@
 
 HttpServer::HttpServer()
 {
-	settings.keepAliveSeconds = 10;
+	settings.keepAliveSeconds = 0;
 	configure(settings);
 }
 

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -25,7 +25,7 @@
 
 typedef struct {
 	int maxActiveConnections = 10; // << the maximum number of concurrent requests..
-	int keepAliveSeconds = 5; // << the default seconds to keep the connection alive before closing it
+	int keepAliveSeconds = 0; // << the default seconds to keep the connection alive before closing it
 	int minHeapSize = -1; // << defines the min heap size that is required to accept connection.
 					      //  -1 - means use server default
 	bool useDefaultBodyParsers = 1; // << if the default body parsers,  as form-url-encoded, should be used


### PR DESCRIPTION
HttpServer: The default keepalive time is set to 0.
TemplateStream: The total length should be calculated from the browser.