### PR TITLE
HttpServer tuning to allow serving of more requests.

### DIFF
--- a/Sming/SmingCore/DataSourceStream.h
+++ b/Sming/SmingCore/DataSourceStream.h
@@ -182,7 +182,7 @@ public:
 	 * @brief Return the total length of the stream
 	 * @retval int -1 is returned when the size cannot be determined
 	 */
-	int length() { return size; }
+	int length() { return -1; }
 
 private:
 	file_t handle;

--- a/Sming/SmingCore/Network/Http/HttpConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpConnection.h
@@ -89,13 +89,17 @@ protected:
 
 private:
 	static int IRAM_ATTR staticOnMessageBegin(http_parser* parser);
+#ifndef COMPACT_MODE
 	static int IRAM_ATTR staticOnStatus(http_parser *parser, const char *at, size_t length);
+#endif
 	static int IRAM_ATTR staticOnHeadersComplete(http_parser* parser);
 	static int IRAM_ATTR staticOnHeaderField(http_parser *parser, const char *at, size_t length);
 	static int IRAM_ATTR staticOnHeaderValue(http_parser *parser, const char *at, size_t length);
 	static int IRAM_ATTR staticOnBody(http_parser *parser, const char *at, size_t length);
+#ifndef COMPACT_MODE
 	static int IRAM_ATTR staticOnChunkHeader(http_parser* parser);
 	static int IRAM_ATTR staticOnChunkComplete(http_parser* parser);
+#endif
 	static int IRAM_ATTR staticOnMessageComplete(http_parser* parser);
 
 protected:
@@ -105,7 +109,8 @@ protected:
 	RequestQueue* waitingQueue;
 	RequestQueue executionQueue;
 	http_parser parser;
-	http_parser_settings parserSettings;
+	static http_parser_settings parserSettings;
+	static bool parserSettingsInitialized;
 	HttpHeaders responseHeaders;
 
 	int code = 0;

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
@@ -17,6 +17,9 @@
 #include "../../Services/cWebsocket/websocket.h"
 #include "WebConstants.h"
 
+bool HttpServerConnection::parserSettingsInitialized = false;
+http_parser_settings HttpServerConnection::parserSettings;
+
 HttpServerConnection::HttpServerConnection(tcp_pcb *clientTcp)
 	: TcpClient(clientTcp, 0, 0), state(eHCS_Ready)
 {
@@ -24,17 +27,20 @@ HttpServerConnection::HttpServerConnection(tcp_pcb *clientTcp)
 	http_parser_init(&parser, HTTP_REQUEST);
 	parser.data = (void*)this;
 
-	memset(&parserSettings, 0, sizeof(parserSettings));
-	// Notification callbacks: on_message_begin, on_headers_complete, on_message_complete.
-	parserSettings.on_message_begin     = staticOnMessageBegin;
-	parserSettings.on_headers_complete  = staticOnHeadersComplete;
-	parserSettings.on_message_complete  = staticOnMessageComplete;
+	if(!parserSettingsInitialized) {
+		memset(&parserSettings, 0, sizeof(parserSettings));
+		// Notification callbacks: on_message_begin, on_headers_complete, on_message_complete.
+		parserSettings.on_message_begin     = staticOnMessageBegin;
+		parserSettings.on_headers_complete  = staticOnHeadersComplete;
+		parserSettings.on_message_complete  = staticOnMessageComplete;
 
-	// Data callbacks: on_url, (common) on_header_field, on_header_value, on_body;
-	parserSettings.on_url               = staticOnPath;
-	parserSettings.on_header_field      = staticOnHeaderField;
-	parserSettings.on_header_value      = staticOnHeaderValue;
-	parserSettings.on_body              = staticOnBody;
+		// Data callbacks: on_url, (common) on_header_field, on_header_value, on_body;
+		parserSettings.on_url               = staticOnPath;
+		parserSettings.on_header_field      = staticOnHeaderField;
+		parserSettings.on_header_value      = staticOnHeaderValue;
+		parserSettings.on_body              = staticOnBody;
+		parserSettingsInitialized = true;
+	}
 }
 
 HttpServerConnection::~HttpServerConnection()

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.h
@@ -78,7 +78,8 @@ private:
 	HttpConnectionState state;
 
 	http_parser parser;
-	http_parser_settings parserSettings;
+	static http_parser_settings parserSettings;
+	static bool parserSettingsInitialized;
 
 	ResourceTree* resourceTree = NULL;
 	HttpResource* resource = NULL;

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -81,8 +81,11 @@ bool TcpClient::send(const char* data, uint16_t len, bool forceCloseAfterSent /*
 	if (stream == NULL)
 		stream = new MemoryDataStream();
 
-	if (stream->write((const uint8_t*)data, len) != len)
+	if (stream->write((const uint8_t*)data, len) != len) {
+		debug_e("ERROR: Unable to store %d bytes in output stream", len);
 		return false;
+	}
+
 	debugf("Storing %d bytes in stream", len);
 
 	asyncTotalLen += len;

--- a/Sming/SmingCore/Network/TcpServer.h
+++ b/Sming/SmingCore/Network/TcpServer.h
@@ -48,7 +48,7 @@ public:
 	uint16_t activeClients = 0;
 
 protected:
-	int minHeapSize = 6500;
+	int minHeapSize = 3000;
 
 #ifdef ENABLE_SSL
 	int sslSessionCacheSize = 50;

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -293,3 +293,16 @@ index ddb5984..fb677c6 100644
  			*optptr++ = DHCP_OPTION_ROUTER;
  			*optptr++ = 4;
  			*optptr++ = ip4_addr1( &if_ip.gw);
+diff --git a/include/lwip/tcp_impl.h b/include/lwip/tcp_impl.h
+index 24ca8bb..0c20b6a 100644
+--- a/include/lwip/tcp_impl.h
++++ b/include/lwip/tcp_impl.h
+@@ -130,7 +130,7 @@ u32_t            tcp_update_rcv_ann_wnd(struct tcp_pcb *pcb)ICACHE_FLASH_ATTR;
+ #define TCP_OOSEQ_TIMEOUT        6U /* x RTO */
+ 
+ #ifndef TCP_MSL
+-#define TCP_MSL 60000UL /* The maximum segment lifetime in milliseconds */
++#define TCP_MSL 2000UL /* The maximum segment lifetime in milliseconds */
+ #endif
+ 
+ /* Keepalive values, compliant with RFC 1122. Don't change this unless you know what you're doing */


### PR DESCRIPTION
- Workaround for issue with incorrect size of files (Disadvantages: The loading process looks slower because the browser waits for the TIMEOUT in order to determine the size)

- TcpClient: Added reporting for condition that shouldn't happen and is not handled optimally.
- TcpServer: Decreased the minimum required heap size.
- LWIP: Decreased the TCP_MSL to 2 seconds. That will lead to faster garbage collection of tcp connections in TIME_WAIT state and will release resources faster.