### PR TITLE
Handle incomplete frame to prevent WebsocketClient ending in an endle…

### DIFF
--- a/Sming/SmingCore/Network/WebsocketFrame.cpp
+++ b/Sming/SmingCore/Network/WebsocketFrame.cpp
@@ -185,6 +185,12 @@ uint8_t WebsocketFrameClass::_getFrameSizes(uint8_t* buffer, size_t length)
 	{
 		_nextReadOffset = 0; // single websocket frame in buffer
 	}
+	else if(length < _nextReadOffset)
+	{
+		// Frame is incomplete
+		_frameType = WSFrameType::incomplete;
+		return false;
+	} 
 
 	return true;
 }
@@ -197,7 +203,8 @@ uint8_t WebsocketFrameClass::decodeFrame(uint8_t * buffer, size_t length)
 	WSFrameType op = (WSFrameType)(buffer[0] & 0b00001111); // Extracting Opcode
 	uint8_t fin = buffer[0] & 0b10000000; // Extracting Fin Bit (Single Frame)
 
-	if (op == WSFrameType::continuation || op == WSFrameType::text || op == WSFrameType::binary) //Data frames
+	// At least there must be one byte that op and fin are vaild
+	if (length > 0 && op == WSFrameType::continuation || op == WSFrameType::text || op == WSFrameType::binary) //Data frames
 	{
 		if (fin > 0)
 		{


### PR DESCRIPTION
…ss loop

When a WebsocketClient receives an incomplete frame it hangs in an endless loop until the watchdog resets the system.
Marking the frame as incomplete and returning false resolves this issue.
But the data received with this frame is lost. I will create another pull-request for temoprary saving the data and combining them with the next frame(s) for correct evaluation 