### PR TITLE
Added WifiStation.connect() to Basic_rboot sample

### DIFF
--- a/samples/Basic_rBoot/app/application.cpp
+++ b/samples/Basic_rBoot/app/application.cpp
@@ -112,6 +112,7 @@ void serialCallBack(Stream& stream, char arrivedChar, unsigned short availableCh
 			// connect to wifi
 			WifiStation.config(WIFI_SSID, WIFI_PWD);
 			WifiStation.enable(true);
+			WifiStation.connect();
 		} else if (!strcmp(str, "ip")) {
 			Serial.printf("ip: %s mac: %s\r\n", WifiStation.getIP().toString().c_str(), WifiStation.getMAC().c_str());
 		} else if (!strcmp(str, "ota")) {


### PR DESCRIPTION
Newer NonOS SDKs seem to need WifiStation.connect() before they will connect to the network. This has been added to the serialCallBack command handler in the Basic_rboot sample.