### PR TITLE
Fix python calls 

### DIFF
--- a/Sming/Libraries/RF24/tests/pingpair_blocking/runtest.py
+++ b/Sming/Libraries/RF24/tests/pingpair_blocking/runtest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 
 import sys,serial
 

--- a/Sming/Libraries/RF24/tests/pingpair_test/runtest.py
+++ b/Sming/Libraries/RF24/tests/pingpair_test/runtest.py
@@ -1,4 +1,4 @@
-#!/opt/local/bin/python
+#!/usr/bin/env python2
 
 import sys,serial
 

--- a/Sming/gdb/gdbstub.c
+++ b/Sming/gdb/gdbstub.c
@@ -44,7 +44,7 @@ static unsigned int getaregval(int reg) {
 static void print_stack(uint32_t start, uint32_t end) {
   uint32_t pos = 0;
   os_printf("\nStack dump:\n");
-  os_printf("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n");
+  os_printf("To decode the stack dump call from command line:\n   python2 $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n");
   os_printf("and copy & paste the text enclosed in '===='.\n");
   os_printf("================================================================\n");
   for (pos = start; pos < end; pos += 0x10) {
@@ -57,7 +57,7 @@ static void print_stack(uint32_t start, uint32_t end) {
   }
   os_printf("\n");
   os_printf("================================================================\n");
-  os_printf("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n");
+  os_printf("To decode the stack dump call from command line:\n   python2 $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n");
   os_printf("and copy & paste the text enclosed in '===='.\n");
 }
 

--- a/samples/Basic_Debug/README.md
+++ b/samples/Basic_Debug/README.md
@@ -19,7 +19,7 @@ r15: 0x3fff1138=1073680696
 
 Stack dump:
 To decode the stack dump call from command line:
-   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out
+   python2 $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out
 and copy & paste the text enclosed in '===='.
 ================================================================
 3ffff640:  40100e96 00000033 00000018 000000f0  

--- a/tools/decode-stacktrace.py
+++ b/tools/decode-stacktrace.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 ########################################################
 #
 #  Stack Trace Decoder

--- a/tools/memanalyzer.py
+++ b/tools/memanalyzer.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 ########################################################
 #
 #  Memory Analyzer


### PR DESCRIPTION
Fix python calls to always use /usr/bin/env, and specify version where necessary (otherwise it won't work on distros like ArchLinux where python3 is the default)