### PR TITLE
Enable pull-up resistor in OneWire library

### DIFF
--- a/Sming/Libraries/OneWire/OneWire.cpp
+++ b/Sming/Libraries/OneWire/OneWire.cpp
@@ -124,7 +124,7 @@ OneWire::OneWire(uint8_t pin)
 
 void OneWire::begin()
 {
-	pinMode(pin, INPUT);
+	pinMode(pin, INPUT_PULLUP);
 	noPullup(pin);
 	bitmask = PIN_TO_BITMASK(pin);
 	baseReg = PIN_TO_BASEREG(pin);
@@ -136,7 +136,7 @@ void OneWire::begin()
 void OneWire::begin(uint8_t pinOneWire)
 {
 	pin = pinOneWire;
-	pinMode(pin, INPUT);
+	pinMode(pin, INPUT_PULLUP);
 	noPullup(pin);
 	bitmask = PIN_TO_BITMASK(pin);
 	baseReg = PIN_TO_BASEREG(pin);

--- a/Sming/Libraries/OneWire/OneWire.h
+++ b/Sming/Libraries/OneWire/OneWire.h
@@ -112,7 +112,7 @@
 #define IO_REG_TYPE						uint16_t
 #define IO_REG_ASM
 #define DIRECT_READ(base, mask)         (digitalRead(mask) ? 1 : 0)
-#define DIRECT_MODE_INPUT(base, mask)   pinMode(mask, INPUT)
+#define DIRECT_MODE_INPUT(base, mask)   pinMode(mask, INPUT_PULLUP)
 #define DIRECT_MODE_OUTPUT(base, mask)  pinMode(mask, OUTPUT)
 #define DIRECT_WRITE_LOW(base, mask)    digitalWrite(mask, LOW);
 #define DIRECT_WRITE_HIGH(base, mask)   digitalWrite(mask, HIGH);
@@ -123,7 +123,7 @@
 #define IO_REG_TYPE 					uint16_t
 #define IO_REG_ASM
 #define DIRECT_READ(base, mask)         ((digitalRead(mask) > 0) ? 1 : 0)
-#define DIRECT_MODE_INPUT(base, mask)   (pinMode(mask, INPUT))
+#define DIRECT_MODE_INPUT(base, mask)   (pinMode(mask, INPUT_PULLUP))
 #define DIRECT_MODE_OUTPUT(base, mask)  (pinMode(mask, OUTPUT))
 #define DIRECT_WRITE_LOW(base, mask)    (digitalWrite(mask, LOW))
 #define DIRECT_WRITE_HIGH(base, mask)   (digitalWrite(mask, HIGH))


### PR DESCRIPTION
Enable the internal pull-up resistor for the GPIO used by OneWire library. OneWire requires by its design a pull-up resistor, and if the internal one is not enabled an external resistor would be required.
