### PR TITLE
Add custom PWM compile flag to enable old PWM library behaviour.

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -221,6 +221,7 @@ LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa main
 ENABLE_CUSTOM_PWM ?= 1
 ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	THIRD_PARTY_DATA += third-party/pwm/pwm.c
+	CFLAGS += -DSDK_PWM_PERIOD_COMPAT_MODE=1
 endif
 
 MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)


### PR DESCRIPTION
Without this compile flag, the PWM library uses different constants, which makes it incompatible with other code which relies on the standard PWM behaviour. This change enables its compatibility mode by default.