### PR TITLE
Allow HttpResponse::sendString to be used multiple times for a single…

### DIFF
--- a/Sming/SmingCore/Network/Http/HttpResponse.cpp
+++ b/Sming/SmingCore/Network/Http/HttpResponse.cpp
@@ -55,22 +55,20 @@ HttpResponse* HttpResponse::setHeader(const String& name, const String& value)
 
 bool HttpResponse::sendString(const String& text)
 {
-	MemoryDataStream* memStream = new MemoryDataStream();
-	if (memStream->write((const uint8_t*)text.c_str(), text.length()) != text.length()) {
-		delete memStream;
-		return false;
-	}
-
-	if (stream != NULL)
-	{
+	if (stream != NULL && stream->getStreamType() != eSST_Memory) {
 		SYSTEM_ERROR("Stream already created");
 		delete stream;
 		stream = NULL;
 	}
 
-	stream = memStream;
+	if(stream == NULL) {
+		stream = new MemoryDataStream();
+	}
 
-	return true;
+	MemoryDataStream *writable = static_cast<MemoryDataStream *>(stream);
+	bool success = (writable->write((const uint8_t*)text.c_str(), text.length()) == text.length());
+
+	return success;
 }
 
 bool HttpResponse::hasHeader(const String& name)


### PR DESCRIPTION
… response.

Fixes #1240.