### PR TITLE
Added support for wildcard content-types for the body parsers.

### DIFF
--- a/Sming/SmingCore/Network/Http/HttpBodyParser.cpp
+++ b/Sming/SmingCore/Network/Http/HttpBodyParser.cpp
@@ -95,3 +95,24 @@ void formUrlParser(HttpRequest& request, const char *at, int length)
 		data = data.substring(pos + 1);
 	}
 }
+
+void bodyToStringParser(HttpRequest& request, const char *at, int length)
+{
+	String* data = static_cast<String *>(request.args);
+
+	if(length == -1) {
+		delete data;
+		data = new String();
+		request.args = (void *)data;
+		return;
+	}
+
+	if(length == -2) {
+		request.setBody(*data);
+		delete data;
+		request.args = NULL;
+		return;
+	}
+
+	*data += String(at, length);
+}

--- a/Sming/SmingCore/Network/Http/HttpBodyParser.h
+++ b/Sming/SmingCore/Network/Http/HttpBodyParser.h
@@ -38,6 +38,17 @@ extern "C" {
  */
 void formUrlParser(HttpRequest& request, const char *at, int length);
 
+/**
+ * @brief Stores the complete body into memory.
+ *        The content later can be retrieved by calling request.getBody()
+ * @param HttpRequest&
+ * @param const *char
+ * @param int length Negative lengths are used to specify special cases
+ * 				-1 - start of incoming data
+ * 				-2 - end of incoming data
+ */
+void bodyToStringParser(HttpRequest& request, const char *at, int length);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -50,9 +50,10 @@ HttpRequest& HttpRequest::operator = (const HttpRequest& rhs) {
 }
 
 HttpRequest::~HttpRequest() {
-	if(queryParams != NULL) {
-		delete queryParams;
-	}
+	delete queryParams;
+	delete stream;
+	queryParams = NULL;
+	stream = NULL;
 }
 
 HttpRequest* HttpRequest::setURL(URL uri) {
@@ -156,6 +157,7 @@ String HttpRequest::getBody()
 		char buf[1024];
 		for(int i=0; i< stream->length(); i += 1024) {
 			int available = memory->readMemoryBlock(buf, 1024);
+			memory->seek(max(available, 0));
 			ret += String(buf, available);
 			if(available < 1024) {
 				break;

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
@@ -199,8 +199,26 @@ int HttpServerConnection::staticOnHeadersComplete(http_parser* parser)
 			contentType = contentType.substring(0, endPos);
 		}
 
-		if(connection->bodyParsers->contains(contentType)) {
-			connection->bodyParser = (*connection->bodyParsers)[contentType];
+		String majorType = contentType.substring(0, contentType.indexOf('/'));
+		majorType += "/*";
+
+		// Content-Type for exact type: application/json
+		// Wildcard type for application: application/*
+		// Wildcard type for the rest*
+
+		Vector<String> types;
+		types.add(contentType);
+		types.add(majorType);
+		types.add("*");
+
+		for(int i=0; i< types.count(); i++) {
+			if(connection->bodyParsers->contains(types.at(i))) {
+				connection->bodyParser = (*connection->bodyParsers)[types.at(i)];
+				break;
+			}
+		}
+
+		if(connection->bodyParser) {
 			connection->bodyParser(connection->request, NULL, -1);
 		}
 	}


### PR DESCRIPTION
Added dummy body parser that stores all content into memory.

Initial work related to #1236. 