### PR TITLE
Updated Sming to SDK 2.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -56,4 +56,8 @@
 [submodule "Sming/third-party/lwip2"]
 	path = Sming/third-party/lwip2
 	url = https://github.com/d-a-v/esp82xx-nonos-linklayer.git
+        ignore = dirty
+[submodule "Sming/third-party/ESP8266_NONOS_SDK"]
+	path = Sming/third-party/ESP8266_NONOS_SDK
+	url = https://github.com/espressif/ESP8266_NONOS_SDK.git
 	ignore = dirty

--- a/.gitmodules
+++ b/.gitmodules
@@ -56,7 +56,7 @@
 [submodule "Sming/third-party/lwip2"]
 	path = Sming/third-party/lwip2
 	url = https://github.com/d-a-v/esp82xx-nonos-linklayer.git
-        ignore = dirty
+	ignore = dirty
 [submodule "Sming/third-party/ESP8266_NONOS_SDK"]
 	path = Sming/third-party/ESP8266_NONOS_SDK
 	url = https://github.com/espressif/ESP8266_NONOS_SDK.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
           env: SDK_VERSION=1.5.0
         - os: linux
           env: SDK_VERSION=2.0.0
+        - os: linux
+          env: SDK_VERSION=2.1.0
           
 git:
   submodules: false
@@ -29,12 +31,12 @@ addons:
       - graphviz
 
 install:
-  - if [ "$SDK_VERSION" != "2.0.0" ] && [ "$TRAVIS_OS_NAME" == "osx" ]; then export SDK_FILE_NAME="esp-alt-sdk-v${SDK_VERSION}.${SDK_BUILD}-macos-x86_64.zip"; fi
-  - if [ "$SDK_VERSION" != "2.0.0" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then export SDK_FILE_NAME="esp-alt-sdk-v${SDK_VERSION}.${SDK_BUILD}-linux-x86_64.tar.gz"; fi
+  - if [ "$SDK_VERSION" == "1.5.0" ] && [ "$TRAVIS_OS_NAME" == "osx" ]; then export SDK_FILE_NAME="esp-alt-sdk-v${SDK_VERSION}.${SDK_BUILD}-macos-x86_64.zip"; fi
+  - if [ "$SDK_VERSION" == "1.5.0" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then export SDK_FILE_NAME="esp-alt-sdk-v${SDK_VERSION}.${SDK_BUILD}-linux-x86_64.tar.gz"; fi
   - mkdir -p $TRAVIS_BUILD_DIR/opt/esp-alt-sdk
-  - if [ "$SDK_VERSION" != "2.0.0" ]; then wget https://bintray.com/artifact/download/kireevco/generic/${SDK_FILE_NAME}; fi
-  - if [ "$SDK_VERSION" != "2.0.0" ]; then bsdtar -xf ${SDK_FILE_NAME} -C $TRAVIS_BUILD_DIR/opt/esp-alt-sdk; fi
-  - if [ "$SDK_VERSION" == "2.0.0" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then wget https://github.com/nodemcu/nodemcu-firmware/raw/master/tools/esp-open-sdk.tar.xz; tar -Jxvf esp-open-sdk.tar.xz; ln -s `pwd`/esp-open-sdk/xtensa-lx106-elf $TRAVIS_BUILD_DIR/opt/esp-alt-sdk/. ; fi
+  - if [ "$SDK_VERSION" == "1.5.0" ]; then wget https://bintray.com/artifact/download/kireevco/generic/${SDK_FILE_NAME}; fi
+  - if [ "$SDK_VERSION" == "1.5.0" ]; then bsdtar -xf ${SDK_FILE_NAME} -C $TRAVIS_BUILD_DIR/opt/esp-alt-sdk; fi
+  - if [[ "$SDK_VERSION" != "1.5.0" && "$TRAVIS_OS_NAME" == "linux" ]]; then wget https://github.com/nodemcu/nodemcu-firmware/raw/master/tools/esp-open-sdk.tar.xz; tar -Jxvf esp-open-sdk.tar.xz; ln -s `pwd`/esp-open-sdk/xtensa-lx106-elf $TRAVIS_BUILD_DIR/opt/esp-alt-sdk/. ; fi
   - if [ "$SDK_VERSION" == "2.0.0" ] && [ "$TRAVIS_OS_NAME" == "linux" ]; then wget http://bbs.espressif.com/download/file.php?id=1690 -O sdk.zip; unzip sdk.zip; ln -s `pwd`/ESP8266_NONOS_SDK/ $TRAVIS_BUILD_DIR/opt/esp-alt-sdk/sdk; export  DEPLOY='true'; fi
 
 script:
@@ -42,6 +44,7 @@ script:
   - export CHANGED_PROJECTS=`for i in $CHANGED_FILES; do echo "$i" |  grep '^samples/' | cut -d'/' -f2; done | uniq`
   - export SMING_HOME=$TRAVIS_BUILD_DIR/Sming
   - export ESP_HOME=$TRAVIS_BUILD_DIR/opt/esp-alt-sdk  
+  - if [ "$SDK_VERSION" == "2.1.0" ]; then export SDK_BASE=$SMING_HOME/third-party/ESP8266_NONOS_SDK; fi
   - export PATH=$PATH:$ESP_HOME/xtensa-lx106-elf/bin:$ESP_HOME/utils/:$SMING_HOME/../.travis/tools
   - cd $SMING_HOME
   - make test 

--- a/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.cpp
+++ b/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.cpp
@@ -157,7 +157,9 @@ void Adafruit_ILI9341::begin(void) {
 	transmitCmdData(0xE1, data, 15);    	//Set Gamma
 
 	transmitCmd(0x11);    	//Exit Sleep
-	os_delay_us(120000);
+//	os_delay_us(120000);
+	os_delay_us(60000);
+	os_delay_us(60000);
 
 	transmitCmd(0x29);    //Display on
 	transmitCmd(0x2c);

--- a/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.cpp
+++ b/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.cpp
@@ -157,7 +157,6 @@ void Adafruit_ILI9341::begin(void) {
 	transmitCmdData(0xE1, data, 15);    	//Set Gamma
 
 	transmitCmd(0x11);    	//Exit Sleep
-//	os_delay_us(120000);
 	os_delay_us(60000);
 	os_delay_us(60000);
 

--- a/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.cpp
+++ b/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.cpp
@@ -157,8 +157,7 @@ void Adafruit_ILI9341::begin(void) {
 	transmitCmdData(0xE1, data, 15);    	//Set Gamma
 
 	transmitCmd(0x11);    	//Exit Sleep
-	os_delay_us(60000);
-	os_delay_us(60000);
+	os_delay_us(120000);
 
 	transmitCmd(0x29);    //Display on
 	transmitCmd(0x2c);

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -173,10 +173,15 @@ THIRD_PARTY_DATA += third-party/http-parser/Makefile
 MODULES		     += third-party/http-parser/
 EXTRA_INCDIR     += third-party/http-parser/
 
-# => webscoket-parser
+# => websocket-parser
 THIRD_PARTY_DATA += third-party/ws_parser/Makefile
 MODULES              += third-party/ws_parser/
 EXTRA_INCDIR     += third-party/ws_parser/
+
+# => SDK
+ifneq (,$(findstring third-party/ESP8266_NONOS_SDK, $(SDK_BASE)))
+	THIRD_PARTY_DATA += third-party/ESP8266_NONOS_SDK/Makefile
+endif
 
 # => esp-gdbstub
 ifeq ($(ENABLE_GDB), 1)

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -181,6 +181,7 @@ EXTRA_INCDIR     += third-party/ws_parser/
 # => SDK
 ifneq (,$(findstring third-party/ESP8266_NONOS_SDK, $(SDK_BASE)))
 	THIRD_PARTY_DATA += third-party/ESP8266_NONOS_SDK/Makefile
+	CFLAGS += -DSDK_INTERNAL
 endif
 
 # => esp-gdbstub
@@ -245,7 +246,7 @@ endif
 MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
 
 # compiler flags using during compilation of source files. Add '-pg' for debugging
-CFLAGS = -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
+CFLAGS += -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
          -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1
 ifeq ($(SMING_RELEASE),1)
 	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -227,6 +227,10 @@ endif
 
 # compiler flags using during compilation of source files
 CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR)
+# => SDK
+ifneq (,$(findstring third-party/ESP8266_NONOS_SDK, $(SDK_BASE)))
+	CFLAGS += -DSDK_INTERNAL
+endif
 ifeq ($(SMING_RELEASE),1)
 	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
 	#      for full list of optimization options

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -198,6 +198,10 @@ USER_LIBDIR  = $(SMING_HOME)/compiler/lib/
 
 # compiler flags using during compilation of source files
 CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR)
+# => SDK
+ifneq (,$(findstring third-party/ESP8266_NONOS_SDK, $(SDK_BASE)))
+	CFLAGS += -DSDK_INTERNAL
+endif
 ifeq ($(SMING_RELEASE),1)
 	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
 	#      for full list of optimization options

--- a/Sming/SmingCore/Clock.cpp
+++ b/Sming/SmingCore/Clock.cpp
@@ -26,10 +26,10 @@ void delay(uint32_t time)
 	int remainder = time % MAX_SAFE_DELAY;
 	for(int i=0, max = quotient + 1; i < max ; i++) {
 		if(i == quotient) {
-			os_delay_us((uint16_t)(remainder * 1000));
+			os_delay_us(remainder * 1000);
 		}
 		else {
-			os_delay_us((uint16_t)(MAX_SAFE_DELAY * 1000));
+			os_delay_us(MAX_SAFE_DELAY * 1000);
 		}
 
 		system_soft_wdt_feed ();

--- a/Sming/SmingCore/Clock.cpp
+++ b/Sming/SmingCore/Clock.cpp
@@ -26,10 +26,10 @@ void delay(uint32_t time)
 	int remainder = time % MAX_SAFE_DELAY;
 	for(int i=0, max = quotient + 1; i < max ; i++) {
 		if(i == quotient) {
-			os_delay_us(remainder * 1000);
+			os_delay_us((uint16_t)(remainder * 1000));
 		}
 		else {
-			os_delay_us(MAX_SAFE_DELAY * 1000);
+			os_delay_us((uint16_t)(MAX_SAFE_DELAY * 1000));
 		}
 
 		system_soft_wdt_feed ();

--- a/Sming/SmingCore/HardwareTimer.cpp
+++ b/Sming/SmingCore/HardwareTimer.cpp
@@ -48,12 +48,12 @@ static void IRAM_ATTR hw_timer_isr_cb(void *arg)
 
 Hardware_Timer::Hardware_Timer()
 {
-    ETS_FRC_TIMER1_INTR_ATTACH((void*)hw_timer_isr_cb, (void *)this);
+    ETS_FRC_TIMER1_INTR_ATTACH((ets_isr_t)hw_timer_isr_cb, (void *)this);
 }
 
 Hardware_Timer::~Hardware_Timer()
 {
-    ETS_FRC_TIMER1_INTR_ATTACH((void*)hw_timer_isr_cb, null);
+    ETS_FRC_TIMER1_INTR_ATTACH((ets_isr_t)hw_timer_isr_cb, null);
 	stop();
 }
 

--- a/Sming/SmingCore/Interrupts.cpp
+++ b/Sming/SmingCore/Interrupts.cpp
@@ -47,7 +47,7 @@ void attachInterruptHandler(uint8_t pin, GPIO_INT_TYPE mode)
 
 	if (!_gpioInterruptsInitialied)
 	{
-		ETS_GPIO_INTR_ATTACH((void*)interruptHandler, NULL); // Register interrupt handler
+		ETS_GPIO_INTR_ATTACH((ets_isr_t)interruptHandler, NULL); // Register interrupt handler
 		_gpioInterruptsInitialied = true;
 	}
 

--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -20,7 +20,6 @@
 #include <stdlib.h>
 #include "eagle_soc.h"
 #include "espinc/spi_register.h"
-//#include "espinc/c_types_compatible.h"
 #include "c_types.h"
 // define the static singleton
 SPIClass SPI;

--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include "eagle_soc.h"
 #include "espinc/spi_register.h"
+//#include "espinc/c_types_compatible.h"
 #include "c_types.h"
 // define the static singleton
 SPIClass SPI;

--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -20,8 +20,8 @@
 #include <stdlib.h>
 #include "eagle_soc.h"
 #include "espinc/spi_register.h"
-#include "espinc/c_types_compatible.h"
-
+//#include "espinc/c_types_compatible.h"
+#include "c_types.h"
 // define the static singleton
 SPIClass SPI;
 

--- a/Sming/compiler/ld/common.ld
+++ b/Sming/compiler/ld/common.ld
@@ -155,8 +155,8 @@ SECTIONS
     
     *libsmartconfig.a:(.literal .text .literal.* .text.*)
     *libstdc++.a:(.literal .text .literal.* .text.*)
-    *liblwip_gcc.a:(.literal .text .literal.* .text.*)
-    *liblwip_src.a:(.literal .text .literal.* .text.*)
+    *liblwip_open.a:(.literal .text .literal.* .text.*)
+    *liblwip_full.a:(.literal .text .literal.* .text.*)
     *libaxtls.a:(.literal .text .literal.* .text.*)
     *libat.a:(.literal.* .text.*)
     *libcrypto.a:(.literal.* .text.*)
@@ -171,6 +171,10 @@ SECTIONS
     *libwpa.a:(.literal.* .text.*)
     *libwpa2.a:(.literal.* .text.*)
     *libwps.a:(.literal.* .text.*)
+    
+    *libmbedtls.a:(.literal.* .text.*)
+
+    *libm.a:(.literal .text .literal.* .text.*)
     
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.debug.*)
 	out/build/app_app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)

--- a/Sming/compiler/ld/common.ld
+++ b/Sming/compiler/ld/common.ld
@@ -152,6 +152,26 @@ SECTIONS
   .irom0.text : ALIGN(4)
   {
     _irom0_text_start = ABSOLUTE(.);
+    
+    *libsmartconfig.a:(.literal .text .literal.* .text.*)
+    *libstdc++.a:(.literal .text .literal.* .text.*)
+    *liblwip_gcc.a:(.literal .text .literal.* .text.*)
+    *liblwip_src.a:(.literal .text .literal.* .text.*)
+    *libaxtls.a:(.literal .text .literal.* .text.*)
+    *libat.a:(.literal.* .text.*)
+    *libcrypto.a:(.literal.* .text.*)
+    *libespnow.a:(.literal.* .text.*)
+    *libjson.a:(.literal.* .text.*)
+    *liblwip.a:(.literal.* .text.*)
+    *libmesh.a:(.literal.* .text.*)
+    *libnet80211.a:(.literal.* .text.*)
+    *libsmartconfig.a:(.literal.* .text.*)
+    *libssl.a:(.literal.* .text.*)
+    *libupgrade.a:(.literal.* .text.*)
+    *libwpa.a:(.literal.* .text.*)
+    *libwpa2.a:(.literal.* .text.*)
+    *libwps.a:(.literal.* .text.*)
+    
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.debug.*)
 	out/build/app_app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
   *libsming.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)

--- a/Sming/compiler/ld/common.ld
+++ b/Sming/compiler/ld/common.ld
@@ -157,6 +157,7 @@ SECTIONS
     *libstdc++.a:(.literal .text .literal.* .text.*)
     *liblwip_open.a:(.literal .text .literal.* .text.*)
     *liblwip_full.a:(.literal .text .literal.* .text.*)
+    *liblwip2.a:(.literal .text .literal.* .text.*)
     *libaxtls.a:(.literal .text .literal.* .text.*)
     *libat.a:(.literal.* .text.*)
     *libcrypto.a:(.literal.* .text.*)
@@ -180,7 +181,7 @@ SECTIONS
 	out/build/app_app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
   *libsming.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
   *libsmingssl.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
-  *liblwip2.a:(.literal .text .literal.* .text.*)
+  
     _irom0_text_end = ABSOLUTE(.);
 	_flash_code_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr

--- a/Sming/include/user_config.h
+++ b/Sming/include/user_config.h
@@ -17,13 +17,10 @@ extern "C" {
 	#include <limits.h>
 	#include <stdint.h>
 
-	// Override c_types.h include and remove buggy espconn
-//	#define _C_TYPES_H_
+	// Remove buggy espconn
 	#define _NO_ESPCON_
 
-	// Updated, compatible version of c_types.h
-	// Just removed types declared in <stdint.h>
-//	#include <espinc/c_types_compatible.h>
+	// Now ESP SDK provide proper c_types.h by itself
 	#include "c_types.h"
 
 	// System API declarations

--- a/Sming/include/user_config.h
+++ b/Sming/include/user_config.h
@@ -18,12 +18,13 @@ extern "C" {
 	#include <stdint.h>
 
 	// Override c_types.h include and remove buggy espconn
-	#define _C_TYPES_H_
+//	#define _C_TYPES_H_
 	#define _NO_ESPCON_
 
 	// Updated, compatible version of c_types.h
 	// Just removed types declared in <stdint.h>
-	#include <espinc/c_types_compatible.h>
+//	#include <espinc/c_types_compatible.h>
+	#include "c_types.h"
 
 	// System API declarations
 	#include <esp_systemapi.h>

--- a/Sming/include/user_config.h
+++ b/Sming/include/user_config.h
@@ -20,8 +20,14 @@ extern "C" {
 	// Remove buggy espconn
 	#define _NO_ESPCON_
 
-	// Now ESP SDK provide proper c_types.h by itself
+#ifdef SDK_INTERNAL
+	// ESP SDK  2.1 or later provide proper c_types.h
 	#include "c_types.h"
+#else
+	// Older SDKs, have wrong or incompatible c_types type definitions
+	#define _C_TYPES_H_
+	#include <espinc/c_types_compatible.h>
+#endif /* SDK_INTERNAL */
 
 	// System API declarations
 	#include <esp_systemapi.h>

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -3,7 +3,7 @@
 #ifndef __ESP_SYSTEM_API_H__
 #define __ESP_SYSTEM_API_H__
 
-#include <ets_sys.h>
+#include "ets_sys.h"
 #include <osapi.h>
 #include <gpio.h>
 #include <os_type.h>
@@ -43,7 +43,7 @@
 #endif
 #define assert(condition) if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__)
 #define SYSTEM_ERROR(fmt, ...) m_printf("ERROR: " fmt "\r\n", ##__VA_ARGS__)
-
+/*
 extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
 extern void ets_timer_disarm(ETSTimer *a);
 extern void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *pfunction, void *parg);
@@ -91,13 +91,17 @@ extern void uart_tx_one_char(char ch);
 
 extern void ets_intr_lock();
 extern void ets_intr_unlock();
-
+*/
 // CPU Frequency
 extern void ets_update_cpu_frequency(uint32_t frq);
 extern uint32_t ets_get_cpu_frequency();
 
 extern void xt_disable_interrupts();
 extern void xt_enable_interrupts();
+
+extern void uart_tx_one_char(char ch);
+extern void ets_isr_mask(unsigned intr);
+extern void ets_isr_unmask(unsigned intr);
 
 typedef signed short file_t;
 

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -43,55 +43,6 @@
 #endif
 #define assert(condition) if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__)
 #define SYSTEM_ERROR(fmt, ...) m_printf("ERROR: " fmt "\r\n", ##__VA_ARGS__)
-/*
-extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
-extern void ets_timer_disarm(ETSTimer *a);
-extern void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *pfunction, void *parg);
-
-//extern void ets_wdt_init(uint32_t val); // signature?
-extern void ets_wdt_enable(void);
-extern void ets_wdt_disable(void);
-extern void wdt_feed(void);
-//extern void wd_reset_cnt(void);
-extern void ets_delay_us(uint32_t us);
-
-extern void ets_isr_mask(unsigned intr);
-extern void ets_isr_unmask(unsigned intr);
-extern void ets_isr_attach(int intr, void *handler, void *arg);
-
-extern int ets_memcmp(const void *s1, const void *s2, size_t n);
-extern void *ets_memcpy(void *dest, const void *src, size_t n);
-extern void *ets_memset(void *s, int c, size_t n);
-
-extern void ets_install_putc1(void *routine);
-extern int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
-extern int ets_str2macaddr(void *, void *);
-extern int ets_strcmp(const char *s1, const char *s2);
-extern char *ets_strcpy(char *dest, const char *src);
-//extern int os_random();
-//extern char *ets_strdup(const char *str); // :(
-const char * ets_strrchr(const char *str, int character);
-extern size_t ets_strlen(const char *s);
-extern int ets_strncmp(const char *s1, const char *s2, int len);
-extern char *ets_strncpy(char *dest, const char *src, size_t n);
-extern char *ets_strstr(const char *haystack, const char *needle);
-extern int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
-extern int os_snprintf(char *str, size_t size, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
-extern int ets_vsnprintf(char * s, size_t n, const char * format, va_list arg) __attribute__ ((format (printf, 3, 0)));
-
-extern void *pvPortMalloc(size_t xWantedSize, const char *file, uint32 line);
-extern void *pvPortZalloc(size_t xWantedSize, const char *file, uint32 line);
-extern void pvPortFree(void *ptr);
-extern void vPortFree(void *ptr, const char *file, uint32 line);
-extern void *vPortMalloc(size_t xWantedSize);
-
-extern void uart_div_modify(int no, unsigned int freq);
-extern int ets_uart_printf(const char *fmt, ...);
-extern void uart_tx_one_char(char ch);
-
-extern void ets_intr_lock();
-extern void ets_intr_unlock();
-*/
 // CPU Frequency
 extern void ets_update_cpu_frequency(uint32_t frq);
 extern uint32_t ets_get_cpu_frequency();

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -3,7 +3,7 @@
 #ifndef __ESP_SYSTEM_API_H__
 #define __ESP_SYSTEM_API_H__
 
-#include <ets_sys.h>
+#include "ets_sys.h"
 #include <osapi.h>
 #include <gpio.h>
 #include <os_type.h>

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -3,7 +3,7 @@
 #ifndef __ESP_SYSTEM_API_H__
 #define __ESP_SYSTEM_API_H__
 
-#include "ets_sys.h"
+#include <ets_sys.h>
 #include <osapi.h>
 #include <gpio.h>
 #include <os_type.h>
@@ -43,6 +43,63 @@
 #endif
 #define assert(condition) if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__)
 #define SYSTEM_ERROR(fmt, ...) m_printf("ERROR: " fmt "\r\n", ##__VA_ARGS__)
+
+#ifndef SDK_INTERNAL
+extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
+extern void ets_timer_disarm(ETSTimer *a);
+extern void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *pfunction, void *parg);
+
+//extern void ets_wdt_init(uint32_t val); // signature?
+extern void ets_wdt_enable(void);
+extern void ets_wdt_disable(void);
+extern void wdt_feed(void);
+//extern void wd_reset_cnt(void);
+extern void ets_delay_us(uint32_t us);
+
+extern void ets_isr_mask(unsigned intr);
+extern void ets_isr_unmask(unsigned intr);
+
+typedef void (* ets_isr_t)(void *);
+
+//extern void ets_isr_attach(int intr, void *handler, void *arg);
+extern void ets_isr_attach(int i, ets_isr_t func, void *arg);
+
+extern int ets_memcmp(const void *s1, const void *s2, size_t n);
+extern void *ets_memcpy(void *dest, const void *src, size_t n);
+extern void *ets_memset(void *s, int c, size_t n);
+
+//extern void ets_install_putc1(void *routine);
+extern void ets_install_putc1(void (*p)(char c));
+extern int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
+extern int ets_str2macaddr(void *, void *);
+extern int ets_strcmp(const char *s1, const char *s2);
+extern char *ets_strcpy(char *dest, const char *src);
+//extern int os_random();
+//extern char *ets_strdup(const char *str); // :(
+const char * ets_strrchr(const char *str, int character);
+extern int ets_strlen(const char *s);
+extern int ets_strncmp(const char *s1, const char *s2, unsigned int len);
+extern char *ets_strncpy(char *dest, const char *src, size_t n);
+extern char *ets_strstr(const char *haystack, const char *needle);
+extern int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
+extern int os_snprintf(char *str, size_t size, const char *format, ...) __attribute__ ((format (printf, 3, 4)));
+extern int ets_vsnprintf(char * s, size_t n, const char * format, va_list arg) __attribute__ ((format (printf, 3, 0)));
+
+extern void *pvPortMalloc(size_t xWantedSize, const char *file, uint32 line);
+extern void *pvPortZalloc(size_t xWantedSize, const char *file, uint32 line);
+extern void pvPortFree(void *ptr);
+extern void vPortFree(void *ptr, const char *file, uint32 line);
+extern void *vPortMalloc(size_t xWantedSize);
+
+extern void uart_div_modify(uint8 uart_no, uint32 DivLatchValue);
+extern int ets_uart_printf(const char *fmt, ...);
+extern void uart_tx_one_char(char ch);
+
+extern void ets_intr_lock();
+extern void ets_intr_unlock();
+
+#endif /* SDK_INTERNAL */
+
 // CPU Frequency
 extern void ets_update_cpu_frequency(uint32_t frq);
 extern uint32_t ets_get_cpu_frequency();

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -3,7 +3,7 @@
 #ifndef __ESP_SYSTEM_API_H__
 #define __ESP_SYSTEM_API_H__
 
-#include "ets_sys.h"
+#include <ets_sys.h>
 #include <osapi.h>
 #include <gpio.h>
 #include <os_type.h>

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -493,20 +493,17 @@ void uart_set_debug(int uart_nr)
         system_set_os_print(1);
         ets_install_putc1((void *) &uart0_write_char);
         ets_install_putc1(uart0_write_char);
-        ets_install_putc1((void (*)(char)) &uart0_write_char);
         break;
     case UART1:
         system_set_os_print(1);
         ets_install_putc1((void *) &uart1_write_char);
         ets_install_putc1(uart1_write_char);
-        ets_install_putc1((void (*)(char)) &uart1_write_char);
         break;
     case UART_NO:
     default:
         system_set_os_print(0);
         ets_install_putc1((void *) &uart_ignore_char);
         ets_install_putc1(uart_ignore_char);
-        ets_install_putc1((void (*)(char)) &uart_ignore_char);
         break;
     }
 }

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -491,16 +491,22 @@ void uart_set_debug(int uart_nr)
     switch(s_uart_debug_nr) {
     case UART0:
         system_set_os_print(1);
+        ets_install_putc1((void *) &uart0_write_char);
         ets_install_putc1(uart0_write_char);
+        ets_install_putc1((void (*)(char)) &uart0_write_char);
         break;
     case UART1:
         system_set_os_print(1);
+        ets_install_putc1((void *) &uart1_write_char);
         ets_install_putc1(uart1_write_char);
+        ets_install_putc1((void (*)(char)) &uart1_write_char);
         break;
     case UART_NO:
     default:
         system_set_os_print(0);
+        ets_install_putc1((void *) &uart_ignore_char);
         ets_install_putc1(uart_ignore_char);
+        ets_install_putc1((void (*)(char)) &uart_ignore_char);
         break;
     }
 }

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -139,8 +139,7 @@ void uart_start_isr(uart_t* uart)
     USC1(uart->uart_nr) = (127 << UCFFT) | (0x02 << UCTOT) | (1 <<UCTOE );
     USIC(uart->uart_nr) = 0xffff;
     USIE(uart->uart_nr) = (1 << UIFF) | (1 << UIFR) | (1 << UITO);
-//    ETS_UART_INTR_ATTACH(uart_isr,  (void *)uart);
-    ETS_UART_INTR_ATTACH((ets_isr_t)uart_isr,  (void *)uart);
+    ETS_UART_INTR_ATTACH(uart_isr,  (void *)uart);
     ETS_UART_INTR_ENABLE();
 }
 
@@ -492,16 +491,16 @@ void uart_set_debug(int uart_nr)
     switch(s_uart_debug_nr) {
     case UART0:
         system_set_os_print(1);
-        ets_install_putc1((void (*)(char)) &uart0_write_char);
+        ets_install_putc1(uart0_write_char);
         break;
     case UART1:
         system_set_os_print(1);
-        ets_install_putc1((void (*)(char)) &uart1_write_char);
+        ets_install_putc1(uart1_write_char);
         break;
     case UART_NO:
     default:
         system_set_os_print(0);
-        ets_install_putc1((void (*)(char)) &uart_ignore_char);
+        ets_install_putc1(uart_ignore_char);
         break;
     }
 }

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -140,7 +140,7 @@ void uart_start_isr(uart_t* uart)
     USIC(uart->uart_nr) = 0xffff;
     USIE(uart->uart_nr) = (1 << UIFF) | (1 << UIFR) | (1 << UITO);
 //    ETS_UART_INTR_ATTACH(uart_isr,  (void *)uart);
-    ETS_UART_INTR_ATTACH((void *)uart_isr,  (void *)uart);
+    ETS_UART_INTR_ATTACH((ets_isr_t)uart_isr,  (void *)uart);
     ETS_UART_INTR_ENABLE();
 }
 
@@ -492,16 +492,16 @@ void uart_set_debug(int uart_nr)
     switch(s_uart_debug_nr) {
     case UART0:
         system_set_os_print(1);
-        ets_install_putc1((void *) &uart0_write_char);
+        ets_install_putc1((void (*)(char)) &uart0_write_char);
         break;
     case UART1:
         system_set_os_print(1);
-        ets_install_putc1((void *) &uart1_write_char);
+        ets_install_putc1((void (*)(char)) &uart1_write_char);
         break;
     case UART_NO:
     default:
         system_set_os_print(0);
-        ets_install_putc1((void *) &uart_ignore_char);
+        ets_install_putc1((void (*)(char)) &uart_ignore_char);
         break;
     }
 }

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -491,18 +491,15 @@ void uart_set_debug(int uart_nr)
     switch(s_uart_debug_nr) {
     case UART0:
         system_set_os_print(1);
-        ets_install_putc1((void *) &uart0_write_char);
         ets_install_putc1(uart0_write_char);
         break;
     case UART1:
         system_set_os_print(1);
-        ets_install_putc1((void *) &uart1_write_char);
         ets_install_putc1(uart1_write_char);
         break;
     case UART_NO:
     default:
         system_set_os_print(0);
-        ets_install_putc1((void *) &uart_ignore_char);
         ets_install_putc1(uart_ignore_char);
         break;
     }

--- a/Sming/third-party/.patches/ESP8266_NONOS_SDK.patch
+++ b/Sming/third-party/.patches/ESP8266_NONOS_SDK.patch
@@ -1,0 +1,13 @@
+diff --git a/include/osapi.h b/include/osapi.h
+index 0462a9c..52ad21f 100644
+--- a/include/osapi.h
++++ b/include/osapi.h
+@@ -30,7 +30,7 @@
+ #include "user_config.h"
+ 
+ void ets_bzero(void *s, size_t n);
+-void ets_delay_us(uint16_t us);
++void ets_delay_us(uint32_t us);
+ void ets_install_putc1(void (*p)(char c));
+ 
+ #define os_bzero ets_bzero

--- a/Sming/third-party/.patches/esp-gdbstub.patch
+++ b/Sming/third-party/.patches/esp-gdbstub.patch
@@ -1,5 +1,5 @@
 diff --git a/gdbstub.c b/gdbstub.c
-index 5fc6633..03f6d49 100644
+index 5fc6633..fe655b8 100644
 --- a/gdbstub.c
 +++ b/gdbstub.c
 @@ -8,6 +8,7 @@
@@ -42,3 +42,12 @@ index 5fc6633..03f6d49 100644
  		while(gdbReadCommand()!=ST_CONT);
  		ets_wdt_enable();
  		//Copy any changed registers back to the frame the Xtensa HAL uses.
+@@ -714,7 +719,7 @@ static void ATTR_GDBFN uart_hdlr(void *arg, void *frame) {
+ }
+ 
+ static void ATTR_GDBINIT install_uart_hdlr() {
+-	ets_isr_attach(ETS_UART_INUM, uart_hdlr, NULL);
++	ets_isr_attach(ETS_UART_INUM, (ets_isr_t)uart_hdlr, NULL);
+ 	SET_PERI_REG_MASK(UART_INT_ENA(0), UART_RXFIFO_FULL_INT_ENA|UART_RXFIFO_TOUT_INT_ENA);
+ 	ets_isr_unmask((1<<ETS_UART_INUM)); //enable uart interrupt
+ }

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -1,30 +1,5 @@
-diff --git a/include/user_config.h b/include/user_config.h
-index e69de29..0c5dff9 100644
---- a/include/user_config.h
-+++ b/include/user_config.h
-@@ -0,0 +1,20 @@
-+#ifndef _USER_CONFIG_LWIP_
-+#define _USER_CONFIG_LWIP_
-+
-+#ifdef __cplusplus
-+extern "C" {
-+#endif
-+
-+typedef signed short        sint16_t;
-+
-+void *ets_bzero(void *block, size_t size);
-+bool ets_post(uint32_t prio, ETSSignal sig, ETSParam par);
-+void ets_task(ETSTask task, uint32_t prio, ETSEvent * queue, uint8 qlen);
-+
-+void system_pp_recycle_rx_pkt(void *eb);
-+
-+#ifdef __cplusplus
-+}
-+#endif
-+
-+#endif /*_USER_CONFIG_LWIP_*/
 diff --git a/Makefile.open b/Makefile.open
-index 1bc584f..0bfc424 100644
+index 1bc584f..e4af916 100644
 --- a/Makefile.open
 +++ b/Makefile.open
 @@ -1,8 +1,10 @@
@@ -75,36 +50,30 @@ index 1bc584f..0bfc424 100644
  $(LIB): $(OBJS)
  	$(AR) rcs $@ $^
 diff --git a/include/arch/cc.h b/include/arch/cc.h
-index ff03b30..6664d59 100644
+index ff03b30..e86ae57 100644
 --- a/include/arch/cc.h
 +++ b/include/arch/cc.h
-@@ -38,8 +38,25 @@
+@@ -34,12 +34,18 @@
+ #ifndef __ARCH_CC_H__
+ #define __ARCH_CC_H__
+ 
+-//#include <string.h>
  #include "c_types.h"
  #include "ets_sys.h"
  #include "osapi.h"
++#include "mem.h"
 +#include <stdarg.h>
 +
  #define EFAULT 14
  
 +//Extra symbols to avoid implicit declaration warnings
-+extern void *ets_memset(void *s, int c, size_t n);
-+extern void *ets_memcpy(void *dest, const void *src, size_t n);
-+
-+extern size_t ets_strlen(const char *s);
-+extern int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
-+extern int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
-+//extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
-+extern void ets_timer_disarm(ETSTimer *a);
-+extern void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *pfunction, void *parg);
 +extern uint32 r_rand(void);
-+extern int ets_memcmp(const void *s1, const void *s2, size_t n);
-+
 +struct netif * eagle_lwip_getif(uint8 index);
 +
  //#define LWIP_PROVIDE_ERRNO
  
  #if (1)
-@@ -56,6 +73,7 @@ typedef signed     short   s16_t;
+@@ -56,6 +62,7 @@ typedef signed     short   s16_t;
  typedef unsigned   long    u32_t;
  typedef signed     long    s32_t;
  typedef unsigned long   mem_ptr_t;
@@ -112,7 +81,7 @@ index ff03b30..6664d59 100644
  
  #define S16_F "d"
  #define U16_F "d"
-@@ -73,11 +91,12 @@ typedef unsigned long   mem_ptr_t;
+@@ -73,11 +80,12 @@ typedef unsigned long   mem_ptr_t;
  #define PACK_STRUCT_BEGIN
  #define PACK_STRUCT_END
  
@@ -129,6 +98,48 @@ index ff03b30..6664d59 100644
  #else
  #define LWIP_PLATFORM_DIAG(x)
  #define LWIP_PLATFORM_ASSERT(x)
+diff --git a/include/lwip/ip_addr.h b/include/lwip/ip_addr.h
+index 1e46ee5..cfc10f8 100644
+--- a/include/lwip/ip_addr.h
++++ b/include/lwip/ip_addr.h
+@@ -210,7 +210,7 @@ u8_t ip4_addr_netmask_valid(u32_t netmask)ICACHE_FLASH_ATTR;
+ #define ip_addr_islinklocal(addr1) (((addr1)->addr & PP_HTONL(0xffff0000UL)) == PP_HTONL(0xa9fe0000UL))
+ 
+ #define ip_addr_debug_print(debug, ipaddr) \
+-  LWIP_DEBUGF(debug, ("%"U16_F".%"U16_F".%"U16_F".%"U16_F,             \
++  LWIP_DEBUGF(debug, ("%" U16_F ".%" U16_F ".%" U16_F ".%" U16_F,             \
+                       ipaddr != NULL ? ip4_addr1_16(ipaddr) : 0,       \
+                       ipaddr != NULL ? ip4_addr2_16(ipaddr) : 0,       \
+                       ipaddr != NULL ? ip4_addr3_16(ipaddr) : 0,       \
+diff --git a/include/lwip/mem.h b/include/lwip/mem.h
+index af6e360..6d8cabd 100644
+--- a/include/lwip/mem.h
++++ b/include/lwip/mem.h
+@@ -52,19 +52,19 @@ typedef size_t mem_size_t;
+  */
+ #ifndef MEMLEAK_DEBUG
+ #ifndef mem_free
+-#define mem_free vPortFree
++#define mem_free(s) vPortFree(s, "", 0)
+ #endif
+ #ifndef mem_malloc
+-#define mem_malloc pvPortMalloc
++#define mem_malloc(s) pvPortMalloc(s, "", 0)
+ #endif
+ #ifndef mem_calloc
+-#define mem_calloc pvPortCalloc
++#define mem_calloc(s) pvPortCalloc(s, "", 0);
+ #endif
+ #ifndef mem_realloc
+-#define mem_realloc pvPortRealloc
++#define mem_realloc(p, s)  pvPortRealloc(p, s, "", 0)
+ #endif
+ #ifndef mem_zalloc
+-#define mem_zalloc pvPortZalloc
++#define mem_zalloc(s)      pvPortZalloc(s, "", 0)
+ #endif
+ #else
+ #ifndef mem_free
 diff --git a/include/lwipopts.h b/include/lwipopts.h
 index eaa8dd6..6568657 100644
 --- a/include/lwipopts.h
@@ -205,49 +216,27 @@ index eaa8dd6..6568657 100644
  #endif
  
  /**
-diff --git a/include/lwip/ip_addr.h b/include/lwip/ip_addr.h
-index 1e46ee5..cfc10f8 100644
---- a/include/lwip/ip_addr.h
-+++ b/include/lwip/ip_addr.h
-@@ -210,7 +210,7 @@ u8_t ip4_addr_netmask_valid(u32_t netmask)ICACHE_FLASH_ATTR;
- #define ip_addr_islinklocal(addr1) (((addr1)->addr & PP_HTONL(0xffff0000UL)) == PP_HTONL(0xa9fe0000UL))
- 
- #define ip_addr_debug_print(debug, ipaddr) \
--  LWIP_DEBUGF(debug, ("%"U16_F".%"U16_F".%"U16_F".%"U16_F,             \
-+  LWIP_DEBUGF(debug, ("%" U16_F ".%" U16_F ".%" U16_F ".%" U16_F,             \
-                       ipaddr != NULL ? ip4_addr1_16(ipaddr) : 0,       \
-                       ipaddr != NULL ? ip4_addr2_16(ipaddr) : 0,       \
-                       ipaddr != NULL ? ip4_addr3_16(ipaddr) : 0,       \
-diff --git a/include/lwip/mem.h b/include/lwip/mem.h
-index af6e360..6d8cabd 100644
---- a/include/lwip/mem.h
-+++ b/include/lwip/mem.h
-@@ -52,19 +52,19 @@ typedef size_t mem_size_t;
-  */
- #ifndef MEMLEAK_DEBUG
- #ifndef mem_free
--#define mem_free vPortFree
-+#define mem_free(s) vPortFree(s, "", 0)
- #endif
- #ifndef mem_malloc
--#define mem_malloc pvPortMalloc
-+#define mem_malloc(s) pvPortMalloc(s, "", 0)
- #endif
- #ifndef mem_calloc
--#define mem_calloc pvPortCalloc
-+#define mem_calloc(s) pvPortCalloc(s, "", 0);
- #endif
- #ifndef mem_realloc
--#define mem_realloc pvPortRealloc
-+#define mem_realloc(p, s)  pvPortRealloc(p, s, "", 0)
- #endif
- #ifndef mem_zalloc
--#define mem_zalloc pvPortZalloc
-+#define mem_zalloc(s)      pvPortZalloc(s, "", 0)
- #endif
- #else
- #ifndef mem_free
- diff --git a/lwip/app/dhcpserver.c b/lwip/app/dhcpserver.c
+diff --git a/include/user_config.h b/include/user_config.h
+index e69de29..07768eb 100644
+--- a/include/user_config.h
++++ b/include/user_config.h
+@@ -0,0 +1,15 @@
++#ifndef _USER_CONFIG_LWIP_
++#define _USER_CONFIG_LWIP_
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++#include "c_types.h"
++void system_pp_recycle_rx_pkt(void *eb);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /*_USER_CONFIG_LWIP_*/
+diff --git a/lwip/app/dhcpserver.c b/lwip/app/dhcpserver.c
 index ddb5984..fb677c6 100644
 --- a/lwip/app/dhcpserver.c
 +++ b/lwip/app/dhcpserver.c

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -1,8 +1,8 @@
 diff --git a/include/user_config.h b/include/user_config.h
-index e69de29..235ceff 100644
+index e69de29..d608ddf 100644
 --- a/include/user_config.h
 +++ b/include/user_config.h
-@@ -0,0 +1,20 @@
+@@ -0,0 +1,21 @@
 +#ifndef _USER_CONFIG_LWIP_
 +#define _USER_CONFIG_LWIP_
 +
@@ -10,6 +10,7 @@ index e69de29..235ceff 100644
 +extern "C" {
 +#endif
 +
++#include "c_types.h"
 +typedef signed short        sint16_t;
 +
 +void ets_bzero(void *block, size_t size);
@@ -75,13 +76,14 @@ index 1bc584f..e4af916 100644
  $(LIB): $(OBJS)
  	$(AR) rcs $@ $^
 diff --git a/include/arch/cc.h b/include/arch/cc.h
-index ff03b30..0da8ed3 100644
+index ff03b30..348ee12 100644
 --- a/include/arch/cc.h
 +++ b/include/arch/cc.h
-@@ -38,8 +38,25 @@
+@@ -38,8 +38,26 @@
  #include "c_types.h"
  #include "ets_sys.h"
  #include "osapi.h"
++#include "mem.h"
 +#include <stdarg.h>
 +
  #define EFAULT 14
@@ -104,7 +106,7 @@ index ff03b30..0da8ed3 100644
  //#define LWIP_PROVIDE_ERRNO
  
  #if (1)
-@@ -56,6 +73,7 @@ typedef signed     short   s16_t;
+@@ -56,6 +74,7 @@ typedef signed     short   s16_t;
  typedef unsigned   long    u32_t;
  typedef signed     long    s32_t;
  typedef unsigned long   mem_ptr_t;
@@ -112,7 +114,7 @@ index ff03b30..0da8ed3 100644
  
  #define S16_F "d"
  #define U16_F "d"
-@@ -73,11 +91,12 @@ typedef unsigned long   mem_ptr_t;
+@@ -73,11 +92,12 @@ typedef unsigned long   mem_ptr_t;
  #define PACK_STRUCT_BEGIN
  #define PACK_STRUCT_END
  

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -1,3 +1,28 @@
+diff --git a/include/user_config.h b/include/user_config.h
+index e69de29..235ceff 100644
+--- a/include/user_config.h
++++ b/include/user_config.h
+@@ -0,0 +1,20 @@
++#ifndef _USER_CONFIG_LWIP_
++#define _USER_CONFIG_LWIP_
++
++#ifdef __cplusplus
++extern "C" {
++#endif
++
++typedef signed short        sint16_t;
++
++void ets_bzero(void *block, size_t size);
++bool ets_post(uint32_t prio, ETSSignal sig, ETSParam par);
++void ets_task(ETSTask task, uint32_t prio, ETSEvent * queue, uint8 qlen);
++
++void system_pp_recycle_rx_pkt(void *eb);
++
++#ifdef __cplusplus
++}
++#endif
++
++#endif /*_USER_CONFIG_LWIP_*/
 diff --git a/Makefile.open b/Makefile.open
 index 1bc584f..e4af916 100644
 --- a/Makefile.open
@@ -50,30 +75,36 @@ index 1bc584f..e4af916 100644
  $(LIB): $(OBJS)
  	$(AR) rcs $@ $^
 diff --git a/include/arch/cc.h b/include/arch/cc.h
-index ff03b30..e86ae57 100644
+index ff03b30..0da8ed3 100644
 --- a/include/arch/cc.h
 +++ b/include/arch/cc.h
-@@ -34,12 +34,18 @@
- #ifndef __ARCH_CC_H__
- #define __ARCH_CC_H__
- 
--//#include <string.h>
+@@ -38,8 +38,25 @@
  #include "c_types.h"
  #include "ets_sys.h"
  #include "osapi.h"
-+#include "mem.h"
 +#include <stdarg.h>
 +
  #define EFAULT 14
  
 +//Extra symbols to avoid implicit declaration warnings
++extern void *ets_memset(void *s, int c, size_t n);
++extern void *ets_memcpy(void *dest, const void *src, size_t n);
++
++extern int ets_strlen(const char *s);
++extern int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
++extern int ets_sprintf(char *str, const char *format, ...)  __attribute__ ((format (printf, 2, 3)));
++//extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
++extern void ets_timer_disarm(ETSTimer *a);
++extern void ets_timer_setfn(ETSTimer *t, ETSTimerFunc *pfunction, void *parg);
 +extern uint32 r_rand(void);
++extern int ets_memcmp(const void *s1, const void *s2, size_t n);
++
 +struct netif * eagle_lwip_getif(uint8 index);
 +
  //#define LWIP_PROVIDE_ERRNO
  
  #if (1)
-@@ -56,6 +62,7 @@ typedef signed     short   s16_t;
+@@ -56,6 +73,7 @@ typedef signed     short   s16_t;
  typedef unsigned   long    u32_t;
  typedef signed     long    s32_t;
  typedef unsigned long   mem_ptr_t;
@@ -81,7 +112,7 @@ index ff03b30..e86ae57 100644
  
  #define S16_F "d"
  #define U16_F "d"
-@@ -73,11 +80,12 @@ typedef unsigned long   mem_ptr_t;
+@@ -73,11 +91,12 @@ typedef unsigned long   mem_ptr_t;
  #define PACK_STRUCT_BEGIN
  #define PACK_STRUCT_END
  
@@ -98,48 +129,6 @@ index ff03b30..e86ae57 100644
  #else
  #define LWIP_PLATFORM_DIAG(x)
  #define LWIP_PLATFORM_ASSERT(x)
-diff --git a/include/lwip/ip_addr.h b/include/lwip/ip_addr.h
-index 1e46ee5..cfc10f8 100644
---- a/include/lwip/ip_addr.h
-+++ b/include/lwip/ip_addr.h
-@@ -210,7 +210,7 @@ u8_t ip4_addr_netmask_valid(u32_t netmask)ICACHE_FLASH_ATTR;
- #define ip_addr_islinklocal(addr1) (((addr1)->addr & PP_HTONL(0xffff0000UL)) == PP_HTONL(0xa9fe0000UL))
- 
- #define ip_addr_debug_print(debug, ipaddr) \
--  LWIP_DEBUGF(debug, ("%"U16_F".%"U16_F".%"U16_F".%"U16_F,             \
-+  LWIP_DEBUGF(debug, ("%" U16_F ".%" U16_F ".%" U16_F ".%" U16_F,             \
-                       ipaddr != NULL ? ip4_addr1_16(ipaddr) : 0,       \
-                       ipaddr != NULL ? ip4_addr2_16(ipaddr) : 0,       \
-                       ipaddr != NULL ? ip4_addr3_16(ipaddr) : 0,       \
-diff --git a/include/lwip/mem.h b/include/lwip/mem.h
-index af6e360..6d8cabd 100644
---- a/include/lwip/mem.h
-+++ b/include/lwip/mem.h
-@@ -52,19 +52,19 @@ typedef size_t mem_size_t;
-  */
- #ifndef MEMLEAK_DEBUG
- #ifndef mem_free
--#define mem_free vPortFree
-+#define mem_free(s) vPortFree(s, "", 0)
- #endif
- #ifndef mem_malloc
--#define mem_malloc pvPortMalloc
-+#define mem_malloc(s) pvPortMalloc(s, "", 0)
- #endif
- #ifndef mem_calloc
--#define mem_calloc pvPortCalloc
-+#define mem_calloc(s) pvPortCalloc(s, "", 0);
- #endif
- #ifndef mem_realloc
--#define mem_realloc pvPortRealloc
-+#define mem_realloc(p, s)  pvPortRealloc(p, s, "", 0)
- #endif
- #ifndef mem_zalloc
--#define mem_zalloc pvPortZalloc
-+#define mem_zalloc(s)      pvPortZalloc(s, "", 0)
- #endif
- #else
- #ifndef mem_free
 diff --git a/include/lwipopts.h b/include/lwipopts.h
 index eaa8dd6..6568657 100644
 --- a/include/lwipopts.h
@@ -216,26 +205,48 @@ index eaa8dd6..6568657 100644
  #endif
  
  /**
-diff --git a/include/user_config.h b/include/user_config.h
-index e69de29..07768eb 100644
---- a/include/user_config.h
-+++ b/include/user_config.h
-@@ -0,0 +1,15 @@
-+#ifndef _USER_CONFIG_LWIP_
-+#define _USER_CONFIG_LWIP_
-+
-+#ifdef __cplusplus
-+extern "C" {
-+#endif
-+
-+#include "c_types.h"
-+void system_pp_recycle_rx_pkt(void *eb);
-+
-+#ifdef __cplusplus
-+}
-+#endif
-+
-+#endif /*_USER_CONFIG_LWIP_*/
+diff --git a/include/lwip/ip_addr.h b/include/lwip/ip_addr.h
+index 1e46ee5..cfc10f8 100644
+--- a/include/lwip/ip_addr.h
++++ b/include/lwip/ip_addr.h
+@@ -210,7 +210,7 @@ u8_t ip4_addr_netmask_valid(u32_t netmask)ICACHE_FLASH_ATTR;
+ #define ip_addr_islinklocal(addr1) (((addr1)->addr & PP_HTONL(0xffff0000UL)) == PP_HTONL(0xa9fe0000UL))
+ 
+ #define ip_addr_debug_print(debug, ipaddr) \
+-  LWIP_DEBUGF(debug, ("%"U16_F".%"U16_F".%"U16_F".%"U16_F,             \
++  LWIP_DEBUGF(debug, ("%" U16_F ".%" U16_F ".%" U16_F ".%" U16_F,             \
+                       ipaddr != NULL ? ip4_addr1_16(ipaddr) : 0,       \
+                       ipaddr != NULL ? ip4_addr2_16(ipaddr) : 0,       \
+                       ipaddr != NULL ? ip4_addr3_16(ipaddr) : 0,       \
+diff --git a/include/lwip/mem.h b/include/lwip/mem.h
+index af6e360..6d8cabd 100644
+--- a/include/lwip/mem.h
++++ b/include/lwip/mem.h
+@@ -52,19 +52,19 @@ typedef size_t mem_size_t;
+  */
+ #ifndef MEMLEAK_DEBUG
+ #ifndef mem_free
+-#define mem_free vPortFree
++#define mem_free(s) vPortFree(s, "", 0)
+ #endif
+ #ifndef mem_malloc
+-#define mem_malloc pvPortMalloc
++#define mem_malloc(s) pvPortMalloc(s, "", 0)
+ #endif
+ #ifndef mem_calloc
+-#define mem_calloc pvPortCalloc
++#define mem_calloc(s) pvPortCalloc(s, "", 0);
+ #endif
+ #ifndef mem_realloc
+-#define mem_realloc pvPortRealloc
++#define mem_realloc(p, s)  pvPortRealloc(p, s, "", 0)
+ #endif
+ #ifndef mem_zalloc
+-#define mem_zalloc pvPortZalloc
++#define mem_zalloc(s)      pvPortZalloc(s, "", 0)
+ #endif
+ #else
+ #ifndef mem_free
 diff --git a/lwip/app/dhcpserver.c b/lwip/app/dhcpserver.c
 index ddb5984..fb677c6 100644
 --- a/lwip/app/dhcpserver.c

--- a/Sming/third-party/.patches/lwip2.patch
+++ b/Sming/third-party/.patches/lwip2.patch
@@ -23,3 +23,54 @@ index 63cd72d..5f100eb 100644
  #ifdef LWIP_BUILD
  
  // define LWIP_BUILD only when building LWIP
+diff --git a/Makefile.sming b/Makefile.sming
+index 842f4fe..7550a72 100644
+--- a/Makefile.sming
++++ b/Makefile.sming
+@@ -4,12 +4,13 @@
+ USER_LIBDIR ?= tweaked-
+ LWIP_LIB_RELEASE=$(USER_LIBDIR)liblwip2.a
+ LWIP_INCLUDES_RELEASE=include
++SDK_BASE ?= $(ESP_HOME)/sdk
+ 
+ all: install
+ 
+ %:
+ 	@make -f makefiles/Makefile.build-lwip2 \
+-			SDK=$(ESP_HOME)/sdk \
++			SDK=$(SDK_BASE) \
+ 			LWIP_LIB=liblwip2.a \
+ 			LWIP_LIB_RELEASE=$(LWIP_LIB_RELEASE) \
+ 			LWIP_INCLUDES_RELEASE=$(LWIP_INCLUDES_RELEASE) \
+diff --git a/glue/esp-missing.h b/glue/esp-missing.h
+index 0e42073..4cb5d6c 100644
+--- a/glue/esp-missing.h
++++ b/glue/esp-missing.h
+@@ -9,9 +9,9 @@
+ 
+ uint32_t r_rand (void);
+ 
+-void* pvPortZalloc (size_t, const char*, int);
+-void* pvPortMalloc (size_t xWantedSize, const char* file, int line) __attribute__((malloc, alloc_size(1)));
+-void vPortFree (void *ptr, const char* file, int line);
++void* pvPortZalloc (size_t, const char*, unsigned line);
++void* pvPortMalloc (size_t xWantedSize, const char* file, unsigned line) __attribute__((malloc, alloc_size(1)));
++void vPortFree (void *ptr, const char* file, unsigned line);
+ 
+ struct netif* eagle_lwip_getif (int netif_index);
+ 
+@@ -27,10 +27,10 @@ int ets_memcmp (const void*, const void*, size_t n);
+ void *ets_memset (void *s, int c, size_t n);
+ void *ets_memcpy (void *dest, const void *src, size_t n);
+ 
+-typedef void ETSTimerFunc(void *timer_arg);
+-void ets_timer_disarm (ETSTimer *a);
+-void ets_timer_arm_new (ETSTimer *a, int b, int c, int isMstimer);
+-void ets_timer_setfn (ETSTimer *t, ETSTimerFunc *fn, void *parg);
++//typedef void ETSTimerFunc(void *timer_arg);
++//void ets_timer_disarm (ETSTimer *a);
++//void ets_timer_arm_new (ETSTimer *a, int b, int c, int isMstimer);
++//void ets_timer_setfn (ETSTimer *t, ETSTimerFunc *fn, void *parg);
+ 
+ struct ip_addr;
+ void wifi_softap_set_station_info (uint8_t* mac, struct ip_addr*);

--- a/Sming/third-party/.patches/pwm.patch
+++ b/Sming/third-party/.patches/pwm.patch
@@ -1,5 +1,5 @@
 diff --git a/pwm.c b/pwm.c
-index 5e7f218..da4c3f1 100644
+index 5e7f218..0386a06 100644
 --- a/pwm.c
 +++ b/pwm.c
 @@ -16,6 +16,8 @@
@@ -11,3 +11,12 @@ index 5e7f218..da4c3f1 100644
  /* Set the following three defines to your needs */
  
  #ifndef SDK_PWM_PERIOD_COMPAT_MODE
+@@ -109,7 +111,7 @@ struct timer_regs {
+ };
+ static struct timer_regs* timer = (void*)(0x60000600);
+ 
+-static void pwm_intr_handler(void)
++static void pwm_intr_handler(void* param)
+ {
+ 	if ((pwm_state.current_set[pwm_state.current_phase].off_mask == 0) &&
+ 	    (pwm_state.current_set[pwm_state.current_phase].on_mask == 0)) {

--- a/Sming/third-party/.patches/pwm.patch
+++ b/Sming/third-party/.patches/pwm.patch
@@ -1,25 +1,13 @@
 diff --git a/pwm.c b/pwm.c
-index 5e7f218..51bdf35 100644
+index 5e7f218..da4c3f1 100644
 --- a/pwm.c
 +++ b/pwm.c
-@@ -18,6 +18,8 @@
+@@ -16,6 +16,8 @@
+  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+  */
  
++#include <user_config.h> 
++
  /* Set the following three defines to your needs */
  
-+#include <user_config.h>
-+
  #ifndef SDK_PWM_PERIOD_COMPAT_MODE
-   #define SDK_PWM_PERIOD_COMPAT_MODE 0
- #endif
-@@ -42,6 +44,11 @@
- #define PWM_MAX_PERIOD PWM_MAX_TICKS
- #endif
- 
-+/* ISR related definitions that are missing in some SDKs */
-+extern void ets_isr_attach(int intr, void *handler, void *arg);
-+extern void ets_isr_mask(unsigned intr);
-+extern void ets_isr_unmask(unsigned intr);
-+
- #include <c_types.h>
- #include <pwm.h>
- #include <eagle_soc.h>


### PR DESCRIPTION
* The good: The code and samples compile for SDK 1.5, 2.0 and 2.1+
* The bad: Unfortunately in samples that use SDK 2.1+ we can see roughly 5K less available free memory.
* The ugly: SDK 2.1+ comes with wrong definitions for core functions, like `ets_delay_us`, that gives the impression that SDK 2.1+ is not really top quality.