### PR TITLE
Allow also poll to trigger sending of data.

### DIFF
--- a/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
@@ -368,10 +368,6 @@ err_t HttpServerConnection::onReceive(pbuf *buf)
 
 void HttpServerConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 {
-	if(sourceEvent == eTCE_Poll) {
-		return;
-	}
-
 	if(state == eHCS_Sent) {
 		state = eHCS_Ready;
 	}


### PR DESCRIPTION
Fixes the following issue reported from @petrynchyn:

"I now noticed that in the sample HttpServer_WebSockets broadcast does not work (does not send event when connecting other friends)
in another my example text message comes from other users only when the first user sends a message"