### PR TITLE
spiffs - Detect rBoot integration and replace default mount and format functions...

### DIFF
--- a/Sming/Services/SpifFS/spiffs_sming.c
+++ b/Sming/Services/SpifFS/spiffs_sming.c
@@ -142,7 +142,7 @@ static void spiffs_mount_internal(spiffs_config *cfg)
   //debugf("%X", dat);
 }
 
-void spiffs_mount()
+void spiffs_mount_default()
 {
   spiffs_config cfg = spiffs_get_storage_config();
   spiffs_mount_internal(&cfg);
@@ -165,7 +165,7 @@ void spiffs_unmount()
 }
 
 // FS formatting function
-bool spiffs_format()
+bool spiffs_format_default()
 {
   spiffs_unmount();
   spiffs_config cfg = spiffs_get_storage_config();

--- a/Sming/Services/SpifFS/spiffs_sming.h
+++ b/Sming/Services/SpifFS/spiffs_sming.h
@@ -7,10 +7,18 @@ extern "C" {
 
 #include "spiffs.h"
 
-void spiffs_mount();
+#ifdef RBOOT_INTEGRATION
+#define spiffs_mount() spiffs_mount_manual(RBOOT_SPIFFS_0, SPIFF_SIZE)
+#define spiffs_format() spiffs_format_manual(RBOOT_SPIFFS_0, SPIFF_SIZE)
+#else
+#define spiffs_mount() spiffs_mount_default()
+#define spiffs_format() spiffs_format_default()
+#endif
+
+void spiffs_mount_default();
 void spiffs_mount_manual(u32_t phys_addr, u32_t phys_size);
 void spiffs_unmount();
-bool spiffs_format();
+bool spiffs_format_default();
 bool spiffs_format_internal(spiffs_config *cfg);
 bool spiffs_format_manual(u32_t phys_addr, u32_t phys_size);
 spiffs_config spiffs_get_storage_config();


### PR DESCRIPTION
by the manual ones with correct spiffs position and size from Makefile-rboot.mk

There is still an issue with the FTPServer as it can call spiffs_format. This call is compiled on libary compile time without any knowlege about rBoot rather than on appilication compile time.
So the use of "FSFORMAT" via the FTP-Server is impossible as long as the application is compiled with rBoot support.