### PR TITLE
Add method to stop HttpSever

### DIFF
--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -17,12 +17,14 @@
 
 HttpServer::HttpServer()
 {
+	active = true;
 	settings.keepAliveSeconds = 0;
 	configure(settings);
 }
 
 HttpServer::HttpServer(HttpServerSettings settings)
 {
+	active = true;
 	configure(settings);
 }
 
@@ -44,6 +46,7 @@ void HttpServer::configure(HttpServerSettings settings) {
 
 HttpServer::~HttpServer()
 {
+	active = true;
 	for(int i=0; i< resourceTree.count(); i++) {
 		if(resourceTree.valueAt(i) != NULL) {
 			delete resourceTree.valueAt(i);
@@ -99,7 +102,23 @@ void HttpServer::setDefaultResource(HttpResource* resource) {
 	addPath("*", resource);
 }
 
+void HttpServer::close() {
+	active = false;
+	if(totalConnections==0){
+		debugf("Closing server");
+		delete this;
+	}
+	else{
+		debugf("Wait end connection before closing server");
+	}
+}
+
+
 void HttpServer::onConnectionClose(TcpClient& connection, bool success) {
 	totalConnections--;
+	if(totalConnections==0 && !active){
+		debugf("Closing server");
+		delete this;
+	}
 	debugf("Closing connection. Total connections: %d", totalConnections);
 }

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -77,6 +77,8 @@ public:
 	void setDefaultHandler(const HttpPathDelegate& callback);
 	void setDefaultResource(HttpResource* resource);
 
+	void close();
+
 
 protected:
 	virtual TcpConnection* createClient(tcp_pcb *clientTcp);
@@ -91,6 +93,7 @@ private:
 	HttpServerSettings settings;
 	ResourceTree resourceTree;
 	BodyParsers bodyParsers;
+	bool active = true;
 };
 
 /** @} */


### PR DESCRIPTION
Done : Add function close() to HttpServer class.
It closes the connection when the last TCP connection is closed.

To do :  free all RAM (heap) taken when HTTP server is created (about 50% is freed now, 50 other % is still losed).