### PR TITLE
fix/MemoryLeak(Heap) during TCP Client connection and delete

### DIFF
--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -79,6 +79,8 @@ public:
 #ifdef ENABLE_SSL
 	static void freeSslSessionPool();
 #endif
+	static void freeHttpConnectionPool();
+	static void freeRequestQueue();
 
 	/**
 	 * Use this method to clean all request queues and object pools

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -56,7 +56,7 @@ TcpClient::~TcpClient()
 bool TcpClient::connect(String server, int port, boolean useSsl /* = false */, uint32_t sslOptions /* = 0 */)
 {
 	if (isProcessing()) return false;
-
+	debugf("TcpClient start connecting : move to TcpConnection");
 	state = eTCS_Connecting;
 	return TcpConnection::connect(server.c_str(), port, useSsl, sslOptions);
 }

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -46,8 +46,11 @@ TcpClient::TcpClient(TcpClientDataDelegate onReceive)
 
 TcpClient::~TcpClient()
 {
-	delete stream;
-	stream = NULL;
+	if (stream != NULL)
+	{
+		delete[] stream;
+		stream = NULL;
+	}
 }
 
 bool TcpClient::connect(String server, int port, boolean useSsl /* = false */, uint32_t sslOptions /* = 0 */)

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -36,6 +36,12 @@ TcpConnection::~TcpConnection()
 		delete[] sslFingerprint.pkSha256;
 	}
 	freeSslClientKeyCert();
+	if(ssl_ext != NULL) {
+		debugf("SSL not null");
+		ssl_ext_free(ssl_ext);
+	}
+
+
 #endif
 	debugf("~TCP connection");
 }

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -48,16 +48,19 @@ TcpConnection::~TcpConnection()
 
 bool TcpConnection::connect(String server, int port, bool useSsl /* = false */, uint32_t sslOptions /* = 0 */)
 {
+	debugf("Tcpconnection : connecting %d",system_get_free_heap_size());
 	if (tcp == NULL)
 		initialize(tcp_new());
-
+	debugf("New TCP %d",system_get_free_heap_size());
 	ip_addr_t addr;
 
 	this->useSsl = useSsl;
+
 #ifdef ENABLE_SSL
 	this->sslOptions |= sslOptions;
 
 	if(ssl_ext != NULL) {
+		debugf("SSL not null");
 		ssl_ext_free(ssl_ext);
 	}
 
@@ -66,7 +69,9 @@ bool TcpConnection::connect(String server, int port, bool useSsl /* = false */, 
 	strcpy(ssl_ext->host_name, server.c_str());
 
 	ssl_ext->max_fragment_size = 4*1024; // 4K max size
+	debugf("New SSL %d",system_get_free_heap_size());
 #endif
+	
 
 	debugf("connect to: %s", server.c_str());
 	canSend = false; // Wait for connection
@@ -324,6 +329,7 @@ void TcpConnection::close()
 
 void TcpConnection::initialize(tcp_pcb* pcb)
 {
+	debugf("New TCP %d",system_get_free_heap_size());
 	tcp = pcb;
 	sleep = 0;
 	canSend = true;
@@ -340,11 +346,13 @@ void TcpConnection::initialize(tcp_pcb* pcb)
 
 	#ifdef NETWORK_DEBUG
 	debugf("+TCP connection");
+	debugf("New TCP %d",system_get_free_heap_size());
 	#endif
 }
 
 void TcpConnection::closeTcpConnection(tcp_pcb *tpcb)
 {
+
 	if (tpcb == NULL) return;
 
 	debugf("-TCP connection");


### PR DESCRIPTION
Not really sure of this fix. 

But on my side, it's help to solve Memory Leak when I call httpClient.cleanup(). (About 50Bytes losed each time)