### PR TITLE
Made spiffs_mount() compatible with rBoot.

### DIFF
--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -179,6 +179,7 @@ endif
 # define your custom directories in the project's own Makefile before including this one
 MODULES      ?= app     # default to app if not set by user
 MODULES      += $(THIRD_PARTY_DIR)/rboot/appcode
+MODULES      += $(SMING_HOME)/appspecific/rboot
 EXTRA_INCDIR ?= include # default to include if not set by user
 
 ENABLE_CUSTOM_LWIP ?= 1
@@ -313,7 +314,7 @@ ifeq ($(DISABLE_SPIFFS), 1)
 endif
 
 # linker flags used to generate the main object file
-LDFLAGS		= -nostdlib -u call_user_start -u Cache_Read_Enable_New -Wl,-static -Wl,--gc-sections -Wl,-Map=$(basename $@).map -Wl,-wrap,system_restart_local 
+LDFLAGS		= -nostdlib -u call_user_start -u Cache_Read_Enable_New -u spiffs_get_storage_config -Wl,-static -Wl,--gc-sections -Wl,-Map=$(basename $@).map -Wl,-wrap,system_restart_local 
 
 ifeq ($(SPI_SPEED), 26)
 	flashimageoptions = -ff 26m

--- a/Sming/Services/SpifFS/spiffs_sming.c
+++ b/Sming/Services/SpifFS/spiffs_sming.c
@@ -1,7 +1,5 @@
 #include "spiffs_sming.h"
 
-#define LOG_PAGE_SIZE       256
-
 spiffs _filesystemStorageHandle;
 
 static u8_t spiffs_work_buf[LOG_PAGE_SIZE*2];
@@ -39,7 +37,7 @@ the entire chip (chip erase). The W25Q32BV has 1,024 erasable sectors and 64 era
 The small 4KB sectors allow for greater flexibility in applications that require data and parameter storage.
 ********************/
 
-spiffs_config spiffs_get_storage_config()
+spiffs_config __attribute__((weak)) spiffs_get_storage_config()
 {
 	spiffs_config cfg = {0};
 	cfg.phys_addr = ( u32_t )flashmem_get_first_free_block_address();
@@ -184,40 +182,4 @@ bool spiffs_format_manual(u32_t phys_addr, u32_t phys_size)
   spiffs_format_internal(&cfg);
   spiffs_mount_manual(phys_addr, phys_size);
   return true;
-}
-
-//int spiffs_check( void )
-//{
-  // ets_wdt_disable();
-  // int res = (int)SPIFFS_check(&_filesystemStorageHandle);
-  // ets_wdt_enable();
-  // return res;
-//}
-
-void test_spiffs()
-{
-  char buf[12] = {0};
-
-  // Surely, I've mounted spiffs before entering here
-  
-  spiffs_file fd;
-  spiffs_stat st = {0};
-  SPIFFS_stat(&_filesystemStorageHandle, "my_file.txt", &st);
-  if (st.size <= 0)
-  {
-	  fd = SPIFFS_open(&_filesystemStorageHandle, "my_file.txt", SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
-	  if (SPIFFS_write(&_filesystemStorageHandle, fd, (u8_t *)"Hello world", 11) < 0)
-		  debugf("errno %d\n", SPIFFS_errno(&_filesystemStorageHandle));
-	  SPIFFS_close(&_filesystemStorageHandle, fd);
-	  debugf("file created");
-  }
-  else
-	  debugf("file %s exist :)", st.name);
-
-
-  fd = SPIFFS_open(&_filesystemStorageHandle, "my_file.txt", SPIFFS_RDWR, 0);
-  if (SPIFFS_read(&_filesystemStorageHandle, fd, (u8_t *)buf, 11) < 0) debugf("errno %d\n", SPIFFS_errno(&_filesystemStorageHandle));
-  SPIFFS_close(&_filesystemStorageHandle, fd);
-
-  debugf("--> %s <--\n", buf);
 }

--- a/Sming/Services/SpifFS/spiffs_sming.h
+++ b/Sming/Services/SpifFS/spiffs_sming.h
@@ -7,6 +7,8 @@ extern "C" {
 
 #include "spiffs.h"
 
+#define LOG_PAGE_SIZE       256
+
 void spiffs_mount();
 void spiffs_mount_manual(u32_t phys_addr, u32_t phys_size);
 void spiffs_unmount();
@@ -14,7 +16,6 @@ bool spiffs_format();
 bool spiffs_format_internal(spiffs_config *cfg);
 bool spiffs_format_manual(u32_t phys_addr, u32_t phys_size);
 spiffs_config spiffs_get_storage_config();
-extern void test_spiffs();
 
 extern spiffs _filesystemStorageHandle;
 

--- a/Sming/appspecific/rboot/overrides.c
+++ b/Sming/appspecific/rboot/overrides.c
@@ -1,0 +1,23 @@
+#include "spiffs_sming.h"
+
+/*
+ * rBoot uses different spiffs organization and we need to override this method
+ * during application compile time  in order to make automatic
+ * mounting with `spiffs_mount()` work as expected.
+ */
+spiffs_config spiffs_get_storage_config()
+{
+  spiffs_config cfg = {0};
+#ifdef RBOOT_SPIFFS_0
+  cfg.phys_addr = RBOOT_SPIFFS_0;
+#elif RBOOT_SPIFFS_1
+  cfg.phys_addr = RBOOT_SPIFFS_1;
+#else
+#error "Define either RBOOT_SPIFFS_0 or RBOOT_SPIFFS_1"
+#endif
+  cfg.phys_size = SPIFF_SIZE;
+  cfg.phys_erase_block = INTERNAL_FLASH_SECTOR_SIZE; // according to datasheet
+  cfg.log_block_size = INTERNAL_FLASH_SECTOR_SIZE * 2; // Important to make large
+  cfg.log_page_size = LOG_PAGE_SIZE; // as we said
+  return cfg;
+}

--- a/samples/Basic_WebClient/app/application.cpp
+++ b/samples/Basic_WebClient/app/application.cpp
@@ -194,7 +194,7 @@ void init()
 
 #ifndef DISABLE_SPIFFS
 	debugf("trying to mount spiffs at 0x%08x, length %d", RBOOT_SPIFFS_0, SPIFF_SIZE);
-	spiffs_mount_manual(RBOOT_SPIFFS_0, SPIFF_SIZE);
+	spiffs_mount();
 #endif
 
 	// Setup the WIFI connection


### PR DESCRIPTION
Fixes #1009.
Closes #1269 