### PR TITLE
Add MQTT message length parameter to enable publishing binary messages.

### DIFF
--- a/Sming/Services/libemqtt/libemqtt.c
+++ b/Sming/Services/libemqtt/libemqtt.c
@@ -404,9 +404,9 @@ int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* ms
 	return mqtt_publish_with_qos(broker, topic, msg, retain, 0, NULL);
 }
 
-int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint8_t retain, uint8_t qos, uint16_t* message_id) {
+int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain, uint8_t qos, uint16_t* message_id) {
 	uint16_t topiclen = strlen(topic);
-	uint16_t msglen = strlen(msg);
+	uint16_t msglen = mlength;
 
 	uint8_t qos_flag = MQTT_QOS0_FLAG;
 	uint8_t qos_size = 0; // No QoS included

--- a/Sming/Services/libemqtt/libemqtt.h
+++ b/Sming/Services/libemqtt/libemqtt.h
@@ -245,7 +245,7 @@ int mqtt_disconnect(mqtt_broker_handle_t* broker);
  * @retval  0 On connection error.
  * @retval -1 On IO error.
  */
-int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint8_t retain);
+int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain);
 
 /** Publish a message on a topic.
  * @param broker Data structure that contains the connection information with the broker.

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -94,7 +94,7 @@ bool MqttClient::connect(const String& clientName, const String& username, const
 
 bool MqttClient::publish(String topic, String message, bool retained /* = false*/)
 {
-	int res = mqtt_publish(&broker, topic.c_str(), message.c_str(), retained);
+	int res = mqtt_publish(&broker, topic.c_str(), message.c_str(), message.length(), retained);
 	return res > 0;
 }
 


### PR DESCRIPTION
During local testing it was found that the Sming-based firmware was not able to submit binary MQTT messages across the network, or only part of the binary message. The problem was localised in the libemqtt library, which assumes that any incoming message string is ASCII or similar, and uses strlen() to determine the length. Any null-byte will thus terminate the message at that point.

By changing the MqttClient class to submit the message length (String::length()) and modifying the libemqtt publish() method to use this new parameter, this issue is prevented.