### PR TITLE
Modified libemqtt & MqttClient to allow the publishing of binary messages

### DIFF
--- a/Sming/Services/libemqtt/libemqtt.c
+++ b/Sming/Services/libemqtt/libemqtt.c
@@ -400,13 +400,12 @@ int mqtt_ping(mqtt_broker_handle_t* broker) {
 	return 1;
 }
 
-int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain) {
-	return mqtt_publish_with_qos(broker, topic, msg, mlength, retain, 0, NULL);
+int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t msglen, uint8_t retain) {
+	return mqtt_publish_with_qos(broker, topic, msg, msglen, retain, 0, NULL);
 }
 
-int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain, uint8_t qos, uint16_t* message_id) {
+int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t msglen, uint8_t retain, uint8_t qos, uint16_t* message_id) {
 	uint16_t topiclen = strlen(topic);
-	uint16_t msglen = mlength;
 
 	uint8_t qos_flag = MQTT_QOS0_FLAG;
 	uint8_t qos_size = 0; // No QoS included

--- a/Sming/Services/libemqtt/libemqtt.c
+++ b/Sming/Services/libemqtt/libemqtt.c
@@ -400,13 +400,13 @@ int mqtt_ping(mqtt_broker_handle_t* broker) {
 	return 1;
 }
 
-int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint8_t retain) {
-	return mqtt_publish_with_qos(broker, topic, msg, retain, 0, NULL);
+int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain) {
+	return mqtt_publish_with_qos(broker, topic, msg, mlength, retain, 0, NULL);
 }
 
-int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint8_t retain, uint8_t qos, uint16_t* message_id) {
+int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain, uint8_t qos, uint16_t* message_id) {
 	uint16_t topiclen = strlen(topic);
-	uint16_t msglen = strlen(msg);
+	uint16_t msglen = mlength;
 
 	uint8_t qos_flag = MQTT_QOS0_FLAG;
 	uint8_t qos_size = 0; // No QoS included

--- a/Sming/Services/libemqtt/libemqtt.h
+++ b/Sming/Services/libemqtt/libemqtt.h
@@ -239,18 +239,20 @@ int mqtt_disconnect(mqtt_broker_handle_t* broker);
  * @param broker Data structure that contains the connection information with the broker.
  * @param topic The topic name.
  * @param msg The message.
+ * @param msglen The length of the message.
  * @param retain Enable or disable the Retain flag (values: 0 or 1).
  *
  * @retval  1 On success.
  * @retval  0 On connection error.
  * @retval -1 On IO error.
  */
-int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain);
+int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t msglen, uint8_t retain);
 
 /** Publish a message on a topic.
  * @param broker Data structure that contains the connection information with the broker.
  * @param topic The topic name.
  * @param msg The message.
+ * @param msglen The length of the message.
  * @param retain Enable or disable the Retain flag (values: 0 or 1).
  * @param qos Quality of Service (values: 0, 1 or 2)
  * @param message_id Variable that will store the Message ID, if the pointer is not NULL.
@@ -259,7 +261,7 @@ int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* ms
  * @retval  0 On connection error.
  * @retval -1 On IO error.
  */
-int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain, uint8_t qos, uint16_t* message_id);
+int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t msglen, uint8_t retain, uint8_t qos, uint16_t* message_id);
 
 /** Send a PUBREL message. It's used for PUBLISH message with 2 QoS level.
  * @param broker Data structure that contains the connection information with the broker.

--- a/Sming/Services/libemqtt/libemqtt.h
+++ b/Sming/Services/libemqtt/libemqtt.h
@@ -245,7 +245,7 @@ int mqtt_disconnect(mqtt_broker_handle_t* broker);
  * @retval  0 On connection error.
  * @retval -1 On IO error.
  */
-int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint8_t retain);
+int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain);
 
 /** Publish a message on a topic.
  * @param broker Data structure that contains the connection information with the broker.
@@ -259,7 +259,7 @@ int mqtt_publish(mqtt_broker_handle_t* broker, const char* topic, const char* ms
  * @retval  0 On connection error.
  * @retval -1 On IO error.
  */
-int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint8_t retain, uint8_t qos, uint16_t* message_id);
+int mqtt_publish_with_qos(mqtt_broker_handle_t* broker, const char* topic, const char* msg, uint16_t mlength, uint8_t retain, uint8_t qos, uint16_t* message_id);
 
 /** Send a PUBREL message. It's used for PUBLISH message with 2 QoS level.
  * @param broker Data structure that contains the connection information with the broker.

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -94,14 +94,14 @@ bool MqttClient::connect(const String& clientName, const String& username, const
 
 bool MqttClient::publish(String topic, String message, bool retained /* = false*/)
 {
-	int res = mqtt_publish(&broker, topic.c_str(), message.c_str(), retained);
+	int res = mqtt_publish(&broker, topic.c_str(), message.c_str(), message.length(), retained);
 	return res > 0;
 }
 
 bool MqttClient::publishWithQoS(String topic, String message, int QoS, bool retained /* = false*/, MqttMessageDeliveredCallback onDelivery /* = NULL */)
 {
 	uint16_t msgId = 0;
-	int res = mqtt_publish_with_qos(&broker, topic.c_str(), message.c_str(), retained, QoS, &msgId);
+	int res = mqtt_publish_with_qos(&broker, topic.c_str(), message.c_str(), message.length(), retained, QoS, &msgId);
 	if(QoS == 0 && onDelivery) {
 		debugf("The delivery callback is ignored for QoS 0.");
 	}


### PR DESCRIPTION
During local testing it was found that the Sming-based firmware was not able to submit binary MQTT messages across the network, or only part of the binary message. The problem was localised in the libemqtt library, which assumes that any incoming message string is ASCII or similar, and uses strlen() to determine the length. Any null-byte will thus terminate the message at that point.

By changing the MqttClient class to submit the message length (String::length()) and modifying the libemqtt publish() method to use this new parameter, this issue is prevented.

(My apologies for the previous broken PR. Hadn't fully tested it before committing)