### PR TITLE
HardwareSerial: Fix for zero availableCharsCount in callback if there…

### DIFF
--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -253,7 +253,7 @@ void HardwareSerial::commandProcessing(bool reqEnable)
 void HardwareSerial::delegateTask (os_event_t *inputEvent)
 {
 	int uartNr = inputEvent->par >> 25; // the uart_nr is in the last byte
-	inputEvent->par = inputEvent->par & 0x0FFF; // clear the last bit
+	inputEvent->par = inputEvent->par & 0x00FFFFFF; // clear the last byte
 	uint8 rcvChar = inputEvent->par % 256;  // can be done by bitlogic, avoid casting from ETSParam
 	uint16 charCount = inputEvent->par / 256 ;
 


### PR DESCRIPTION
… are more than 15 chars available.

In HardwareSerial::callbackHandler the encoding of last character, number of available characters and the uart nr is done like this:

void HardwareSerial::callbackHandler(uart_t *uart) {
...
		uint32 serialQueueParameter;
		uint16 cc = uart_rx_available(uart);
		serialQueueParameter = (cc * 256) + receivedChar;
		serialQueueParameter += (uart->uart_nr << 25);
...
}
The logic & for the decoding in HardwareSerial::delegateTask is done on 0x0FFF. But one F stands for 4 bit. So we need six F.