### PR TITLE
Updated axtls to 0c3a9f7

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -455,7 +455,7 @@ clean:
 	$(Q) rm -rf $(BUILD_BASE)
 	$(Q) rm -rf $(FW_BASE)
 ifeq ($(ENABLE_SSL), 1)
-	$(Q) -$(MAKE) --no-print-directory -C third-party/axtls-8266 clean -e V=$(V) BIN_DIR="$(SMING_HOME)/$(USER_LIBDIR)" FLAGS_EXTRA="$(EXTRA_CFLAGS_AXTLS)"
+	$(Q) -$(MAKE) --no-print-directory -C third-party/axtls-8266 clean -e V=$(V) BIN_DIR="$(SMING_HOME)/$(USER_LIBDIR)" CFLAGS_EXTRA="$(EXTRA_CFLAGS_AXTLS)"
 endif	
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 	$(Q) -$(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open ENABLE_ESPCONN=$(ENABLE_ESPCONN) SDK_BASE="$(SDK_BASE)" USER_LIBDIR="$(SMING_HOME)/$(USER_LIBDIR)/" CFLAGS_EXTRA="$(EXTRA_CFLAGS_LWIP)" clean

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -266,7 +266,7 @@ MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
 
 # compiler flags using during compilation of source files. Add '-pg' for debugging
 CFLAGS += -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
-         -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1
+         -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1 -DSMING_INCLUDED=1 
 ifeq ($(SMING_RELEASE),1)
 	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
 	#      for full list of optimization options
@@ -312,7 +312,7 @@ ifeq ($(ENABLE_SSL),1)
 		AXTLS_FLAGS += -DSSL_DEBUG=1 -DDEBUG_TLS_MEM=1 -DAXL_DEBUG=1
 	endif
 	CUSTOM_TARGETS += $(USER_LIBDIR)/libaxtls.a
-	EXTRA_CFLAGS_AXTLS = -I../../system/include -I../../Wiring
+#	EXTRA_CFLAGS_AXTLS = -I../../system/include -I../../Wiring
 	CFLAGS += $(AXTLS_FLAGS)  
 	CXXFLAGS += $(AXTLS_FLAGS)
 endif
@@ -455,7 +455,7 @@ clean:
 	$(Q) rm -rf $(BUILD_BASE)
 	$(Q) rm -rf $(FW_BASE)
 ifeq ($(ENABLE_SSL), 1)
-	$(Q) -$(MAKE) --no-print-directory -C third-party/axtls-8266 clean -e V=$(V) BIN_DIR="$(SMING_HOME)/$(USER_LIBDIR)" CFLAGS_EXTRA="$(EXTRA_CFLAGS_AXTLS)"
+	$(Q) -$(MAKE) --no-print-directory -C third-party/axtls-8266 clean -e V=$(V) BIN_DIR="$(SMING_HOME)/$(USER_LIBDIR)" FLAGS_EXTRA="$(EXTRA_CFLAGS_AXTLS)"
 endif	
 ifeq ($(ENABLE_CUSTOM_LWIP), 1)
 	$(Q) -$(MAKE) -C third-party/esp-open-lwip/ -f Makefile.open ENABLE_ESPCONN=$(ENABLE_ESPCONN) SDK_BASE="$(SDK_BASE)" USER_LIBDIR="$(SMING_HOME)/$(USER_LIBDIR)/" CFLAGS_EXTRA="$(EXTRA_CFLAGS_LWIP)" clean

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -256,7 +256,8 @@ ifeq ($(ENABLE_WPS),1)
 endif
 
 # compiler flags using during compilation of source files
-CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR)
+CFLAGS  = -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
+          -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1
 # => SDK
 ifneq (,$(findstring third-party/ESP8266_NONOS_SDK, $(SDK_BASE)))
 	CFLAGS += -DSDK_INTERNAL

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -419,10 +419,8 @@ $1/%.o: %.cpp $1/%.cpp.d
 	$(vecho) "C+ $$<" 
 	$(Q) $(CXX) $(INCDIR) $(MODULE_INCDIR) $(EXTRA_INCDIR) $(SDK_INCDIR) $(CXXFLAGS) -c $$< -o $$@
 $1/%.c.d: %.c
-	$(vecho) "DEP $$<"
 	$(Q) $(CC) $(INCDIR) $(MODULE_INCDIR) $(EXTRA_INCDIR) $(SDK_INCDIR) $(CFLAGS) -MM -MT $1/$$*.o $$< -o $$@
 $1/%.cpp.d: %.cpp
-	$(vecho) "DEP $$<"
 	$(Q) $(CXX) $(INCDIR) $(MODULE_INCDIR) $(EXTRA_INCDIR) $(SDK_INCDIR) $(CXXFLAGS) -MM -MT $1/$$*.o $$< -o $$@
 
 .PRECIOUS: $1/%.c.d $1/%.cpp.d

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -257,7 +257,7 @@ endif
 
 # compiler flags using during compilation of source files
 CFLAGS  = -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
-          -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1
+          -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DSMING_INCLUDED=1
 # => SDK
 ifneq (,$(findstring third-party/ESP8266_NONOS_SDK, $(SDK_BASE)))
 	CFLAGS += -DSDK_INTERNAL

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -235,7 +235,7 @@ USER_LIBDIR  = $(SMING_HOME)/compiler/lib/
 
 # compiler flags using during compilation of source files
 CFLAGS   = -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
-           -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1
+           -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DSMING_INCLUDED=1 
 # => SDK
 ifneq (,$(findstring third-party/ESP8266_NONOS_SDK, $(SDK_BASE)))
 	CFLAGS += -DSDK_INTERNAL

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -234,7 +234,8 @@ EXTRA_INCDIR += $(SMING_HOME)/include $(SMING_HOME)/ $(LWIP_INCDIR) $(SMING_HOME
 USER_LIBDIR  = $(SMING_HOME)/compiler/lib/
 
 # compiler flags using during compilation of source files
-CFLAGS		= -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR)
+CFLAGS   = -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
+           -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1
 # => SDK
 ifneq (,$(findstring third-party/ESP8266_NONOS_SDK, $(SDK_BASE)))
 	CFLAGS += -DSDK_INTERNAL

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -499,10 +499,8 @@ $1/%.o: %.cpp $1/%.cpp.d
 	$(vecho) "C+ $$<" 
 	$(Q) $(CXX) $(INCDIR) $(MODULE_INCDIR) $(EXTRA_INCDIR) $(SDK_INCDIR) $(CXXFLAGS) -c $$< -o $$@
 $1/%.c.d: %.c
-	$(vecho) "DEP $$<"
 	$(Q) $(CC) $(INCDIR) $(MODULE_INCDIR) $(EXTRA_INCDIR) $(SDK_INCDIR) $(CFLAGS) -MM -MT $1/$$*.o $$< -o $$@
 $1/%.cpp.d: %.cpp
-	$(vecho) "DEP $$<"
 	$(Q) $(CXX) $(INCDIR) $(MODULE_INCDIR) $(EXTRA_INCDIR) $(SDK_INCDIR) $(CXXFLAGS) -MM -MT $1/$$*.o $$< -o $$@
 
 .PRECIOUS: $1/%.c.d $1/%.cpp.d

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -60,10 +60,8 @@ bool TcpConnection::connect(String server, int port, bool useSsl /* = false */, 
 	}
 
 	sslExtension = ssl_ext_new();
-	sslExtension->host_name = (char *)malloc(server.length() + 1);
-	strcpy(sslExtension->host_name, server.c_str());
-
-	sslExtension->max_fragment_size = 4*1024; // 4K max size
+	ssl_ext_set_host_name(sslExtension, server.c_str()) ;
+	ssl_ext_set_max_fragment_size(sslExtension, 4); // 4K max size
 #endif
 
 	debug_d("connect to: %s", server.c_str());

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -4,7 +4,7 @@
 #include "m_printf.h"
 
 #define PGM_P  const char *
-#define PSTR(str) (str)
+
 #define PRIPSTR "%s"
 
 typedef void prog_void;
@@ -24,6 +24,8 @@ typedef uint32_t prog_uint32_t;
 #ifndef PROGMEM
 #define PROGMEM __attribute__((aligned(4))) __attribute__((section(".irom.text")))
 #endif
+
+#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
 
 #define pgm_read_byte(addr) \
 ({ \
@@ -82,9 +84,11 @@ extern "C"
 }
 #endif
 
-#else
+#else /* ICACHE_FLASH */
 
 #define PROGMEM
+
+#define PSTR(str) (str)
 
 #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
@@ -99,7 +103,7 @@ extern "C"
 #define sprintf_P(s, f, ...) m_sprintf((s), (f), ##__VA_ARGS__)
 #define printf_P(f, ...) m_printf((f), ##__VA_ARGS__)
 
-#endif
+#endif /* ICACHE_FLASH */
 
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)
 #define pgm_read_word_near(addr) pgm_read_word(addr)
@@ -110,4 +114,4 @@ extern "C"
 #define pgm_read_dword_far(addr) pgm_read_dword(addr)
 #define pgm_read_float_far(addr) pgm_read_float(addr)
 
-#endif
+#endif /* __FAKE_PGMSPACE_H_ */

--- a/Sming/include/user_config.h
+++ b/Sming/include/user_config.h
@@ -42,13 +42,6 @@ extern "C" {
 	// Beta boards
 	#define BOARD_ESP01
 
-	// axTLS stuff
-#ifdef ENABLE_SSL
-	#include <time.h>
-	#include "util/time.h"
-	#include "../axtls-8266/compat/lwipr_compat.h"
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/system/crash_handler.c
+++ b/Sming/system/crash_handler.c
@@ -26,7 +26,7 @@
 
 extern void __real_system_restart_local();
 
-extern void ets_printf(const char*, ...);
+extern int ets_printf(const char*, ...);
 
 void uart_write_char_d(char c);
 static void uart0_write_char_d(char c);
@@ -96,7 +96,7 @@ void __wrap_system_restart_local() {
 
 
 static void print_stack(uint32_t start, uint32_t end) {
-	uint32_t pos = 0;
+    uint32_t pos = 0;
 
     ets_printf("\n================================================================\n");
     for (pos = start; pos < end; pos += 0x10) {

--- a/Sming/third-party/.patches/axtls-8266.patch
+++ b/Sming/third-party/.patches/axtls-8266.patch
@@ -1,6 +1,6 @@
 diff -Nuar a/replacements/libc.c b/replacements/libc.c
---- a/replacements/libc.c	1970-01-01 01:00:00.000000000 +0100
-+++ b/replacements/libc.c	2016-11-21 11:03:47.152184514 +0100
+--- a/replacements/libc.c   1970-01-01 01:00:00.000000000 +0100
++++ b/replacements/libc.c   2016-11-21 11:03:47.152184514 +0100
 @@ -0,0 +1,29 @@
 +/*
 + libc_replacements.c - replaces libc functions with functions
@@ -31,387 +31,54 @@ diff -Nuar a/replacements/libc.c b/replacements/libc.c
 +int vprintf(const char * format, va_list arg) {
 +    return ets_vprintf(ets_putc, format, arg);
 +}
-diff -Nuar a/replacements/mem.c b/replacements/mem.c
---- a/replacements/mem.c	1970-01-01 01:00:00.000000000 +0100
-+++ b/replacements/mem.c	2016-11-21 11:02:07.672185632 +0100
-@@ -0,0 +1,81 @@
-+/*
-+ * Memory functions for ESP8266 taken from Arduino-Esp project
-+
-+  WiFiClientSecure.cpp - Variant of WiFiClient with TLS support
-+  Copyright (c) 2015 Ivan Grokhotkov. All rights reserved.
-+  This file is part of the esp8266 core for Arduino environment.
-+
-+
-+  This library is free software; you can redistribute it and/or
-+  modify it under the terms of the GNU Lesser General Public
-+  License as published by the Free Software Foundation; either
-+  version 2.1 of the License, or (at your option) any later version.
-+
-+  This library is distributed in the hope that it will be useful,
-+  but WITHOUT ANY WARRANTY; without even the implied warranty of
-+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-+  Lesser General Public License for more details.
-+
-+  You should have received a copy of the GNU Lesser General Public
-+  License along with this library; if not, write to the Free Software
-+  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
-+
-+*/
-+
-+#include <stdint.h>
-+#include "espinc/c_types_compatible.h"
-+
-+// Those Espressif functions are needed
-+extern void *pvPortMalloc(size_t xWantedSize, const char *file, uint32 line);
-+extern void *pvPortRealloc(void* ptr, size_t xWantedSize, const char *file, uint32 line);
-+extern void vPortFree(void *ptr, const char *file, uint32 line);
-+extern void *ets_memset(void *s, int c, size_t n);
-+
-+#include "mem_manager.h"
-+
-+#define free os_free
-+#define malloc os_malloc
-+#define realloc os_realloc
-+#define memset ets_memset
-+
-+#ifdef DEBUG_TLS_MEM
-+extern int m_printf(const char *fmt, ...);
-+#define DEBUG_TLS_MEM_PRINT(...) m_printf(__VA_ARGS__)
-+#else
-+#define DEBUG_TLS_MEM_PRINT(...)
-+#endif
-+
-+void* ax_port_malloc(size_t size, const char* file, int line) {
-+    void* result = (void *)malloc(size);
-+
-+    if (result == NULL) {
-+        DEBUG_TLS_MEM_PRINT("%s:%d malloc %d failed, left %d\r\n", file, line, size, system_get_free_heap_size());
-+
-+        while(true){}
-+    }
-+    if (size >= 1024)
-+        DEBUG_TLS_MEM_PRINT("%s:%d malloc %d, left %d\r\n", file, line, size, system_get_free_heap_size());
-+    return result;
-+}
-+
-+void* ax_port_calloc(size_t size, size_t count, const char* file, int line) {
-+    void* result = (void* )ax_port_malloc(size * count, file, line);
-+    memset(result, 0, size * count);
-+    return result;
-+}
-+
-+void* ax_port_realloc(void* ptr, size_t size, const char* file, int line) {
-+    void* result = (void* )realloc(ptr, size);
-+    if (result == NULL) {
-+        DEBUG_TLS_MEM_PRINT("%s:%d realloc %d failed, left %d\r\n", file, line, size, system_get_free_heap_size());
-+        while(true){}
-+    }
-+    if (size >= 1024)
-+        DEBUG_TLS_MEM_PRINT("%s:%d realloc %d, left %d\r\n", file, line, size, system_get_free_heap_size());
-+    return result;
-+}
-+
-+void ax_port_free(void* ptr) {
-+    free(ptr);
-+    DEBUG_TLS_MEM_PRINT("free %x, left %d\r\n", ptr, system_get_free_heap_size());
-+}
 diff --git a/Makefile b/Makefile
-index 538f340..6fdb4ad 100644
+index e48e869..90da087 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -7,7 +7,9 @@ OBJCOPY := $(TOOLCHAIN_PREFIX)objcopy
- MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
+@@ -5,6 +5,9 @@ LD := $(TOOLCHAIN_PREFIX)gcc
+ OBJCOPY := $(TOOLCHAIN_PREFIX)objcopy
  
  XTENSA_LIBS ?= $(shell $(CC) -print-sysroot)
--
 +ifeq ($(XTENSA_LIBS),)
-+	XTENSA_LIBS = $(ESP_HOME)/xtensa-lx106-elf/
++   XTENSA_LIBS = $(ESP_HOME)/xtensa-lx106-elf/
 +endif
  
- OBJ_FILES := \
- 	crypto/aes.o \
-@@ -44,6 +46,7 @@ LDFLAGS  += 	-L$(XTENSA_LIBS)/lib \
- CFLAGS+=-std=c99 -DESP8266
+ TOOLCHAIN_DIR=$(shell cd $(XTENSA_LIBS)/../../; pwd)
  
- CFLAGS += -Wall -Os -g -O2 -Wpointer-arith -Wno-implicit-function-declaration -Wl,-EL -fno-inline-functions -nostdlib -mlongcalls -mno-text-section-literals  -D__ets__ -DICACHE_FLASH
+@@ -48,15 +51,24 @@ CFLAGS += -ffunction-sections -fdata-sections
+ 
+ CFLAGS += -fdebug-prefix-map=$(PWD)= -fdebug-prefix-map=$(TOOLCHAIN_DIR)=xtensa-lx106-elf -gno-record-gcc-switches
+ 
+-MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
+-ifneq ($(MFORCE32),)
+-    # If the compiler supports the -mforce-l32 flag, the compiler will generate correct code for loading
+-    # 16- and 8-bit constants from program memory. So in the code we can directly access the arrays
+-    # placed into program memory.
+-    CFLAGS +=  -mforce-l32
+-else
+-   # Otherwise we need to use a helper function to load 16- and 8-bit constants from program memory.
+-    CFLAGS += -DWITH_PGM_READ_HELPER
 +CFLAGS += $(CFLAGS_EXTRA)
- 
- ifneq ($(MFORCE32),)
-     # Your compiler supports the -mforce-l32 flag which means that 
-diff --git a/ssl/os_port.h b/ssl/os_port.h
-index e672f10..88a9ff7 100644
---- a/ssl/os_port.h
-+++ b/ssl/os_port.h
-@@ -44,6 +44,7 @@ extern "C" {
- #include "os_int.h"
- #include "config.h"
- #include <stdio.h>
-+#include "debug_progmem.h"
- 
- #ifdef WIN32
- #define STDCALL                 __stdcall
-@@ -60,18 +61,25 @@ extern "C" {
- 
- #if defined(ESP8266)
- 
-+extern int ax_port_read(int clientfd, uint8_t *buf, int bytes_needed);
-+extern int ax_port_write(int clientfd, uint8_t *buf, uint16_t bytes_needed);
 +
- #include "util/time.h"
-+extern void gettimeofday(struct timeval* t,void* timezone);
++WITH_PGM_READ_HELPER ?= 1
 +
- #include <errno.h>
- #define alloca(size) __builtin_alloca(size)
- #define TTY_FLUSH()
- #ifdef putc
- #undef putc
- #endif
--#define putc(x, f)   ets_putc(x)
-+#define putc(x, f)   debug_i("%c", (x))
- #ifdef printf
- #undef printf
- #endif
--#define printf(...)  ets_printf(__VA_ARGS__)
-+#define printf  debug_i
-+#define snprintf m_snprintf
-+#define vprintf m_vprintf
- 
- #define SOCKET_READ(A,B,C)      ax_port_read(A,B,C)
- #define SOCKET_WRITE(A,B,C)     ax_port_write(A,B,C)
-@@ -96,7 +104,8 @@ extern "C" {
- #define be64toh(x) __bswap_constant_64(x)
- #endif
- 
--void ax_wdt_feed();
-+extern void system_soft_wdt_feed(void);
-+#define ax_wdt_feed system_soft_wdt_feed
- 
- #elif defined(WIN32)
- 
-@@ -190,6 +199,18 @@ EXP_FUNC int STDCALL getdomainname(char *buf, int buf_size);
- #endif  /* Not Win32 */
- 
- /* some functions to mutate the way these work */
-+#define malloc(A)       ax_port_malloc(A, __FILE__, __LINE__)
-+#ifndef realloc
-+#define realloc(A,B)    ax_port_realloc(A,B, __FILE__, __LINE__)
-+#endif
-+#define calloc(A,B)     ax_port_calloc(A,B, __FILE__, __LINE__)
-+#define free(x)         ax_port_free(x)
-+
-+EXP_FUNC void * STDCALL ax_port_malloc(size_t s, const char*, int);
-+EXP_FUNC void * STDCALL ax_port_realloc(void *y, size_t s, const char*, int);
-+EXP_FUNC void * STDCALL ax_port_calloc(size_t n, size_t s, const char*, int);
-+EXP_FUNC void * STDCALL ax_port_free(void*);
-+
- inline uint32_t htonl(uint32_t n){
-   return ((n & 0xff) << 24) |
-     ((n & 0xff00) << 8) |
-diff --git a/ssl/tls1.c b/ssl/tls1.c
-index 0cf2e4c..fd14dea 100644
---- a/ssl/tls1.c
-+++ b/ssl/tls1.c
-@@ -1334,6 +1334,9 @@ int basic_read(SSL *ssl, uint8_t **in_data)
-     int read_len, is_client = IS_SET_SSL_FLAG(SSL_IS_CLIENT);
-     uint8_t *buf = ssl->bm_data;
- 
-+    if (ssl->can_free_certificates) {
-+        certificate_free(ssl);
-+    }
-     if (IS_SET_SSL_FLAG(SSL_SENT_CLOSE_NOTIFY))
-         return SSL_CLOSE_NOTIFY;
- 
-@@ -2226,8 +2229,15 @@ void DISPLAY_STATE(SSL *ssl, int is_send, uint8_t state, int not_ok)
-     if (!IS_SET_SSL_FLAG(SSL_DISPLAY_STATES))
-         return;
- 
--    printf(not_ok ? "Error - invalid State:\t" : "State:\t");
--    printf(is_send ? "sending " : "receiving ");
-+    if(not_ok)
-+    	printf("Error - invalid State:\t");
++ifeq ($(WITH_PGM_READ_HELPER), 0)
++   MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
++   ifneq ($(MFORCE32),)
++        # If the compiler supports the -mforce-l32 flag, the compiler will generate correct code for loading
++       # 16- and 8-bit constants from program memory. So in the code we can directly access the arrays
++       # placed into program memory.
++       CFLAGS +=  -mforce-l32
 +    else
-+    	printf("State:\t");
++       WITH_PGM_READ_HELPER=1
++   endif
++endif
 +
-+    if(is_send)
-+    	printf("sending ");
-+    else
-+    	printf("receiving ");
++ifeq ($(WITH_PGM_READ_HELPER), 1)
++   CFLAGS += -DWITH_PGM_READ_HELPER
+ endif
  
-     switch (state)
-     {
-diff --git a/ssl/tls1.h b/ssl/tls1.h
-index 6565625..c644321 100644
---- a/ssl/tls1.h
-+++ b/ssl/tls1.h
-@@ -43,7 +43,6 @@ extern "C" {
- #include "version.h"
- #include "config.h"
- #include "os_int.h"
--#include "os_port.h"
- #include "crypto.h"
- #include "crypto_misc.h"
- 
-diff --git a/tools/make_certs.sh b/tools/make_certs.sh
-index dc577e7..3113355 100644
---- a/tools/make_certs.sh
-+++ b/tools/make_certs.sh
-@@ -29,7 +29,12 @@
- # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- #
- 
--AXDIR=`pwd`/`dirname $0`
-+OLDCWD=`pwd`
-+
-+if [ -z $AXDIR ]; then
-+	AXDIR = $OLDCWD/`dirname $0`
-+fi
-+
- CWD=`mktemp -d` && cd $dir
- cd $CWD 
- 
-@@ -56,7 +61,7 @@ prompt                 = no
- 
- [ req_distinguished_name ]
-  O                      = $PROJECT_NAME
-- CN                     = localhost
-+ CN                     = 127.0.0.1
- EOF
- 
- cat > device_cert.conf << EOF  
-@@ -69,16 +74,21 @@ prompt                 = no
- EOF
- 
- # private key generation
--openssl genrsa -out axTLS.ca_key.pem 2048
-+openssl genrsa -out axTLS.ca_key.pem 1024
-+openssl genrsa -out axTLS.key_512.pem 512
- openssl genrsa -out axTLS.key_1024.pem 1024
-+openssl genrsa -out axTLS.key_1042.pem 1042
- openssl genrsa -out axTLS.key_2048.pem 2048
- openssl genrsa -out axTLS.key_4096.pem 4096
- openssl genrsa -out axTLS.device_key.pem 1024
--openssl genrsa -aes128 -passout pass:abcd -out axTLS.key_aes128.pem 1024
--openssl genrsa -aes256 -passout pass:abcd -out axTLS.key_aes256.pem 1024
-+openssl genrsa -aes128 -passout pass:abcd -out axTLS.key_aes128.pem 512
-+openssl genrsa -aes256 -passout pass:abcd -out axTLS.key_aes256.pem 512
-+
- 
- # convert private keys into DER format
-+openssl rsa -in axTLS.key_512.pem -out axTLS.key_512 -outform DER
- openssl rsa -in axTLS.key_1024.pem -out axTLS.key_1024 -outform DER
-+openssl rsa -in axTLS.key_1042.pem -out axTLS.key_1042 -outform DER
- openssl rsa -in axTLS.key_2048.pem -out axTLS.key_2048 -outform DER
- openssl rsa -in axTLS.key_4096.pem -out axTLS.key_4096 -outform DER
- openssl rsa -in axTLS.device_key.pem -out axTLS.device_key -outform DER
-@@ -86,8 +96,12 @@ openssl rsa -in axTLS.device_key.pem -out axTLS.device_key -outform DER
- # cert requests
- openssl req -out axTLS.ca_x509.req -key axTLS.ca_key.pem -new \
-             -config ./ca_cert.conf 
-+openssl req -out axTLS.x509_512.req -key axTLS.key_512.pem -new \
-+            -config ./certs.conf 
- openssl req -out axTLS.x509_1024.req -key axTLS.key_1024.pem -new \
-             -config ./certs.conf 
-+openssl req -out axTLS.x509_1042.req -key axTLS.key_1042.pem -new \
-+            -config ./certs.conf 
- openssl req -out axTLS.x509_2048.req -key axTLS.key_2048.pem -new \
-             -config ./certs.conf 
- openssl req -out axTLS.x509_4096.req -key axTLS.key_4096.pem -new \
-@@ -101,32 +115,25 @@ openssl req -out axTLS.x509_aes256.req -key axTLS.key_aes256.pem \
- 
- # generate the actual certs.
- openssl x509 -req -in axTLS.ca_x509.req -out axTLS.ca_x509.pem \
--            -sha1 -days 5000 -signkey axTLS.ca_key.pem \
--            -CAkey axTLS.ca_key.pem
--openssl x509 -req -in axTLS.ca_x509.req -out axTLS.ca_x509_sha256.pem \
--            -sha256 -days 5000 -signkey axTLS.ca_key.pem \
--            -CAkey axTLS.ca_key.pem
-+            -sha1 -days 5000 -signkey axTLS.ca_key.pem
-+openssl x509 -req -in axTLS.x509_512.req -out axTLS.x509_512.pem \
-+            -sha1 -CAcreateserial -days 5000 \
-+            -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
- openssl x509 -req -in axTLS.x509_1024.req -out axTLS.x509_1024.pem \
-             -sha1 -CAcreateserial -days 5000 \
-             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
--openssl x509 -req -in axTLS.x509_1024.req -out axTLS.x509_1024_sha256.pem \
--            -sha256 -CAcreateserial -days 5000 \
--            -CA axTLS.ca_x509_sha256.pem -CAkey axTLS.ca_key.pem
--openssl x509 -req -in axTLS.x509_1024.req -out axTLS.x509_1024_sha384.pem \
--            -sha384 -CAcreateserial -days 5000 \
--            -CA axTLS.ca_x509_sha256.pem -CAkey axTLS.ca_key.pem
--openssl x509 -req -in axTLS.x509_1024.req -out axTLS.x509_1024_sha512.pem \
--            -sha512 -CAcreateserial -days 5000 \
--            -CA axTLS.ca_x509_sha256.pem -CAkey axTLS.ca_key.pem
--openssl x509 -req -in axTLS.x509_2048.req -out axTLS.x509_2048.pem \
-+openssl x509 -req -in axTLS.x509_1042.req -out axTLS.x509_1042.pem \
-             -sha1 -CAcreateserial -days 5000 \
-             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
-+openssl x509 -req -in axTLS.x509_2048.req -out axTLS.x509_2048.pem \
-+            -md5 -CAcreateserial -days 5000 \
-+            -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
- openssl x509 -req -in axTLS.x509_4096.req -out axTLS.x509_4096.pem \
--            -sha1 -CAcreateserial -days 5000 \
-+            -md5 -CAcreateserial -days 5000 \
-             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
- openssl x509 -req -in axTLS.x509_device.req -out axTLS.x509_device.pem \
-             -sha1 -CAcreateserial -days 5000 \
--            -CA axTLS.x509_1024.pem -CAkey axTLS.key_1024.pem
-+            -CA axTLS.x509_512.pem -CAkey axTLS.key_512.pem
- openssl x509 -req -in axTLS.x509_aes128.req \
-             -out axTLS.x509_aes128.pem \
-             -sha1 -CAcreateserial -days 5000 \
-@@ -139,33 +146,35 @@ openssl x509 -req -in axTLS.x509_aes256.req \
- # note: must be root to do this
- DATE_NOW=`date`
- if date -s "Jan 1 2025"; then
--openssl x509 -req -in axTLS.x509_1024.req -out axTLS.x509_bad_before.pem \
-+openssl x509 -req -in axTLS.x509_512.req -out axTLS.x509_bad_before.pem \
-             -sha1 -CAcreateserial -days 365 \
-             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
- date -s "$DATE_NOW"
- touch axTLS.x509_bad_before.pem
- fi
--openssl x509 -req -in axTLS.x509_1024.req -out axTLS.x509_bad_after.pem \
-+openssl x509 -req -in axTLS.x509_512.req -out axTLS.x509_bad_after.pem \
-             -sha1 -CAcreateserial -days -365 \
-             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
- 
- # some cleanup
- rm axTLS*.req
--rm *.srl
-+rm axTLS.srl
- rm *.conf
- 
- # need this for the client tests
- openssl x509 -in axTLS.ca_x509.pem -outform DER -out axTLS.ca_x509.cer 
-+openssl x509 -in axTLS.x509_512.pem -outform DER -out axTLS.x509_512.cer
- openssl x509 -in axTLS.x509_1024.pem -outform DER -out axTLS.x509_1024.cer
-+openssl x509 -in axTLS.x509_1042.pem -outform DER -out axTLS.x509_1042.cer
- openssl x509 -in axTLS.x509_2048.pem -outform DER -out axTLS.x509_2048.cer
- openssl x509 -in axTLS.x509_4096.pem -outform DER -out axTLS.x509_4096.cer
- openssl x509 -in axTLS.x509_device.pem -outform DER -out axTLS.x509_device.cer
- 
- # generate pkcs8 files (use RC4-128 for encryption)
--openssl pkcs8 -in axTLS.key_1024.pem -passout pass:abcd -topk8 -v1 PBE-SHA1-RC4-128 -out axTLS.encrypted_pem.p8
--openssl pkcs8 -in axTLS.key_1024.pem -passout pass:abcd -topk8 -outform DER -v1 PBE-SHA1-RC4-128 -out axTLS.encrypted.p8
--openssl pkcs8 -in axTLS.key_1024.pem -nocrypt -topk8 -out axTLS.unencrypted_pem.p8
--openssl pkcs8 -in axTLS.key_1024.pem -nocrypt -topk8 -outform DER -out axTLS.unencrypted.p8
-+openssl pkcs8 -in axTLS.key_512.pem -passout pass:abcd -topk8 -v1 PBE-SHA1-RC4-128 -out axTLS.encrypted_pem.p8
-+openssl pkcs8 -in axTLS.key_512.pem -passout pass:abcd -topk8 -outform DER -v1 PBE-SHA1-RC4-128 -out axTLS.encrypted.p8
-+openssl pkcs8 -in axTLS.key_512.pem -nocrypt -topk8 -out axTLS.unencrypted_pem.p8
-+openssl pkcs8 -in axTLS.key_512.pem -nocrypt -topk8 -outform DER -out axTLS.unencrypted.p8
- 
- # generate pkcs12 files (use RC4-128 for encryption)
- openssl pkcs12 -export -in axTLS.x509_1024.pem -inkey axTLS.key_1024.pem -certfile axTLS.ca_x509.pem -keypbe PBE-SHA1-RC4-128 -certpbe PBE-SHA1-RC4-128 -name "p12_with_CA" -out axTLS.withCA.p12 -password pass:abcd
-@@ -177,6 +186,6 @@ cat axTLS.ca_x509.pem >> axTLS.x509_device.pem
- 
- # set default key/cert for use in the server
- xxd -i axTLS.x509_1024.cer | sed -e \
--        "s/axTLS_x509_1024_cer/default_certificate/" > $AXDIR/../ssl/cert.h
-+        "s/axTLS_x509_1024_cer/default_certificate/" > $AXDIR/cert.h
- xxd -i axTLS.key_1024 | sed -e \
--        "s/axTLS_key_1024/default_private_key/" > $AXDIR/../ssl/private_key.h
-+        "s/axTLS_key_1024/default_private_key/" > $AXDIR/private_key.h
+ BIN_DIR := bin
 diff --git a/replacements/time.c b/replacements/time.c
 index 4972119..f6f44f8 100644
 --- a/replacements/time.c
@@ -503,46 +170,105 @@ index 4972119..f6f44f8 100644
  {
      if (tp)
      {
-diff --git a/crypto/rsa.c b/crypto/rsa.c
-index ab74b4d..5651a69 100644
---- a/crypto/rsa.c
-+++ b/crypto/rsa.c
-@@ -73,6 +73,7 @@ void RSA_priv_key_new(RSA_CTX **ctx,
-     bi_set_mod(bi_ctx, rsa_ctx->p, BIGINT_P_OFFSET);
-     bi_set_mod(bi_ctx, rsa_ctx->q, BIGINT_Q_OFFSET);
+diff --git a/ssl/os_port.h b/ssl/os_port.h
+index b67066c..1645ece 100644
+--- a/ssl/os_port.h
++++ b/ssl/os_port.h
+@@ -92,15 +92,26 @@ extern "C" {
+ #define be64toh(x) __bswap_constant_64(x)
  #endif
-+    bi_clear_cache(bi_ctx);
+ 
+-void ax_wdt_feed();
++extern void system_soft_wdt_feed(void);
++#define ax_wdt_feed system_soft_wdt_feed
+ 
+ #ifndef PROGMEM
+ #define PROGMEM __attribute__((aligned(4))) __attribute__((section(".irom.text")))
+ #endif
+ 
++#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
++
++extern int m_printf(char const*, ...);
++#define printf(...) m_printf(__VA_ARGS__)
++
+ #ifndef WITH_PGM_READ_HELPER
++
++#define strcpy_P(dst, src)      strcpy(dst, src)
++#define strlen_P(A)         strlen(A)
++#define memcpy_P(A, B, C)    memcpy(A, B, C)
+ #define ax_array_read_u8(x, y) x[y]
+-#else
++
++#else /* WITH_PGM_READ_HELPER */
+ 
+ static inline uint8_t pgm_read_byte(const void* addr) {
+   register uint32_t res;
+@@ -116,14 +127,10 @@ static inline uint8_t pgm_read_byte(const void* addr) {
+   return (uint8_t) res;     /* This masks the lower byte from the returned word */
  }
  
- void RSA_pub_key_new(RSA_CTX **ctx, 
-@@ -94,6 +95,7 @@ void RSA_pub_key_new(RSA_CTX **ctx,
-     bi_set_mod(bi_ctx, rsa_ctx->m, BIGINT_M_OFFSET);
-     rsa_ctx->e = bi_import(bi_ctx, pub_exp, pub_len);
-     bi_permanent(rsa_ctx->e);
-+    bi_clear_cache(bi_ctx);
+-#define ax_array_read_u8(x, y) pgm_read_byte((x)+(y))
+-#endif //WITH_PGM_READ_HELPER
+-
+ #ifdef printf
+ #undef printf
+ #endif
+ //#define printf(...)  ets_printf(__VA_ARGS__)
+-#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
+ #define PGM_VOID_P const void *
+ static inline void* memcpy_P(void* dest, PGM_VOID_P src, size_t count) {
+     const uint8_t* read = (const uint8_t*)(src);
+@@ -145,13 +152,16 @@ static inline int strlen_P(const char *str) {
+ #define printf(fmt, ...) do { static const char fstr[] PROGMEM = fmt; char rstr[sizeof(fmt)]; memcpy_P(rstr, fstr, sizeof(rstr)); ets_printf(rstr, ##__VA_ARGS__); } while (0)
+ #define strcpy_P(dst, src) do { static const char fstr[] PROGMEM = src; memcpy_P(dst, fstr, sizeof(src)); } while (0)
+ 
++#define ax_array_read_u8(x, y) pgm_read_byte((x)+(y))
++#endif  /* WITH_PGM_READ_HELPER */
++
+ // Copied from ets_sys.h to avoid compile warnings
+ extern int ets_printf(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
+ extern int ets_putc(int);
+ 
+ // The network interface in WiFiClientSecure
+-extern int ax_port_read(int fd, uint8_t* buffer, size_t count);
+-extern int ax_port_write(int fd, uint8_t* buffer, size_t count);
++extern int ax_port_read(int fd, uint8_t* buffer, int count);
++extern int ax_port_write(int fd, uint8_t* buffer, uint16_t count);
+ 
+ // TODO: Why is this not being imported from <string.h>?
+ extern char *strdup(const char *orig);
+@@ -248,6 +258,7 @@ EXP_FUNC int STDCALL getdomainname(char *buf, int buf_size);
+ #endif  /* Not Win32 */
+ 
+ /* some functions to mutate the way these work */
++#ifndef ntohl
+ inline uint32_t htonl(uint32_t n){
+   return ((n & 0xff) << 24) |
+     ((n & 0xff00) << 8) |
+@@ -256,6 +267,7 @@ inline uint32_t htonl(uint32_t n){
  }
+ 
+ #define ntohl htonl
++#endif /* ntohl */
+ 
+ EXP_FUNC int STDCALL ax_open(const char *pathname, int flags); 
+ 
+diff --git a/compat/lwipr_compat.h b/compat/lwipr_compat.h
+index 0916412..08daa8c 100644
+--- a/compat/lwipr_compat.h
++++ b/compat/lwipr_compat.h
+@@ -27,7 +27,14 @@ extern "C" {
+ #define ERR_AXL_INVALID_CLIENTFD_DATA -104
+ #define ERR_AXL_INVALID_PBUF -105
+ 
++#ifdef SOCKET_READ
++#undef SOCKET_READ
++#endif
+ #define SOCKET_READ(A, B, C) 	ax_port_read(A, B, C)
++
++#ifdef SOCKET_WRITE
++#undef SOCKET_WRITE
++#endif
+ #define SOCKET_WRITE(A, B, C) 	ax_port_write(A, B, C)
  
  /**
-diff --git a/ssl/x509.c b/ssl/x509.c
-index 35bd728..f76fa5e 100644
---- a/ssl/x509.c
-+++ b/ssl/x509.c
-@@ -247,6 +247,9 @@ int x509_new(const uint8_t *cert, int *len, X509_CTX **ctx)
-     if (asn1_skip_obj(cert, &offset, ASN1_SEQUENCE) || 
-             asn1_signature(cert, &offset, x509_ctx))
-         goto end_cert;
-+
-+    /* Saves a few bytes of memory */
-+    bi_clear_cache(bi_ctx);
- #endif
-     ret = X509_OK;
- end_cert:
-@@ -485,6 +488,8 @@ int x509_verify(const CA_CERT_CTX *ca_cert_ctx, const X509_CTX *cert)
-         ret = X509_VFY_ERROR_BAD_SIGNATURE;
-     }
- 
-+    bi_clear_cache(ctx);
-+
-     if (ret)
-         goto end_verify;
- 

--- a/Sming/third-party/.patches/axtls-8266.patch
+++ b/Sming/third-party/.patches/axtls-8266.patch
@@ -229,3 +229,298 @@ index b67066c..d92585e 100644
  #ifdef __cplusplus
  }
  #endif
+diff --git a/ssl/tls1.c b/ssl/tls1.c
+index 10b592c..10fe9d5 100644
+--- a/ssl/tls1.c
++++ b/ssl/tls1.c
+@@ -1368,6 +1368,10 @@ int basic_read(SSL *ssl, uint8_t **in_data)
+     int read_len, is_client = IS_SET_SSL_FLAG(SSL_IS_CLIENT);
+     uint8_t *buf = ssl->bm_data;
+ 
++    if (ssl->can_free_certificates) {
++    	certificate_free(ssl);
++    }
++
+     if (IS_SET_SSL_FLAG(SSL_SENT_CLOSE_NOTIFY))
+         return SSL_CLOSE_NOTIFY;
+ 
+diff --git a/tools/make_certs.sh b/tools/make_certs.sh
+index fc6cc90..3113355 100644
+--- a/tools/make_certs.sh
++++ b/tools/make_certs.sh
+@@ -29,7 +29,12 @@
+ # THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #
+ 
+-AXDIR=`pwd`/`dirname $0`
++OLDCWD=`pwd`
++
++if [ -z $AXDIR ]; then
++	AXDIR = $OLDCWD/`dirname $0`
++fi
++
+ CWD=`mktemp -d` && cd $dir
+ cd $CWD 
+ 
+@@ -42,36 +47,21 @@ PROJECT_NAME="axTLS Project"
+ # Generate the openssl configuration files.
+ cat > ca_cert.conf << EOF  
+ [ req ]
+-distinguished_name      = req_distinguished_name
+-prompt                  = no
+-req_extensions          = v3_ca
++distinguished_name     = req_distinguished_name
++prompt                 = no
+ 
+ [ req_distinguished_name ]
+  O                      = $PROJECT_NAME Dodgy Certificate Authority
+-
+-[ v3_ca ]
+-basicConstraints        = critical, CA:true
+-keyUsage                = critical, cRLSign, keyCertSign, digitalSignature
+ EOF
+ 
+ cat > certs.conf << EOF  
+ [ req ]
+-distinguished_name      = req_distinguished_name
+-prompt                  = no
+-req_extensions          = v3_usr_cert
++distinguished_name     = req_distinguished_name
++prompt                 = no
+ 
+ [ req_distinguished_name ]
+  O                      = $PROJECT_NAME
+- CN                     = localhost
+-
+-[ v3_usr_cert ]
+-basicConstraints        = critical, CA:false
+-keyUsage                = critical, nonRepudiation, digitalSignature, keyEncipherment
+-subjectAltName          = @alt_names
+- 
+-[alt_names]
+-DNS.1 = www.example.net
+-DNS.2 = www.example.org
++ CN                     = 127.0.0.1
+ EOF
+ 
+ cat > device_cert.conf << EOF  
+@@ -83,130 +73,72 @@ prompt                 = no
+  O                      = $PROJECT_NAME Device Certificate
+ EOF
+ 
+-cat > intermediate_ca.conf << EOF  
+-[ req ]
+-distinguished_name     = req_distinguished_name
+-prompt                 = no
+-req_extensions         = v3_intermediate_ca
+-
+-[ req_distinguished_name ]
+- O                      = $PROJECT_NAME Intermediate CA
+-
+-[ v3_intermediate_ca ]
+-basicConstraints        = critical, CA:true, pathlen:0
+-keyUsage                = cRLSign, keyCertSign, digitalSignature
+-EOF
+-
+-cat > intermediate_ca2.conf << EOF  
+-[ req ]
+-distinguished_name      = req_distinguished_name
+-prompt                  = no
+-req_extensions          = v3_intermediate_ca2
+-
+-[ req_distinguished_name ]
+- O                      = $PROJECT_NAME Intermediate 2 CA
+-
+-[ v3_intermediate_ca2 ]
+-basicConstraints        = critical, CA:true, pathlen:10
+-keyUsage                = encipherOnly, keyCertSign, decipherOnly
+-EOF
+-
+ # private key generation
+-openssl genrsa -out axTLS.ca_key.pem 2048
++openssl genrsa -out axTLS.ca_key.pem 1024
++openssl genrsa -out axTLS.key_512.pem 512
+ openssl genrsa -out axTLS.key_1024.pem 1024
++openssl genrsa -out axTLS.key_1042.pem 1042
+ openssl genrsa -out axTLS.key_2048.pem 2048
+ openssl genrsa -out axTLS.key_4096.pem 4096
+-openssl genrsa -out axTLS.key_device.pem 2048
+-openssl genrsa -out axTLS.key_intermediate_ca.pem 2048
+-openssl genrsa -out axTLS.key_intermediate_ca2.pem 2048
+-openssl genrsa -out axTLS.key_end_chain.pem 2048
+-openssl genrsa -aes128 -passout pass:abcd -out axTLS.key_aes128.pem 1024
+-openssl genrsa -aes256 -passout pass:abcd -out axTLS.key_aes256.pem 1024
++openssl genrsa -out axTLS.device_key.pem 1024
++openssl genrsa -aes128 -passout pass:abcd -out axTLS.key_aes128.pem 512
++openssl genrsa -aes256 -passout pass:abcd -out axTLS.key_aes256.pem 512
++
+ 
+ # convert private keys into DER format
++openssl rsa -in axTLS.key_512.pem -out axTLS.key_512 -outform DER
+ openssl rsa -in axTLS.key_1024.pem -out axTLS.key_1024 -outform DER
++openssl rsa -in axTLS.key_1042.pem -out axTLS.key_1042 -outform DER
+ openssl rsa -in axTLS.key_2048.pem -out axTLS.key_2048 -outform DER
+ openssl rsa -in axTLS.key_4096.pem -out axTLS.key_4096 -outform DER
++openssl rsa -in axTLS.device_key.pem -out axTLS.device_key -outform DER
+ 
+ # cert requests
+-openssl req -out axTLS.ca_x509.csr -key axTLS.ca_key.pem -new \
++openssl req -out axTLS.ca_x509.req -key axTLS.ca_key.pem -new \
+             -config ./ca_cert.conf 
+-openssl req -out axTLS.x509_1024.csr -key axTLS.key_1024.pem -new \
++openssl req -out axTLS.x509_512.req -key axTLS.key_512.pem -new \
++            -config ./certs.conf 
++openssl req -out axTLS.x509_1024.req -key axTLS.key_1024.pem -new \
+             -config ./certs.conf 
+-openssl req -out axTLS.x509_2048.csr -key axTLS.key_2048.pem -new \
++openssl req -out axTLS.x509_1042.req -key axTLS.key_1042.pem -new \
+             -config ./certs.conf 
+-openssl req -out axTLS.x509_4096.csr -key axTLS.key_4096.pem -new \
++openssl req -out axTLS.x509_2048.req -key axTLS.key_2048.pem -new \
+             -config ./certs.conf 
+-openssl req -out axTLS.x509_device.csr -key axTLS.key_device.pem -new \
++openssl req -out axTLS.x509_4096.req -key axTLS.key_4096.pem -new \
++            -config ./certs.conf 
++openssl req -out axTLS.x509_device.req -key axTLS.device_key.pem -new \
+             -config ./device_cert.conf
+-openssl req -out axTLS.x509_intermediate_ca.csr \
+-            -key axTLS.key_intermediate_ca.pem -new \
+-            -config ./intermediate_ca.conf
+-openssl req -out axTLS.x509_intermediate_ca2.csr \
+-            -key axTLS.key_intermediate_ca2.pem -new \
+-            -config ./intermediate_ca2.conf
+-openssl req -out axTLS.x509_end_chain.csr -key axTLS.key_end_chain.pem -new \
+-            -config ./certs.conf
+-openssl req -out axTLS.x509_aes128.csr -key axTLS.key_aes128.pem \
++openssl req -out axTLS.x509_aes128.req -key axTLS.key_aes128.pem \
+             -new -config ./certs.conf -passin pass:abcd
+-openssl req -out axTLS.x509_aes256.csr -key axTLS.key_aes256.pem \
++openssl req -out axTLS.x509_aes256.req -key axTLS.key_aes256.pem \
+             -new -config ./certs.conf -passin pass:abcd
+ 
+ # generate the actual certs.
+-openssl x509 -req -in axTLS.ca_x509.csr -out axTLS.ca_x509.pem \
+-            -sha1 -days 5000 -signkey axTLS.ca_key.pem \
+-            -CAkey axTLS.ca_key.pem -extfile ./ca_cert.conf -extensions v3_ca
+-openssl x509 -req -in axTLS.ca_x509.csr -out axTLS.ca_x509_sha256.pem \
+-            -sha256 -days 5000 -signkey axTLS.ca_key.pem \
+-            -CAkey axTLS.ca_key.pem -extfile ./ca_cert.conf -extensions v3_ca
+-openssl x509 -req -in axTLS.x509_1024.csr -out axTLS.x509_1024.pem \
++openssl x509 -req -in axTLS.ca_x509.req -out axTLS.ca_x509.pem \
++            -sha1 -days 5000 -signkey axTLS.ca_key.pem
++openssl x509 -req -in axTLS.x509_512.req -out axTLS.x509_512.pem \
+             -sha1 -CAcreateserial -days 5000 \
+             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
+-openssl x509 -req -in axTLS.x509_1024.csr -out axTLS.x509_1024_sha256.pem \
+-            -sha256 -CAcreateserial -days 5000 \
+-            -CA axTLS.ca_x509_sha256.pem -CAkey axTLS.ca_key.pem
+-openssl x509 -req -in axTLS.x509_1024.csr -out axTLS.x509_1024_sha384.pem \
+-            -sha384 -CAcreateserial -days 5000 \
+-            -CA axTLS.ca_x509_sha256.pem -CAkey axTLS.ca_key.pem
+-openssl x509 -req -in axTLS.x509_1024.csr -out axTLS.x509_1024_sha512.pem \
+-            -sha512 -CAcreateserial -days 5000 \
+-            -CA axTLS.ca_x509_sha256.pem -CAkey axTLS.ca_key.pem
+-openssl x509 -req -in axTLS.x509_2048.csr -out axTLS.x509_2048.pem \
++openssl x509 -req -in axTLS.x509_1024.req -out axTLS.x509_1024.pem \
+             -sha1 -CAcreateserial -days 5000 \
+             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
+-openssl x509 -req -in axTLS.x509_4096.csr -out axTLS.x509_4096.pem \
++openssl x509 -req -in axTLS.x509_1042.req -out axTLS.x509_1042.pem \
+             -sha1 -CAcreateserial -days 5000 \
+             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
+-openssl x509 -req -in axTLS.x509_device.csr -out axTLS.x509_device.pem \
++openssl x509 -req -in axTLS.x509_2048.req -out axTLS.x509_2048.pem \
++            -md5 -CAcreateserial -days 5000 \
++            -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
++openssl x509 -req -in axTLS.x509_4096.req -out axTLS.x509_4096.pem \
++            -md5 -CAcreateserial -days 5000 \
++            -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
++openssl x509 -req -in axTLS.x509_device.req -out axTLS.x509_device.pem \
+             -sha1 -CAcreateserial -days 5000 \
+-            -CA axTLS.x509_1024.pem -CAkey axTLS.key_1024.pem
+-openssl x509 -req -in axTLS.x509_intermediate_ca.csr -out axTLS.x509_intermediate_ca.pem \
+-            -sha256 -CAcreateserial -days 5000 \
+-            -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem \
+-            -extfile ./intermediate_ca.conf -extensions v3_intermediate_ca
+-openssl x509 -req -in axTLS.x509_intermediate_ca2.csr -out axTLS.x509_intermediate_ca2.pem \
+-            -sha256 -CAcreateserial -days 5000 \
+-            -CA axTLS.x509_intermediate_ca.pem \
+-            -CAkey axTLS.key_intermediate_ca.pem \
+-            -extfile ./intermediate_ca2.conf -extensions v3_intermediate_ca2
+-openssl x509 -req -in axTLS.x509_end_chain.csr -out axTLS.x509_end_chain.pem \
+-            -sha256 -CAcreateserial -days 5000 \
+-            -CA axTLS.x509_intermediate_ca.pem \
+-            -CAkey axTLS.key_intermediate_ca.pem \
+-            -extfile ./certs.conf -extensions v3_usr_cert 
+-# basic constraint path len failure
+-openssl x509 -req -in axTLS.x509_end_chain.csr \
+-            -out axTLS.x509_end_chain_bad.pem \
+-            -sha256 -CAcreateserial -days 5000 \
+-            -CA axTLS.x509_intermediate_ca2.pem \
+-            -CAkey axTLS.key_intermediate_ca2.pem \
+-            -extfile ./certs.conf -extensions v3_usr_cert 
+-cat axTLS.x509_intermediate_ca.pem >> axTLS.x509_intermediate_ca2.pem 
+-openssl x509 -req -in axTLS.x509_aes128.csr \
++            -CA axTLS.x509_512.pem -CAkey axTLS.key_512.pem
++openssl x509 -req -in axTLS.x509_aes128.req \
+             -out axTLS.x509_aes128.pem \
+             -sha1 -CAcreateserial -days 5000 \
+             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
+-openssl x509 -req -in axTLS.x509_aes256.csr \
++openssl x509 -req -in axTLS.x509_aes256.req \
+             -out axTLS.x509_aes256.pem \
+             -sha1 -CAcreateserial -days 5000 \
+             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
+@@ -214,32 +146,35 @@ openssl x509 -req -in axTLS.x509_aes256.csr \
+ # note: must be root to do this
+ DATE_NOW=`date`
+ if date -s "Jan 1 2025"; then
+-openssl x509 -req -in axTLS.x509_1024.csr -out axTLS.x509_bad_before.pem \
++openssl x509 -req -in axTLS.x509_512.req -out axTLS.x509_bad_before.pem \
+             -sha1 -CAcreateserial -days 365 \
+             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
+ date -s "$DATE_NOW"
+ touch axTLS.x509_bad_before.pem
+ fi
+-openssl x509 -req -in axTLS.x509_1024.csr -out axTLS.x509_bad_after.pem \
++openssl x509 -req -in axTLS.x509_512.req -out axTLS.x509_bad_after.pem \
+             -sha1 -CAcreateserial -days -365 \
+             -CA axTLS.ca_x509.pem -CAkey axTLS.ca_key.pem
+ 
+ # some cleanup
+-rm axTLS*.csr
+-rm *.srl
++rm axTLS*.req
++rm axTLS.srl
+ rm *.conf
+ 
+ # need this for the client tests
+ openssl x509 -in axTLS.ca_x509.pem -outform DER -out axTLS.ca_x509.cer 
++openssl x509 -in axTLS.x509_512.pem -outform DER -out axTLS.x509_512.cer
+ openssl x509 -in axTLS.x509_1024.pem -outform DER -out axTLS.x509_1024.cer
++openssl x509 -in axTLS.x509_1042.pem -outform DER -out axTLS.x509_1042.cer
+ openssl x509 -in axTLS.x509_2048.pem -outform DER -out axTLS.x509_2048.cer
+ openssl x509 -in axTLS.x509_4096.pem -outform DER -out axTLS.x509_4096.cer
++openssl x509 -in axTLS.x509_device.pem -outform DER -out axTLS.x509_device.cer
+ 
+ # generate pkcs8 files (use RC4-128 for encryption)
+-openssl pkcs8 -in axTLS.key_1024.pem -passout pass:abcd -topk8 -v1 PBE-SHA1-RC4-128 -out axTLS.encrypted_pem.p8
+-openssl pkcs8 -in axTLS.key_1024.pem -passout pass:abcd -topk8 -outform DER -v1 PBE-SHA1-RC4-128 -out axTLS.encrypted.p8
+-openssl pkcs8 -in axTLS.key_1024.pem -nocrypt -topk8 -out axTLS.unencrypted_pem.p8
+-openssl pkcs8 -in axTLS.key_1024.pem -nocrypt -topk8 -outform DER -out axTLS.unencrypted.p8
++openssl pkcs8 -in axTLS.key_512.pem -passout pass:abcd -topk8 -v1 PBE-SHA1-RC4-128 -out axTLS.encrypted_pem.p8
++openssl pkcs8 -in axTLS.key_512.pem -passout pass:abcd -topk8 -outform DER -v1 PBE-SHA1-RC4-128 -out axTLS.encrypted.p8
++openssl pkcs8 -in axTLS.key_512.pem -nocrypt -topk8 -out axTLS.unencrypted_pem.p8
++openssl pkcs8 -in axTLS.key_512.pem -nocrypt -topk8 -outform DER -out axTLS.unencrypted.p8
+ 
+ # generate pkcs12 files (use RC4-128 for encryption)
+ openssl pkcs12 -export -in axTLS.x509_1024.pem -inkey axTLS.key_1024.pem -certfile axTLS.ca_x509.pem -keypbe PBE-SHA1-RC4-128 -certpbe PBE-SHA1-RC4-128 -name "p12_with_CA" -out axTLS.withCA.p12 -password pass:abcd
+@@ -251,6 +186,6 @@ cat axTLS.ca_x509.pem >> axTLS.x509_device.pem
+ 
+ # set default key/cert for use in the server
+ xxd -i axTLS.x509_1024.cer | sed -e \
+-        "s/axTLS_x509_1024_cer/default_certificate/" > $AXDIR/../ssl/cert.h
++        "s/axTLS_x509_1024_cer/default_certificate/" > $AXDIR/cert.h
+ xxd -i axTLS.key_1024 | sed -e \
+-        "s/axTLS_key_1024/default_private_key/" > $AXDIR/../ssl/private_key.h
++        "s/axTLS_key_1024/default_private_key/" > $AXDIR/private_key.h

--- a/Sming/third-party/.patches/axtls-8266.patch
+++ b/Sming/third-party/.patches/axtls-8266.patch
@@ -32,7 +32,7 @@ diff -Nuar a/replacements/libc.c b/replacements/libc.c
 +    return ets_vprintf(ets_putc, format, arg);
 +}
 diff --git a/Makefile b/Makefile
-index e48e869..90da087 100644
+index e48e869..e632b44 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -5,6 +5,9 @@ LD := $(TOOLCHAIN_PREFIX)gcc
@@ -56,7 +56,7 @@ index e48e869..90da087 100644
 -    # placed into program memory.
 -    CFLAGS +=  -mforce-l32
 -else
--   # Otherwise we need to use a helper function to load 16- and 8-bit constants from program memory.
+-	# Otherwise we need to use a helper function to load 16- and 8-bit constants from program memory.
 -    CFLAGS += -DWITH_PGM_READ_HELPER
 +CFLAGS += $(CFLAGS_EXTRA)
 +
@@ -171,10 +171,19 @@ index 4972119..f6f44f8 100644
      if (tp)
      {
 diff --git a/ssl/os_port.h b/ssl/os_port.h
-index b67066c..1645ece 100644
+index b67066c..d92585e 100644
 --- a/ssl/os_port.h
 +++ b/ssl/os_port.h
-@@ -92,15 +92,26 @@ extern "C" {
+@@ -53,6 +53,8 @@ extern "C" {
+ #define EXP_FUNC
+ #endif
+ 
++#ifndef SMING_INCLUDED
++
+ #if defined(_WIN32_WCE)
+ #undef WIN32
+ #define WIN32
+@@ -92,7 +94,8 @@ extern "C" {
  #define be64toh(x) __bswap_constant_64(x)
  #endif
  
@@ -184,49 +193,7 @@ index b67066c..1645ece 100644
  
  #ifndef PROGMEM
  #define PROGMEM __attribute__((aligned(4))) __attribute__((section(".irom.text")))
- #endif
- 
-+#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
-+
-+extern int m_printf(char const*, ...);
-+#define printf(...) m_printf(__VA_ARGS__)
-+
- #ifndef WITH_PGM_READ_HELPER
-+
-+#define strcpy_P(dst, src)      strcpy(dst, src)
-+#define strlen_P(A)         strlen(A)
-+#define memcpy_P(A, B, C)    memcpy(A, B, C)
- #define ax_array_read_u8(x, y) x[y]
--#else
-+
-+#else /* WITH_PGM_READ_HELPER */
- 
- static inline uint8_t pgm_read_byte(const void* addr) {
-   register uint32_t res;
-@@ -116,14 +127,10 @@ static inline uint8_t pgm_read_byte(const void* addr) {
-   return (uint8_t) res;     /* This masks the lower byte from the returned word */
- }
- 
--#define ax_array_read_u8(x, y) pgm_read_byte((x)+(y))
--#endif //WITH_PGM_READ_HELPER
--
- #ifdef printf
- #undef printf
- #endif
- //#define printf(...)  ets_printf(__VA_ARGS__)
--#define PSTR(s) (__extension__({static const char __c[] PROGMEM = (s); &__c[0];}))
- #define PGM_VOID_P const void *
- static inline void* memcpy_P(void* dest, PGM_VOID_P src, size_t count) {
-     const uint8_t* read = (const uint8_t*)(src);
-@@ -145,13 +152,16 @@ static inline int strlen_P(const char *str) {
- #define printf(fmt, ...) do { static const char fstr[] PROGMEM = fmt; char rstr[sizeof(fmt)]; memcpy_P(rstr, fstr, sizeof(rstr)); ets_printf(rstr, ##__VA_ARGS__); } while (0)
- #define strcpy_P(dst, src) do { static const char fstr[] PROGMEM = src; memcpy_P(dst, fstr, sizeof(src)); } while (0)
- 
-+#define ax_array_read_u8(x, y) pgm_read_byte((x)+(y))
-+#endif  /* WITH_PGM_READ_HELPER */
-+
- // Copied from ets_sys.h to avoid compile warnings
- extern int ets_printf(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
+@@ -150,8 +153,8 @@ extern int ets_printf(const char *format, ...)  __attribute__ ((format (printf,
  extern int ets_putc(int);
  
  // The network interface in WiFiClientSecure
@@ -237,7 +204,7 @@ index b67066c..1645ece 100644
  
  // TODO: Why is this not being imported from <string.h>?
  extern char *strdup(const char *orig);
-@@ -248,6 +258,7 @@ EXP_FUNC int STDCALL getdomainname(char *buf, int buf_size);
+@@ -248,6 +251,7 @@ EXP_FUNC int STDCALL getdomainname(char *buf, int buf_size);
  #endif  /* Not Win32 */
  
  /* some functions to mutate the way these work */
@@ -245,30 +212,20 @@ index b67066c..1645ece 100644
  inline uint32_t htonl(uint32_t n){
    return ((n & 0xff) << 24) |
      ((n & 0xff00) << 8) |
-@@ -256,6 +267,7 @@ inline uint32_t htonl(uint32_t n){
+@@ -256,6 +260,7 @@ inline uint32_t htonl(uint32_t n){
  }
  
  #define ntohl htonl
-+#endif /* ntohl */
++#endif
  
  EXP_FUNC int STDCALL ax_open(const char *pathname, int flags); 
  
-diff --git a/compat/lwipr_compat.h b/compat/lwipr_compat.h
-index 0916412..08daa8c 100644
---- a/compat/lwipr_compat.h
-+++ b/compat/lwipr_compat.h
-@@ -27,7 +27,14 @@ extern "C" {
- #define ERR_AXL_INVALID_CLIENTFD_DATA -104
- #define ERR_AXL_INVALID_PBUF -105
+@@ -292,6 +297,8 @@ void exit_now(const char *format, ...);
+ #define PROGMEM
+ #endif
  
-+#ifdef SOCKET_READ
-+#undef SOCKET_READ
-+#endif
- #define SOCKET_READ(A, B, C) 	ax_port_read(A, B, C)
++#endif /* SMING_INCLUDED */
 +
-+#ifdef SOCKET_WRITE
-+#undef SOCKET_WRITE
-+#endif
- #define SOCKET_WRITE(A, B, C) 	ax_port_write(A, B, C)
- 
- /**
+ #ifdef __cplusplus
+ }
+ #endif

--- a/samples/Basic_Ssl/include/user_config.h
+++ b/samples/Basic_Ssl/include/user_config.h
@@ -38,11 +38,6 @@ extern "C" {
 	// Beta boards
 	#define BOARD_ESP01
 
-	// axTLS stuff
-	#include <time.h>
-	#include "util/time.h"
-	#include "compat/lwipr_compat.h"
-
 #ifdef __cplusplus
 }
 #endif

--- a/samples/Basic_WebClient/include/user_config.h
+++ b/samples/Basic_WebClient/include/user_config.h
@@ -38,11 +38,6 @@ extern "C" {
 	// Beta boards
 	#define BOARD_ESP01
 
-	// axTLS stuff
-	#include <time.h>
-	#include "util/time.h"
-	#include "compat/lwipr_compat.h"
-
 #ifdef __cplusplus
 }
 #endif

--- a/samples/Echo_Ssl/include/user_config.h
+++ b/samples/Echo_Ssl/include/user_config.h
@@ -38,11 +38,6 @@ extern "C" {
 	// Beta boards
 	#define BOARD_ESP01
 
-	// axTLS stuff
-	#include <time.h>
-	#include "util/time.h"
-	#include "compat/lwipr_compat.h"
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
- Separated the compilation of axTLS and Sming a bit more. Future updates should be easier.
- Updated TcpConnection to use the max fragment size updates.
- The new version brings more free heap space without the need of a compiler with `mforce-l32` support.