### PR TITLE
fixed buggy reading of http body from stream resulting in incomplete …

### DIFF
--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -157,7 +157,7 @@ String HttpRequest::getBody()
 	if(stream->available() != -1 && stream->getStreamType() == eSST_Memory) {
 		MemoryDataStream *memory = (MemoryDataStream *)stream;
 		char buf[1024];
-		for(int i=0; i< stream->available(); i += 1024) {
+		while(stream->available() > 0) {
 			int available = memory->readMemoryBlock(buf, 1024);
 			memory->seek(max(available, 0));
 			ret += String(buf, available);


### PR DESCRIPTION
…body returned when size >1024 byte

For me sending HTTP POST requests with bodies greater than 1024 byte led to bodies cut to 1024.