### PR TITLE
Make Delegators Compatible with Lambdas and std::function - issue 1337

### DIFF
--- a/Sming/Libraries/RF24/RF24.cpp
+++ b/Sming/Libraries/RF24/RF24.cpp
@@ -5,7 +5,7 @@
  modify it under the terms of the GNU General Public License
  version 2 as published by the Free Software Foundation.
  */
-
+#include "Arduino.h"
 #include "nRF24L01.h"
 #include "RF24_config.h"
 #include "RF24.h"

--- a/Sming/Services/DateTime/DateTime.cpp
+++ b/Sming/Services/DateTime/DateTime.cpp
@@ -8,7 +8,6 @@
 */
 
 #include "DateTime.h"
-#include <Arduino.h>
 #include <stdlib.h>
 #include <stdio.h>
 

--- a/Sming/SmingCore/ArduinoCompat.h
+++ b/Sming/SmingCore/ArduinoCompat.h
@@ -34,5 +34,15 @@ void yield();
 }
 #endif
 
+#define abs(x)                         ((x)>0?(x):-(x))
+#ifndef min
+#define min(a,b)                       ((a)<(b)?(a):(b))
+#endif
+#ifndef max
+#define max(a,b)                       ((a)>(b)?(a):(b))
+#endif
+#define round(x)                       ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
+
+
 
 #endif /* SMINGCORE_ARDUINOCOMPAT_H_ */

--- a/Sming/SmingCore/ArduinoCompat.h
+++ b/Sming/SmingCore/ArduinoCompat.h
@@ -19,6 +19,15 @@
 extern "C" {
 #endif
 
+#define abs(x)                         ((x)>0?(x):-(x))
+#ifndef min
+#define min(a,b)                       ((a)<(b)?(a):(b))
+#endif
+#ifndef max
+#define max(a,b)                       ((a)>(b)?(a):(b))
+#endif
+#define round(x)                       ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
+
 void yield();
 
 #ifdef __cplusplus

--- a/Sming/SmingCore/DataSourceStream.cpp
+++ b/Sming/SmingCore/DataSourceStream.cpp
@@ -6,6 +6,7 @@
  ****/
 
 #include "../SmingCore/DataSourceStream.h"
+#include <algorithm>
 
 int IDataSourceStream::read()
 {
@@ -91,7 +92,7 @@ size_t MemoryDataStream::write(const uint8_t* data, size_t len)
 
 uint16_t MemoryDataStream::readMemoryBlock(char* data, int bufSize)
 {
-	int available = min(size - (pos - buf), bufSize);
+	int available = std::min(size - (pos - buf), bufSize);
 	memcpy(data, pos, available);
 	return available;
 }
@@ -154,7 +155,7 @@ FileStream::~FileStream()
 
 uint16_t FileStream::readMemoryBlock(char* data, int bufSize)
 {
-	int len = min(bufSize, size - pos);
+	int len = std::min(bufSize, size - pos);
 	int available = fileRead(handle, data, len);
 	fileSeek(handle, pos, eSO_FileStart); // Don't move cursor now (waiting seek)
 	if(available < 0) {
@@ -250,7 +251,7 @@ uint16_t TemplateFileStream::readMemoryBlock(char* data, int bufSize)
 			debug_d("var %s not found", varName.c_str());
 			state = eTES_Wait;
 			int len = FileStream::readMemoryBlock(data, bufSize);
-			return min(len, skipBlockSize);
+			return std::min(len, skipBlockSize);
 		}
 	}
 	else if (state == eTES_SendingVar)

--- a/Sming/SmingCore/DataSourceStream.cpp
+++ b/Sming/SmingCore/DataSourceStream.cpp
@@ -5,6 +5,7 @@
  * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
+#include <algorithm>
 #include "../SmingCore/DataSourceStream.h"
 #include <algorithm>
 

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -12,6 +12,8 @@
 
 #include "HttpRequest.h"
 
+#include <algorithm>
+
 HttpRequest::HttpRequest(const URL& uri) {
 	this->uri = uri;
 }
@@ -159,7 +161,7 @@ String HttpRequest::getBody()
 		char buf[1024];
 		while(stream->available() > 0) {
 			int available = memory->readMemoryBlock(buf, 1024);
-			memory->seek(max(available, 0));
+			memory->seek(std::max(available, 0));
 			ret += String(buf, available);
 			if(available < 1024) {
 				break;

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -10,6 +10,7 @@
  * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
+#include <algorithm>
 #include "HttpRequest.h"
 
 #include <algorithm>

--- a/Sming/SmingCore/Network/Http/Stream/HttpChunkedStream.cpp
+++ b/Sming/SmingCore/Network/Http/Stream/HttpChunkedStream.cpp
@@ -1,5 +1,7 @@
 #include "HttpChunkedStream.h"
 
+#include <algorithm>
+
 HttpChunkedStream::HttpChunkedStream(ReadWriteStream *stream)
 {
 	this->stream = stream;
@@ -43,7 +45,7 @@ uint16_t HttpChunkedStream::readMemoryBlock(char* data, int bufSize)
 	int len = readSize;
 	char buffer[len];
 	len = stream->readMemoryBlock(buffer, len);
-	stream->seek(max(len, 0));
+	stream->seek(std::max(len, 0));
 	if(len < 1) {
 		return 0;
 	}

--- a/Sming/SmingCore/Network/Http/Stream/HttpChunkedStream.cpp
+++ b/Sming/SmingCore/Network/Http/Stream/HttpChunkedStream.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include "HttpChunkedStream.h"
 
 #include <algorithm>

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -47,7 +47,7 @@ void MqttClient::setPingRepeatTime(int seconds)
 {
 	if (PingRepeatTime > keepAlive)
 	   PingRepeatTime = keepAlive;
-	else   
+	else
 	   PingRepeatTime = seconds;
 }
 
@@ -239,7 +239,7 @@ err_t MqttClient::onReceive(pbuf *buf)
 					continue;
 			}
 
-			int available = min(waitingSize, buf->tot_len - received);
+			int available = std::min(waitingSize, buf->tot_len - received);
 			waitingSize -= available;
 			if (current != NULL)
 			{

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -5,6 +5,7 @@
  * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
+#include <algorithm>
 #include "TcpConnection.h"
 
 #include "../../SmingCore/DataSourceStream.h"

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -13,6 +13,8 @@
 #include "../Wiring/WString.h"
 #include "../Wiring/IPAddress.h"
 
+#include <algorithm>
+
 TcpConnection::TcpConnection(bool autoDestruct) : autoSelfDestruct(autoDestruct), sleep(0), canSend(true), timeOut(70)
 {
 
@@ -265,7 +267,7 @@ int TcpConnection::write(IDataSourceStream* stream)
 		do
 		{
 			pushCount++;
-			int read = min(NETWORK_SEND_BUFFER_SIZE, getAvailableWriteSize());
+			int read = std::min((uint16_t)NETWORK_SEND_BUFFER_SIZE, getAvailableWriteSize());
 			if (read > 0)
 				available = stream->readMemoryBlock(buffer, read);
 			else
@@ -275,7 +277,7 @@ int TcpConnection::write(IDataSourceStream* stream)
 			{
 				int written = write(buffer, available, TCP_WRITE_FLAG_COPY | TCP_WRITE_FLAG_MORE);
 				total += written;
-				stream->seek(max(written, 0));
+				stream->seek(std::max(written, 0));
 				debug_d("Written: %d, Available: %d, isFinished: %d, PushCount: %d [TcpBuf: %d]", written, available, (stream->isFinished()?1:0), pushCount, tcp_sndbuf(tcp));
 				repeat = written == available && !stream->isFinished() && pushCount < 25;
 			}

--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -197,7 +197,7 @@ void SPIClass::transfer(uint8 *buffer, size_t numberBytes) {
 	while  (blocks--) {
 
 		// get full BLOCKSIZE or number of remaining bytes
-		bufLenght = min(numberBytes-bufIndx, (unsigned int)BLOCKSIZE);
+		bufLenght = std::min(numberBytes-bufIndx, (unsigned int)BLOCKSIZE);
 
 #ifdef SPI_DEBUG
 		debugf("Write/Read Block %d total %d bytes", total-blocks, bufLenght);
@@ -453,7 +453,7 @@ void SPIClass::setFrequency(int freq) {
 		return;
 	}
 
-	freq = min(freq, _CPU_freq/2);
+	freq = std::min(freq, _CPU_freq/2);
 	_SPISettings._speed = freq;
 
 

--- a/Sming/SmingCore/SmingCore.h
+++ b/Sming/SmingCore/SmingCore.h
@@ -12,9 +12,6 @@
 
 #include <functional>
 
-#define min(A, B) std::min(A, B)
-#define max(A, B) std::max(A, B)
-
 #include "../Wiring/WiringFrameworkIncludes.h"
 
 #include "Delegate.h"

--- a/Sming/SmingCore/Timer.cpp
+++ b/Sming/SmingCore/Timer.cpp
@@ -44,6 +44,20 @@ Timer& Timer::initializeUs(uint32_t microseconds, TimerDelegate delegateFunction
 	return *this;
 }
 
+Timer& Timer::initializeMs(uint32_t milliseconds, TimerDelegateStdFunction delegateFunction)
+{
+	setCallback(delegateFunction);
+	setIntervalMs(milliseconds);
+	return *this;
+}
+
+Timer& Timer::initializeUs(uint32_t microseconds, TimerDelegateStdFunction delegateFunction)
+{
+	setCallback(delegateFunction);
+	setIntervalUs(microseconds);
+	return *this;
+}
+
 void Timer::start(bool repeating/* = true*/)
 {
 	this->repeating = repeating;
@@ -135,6 +149,7 @@ void Timer::setCallback(InterruptCallback interrupt/* = NULL*/)
 	ETS_INTR_LOCK();
 	callback = interrupt;
 	delegate_func = nullptr;
+	delegate_stdfunc = nullptr;
 	ETS_INTR_UNLOCK();
 
 	if (!interrupt)
@@ -146,6 +161,19 @@ void Timer::setCallback(TimerDelegate delegateFunction)
 	ETS_INTR_LOCK();
 	callback = nullptr;
 	delegate_func = delegateFunction;
+	delegate_stdfunc = nullptr;
+	ETS_INTR_UNLOCK();
+
+	if (!delegateFunction)
+		stop();
+}
+
+void Timer::setCallback(const TimerDelegateStdFunction& delegateFunction)
+{
+	ETS_INTR_LOCK();
+	callback = nullptr;
+	delegate_func = nullptr;
+	delegate_stdfunc = delegateFunction;
 	ETS_INTR_UNLOCK();
 
 	if (!delegateFunction)
@@ -196,6 +224,10 @@ void Timer::tick()
 	else if (delegate_func)
 	{
 		delegate_func();
+	}
+	else if (delegate_stdfunc)
+	{
+		delegate_stdfunc();
 	}
 	else{
 		stop();

--- a/Sming/SmingCore/Timer.h
+++ b/Sming/SmingCore/Timer.h
@@ -11,7 +11,7 @@
 #ifndef _SMING_CORE_Timer_H_
 #define _SMING_CORE_Timer_H_
 
-
+#include <functional>
 #include "../SmingCore/Interrupts.h"
 #include "../SmingCore/Delegate.h"
 #include "../Wiring/WiringFrameworkDependencies.h"
@@ -25,6 +25,7 @@
 #define MAX_OS_TIMER_INTERVAL_US 268435000
 
 typedef Delegate<void()> TimerDelegate;
+typedef std::function<void()> TimerDelegateStdFunction;
 
 class Timer
 {
@@ -59,6 +60,7 @@ public:
      *  @param  milliseconds Duration of timer in milliseconds
      *  @param  delegateFunction Function to call when timer triggers
      *  @note   Delegate callback method
+     *  @deprecated Use initializeMs(xx, TimerDelegateStdFunction); instead.
      */
 	Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, TimerDelegate delegateFunction = NULL); // Init in Milliseconds.
 
@@ -66,9 +68,23 @@ public:
      *  @param  microseconds Duration of timer in milliseconds
      *  @param  delegateFunction Function to call when timer triggers
      *  @note   Delegate callback method
+     *  @deprecated Use initializeMs(xx, TimerDelegateStdFunction); instead.
      */
 	Timer& IRAM_ATTR initializeUs(uint32_t microseconds, TimerDelegate delegateFunction = NULL); // Init in Microseconds.
 
+    /** @brief  Initialise millisecond timer
+     *  @param  milliseconds Duration of timer in milliseconds
+     *  @param  delegateFunction Function to call when timer triggers
+     *  @note   Delegate callback method
+     */
+	Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, TimerDelegateStdFunction delegateFunction = nullptr); // Init in Milliseconds.
+
+    /** @brief  Initialise microsecond timer
+     *  @param  microseconds Duration of timer in milliseconds
+     *  @param  delegateFunction Function to call when timer triggers
+     *  @note   Delegate callback method
+     */
+	Timer& IRAM_ATTR initializeUs(uint32_t microseconds, TimerDelegateStdFunction delegateFunction = nullptr); // Init in Microseconds.
     /** @brief  Start timer running
      *  @param  repeating Set to true for repeating timer. Set to false for one-shot.
      */
@@ -120,11 +136,16 @@ public:
      */
     void IRAM_ATTR setCallback(InterruptCallback interrupt = NULL);
 
-    /** @brief  Set timer trigger function
-     *  @param  delegateFunction Function to be called on timer trigger
-     *  @note   Delegate callback method
-     */
-    void IRAM_ATTR setCallback(TimerDelegate delegateFunction);
+	/** @brief  Set timer trigger function
+	*  @param  delegateFunction Function to be called on timer trigger
+	*  @note   Delegate callback method
+	*/
+	void IRAM_ATTR setCallback(TimerDelegate delegateFunction);
+	/** @brief  Set timer trigger function
+	*  @param  delegateFunction Function to be called on timer trigger
+	*  @note   Delegate callback method
+	*/
+	void IRAM_ATTR setCallback(const TimerDelegateStdFunction& delegateFunction);
 
 
 protected:
@@ -142,6 +163,7 @@ private:
     uint64_t interval = 0;
     InterruptCallback callback = nullptr;
     TimerDelegate delegate_func = nullptr;
+    TimerDelegateStdFunction delegate_stdfunc = nullptr;
     bool repeating = false;
     bool started = false;
 

--- a/Sming/Wiring/WConstants.h
+++ b/Sming/Wiring/WConstants.h
@@ -114,12 +114,12 @@
 
 #define sq(x)                          ((x)*(x))
 //#define abs(x)                         ((x)>0?(x):-(x))
-#ifndef min
-#define min(a,b)                       ((a)<(b)?(a):(b))
-#endif
-#ifndef max
-#define max(a,b)                       ((a)>(b)?(a):(b))
-#endif
+//#ifndef min
+//#define min(a,b)                       ((a)<(b)?(a):(b))
+//#endif
+//#ifndef max
+//#define max(a,b)                       ((a)>(b)?(a):(b))
+//#endif
 //#define round(x)                       ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
 #define radians(deg)                   ((deg)*DEG_TO_RAD)
 #define degrees(rad)                   ((rad)*RAD_TO_DEG)

--- a/Sming/third-party/.patches/pwm.patch
+++ b/Sming/third-party/.patches/pwm.patch
@@ -1,5 +1,5 @@
 diff --git a/pwm.c b/pwm.c
-index 5e7f218..0386a06 100644
+index 6df21ac..d039908 100644
 --- a/pwm.c
 +++ b/pwm.c
 @@ -16,6 +16,8 @@
@@ -11,12 +11,14 @@ index 5e7f218..0386a06 100644
  /* Set the following three defines to your needs */
  
  #ifndef SDK_PWM_PERIOD_COMPAT_MODE
-@@ -109,7 +111,7 @@ struct timer_regs {
+@@ -109,8 +111,8 @@ struct timer_regs {
  };
- static struct timer_regs* timer = (void*)(0x60000600);
+ static struct timer_regs* timer = (struct timer_regs*)(0x60000600);
  
--static void pwm_intr_handler(void)
-+static void pwm_intr_handler(void* param)
+-static void ICACHE_RAM_ATTR
+-pwm_intr_handler(void)
++static void IRAM_ATTR
++pwm_intr_handler(void* param)
  {
  	if ((pwm_state.current_set[pwm_state.current_phase].off_mask == 0) &&
  	    (pwm_state.current_set[pwm_state.current_phase].on_mask == 0)) {

--- a/samples/Basic_APA102/.cproject
+++ b/samples/Basic_APA102/.cproject
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" moduleId="org.eclipse.cdt.core.settings" name="Sming">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" name="Sming" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.1164554300" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.521205673" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.393887888" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.712123812" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.2110485170" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option id="gnu.c.compiler.option.include.paths.357494572" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.313321806" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler">
+								<option id="gnu.cpp.compiler.option.include.paths.611746109" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.65193859" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.1795850540" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.364843833" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.525412186" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.587940548" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option id="gnu.both.asm.option.include.paths.1067006329" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.651581712" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="{{ProjectName}}.null.1347473968" name="{{ProjectName}}"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Sming">
+			<resource resourceType="PROJECT" workspacePath="/{{ProjectName}}"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets">
+		<buildTargets>
+			<target name="all" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>all</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="clean" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>clean</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flash" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flash</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashonefile" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashonefile</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashinit" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashinit</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashboot" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashboot</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="rebuild" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>rebuild</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+		</buildTargets>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.c.compiler.mingw.base.2032390008;cdt.managedbuild.tool.gnu.c.compiler.input.1700912488">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903;cdt.managedbuild.tool.gnu.c.compiler.input.313321806">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015;cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cpp.compiler.mingw.base.454898447;cdt.managedbuild.tool.gnu.cpp.compiler.input.501261625">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+</cproject>

--- a/samples/Basic_APA102/.project
+++ b/samples/Basic_APA102/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Basic_APA102</name>
+	<comment></comment>
+	<projects>
+		<project>SmingFramework</project>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/samples/Basic_Delegates/app/application.cpp
+++ b/samples/Basic_Delegates/app/application.cpp
@@ -1,6 +1,11 @@
 #include <user_config.h>
 #include <SmingCore.h>
 
+void plainOldOrdinaryFunction()
+{
+	debugf("plainOldOrdinaryFunction");
+}
+
 class LedBlinker
 {
 
@@ -9,19 +14,86 @@ public :
 		pinMode(ledPin, OUTPUT);
 	};
 	bool setTimer(int reqInterval) {
-		if (reqInterval <= 0) return false;
+		if (reqInterval <= 0) {
+			return false;
+		}
 		ledInterval = reqInterval;
 		return true;
 	}
-	void blink(bool reqRun) {
+
+	// This example show the way delegates have been used in Sming in the past.
+	void blinkOldDelegate(bool reqRun) {
 		if (reqRun) {
-			ledTimer.initializeMs(ledInterval, TimerDelegate(&LedBlinker::ledBlink,this)).start();
+			ledTimer.initializeMs(ledInterval, TimerDelegate(&LedBlinker::ledBlink, this)).start();
 		}
 		else {
 			ledTimer.stop();
 		}
 	}
-	void ledBlink () { ledState = !ledState ; digitalWrite(ledPin, ledState);}
+
+	// This example shows how to use a plain old ordinary function as a callback
+	void callPlainOldOrdinaryFunction(bool reqRun) {
+		if (reqRun) {
+			ledTimer.initializeMs(ledInterval, TimerDelegateStdFunction(plainOldOrdinaryFunction)).start();
+			// or just
+			// ledTimer.initializeMs(ledInterval, plainOldOrdinaryFunction).start();
+		}
+		else {
+			ledTimer.stop();
+		}
+	}
+
+
+	// Sming now allows the use of std::function
+	// This example shows how to use a lamda expression as a callback
+	void callLamda(bool reqRun) {
+		if (reqRun) {
+			int foo = 123;
+			ledTimer.initializeMs(ledInterval, 
+				[&]	// capture everything by reference - so foo will be available inside the lamda
+				()  // No parameters to the callback
+				{
+					debugf("lamda Callback ");
+					if (foo > 123) {
+						debugf("foo is 123");
+					}
+				})
+				.start();
+		}
+		else {
+			ledTimer.stop();
+		}
+	}
+
+
+
+	// This example shows how to use a member function as a callback
+	void callMemberFunction(bool reqRun) {
+		if (reqRun) {
+
+			// A non-static member function must be called with an object. 
+			// That is, it always implicitly passes "this" pointer as its argument.
+			// But because our callback specifies that we don't take any arguments (<void(void)>), 
+			// you must use std::bind to bind the first (and the only) argument.
+
+			TimerDelegateStdFunction b = std::bind(&LedBlinker::callbackMemberFunction, this);
+			ledTimer.initializeMs(ledInterval, b).start();
+		}
+		else {
+			ledTimer.stop();
+		}
+	}
+
+	void ledBlink()
+	{
+		ledState = !ledState;
+		digitalWrite(ledPin, ledState);
+	}
+	void callbackMemberFunction()
+	{
+		debugf("callMemberFunction");
+	}
+	
 
 private :
 	int ledPin = 2;
@@ -35,11 +107,24 @@ private :
 
 LedBlinker myLed1 = LedBlinker(LEDPIN_1);
 LedBlinker myLed2 = LedBlinker(LEDPIN_2);
+LedBlinker myLed3 = LedBlinker(0);
+LedBlinker myLed4 = LedBlinker(0);
+LedBlinker myLed5 = LedBlinker(0);
 
 void init()
 {
 	myLed1.setTimer(1000);
-	myLed1.blink(true);
+	myLed1.blinkOldDelegate(true);
+	
 	myLed2.setTimer(500);
-	myLed2.blink(true);
+	myLed2.blinkOldDelegate(true);
+	
+	myLed3.setTimer(1000);
+	myLed3.callPlainOldOrdinaryFunction(true);
+
+	myLed4.setTimer(1000);
+	myLed4.callMemberFunction(true);
+
+	myLed5.setTimer(1000);
+	myLed5.callLamda(true);
 }

--- a/samples/Basic_Delegates/app/application.cpp
+++ b/samples/Basic_Delegates/app/application.cpp
@@ -6,88 +6,82 @@ void plainOldOrdinaryFunction()
 	debugf("plainOldOrdinaryFunction");
 }
 
-class LedBlinker
+
+void functionWithMoreComlicatedSignature(int a, String b)
+{
+	debugf("functionWithMoreComlicatedSignature %d %s", a, b.c_str());
+}
+
+
+class Task
 {
 
 public :
-	LedBlinker(int reqPin) : ledPin(reqPin) {
-		pinMode(ledPin, OUTPUT);
-	};
+	Task() {};
 	bool setTimer(int reqInterval) {
 		if (reqInterval <= 0) {
 			return false;
 		}
-		ledInterval = reqInterval;
+		taskInterval = reqInterval;
 		return true;
 	}
 
 	// This example show the way delegates have been used in Sming in the past.
-	void blinkOldDelegate(bool reqRun) {
-		if (reqRun) {
-			ledTimer.initializeMs(ledInterval, TimerDelegate(&LedBlinker::ledBlink, this)).start();
-		}
-		else {
-			ledTimer.stop();
-		}
+	void blinkOldDelegate() {
+		taskTimer.initializeMs(taskInterval, TimerDelegate(&Task::doOldDelegate, this)).start();
 	}
 
 	// This example shows how to use a plain old ordinary function as a callback
-	void callPlainOldOrdinaryFunction(bool reqRun) {
-		if (reqRun) {
-			ledTimer.initializeMs(ledInterval, TimerDelegateStdFunction(plainOldOrdinaryFunction)).start();
-			// or just
-			// ledTimer.initializeMs(ledInterval, plainOldOrdinaryFunction).start();
-		}
-		else {
-			ledTimer.stop();
-		}
+	void callPlainOldOrdinaryFunction() {
+		taskTimer.initializeMs(taskInterval, TimerDelegateStdFunction(plainOldOrdinaryFunction)).start();
+		// or just
+		// taskTimer.initializeMs(taskInterval, plainOldOrdinaryFunction).start();
 	}
 
+
+	// This example shows how to use std::bind to make us of a function that has more parameters than our signature has
+	void showHowToUseBind() {
+		auto b = std::bind(functionWithMoreComlicatedSignature, 2, "parameters");
+		taskTimer.initializeMs(taskInterval, b).start();
+	}
 
 	// Sming now allows the use of std::function
 	// This example shows how to use a lamda expression as a callback
-	void callLamda(bool reqRun) {
-		if (reqRun) {
-			int foo = 123;
-			ledTimer.initializeMs(ledInterval, 
-				[&]	// capture everything by reference - so foo will be available inside the lamda
-				()  // No parameters to the callback
+	void callLamda() {
+		int foo = 123;
+		taskTimer.initializeMs(taskInterval, 
+			[foo]		// capture just foo by value (Note it would be bad to pass by reference as foo would be out of scope when the lamda function runs later)
+			()			// No parameters to the callback
+			-> void		// Returns nothing
+			{
+				if (foo == 123) {
+					debugf("lamda Callback foo is 123");
+				}
+				else
 				{
-					debugf("lamda Callback ");
-					if (foo > 123) {
-						debugf("foo is 123");
-					}
-				})
-				.start();
-		}
-		else {
-			ledTimer.stop();
-		}
+					debugf("lamda Callback foo is not 123, crikey!");
+				}
+			})
+			.start();
 	}
 
-
+	
 
 	// This example shows how to use a member function as a callback
-	void callMemberFunction(bool reqRun) {
-		if (reqRun) {
+	void callMemberFunction() {
 
-			// A non-static member function must be called with an object. 
-			// That is, it always implicitly passes "this" pointer as its argument.
-			// But because our callback specifies that we don't take any arguments (<void(void)>), 
-			// you must use std::bind to bind the first (and the only) argument.
+		// A non-static member function must be called with an object. 
+		// That is, it always implicitly passes "this" pointer as its argument.
+		// But because our callback specifies that we don't take any arguments (<void(void)>), 
+		// you must use std::bind to bind the first (and the only) argument.
 
-			TimerDelegateStdFunction b = std::bind(&LedBlinker::callbackMemberFunction, this);
-			ledTimer.initializeMs(ledInterval, b).start();
-		}
-		else {
-			ledTimer.stop();
-		}
+		TimerDelegateStdFunction b = std::bind(&Task::callbackMemberFunction, this);
+		taskTimer.initializeMs(taskInterval, b).start();
 	}
 
-	void ledBlink()
-	{
-		ledState = !ledState;
-		digitalWrite(ledPin, ledState);
+	void doOldDelegate()
+	{		
+		debugf("doOldDelegate");
 	}
 	void callbackMemberFunction()
 	{
@@ -96,35 +90,36 @@ public :
 	
 
 private :
-	int ledPin = 2;
-	Timer ledTimer;
-	int ledInterval = 1000;
-	bool ledState = true;
+	Timer taskTimer;
+	int taskInterval = 1000;
+
 };
 
-#define LEDPIN_1  2 // GPIO2
-#define LEDPIN_2  4 // GPIO4
-
-LedBlinker myLed1 = LedBlinker(LEDPIN_1);
-LedBlinker myLed2 = LedBlinker(LEDPIN_2);
-LedBlinker myLed3 = LedBlinker(0);
-LedBlinker myLed4 = LedBlinker(0);
-LedBlinker myLed5 = LedBlinker(0);
+Task task1;
+Task task2;
+Task task3;
+Task task4;
+Task task5;
 
 void init()
 {
-	myLed1.setTimer(1000);
-	myLed1.blinkOldDelegate(true);
-	
-	myLed2.setTimer(500);
-	myLed2.blinkOldDelegate(true);
-	
-	myLed3.setTimer(1000);
-	myLed3.callPlainOldOrdinaryFunction(true);
+	WifiStation.enable(false);
+	WifiAccessPoint.enable(false);
+	Serial.begin(115200);
 
-	myLed4.setTimer(1000);
-	myLed4.callMemberFunction(true);
+	task1.setTimer(1500);
+	task1.blinkOldDelegate();
+	
+	task2.setTimer(1600);
+	task2.callPlainOldOrdinaryFunction();
 
-	myLed5.setTimer(1000);
-	myLed5.callLamda(true);
+	task3.setTimer(1900);
+	task3.showHowToUseBind();
+	
+	task4.setTimer(1700);
+	task4.callMemberFunction();
+
+	task5.setTimer(1800);
+	task5.callLamda();
+
 }

--- a/samples/Basic_Ssl/.cproject
+++ b/samples/Basic_Ssl/.cproject
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" moduleId="org.eclipse.cdt.core.settings" name="Sming">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" name="Sming" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.1164554300" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.521205673" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.393887888" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.712123812" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.2110485170" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option id="gnu.c.compiler.option.include.paths.357494572" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.313321806" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler">
+								<option id="gnu.cpp.compiler.option.include.paths.611746109" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.65193859" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.1795850540" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.364843833" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.525412186" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.587940548" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option id="gnu.both.asm.option.include.paths.1067006329" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.651581712" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="{{ProjectName}}.null.1347473968" name="{{ProjectName}}"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Sming">
+			<resource resourceType="PROJECT" workspacePath="/{{ProjectName}}"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets">
+		<buildTargets>
+			<target name="all" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>all</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="clean" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>clean</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flash" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flash</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashonefile" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashonefile</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashinit" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashinit</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashboot" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashboot</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="rebuild" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>rebuild</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+		</buildTargets>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.c.compiler.mingw.base.2032390008;cdt.managedbuild.tool.gnu.c.compiler.input.1700912488">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903;cdt.managedbuild.tool.gnu.c.compiler.input.313321806">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015;cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cpp.compiler.mingw.base.454898447;cdt.managedbuild.tool.gnu.cpp.compiler.input.501261625">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+</cproject>

--- a/samples/Gesture_APDS-9960/.cproject
+++ b/samples/Gesture_APDS-9960/.cproject
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" moduleId="org.eclipse.cdt.core.settings" name="Sming">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" name="Sming" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.1164554300" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.521205673" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.393887888" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.712123812" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.2110485170" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option id="gnu.c.compiler.option.include.paths.357494572" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.313321806" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler">
+								<option id="gnu.cpp.compiler.option.include.paths.611746109" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.65193859" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.1795850540" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.364843833" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.525412186" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.587940548" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option id="gnu.both.asm.option.include.paths.1067006329" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.651581712" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="{{ProjectName}}.null.1347473968" name="{{ProjectName}}"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Sming">
+			<resource resourceType="PROJECT" workspacePath="/{{ProjectName}}"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets">
+		<buildTargets>
+			<target name="all" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>all</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="clean" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>clean</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flash" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flash</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashonefile" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashonefile</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashinit" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashinit</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashboot" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashboot</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="rebuild" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>rebuild</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+		</buildTargets>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.c.compiler.mingw.base.2032390008;cdt.managedbuild.tool.gnu.c.compiler.input.1700912488">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903;cdt.managedbuild.tool.gnu.c.compiler.input.313321806">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015;cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cpp.compiler.mingw.base.454898447;cdt.managedbuild.tool.gnu.cpp.compiler.input.501261625">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+</cproject>

--- a/samples/Gesture_APDS-9960/.project
+++ b/samples/Gesture_APDS-9960/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>Gesture_APDS-9960</name>
+	<comment></comment>
+	<projects>
+		<project>SmingFramework</project>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/samples/IR_lib/.cproject
+++ b/samples/IR_lib/.cproject
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" moduleId="org.eclipse.cdt.core.settings" name="Sming">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" name="Sming" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.1164554300" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.521205673" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.393887888" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.712123812" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.2110485170" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option id="gnu.c.compiler.option.include.paths.357494572" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.313321806" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler">
+								<option id="gnu.cpp.compiler.option.include.paths.611746109" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.65193859" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.1795850540" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.364843833" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.525412186" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.587940548" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option id="gnu.both.asm.option.include.paths.1067006329" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.651581712" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="{{ProjectName}}.null.1347473968" name="{{ProjectName}}"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Sming">
+			<resource resourceType="PROJECT" workspacePath="/{{ProjectName}}"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets">
+		<buildTargets>
+			<target name="all" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>all</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="clean" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>clean</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flash" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flash</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashonefile" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashonefile</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashinit" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashinit</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashboot" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashboot</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="rebuild" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>rebuild</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+		</buildTargets>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.c.compiler.mingw.base.2032390008;cdt.managedbuild.tool.gnu.c.compiler.input.1700912488">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903;cdt.managedbuild.tool.gnu.c.compiler.input.313321806">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015;cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cpp.compiler.mingw.base.454898447;cdt.managedbuild.tool.gnu.cpp.compiler.input.501261625">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+</cproject>

--- a/samples/IR_lib/.project
+++ b/samples/IR_lib/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>IR_lib</name>
+	<comment></comment>
+	<projects>
+		<project>SmingFramework</project>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>

--- a/samples/ScreenTFT_ST7735/.cproject
+++ b/samples/ScreenTFT_ST7735/.cproject
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<?fileVersion 4.0.0?><cproject storage_type_id="org.eclipse.cdt.core.XmlProjectDescriptionStorage">
+	<storageModule moduleId="org.eclipse.cdt.core.settings">
+		<cconfiguration id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147">
+			<storageModule buildSystemId="org.eclipse.cdt.managedbuilder.core.configurationDataProvider" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" moduleId="org.eclipse.cdt.core.settings" name="Sming">
+				<externalSettings/>
+				<extensions>
+					<extension id="org.eclipse.cdt.core.ELF" point="org.eclipse.cdt.core.BinaryParser"/>
+					<extension id="org.eclipse.cdt.core.GCCErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GASErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GLDErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.GmakeErrorParser" point="org.eclipse.cdt.core.ErrorParser"/>
+					<extension id="org.eclipse.cdt.core.CWDLocator" point="org.eclipse.cdt.core.ErrorParser"/>
+				</extensions>
+			</storageModule>
+			<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+				<configuration artifactName="${ProjName}" buildProperties="" description="" id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147" name="Sming" parent="org.eclipse.cdt.build.core.emptycfg">
+					<folderInfo id="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463" name="/" resourcePath="">
+						<toolChain id="cdt.managedbuild.toolchain.gnu.cross.base.1164554300" name="Cross GCC" superClass="cdt.managedbuild.toolchain.gnu.cross.base">
+							<option id="cdt.managedbuild.option.gnu.cross.prefix.521205673" name="Prefix" superClass="cdt.managedbuild.option.gnu.cross.prefix"/>
+							<option id="cdt.managedbuild.option.gnu.cross.path.393887888" name="Path" superClass="cdt.managedbuild.option.gnu.cross.path"/>
+							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="cdt.managedbuild.targetPlatform.gnu.cross.712123812" isAbstract="false" osList="all" superClass="cdt.managedbuild.targetPlatform.gnu.cross"/>
+							<builder id="cdt.managedbuild.builder.gnu.cross.2110485170" keepEnvironmentInBuildfile="false" managedBuildOn="false" name="Gnu Make Builder" superClass="cdt.managedbuild.builder.gnu.cross"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903" name="Cross GCC Compiler" superClass="cdt.managedbuild.tool.gnu.cross.c.compiler">
+								<option id="gnu.c.compiler.option.include.paths.357494572" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.c.compiler.input.313321806" superClass="cdt.managedbuild.tool.gnu.c.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015" name="Cross G++ Compiler" superClass="cdt.managedbuild.tool.gnu.cross.cpp.compiler">
+								<option id="gnu.cpp.compiler.option.include.paths.611746109" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" useByScannerDiscovery="false" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366" superClass="cdt.managedbuild.tool.gnu.cpp.compiler.input"/>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.c.linker.65193859" name="Cross GCC Linker" superClass="cdt.managedbuild.tool.gnu.cross.c.linker"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.cpp.linker.1795850540" name="Cross G++ Linker" superClass="cdt.managedbuild.tool.gnu.cross.cpp.linker">
+								<inputType id="cdt.managedbuild.tool.gnu.cpp.linker.input.364843833" superClass="cdt.managedbuild.tool.gnu.cpp.linker.input">
+									<additionalInput kind="additionalinputdependency" paths="$(USER_OBJS)"/>
+									<additionalInput kind="additionalinput" paths="$(LIBS)"/>
+								</inputType>
+							</tool>
+							<tool id="cdt.managedbuild.tool.gnu.cross.archiver.525412186" name="Cross GCC Archiver" superClass="cdt.managedbuild.tool.gnu.cross.archiver"/>
+							<tool id="cdt.managedbuild.tool.gnu.cross.assembler.587940548" name="Cross GCC Assembler" superClass="cdt.managedbuild.tool.gnu.cross.assembler">
+								<option id="gnu.both.asm.option.include.paths.1067006329" name="Include paths (-I)" superClass="gnu.both.asm.option.include.paths" valueType="includePath">
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/system/include&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${SMING_HOME}/Libraries&quot;"/>
+									<listOptionValue builtIn="false" value="&quot;${ESP_HOME}/sdk/include&quot;"/>
+								</option>
+								<inputType id="cdt.managedbuild.tool.gnu.assembler.input.651581712" superClass="cdt.managedbuild.tool.gnu.assembler.input"/>
+							</tool>
+						</toolChain>
+					</folderInfo>
+				</configuration>
+			</storageModule>
+			<storageModule moduleId="org.eclipse.cdt.core.externalSettings"/>
+		</cconfiguration>
+	</storageModule>
+	<storageModule moduleId="cdtBuildSystem" version="4.0.0">
+		<project id="{{ProjectName}}.null.1347473968" name="{{ProjectName}}"/>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.core.LanguageSettingsProviders"/>
+	<storageModule moduleId="refreshScope" versionNumber="2">
+		<configuration configurationName="Sming">
+			<resource resourceType="PROJECT" workspacePath="/{{ProjectName}}"/>
+		</configuration>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.make.core.buildtargets">
+		<buildTargets>
+			<target name="all" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>all</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="clean" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>clean</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flash" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flash</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashonefile" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashonefile</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashinit" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashinit</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="flashboot" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>flashboot</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+			<target name="rebuild" path="" targetID="org.eclipse.cdt.build.MakeTargetBuilder">
+				<buildCommand>make</buildCommand>
+				<buildArguments>-f ${ProjDirPath}/Makefile</buildArguments>
+				<buildTarget>rebuild</buildTarget>
+				<stopOnError>true</stopOnError>
+				<useDefaultCommand>true</useDefaultCommand>
+				<runAllBuilders>true</runAllBuilders>
+			</target>
+		</buildTargets>
+	</storageModule>
+	<storageModule moduleId="org.eclipse.cdt.internal.ui.text.commentOwnerProjectMappings"/>
+	<storageModule moduleId="scannerConfiguration">
+		<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.c.compiler.mingw.base.2032390008;cdt.managedbuild.tool.gnu.c.compiler.input.1700912488">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.c.compiler.1168221903;cdt.managedbuild.tool.gnu.c.compiler.input.313321806">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cross.cpp.compiler.1999763015;cdt.managedbuild.tool.gnu.cpp.compiler.input.1330530366">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+		<scannerConfigBuildInfo instanceId="cdt.managedbuild.toolchain.gnu.mingw.base.1135534147;cdt.managedbuild.toolchain.gnu.mingw.base.1135534147.86962463;cdt.managedbuild.tool.gnu.cpp.compiler.mingw.base.454898447;cdt.managedbuild.tool.gnu.cpp.compiler.input.501261625">
+			<autodiscovery enabled="true" problemReportingEnabled="true" selectedProfileId=""/>
+		</scannerConfigBuildInfo>
+	</storageModule>
+</cproject>

--- a/samples/ScreenTFT_ST7735/.project
+++ b/samples/ScreenTFT_ST7735/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>ScreenTFT_ST7735</name>
+	<comment></comment>
+	<projects>
+		<project>SmingFramework</project>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.genmakebuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.cdt.managedbuilder.core.ScannerConfigBuilder</name>
+			<triggers>full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.cdt.core.cnature</nature>
+		<nature>org.eclipse.cdt.core.ccnature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.managedBuildNature</nature>
+		<nature>org.eclipse.cdt.managedbuilder.core.ScannerConfigNature</nature>
+	</natures>
+</projectDescription>


### PR DESCRIPTION
```
Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, TimerDelegateStdFunction delegateFunction = nullptr); // Init in Milliseconds.
```
For the moment the others can stay.
This allows for easier comment and review.
The sample code Basic_Delegate has example calls for old style delegates,
plainOldOrdinaryFunctions,  memberFunctions and lamdas.

The defines for min and max in SmingCore.h have been moved into ArduinoCompat.h
This allows the use of the <algorithm> header which has std::max and std::min.

Macros are nasty, especially those with the same names as standard functions.  I can see those macros are needed for code that comes form the Arduino world, and they are still available by including Arduino.h
