### PR TITLE
The C++ part should use std::max and std::min instead of the max() an…

### DIFF
--- a/Sming/SmingCore/ArduinoCompat.h
+++ b/Sming/SmingCore/ArduinoCompat.h
@@ -19,6 +19,15 @@
 extern "C" {
 #endif
 
+#define abs(x)                         ((x)>0?(x):-(x))
+#ifndef min
+#define min(a,b)                       ((a)<(b)?(a):(b))
+#endif
+#ifndef max
+#define max(a,b)                       ((a)>(b)?(a):(b))
+#endif
+#define round(x)                       ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
+
 void yield();
 
 #ifdef __cplusplus

--- a/Sming/SmingCore/DataSourceStream.cpp
+++ b/Sming/SmingCore/DataSourceStream.cpp
@@ -6,6 +6,7 @@
  ****/
 
 #include "../SmingCore/DataSourceStream.h"
+#include <algorithm>
 
 int IDataSourceStream::read()
 {
@@ -91,7 +92,7 @@ size_t MemoryDataStream::write(const uint8_t* data, size_t len)
 
 uint16_t MemoryDataStream::readMemoryBlock(char* data, int bufSize)
 {
-	int available = min(size - (pos - buf), bufSize);
+	int available = std::min(size - (pos - buf), bufSize);
 	memcpy(data, pos, available);
 	return available;
 }
@@ -154,7 +155,7 @@ FileStream::~FileStream()
 
 uint16_t FileStream::readMemoryBlock(char* data, int bufSize)
 {
-	int len = min(bufSize, size - pos);
+	int len = std::min(bufSize, size - pos);
 	int available = fileRead(handle, data, len);
 	fileSeek(handle, pos, eSO_FileStart); // Don't move cursor now (waiting seek)
 	if(available < 0) {
@@ -250,7 +251,7 @@ uint16_t TemplateFileStream::readMemoryBlock(char* data, int bufSize)
 			debug_d("var %s not found", varName.c_str());
 			state = eTES_Wait;
 			int len = FileStream::readMemoryBlock(data, bufSize);
-			return min(len, skipBlockSize);
+			return std::min(len, skipBlockSize);
 		}
 	}
 	else if (state == eTES_SendingVar)

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -12,6 +12,8 @@
 
 #include "HttpRequest.h"
 
+#include <algorithm>
+
 HttpRequest::HttpRequest(const URL& uri) {
 	this->uri = uri;
 }
@@ -159,7 +161,7 @@ String HttpRequest::getBody()
 		char buf[1024];
 		while(stream->available() > 0) {
 			int available = memory->readMemoryBlock(buf, 1024);
-			memory->seek(max(available, 0));
+			memory->seek(std::max(available, 0));
 			ret += String(buf, available);
 			if(available < 1024) {
 				break;

--- a/Sming/SmingCore/Network/Http/Stream/HttpChunkedStream.cpp
+++ b/Sming/SmingCore/Network/Http/Stream/HttpChunkedStream.cpp
@@ -1,5 +1,7 @@
 #include "HttpChunkedStream.h"
 
+#include <algorithm>
+
 HttpChunkedStream::HttpChunkedStream(ReadWriteStream *stream)
 {
 	this->stream = stream;
@@ -43,7 +45,7 @@ uint16_t HttpChunkedStream::readMemoryBlock(char* data, int bufSize)
 	int len = readSize;
 	char buffer[len];
 	len = stream->readMemoryBlock(buffer, len);
-	stream->seek(max(len, 0));
+	stream->seek(std::max(len, 0));
 	if(len < 1) {
 		return 0;
 	}

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -47,7 +47,7 @@ void MqttClient::setPingRepeatTime(int seconds)
 {
 	if (PingRepeatTime > keepAlive)
 	   PingRepeatTime = keepAlive;
-	else   
+	else
 	   PingRepeatTime = seconds;
 }
 
@@ -239,7 +239,7 @@ err_t MqttClient::onReceive(pbuf *buf)
 					continue;
 			}
 
-			int available = min(waitingSize, buf->tot_len - received);
+			int available = std::min(waitingSize, buf->tot_len - received);
 			waitingSize -= available;
 			if (current != NULL)
 			{

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -13,6 +13,8 @@
 #include "../Wiring/WString.h"
 #include "../Wiring/IPAddress.h"
 
+#include <algorithm>
+
 TcpConnection::TcpConnection(bool autoDestruct) : autoSelfDestruct(autoDestruct), sleep(0), canSend(true), timeOut(70)
 {
 
@@ -265,7 +267,7 @@ int TcpConnection::write(IDataSourceStream* stream)
 		do
 		{
 			pushCount++;
-			int read = min(NETWORK_SEND_BUFFER_SIZE, getAvailableWriteSize());
+			int read = std::min((uint16_t)NETWORK_SEND_BUFFER_SIZE, getAvailableWriteSize());
 			if (read > 0)
 				available = stream->readMemoryBlock(buffer, read);
 			else
@@ -275,7 +277,7 @@ int TcpConnection::write(IDataSourceStream* stream)
 			{
 				int written = write(buffer, available, TCP_WRITE_FLAG_COPY | TCP_WRITE_FLAG_MORE);
 				total += written;
-				stream->seek(max(written, 0));
+				stream->seek(std::max(written, 0));
 				debug_d("Written: %d, Available: %d, isFinished: %d, PushCount: %d [TcpBuf: %d]", written, available, (stream->isFinished()?1:0), pushCount, tcp_sndbuf(tcp));
 				repeat = written == available && !stream->isFinished() && pushCount < 25;
 			}

--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -197,7 +197,7 @@ void SPIClass::transfer(uint8 *buffer, size_t numberBytes) {
 	while  (blocks--) {
 
 		// get full BLOCKSIZE or number of remaining bytes
-		bufLenght = min(numberBytes-bufIndx, (unsigned int)BLOCKSIZE);
+		bufLenght = std::min(numberBytes-bufIndx, (unsigned int)BLOCKSIZE);
 
 #ifdef SPI_DEBUG
 		debugf("Write/Read Block %d total %d bytes", total-blocks, bufLenght);
@@ -453,7 +453,7 @@ void SPIClass::setFrequency(int freq) {
 		return;
 	}
 
-	freq = min(freq, _CPU_freq/2);
+	freq = std::min(freq, _CPU_freq/2);
 	_SPISettings._speed = freq;
 
 

--- a/Sming/SmingCore/SmingCore.h
+++ b/Sming/SmingCore/SmingCore.h
@@ -12,9 +12,6 @@
 
 #include <functional>
 
-#define min(A, B) std::min(A, B)
-#define max(A, B) std::max(A, B)
-
 #include "../Wiring/WiringFrameworkIncludes.h"
 
 #include "Delegate.h"

--- a/Sming/Wiring/WConstants.h
+++ b/Sming/Wiring/WConstants.h
@@ -114,12 +114,12 @@
 
 #define sq(x)                          ((x)*(x))
 //#define abs(x)                         ((x)>0?(x):-(x))
-#ifndef min
-#define min(a,b)                       ((a)<(b)?(a):(b))
-#endif
-#ifndef max
-#define max(a,b)                       ((a)>(b)?(a):(b))
-#endif
+//#ifndef min
+//#define min(a,b)                       ((a)<(b)?(a):(b))
+//#endif
+//#ifndef max
+//#define max(a,b)                       ((a)>(b)?(a):(b))
+//#endif
 //#define round(x)                       ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
 #define radians(deg)                   ((deg)*DEG_TO_RAD)
 #define degrees(rad)                   ((rad)*RAD_TO_DEG)


### PR DESCRIPTION
…d min() macros.

The old Arduino libs can still continue to use the macros.

credits: @frankdownunder 