### PR TITLE
Refactored SSL validators

### DIFF
--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -37,7 +37,7 @@ HttpRequest::HttpRequest(const HttpRequest& value) {
 #ifdef ENABLE_SSL
 	sslOptions = value.sslOptions;
 	sslFingerprint = value.sslFingerprint;
-	sslClientKeyCert = value.sslClientKeyCert;
+	sslKeyCertPair = value.sslKeyCertPair;
 #endif
 }
 
@@ -196,8 +196,8 @@ HttpRequest* HttpRequest::pinCertificate(const SSLFingerprints& fingerprints) {
 	return this;
 }
 
-HttpRequest* HttpRequest::setSslClientKeyCert(const SSLKeyCertPair& clientKeyCert) {
-	this->sslClientKeyCert = clientKeyCert;
+HttpRequest* HttpRequest::setSslKeyCert(const SSLKeyCertPair& keyCertPair) {
+	this->sslKeyCertPair = keyCertPair;
 	return this;
 }
 
@@ -262,8 +262,8 @@ String HttpRequest::toString() {
 	content += "> SSL options: " + String(sslOptions) + "\n";
 	content += "> SSL Cert Fingerprint Length: " + String((sslFingerprint.certSha1 == NULL)? 0: SHA1_SIZE) + "\n";
 	content += "> SSL PK Fingerprint Length: " + String((sslFingerprint.pkSha256 == NULL)? 0: SHA256_SIZE) + "\n";
-	content += "> SSL ClientCert Length: " + String(sslClientKeyCert.certificateLength) + "\n";
-	content += "> SSL ClientCert PK Length: " + String(sslClientKeyCert.keyLength) + "\n";
+	content += "> SSL ClientCert Length: " + String(sslKeyCertPair.certificateLength) + "\n";
+	content += "> SSL ClientCert PK Length: " + String(sslKeyCertPair.keyLength) + "\n";
 	content += "\n";
 #endif
 

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -18,7 +18,7 @@
 #include "HttpRequestAuth.h"
 #endif
 #include "../TcpConnection.h"
-#include "../../Data/Stream/OutputStream.h"
+#include "Data/Stream/OutputStream.h"
 
 class HttpClient;
 class HttpServerConnection;
@@ -103,7 +103,7 @@ public:
 	 *
 	 * @return HttpRequest pointer
 	 */
- 	HttpRequest* setSslClientKeyCert(const SSLKeyCertPair& clientKeyCert);
+ 	HttpRequest* setSslKeyCert(const SSLKeyCertPair& keyCertPair);
 #endif
 
 	HttpRequest* setBody(const String& body);
@@ -155,7 +155,7 @@ protected:
 #ifdef ENABLE_SSL
 	uint32_t sslOptions = 0;
 	SSLFingerprints sslFingerprint;
-	SSLKeyCertPair sslClientKeyCert;
+	SSLKeyCertPair  sslKeyCertPair;
 #endif
 
 private:

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -57,7 +57,7 @@ bool HttpClient::send(HttpRequest* request)
 		}
 		httpConnectionPool[cacheKey]->addSslOptions(request->getSslOptions());
 		httpConnectionPool[cacheKey]->pinCertificate(request->sslFingerprint);
-		httpConnectionPool[cacheKey]->setSslClientKeyCert(request->sslClientKeyCert);
+		httpConnectionPool[cacheKey]->setSslKeyCert(request->sslKeyCertPair);
 		httpConnectionPool[cacheKey]->sslSessionId = sslSessionIdPool[cacheKey];
 	}
 #endif

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -57,10 +57,10 @@ public:
 
 #ifdef ENABLE_SSL
 	using TcpClient::addSslOptions;
-	using TcpClient::setSslFingerprint;
+	using TcpClient::addSslValidator;
 	using TcpClient::pinCertificate;
-	using TcpClient::setSslClientKeyCert;
-	using TcpClient::freeSslClientKeyCert;
+	using TcpClient::setSslKeyCert;
+	using TcpClient::freeSslKeyCert;
 	using TcpClient::getSsl;
 #endif
 

--- a/Sming/SmingCore/Network/SslValidator.cpp
+++ b/Sming/SmingCore/Network/SslValidator.cpp
@@ -1,0 +1,39 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * @author: 2018 - Slavey Karadzhov <slav@attachix.com>
+ *
+ ****/
+
+#include "SslValidator.h"
+
+#ifdef ENABLE_SSL
+
+bool sslValidateCertificateSha1(SSL *ssl, void* data)
+{
+	uint8_t* hash = (uint8_t*)data;
+	bool success = false;
+	if(hash != NULL) {
+		success = (ssl_match_fingerprint(ssl, hash) == 0);
+		delete[] hash;
+	}
+
+	return success;
+}
+
+bool sslValidatePublicKeySha256(SSL *ssl, void* data)
+{
+	uint8_t* hash = (uint8_t*)data;
+	bool success = false;
+	if(hash != NULL) {
+		success = (ssl_match_spki_sha256(ssl, hash) == 0);
+		delete[] hash;
+	}
+
+	return success;
+}
+
+#endif /* ENABLE_SSL */

--- a/Sming/SmingCore/Network/SslValidator.h
+++ b/Sming/SmingCore/Network/SslValidator.h
@@ -1,0 +1,35 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * @author: 2018 - Slavey Karadzhov <slav@attachix.com>
+ *
+ ****/
+
+/** @defgroup tcp TCP
+ *  @ingroup networking
+ *  @{
+ */
+
+#ifndef _SMING_CORE_SSLVALIDATOR_H_
+#define _SMING_CORE_SSLVALIDATOR_H_
+
+#ifdef ENABLE_SSL
+
+#include "ssl/ssl.h"
+#include "ssl/tls1.h"
+
+#include <functional>
+
+typedef std::function<bool(SSL *ssl, void* data)> SslValidatorCallback;
+
+bool sslValidateCertificateSha1(SSL *ssl, void* data);
+
+bool sslValidatePublicKeySha256(SSL *ssl, void* data);
+
+#endif /* ENABLE_SSL */
+
+/** @} */
+#endif /* _SMING_CORE_SSLVALIDATOR_H_ */

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -17,6 +17,10 @@
 #include "TcpConnection.h"
 #include "../Delegate.h"
 
+#ifdef ENABLE_SSL
+#include "SslValidator.h"
+#endif
+
 class TcpClient;
 class ReadWriteStream;
 class IPAddress;
@@ -68,6 +72,55 @@ public:
 	__forceinline bool isProcessing()  { return state == eTCS_Connected || state == eTCS_Connecting; }
 	__forceinline TcpClientState getConnectionState() { return state; }
 
+#ifdef ENABLE_SSL
+	/**
+	 * @brief Allows setting of multiple SSL validators after a successful handshake
+	 * @param SslValidatorCallback callback
+	 * @param void* data - The data that should be passed to the callback.
+	 * 					   The callback will cast the data to the correct type and take care
+	 * 					   to delete it.
+	 *
+	 */
+	void addSslValidator(SslValidatorCallback callback, void* data = NULL);
+
+	/**
+	 * @brief   Requires(pins) the remote SSL certificate to match certain fingerprints
+	 * 			Check if SHA256 hash of Subject Public Key Info matches the one given.
+	 * @note    For HTTP public key pinning (RFC7469), the SHA-256 hash of the
+	 * 		    Subject Public Key Info (which usually only changes when the public key changes)
+	 * 		    is used rather than the SHA-1 hash of the entire certificate
+	 * 		    (which will change on each certificate renewal).
+	 * @param const uint8_t *finterprint - the fingeprint data against which the match should be performed
+	 * 									   The fingerprint will be deleted after use and should
+	 * 									   not be reused outside of this method
+	 * @param SslFingerprintType type - the fingerprint type
+	 * @note    Type: eSFT_PkSha256
+	 * 			For HTTP public key pinning (RFC7469), the SHA-256 hash of the
+	 * 		    Subject Public Key Info (which usually only changes when the public key changes)
+	 * 		    is used rather than the SHA-1 hash of the entire certificate
+	 * 		    (which will change on each certificate renewal).
+	 * 		    Advantages: The
+	 * 		    Disadvantages: Takes more time (in ms) to verify.
+	 * @note    Type: eSFT_CertSha1
+	 * 			The SHA1 hash of the remote certificate will be calculated and compared with the given one.
+	 * 			Disadvantages: The hash needs to be updated every time the remote server updates its certificate
+	 *
+	 * @return bool  true of success, false or failure
+	 */
+	bool pinCertificate(const uint8_t *fingerprint, SslFingerprintType type);
+
+	/**
+	 * @brief   Requires(pins) the remote SSL certificate to match certain fingerprints
+	 *
+	 * @note  The data inside the fingerprints parameter is passed by reference
+	 *
+	 * @param SSLFingerprints - passes the certificate fingerprints by reference.
+	 *
+	 * @return bool  true of success, false or failure
+	 */
+	bool pinCertificate(SSLFingerprints fingerprints);
+#endif
+
 protected:
 	virtual err_t onConnected(err_t err);
 	virtual err_t onReceive(pbuf *buf);
@@ -75,6 +128,10 @@ protected:
 	virtual void onError(err_t err);
 	virtual void onReadyToSendData(TcpConnectionEvent sourceEvent);
 	virtual void onFinished(TcpClientState finishState);
+
+#ifdef ENABLE_SSL
+	virtual err_t onSslConnected(SSL *ssl);
+#endif
 
 	void pushAsyncPart();
 
@@ -90,6 +147,10 @@ private:
 	bool asyncCloseAfterSent = false;
 	int16_t asyncTotalSent = 0;
 	int16_t asyncTotalLen = 0;
+#ifdef ENABLE_SSL
+	Vector<SslValidatorCallback> sslValidators;
+	Vector<void *> sslValidatorsData;
+#endif
 };
 
 /** @} */

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -31,13 +31,7 @@ TcpConnection::~TcpConnection()
 	close();
 
 #ifdef ENABLE_SSL
-	if(sslFingerprint.certSha1) {
-		delete[] sslFingerprint.certSha1;
-	}
-	if(sslFingerprint.pkSha256) {
-		delete[] sslFingerprint.pkSha256;
-	}
-	freeSslClientKeyCert();
+	freeSslKeyCert();
 #endif
 	debug_d("~TCP connection");
 
@@ -46,7 +40,7 @@ TcpConnection::~TcpConnection()
 	}
 }
 
-bool TcpConnection::connect(String server, int port, bool useSsl /* = false */, uint32_t sslOptions /* = 0 */)
+bool TcpConnection::connect(const String& server, int port, bool useSsl /* = false */, uint32_t sslOptions /* = 0 */)
 {
 	if (tcp == NULL)
 		initialize(tcp_new());
@@ -163,13 +157,7 @@ err_t TcpConnection::onConnected(err_t err)
 void TcpConnection::onError(err_t err)
 {
 #ifdef ENABLE_SSL
-	if(ssl) {
-		sslConnected = false;
-		ssl_ctx_free(sslContext);
-		sslContext=nullptr;
-		sslExtension = NULL;
-		ssl=nullptr;
-	}
+	closeSsl();
 #endif
 	debug_d("TCP connection error: %d", err);
 }
@@ -178,6 +166,13 @@ void TcpConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 {
 	if (sourceEvent != eTCE_Poll) debug_d("onReadyToSendData: %d", sourceEvent);
 }
+
+#ifdef ENABLE_SSL
+err_t TcpConnection::onSslConnected(SSL *ssl)
+{
+	return ERR_OK;
+}
+#endif
 
 int TcpConnection::writeString(const String& data, uint8_t apiflags /* = TCP_WRITE_FLAG_COPY*/)
 {
@@ -295,14 +290,7 @@ int TcpConnection::write(IDataSourceStream* stream)
 void TcpConnection::close()
 {
 #ifdef ENABLE_SSL
-	if (ssl != nullptr) {
-		debug_d("SSL: closing ...");
-		ssl_ctx_free(sslContext);
-		sslContext=nullptr;
-		ssl=nullptr;
-		sslConnected = false;
-		debug_d("done\n");
-	}
+	closeSsl();
 #endif
 
 	if (tcp == NULL) return;
@@ -424,20 +412,20 @@ err_t TcpConnection::staticOnConnected(void *arg, tcp_pcb *tcp, err_t err)
 
 			con->sslContext = ssl_ctx_new(SSL_CONNECT_IN_PARTS | sslOptions, 1);
 
-			if (con->clientKeyCert.keyLength && con->clientKeyCert.certificateLength) {
+			if (con->sslKeyCert.keyLength && con->sslKeyCert.certificateLength) {
 				// if we have client certificate -> try to use it.
 				if (ssl_obj_memory_load(con->sslContext, SSL_OBJ_RSA_KEY,
-						con->clientKeyCert.key, con->clientKeyCert.keyLength,
-						con->clientKeyCert.keyPassword) != SSL_OK) {
+						con->sslKeyCert.key, con->sslKeyCert.keyLength,
+						con->sslKeyCert.keyPassword) != SSL_OK) {
 					debug_d("SSL: Unable to load client private key");
 				} else if (ssl_obj_memory_load(con->sslContext, SSL_OBJ_X509_CERT,
-						con->clientKeyCert.certificate,
-						con->clientKeyCert.certificateLength, NULL) != SSL_OK) {
+						con->sslKeyCert.certificate,
+						con->sslKeyCert.certificateLength, NULL) != SSL_OK) {
 					debug_d("SSL: Unable to load client certificate");
 				}
 
-				if(con->freeClientKeyCert) {
-					con->freeSslClientKeyCert();
+				if(con->freeKeyCert) {
+					con->freeSslKeyCert();
 				}
 			}
 
@@ -560,27 +548,7 @@ err_t TcpConnection::staticOnReceive(void *arg, tcp_pcb *tcp, pbuf *p, err_t err
 				debug_d("SSL: Switching back to 80 MHz");
 				System.setCpuFrequency(eCF_80MHz); // Preserve some CPU cycles
 #endif
-
-				bool hasError = false;
-				do {
-					if(con->sslFingerprint.certSha1 && ssl_match_fingerprint(con->ssl, con->sslFingerprint.certSha1) != SSL_OK) {
-						debug_d("SSL: Certificate fingerprint does not match!");
-						hasError = true;
-						break;
-					}
-
-					if(con->sslFingerprint.pkSha256 && ssl_match_spki_sha256(con->ssl, con->sslFingerprint.pkSha256) != SSL_OK) {
-						debug_d("SSL: Certificate PK fingerprint does not match!");
-						hasError = true;
-						break;
-					}
-				} while(0);
-
-				if(con->freeFingerprints) {
-					con->freeSslFingerprints();
-				}
-
-				if(hasError) {
+				if(con->onSslConnected(con->ssl) != ERR_OK) {
 					con->close();
 					closeTcpConnection(tcp);
 
@@ -712,133 +680,82 @@ void TcpConnection::addSslOptions(uint32_t sslOptions)
 	this->sslOptions |= sslOptions;
 }
 
-bool TcpConnection::pinCertificate(const uint8_t *fingerprint, SslFingerprintType type, bool freeAfterHandshake /* = false */)
-{
-	int length = 0;
-	uint8_t *localStore;
-
-	switch(type) {
-	case eSFT_CertSha1:
-		localStore = sslFingerprint.certSha1;
-		length = SHA1_SIZE;
-		break;
-	case eSFT_PkSha256:
-		localStore = sslFingerprint.pkSha256;
-		length = SHA256_SIZE;
-		break;
-	default:
-		debug_d("Unsupported SSL certificate fingerprint type");
-	}
-
-	if(!length) {
-		return false;
-	}
-
-	freeFingerprints = freeAfterHandshake;
-
-	if(localStore) {
-		delete[] localStore;
-	}
-	localStore = new uint8_t[length];
-	if(localStore == NULL) {
-		return false;
-	}
-
-	memcpy(localStore, fingerprint, length);
-
-	switch(type) {
-		case eSFT_CertSha1:
-			sslFingerprint.certSha1 = localStore;
-			break;
-		case eSFT_PkSha256:
-			sslFingerprint.pkSha256 = localStore;
-			break;
-	}
-
-
-	return true;
-}
-
-bool TcpConnection::pinCertificate(SSLFingerprints fingerprints, bool freeAfterHandshake /* = false */)
-{
-	sslFingerprint = fingerprints;
-	freeFingerprints = freeAfterHandshake;
-	return true;
-}
-
-bool TcpConnection::setSslClientKeyCert(const uint8_t *key, int keyLength,
+bool TcpConnection::setSslKeyCert(const uint8_t *key, int keyLength,
 							 const uint8_t *certificate, int certificateLength,
 							 const char *keyPassword /* = NULL */, bool freeAfterHandshake /* = false */)
 {
 
 
-	clientKeyCert.key = new uint8_t[keyLength];
-	clientKeyCert.certificate = new uint8_t[certificateLength];
+	sslKeyCert.key = new uint8_t[keyLength];
+	sslKeyCert.certificate = new uint8_t[certificateLength];
 	int passwordLength = 0;
 	if(keyPassword != NULL) {
 		passwordLength = strlen(keyPassword);
-		clientKeyCert.keyPassword = new char[passwordLength+1];
+		sslKeyCert.keyPassword = new char[passwordLength+1];
 	}
 
-	if(!(clientKeyCert.key && clientKeyCert.certificate &&
-	    (passwordLength==0 || (passwordLength!=0 && clientKeyCert.keyPassword)))) {
+	if(!(sslKeyCert.key && sslKeyCert.certificate &&
+	    (passwordLength==0 || (passwordLength!=0 && sslKeyCert.keyPassword)))) {
 		return false;
 	}
 
-	memcpy(clientKeyCert.key, key, keyLength);
-	memcpy(clientKeyCert.certificate, certificate, certificateLength);
-	memcpy(clientKeyCert.keyPassword, keyPassword, passwordLength);
-	freeClientKeyCert = freeAfterHandshake;
+	memcpy(sslKeyCert.key, key, keyLength);
+	memcpy(sslKeyCert.certificate, certificate, certificateLength);
+	memcpy(sslKeyCert.keyPassword, keyPassword, passwordLength);
+	freeKeyCert = freeAfterHandshake;
 
-	clientKeyCert.keyLength = keyLength;
-	clientKeyCert.certificateLength = certificateLength;
-	clientKeyCert.keyLength = keyLength;
-
-	return true;
-}
-
-bool TcpConnection::setSslClientKeyCert(SSLKeyCertPair clientKeyCert, bool freeAfterHandshake /* = false */)
-{
-	this->clientKeyCert = clientKeyCert;
-	freeClientKeyCert = freeAfterHandshake;
+	sslKeyCert.keyLength = keyLength;
+	sslKeyCert.certificateLength = certificateLength;
+	sslKeyCert.keyLength = keyLength;
 
 	return true;
 }
 
-void TcpConnection::freeSslClientKeyCert()
+bool TcpConnection::setSslKeyCert(const SSLKeyCertPair& keyCertPair, bool freeAfterHandshake /* = false */)
 {
-	if(clientKeyCert.key) {
-		delete[] clientKeyCert.key;
-		clientKeyCert.key = NULL;
-	}
+	this->sslKeyCert = keyCertPair;
+	freeKeyCert = freeAfterHandshake;
 
-	if(clientKeyCert.certificate) {
-		delete[] clientKeyCert.certificate;
-		clientKeyCert.certificate = NULL;
-	}
-
-	if(clientKeyCert.keyPassword) {
-		delete[] clientKeyCert.keyPassword;
-		clientKeyCert.keyPassword = NULL;
-	}
-
-	clientKeyCert.keyLength = 0;
-	clientKeyCert.certificateLength = 0;
+	return true;
 }
 
-void TcpConnection::freeSslFingerprints()
+void TcpConnection::freeSslKeyCert()
 {
-	if(sslFingerprint.certSha1) {
-		delete[] sslFingerprint.certSha1;
-		sslFingerprint.certSha1 = NULL;
+	if(sslKeyCert.key) {
+		delete[] sslKeyCert.key;
+		sslKeyCert.key = NULL;
 	}
-	if(sslFingerprint.pkSha256) {
-		delete[] sslFingerprint.pkSha256;
-		sslFingerprint.pkSha256 = NULL;
+
+	if(sslKeyCert.certificate) {
+		delete[] sslKeyCert.certificate;
+		sslKeyCert.certificate = NULL;
 	}
+
+	if(sslKeyCert.keyPassword) {
+		delete[] sslKeyCert.keyPassword;
+		sslKeyCert.keyPassword = NULL;
+	}
+
+	sslKeyCert.keyLength = 0;
+	sslKeyCert.certificateLength = 0;
 }
 
-SSL* TcpConnection::getSsl() {
+SSL* TcpConnection::getSsl()
+{
 	return ssl;
+}
+
+void TcpConnection::closeSsl()
+{
+	if (ssl == nullptr) {
+		return;
+	}
+
+	debug_d("SSL: closing ...");
+	ssl_ctx_free(sslContext);
+	sslContext   = nullptr;
+	sslExtension = nullptr;
+	ssl          = nullptr;
+	sslConnected = false;
 }
 #endif

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -684,7 +684,10 @@ bool TcpConnection::setSslKeyCert(const uint8_t *key, int keyLength,
 							 const uint8_t *certificate, int certificateLength,
 							 const char *keyPassword /* = NULL */, bool freeAfterHandshake /* = false */)
 {
-
+	delete[] sslKeyCert.key;
+	delete[] sslKeyCert.certificate;
+	delete[] sslKeyCert.keyPassword;
+	sslKeyCert.keyPassword = NULL;
 
 	sslKeyCert.key = new uint8_t[keyLength];
 	sslKeyCert.certificate = new uint8_t[certificateLength];
@@ -695,13 +698,15 @@ bool TcpConnection::setSslKeyCert(const uint8_t *key, int keyLength,
 	}
 
 	if(!(sslKeyCert.key && sslKeyCert.certificate &&
-	    (passwordLength==0 || (passwordLength!=0 && sslKeyCert.keyPassword)))) {
+		(passwordLength==0 || sslKeyCert.keyPassword))) {
 		return false;
 	}
 
 	memcpy(sslKeyCert.key, key, keyLength);
 	memcpy(sslKeyCert.certificate, certificate, certificateLength);
-	memcpy(sslKeyCert.keyPassword, keyPassword, passwordLength);
+	if(keyPassword != NULL) {
+		memcpy(sslKeyCert.keyPassword, keyPassword, passwordLength);
+	}
 	freeKeyCert = freeAfterHandshake;
 
 	sslKeyCert.keyLength = keyLength;

--- a/Sming/SmingCore/Network/TcpServer.cpp
+++ b/Sming/SmingCore/Network/TcpServer.cpp
@@ -20,30 +20,22 @@ TcpServer::TcpServer() : TcpConnection(false)
 }
 
 TcpServer::TcpServer(TcpClientConnectDelegate onClientHandler, TcpClientDataDelegate clientReceiveDataHandler, TcpClientCompleteDelegate clientCompleteHandler)
-: TcpConnection(false)
+: TcpConnection(false), clientConnectDelegate(onClientHandler), clientReceiveDelegate(clientReceiveDataHandler), clientCompleteDelegate(clientCompleteHandler)
 {
-	clientConnectDelegate = onClientHandler;
-	clientReceiveDelegate = clientReceiveDataHandler;
-	clientCompleteDelegate = clientCompleteHandler;
 	timeOut = 40;
 	TcpConnection::setTimeOut(USHRT_MAX);
-
 }
 
-
 TcpServer::TcpServer(TcpClientDataDelegate clientReceiveDataHandler, TcpClientCompleteDelegate clientCompleteHandler)
-: TcpConnection(false)
+: TcpConnection(false), clientReceiveDelegate(clientReceiveDataHandler), clientCompleteDelegate(clientCompleteHandler)
 {
-	clientReceiveDelegate = clientReceiveDataHandler;
-	clientCompleteDelegate = clientCompleteHandler;
 	timeOut = 40;
 	TcpConnection::setTimeOut(USHRT_MAX);
 }
 
 TcpServer::TcpServer(TcpClientDataDelegate clientReceiveDataHandler)
-: TcpConnection(false)
+: TcpConnection(false), clientReceiveDelegate(clientReceiveDataHandler)
 {
-	clientReceiveDelegate = clientReceiveDataHandler;
 	timeOut = 40;
 	TcpConnection::setTimeOut(USHRT_MAX);
 }

--- a/Sming/SmingCore/Network/TcpServer.cpp
+++ b/Sming/SmingCore/Network/TcpServer.cpp
@@ -88,13 +88,6 @@ void TcpServer::setTimeOut(uint16_t waitTimeOut)
 	timeOut = waitTimeOut;
 }
 
-#ifdef ENABLE_SSL
-void TcpServer::setServerKeyCert(SSLKeyCertPair serverKeyCert)
-{
-	clientKeyCert = serverKeyCert;
-}
-#endif
-
 bool TcpServer::listen(int port, bool useSsl /*= false */)
 {
 	if (tcp == NULL)
@@ -114,27 +107,27 @@ bool TcpServer::listen(int port, bool useSsl /*= false */)
 
 		sslContext = ssl_ctx_new(sslOptions, sslSessionCacheSize);
 
-		if (!(clientKeyCert.keyLength && clientKeyCert.certificateLength)) {
+		if (!(sslKeyCert.keyLength && sslKeyCert.certificateLength)) {
 			debug_e("SSL: server certificate and key are not provided!");
 			return false;
 		}
 
 		if (ssl_obj_memory_load(sslContext, SSL_OBJ_RSA_KEY,
-								clientKeyCert.key, clientKeyCert.keyLength,
-								clientKeyCert.keyPassword) != SSL_OK) {
+								sslKeyCert.key, sslKeyCert.keyLength,
+								sslKeyCert.keyPassword) != SSL_OK) {
 			debug_e("SSL: Unable to load server private key");
 			return false;
 		}
 
 		if (ssl_obj_memory_load(sslContext, SSL_OBJ_X509_CERT,
-			clientKeyCert.certificate,
-			clientKeyCert.certificateLength, NULL) != SSL_OK) {
+			sslKeyCert.certificate,
+			sslKeyCert.certificateLength, NULL) != SSL_OK) {
 			debug_e("SSL: Unable to load server certificate");
 			return false;
 		}
 
 		// TODO: test: free the certificate data on server destroy...
-		freeClientKeyCert = true;
+		freeKeyCert = true;
 	}
 #endif
 

--- a/Sming/SmingCore/Network/TcpServer.h
+++ b/Sming/SmingCore/Network/TcpServer.h
@@ -38,8 +38,17 @@ public:
 #ifdef ENABLE_SSL
 	/**
 	 * @brief Adds SSL support and specifies the server certificate and private key.
+	 * @deprecated: Use setSslKeyCert instead
 	 */
-	void setServerKeyCert(SSLKeyCertPair serverKeyCert);
+	void setServerKeyCert(SSLKeyCertPair serverKeyCert)
+	{
+		setSslKeyCert(serverKeyCert);
+	}
+
+	/**
+	 * @brief Adds SSL support and specifies the server certificate and private key.
+	 */
+	using TcpConnection::setSslKeyCert;
 #endif
 
 protected:

--- a/Sming/SmingCore/Network/WebsocketClient.h
+++ b/Sming/SmingCore/Network/WebsocketClient.h
@@ -137,10 +137,10 @@ public:
 
 #ifdef ENABLE_SSL
 	using TcpClient::addSslOptions;
-	using TcpClient::setSslFingerprint;
+	using TcpClient::addSslValidator;
 	using TcpClient::pinCertificate;
-	using TcpClient::setSslClientKeyCert;
-	using TcpClient::freeSslClientKeyCert;
+	using TcpClient::setSslKeyCert;
+	using TcpClient::freeSslKeyCert;
 	using TcpClient::getSsl;
 #endif
 


### PR DESCRIPTION
- To be more consistent
- To allow multiple check from the same type 

Should be merged AFTER PR #1377.

# Migration from version 3.5.2 or earlier
- The deprecated `TcpConnection::setSslFingerprint` is removed. Use `TcpClient::pinCertificate` instead.
- `TcpConnection::setSslClientKeyCert`  is deprecated. Use `TcpConnection::setSslKeyCert` instead. It can be used on a server  to set the server certificate used for encryption, or on a client to set a client certificate used for authentication. 
- All SSL fingerprinting is moved to the TcpClient as it is relevant only for the client SSL connections.
- Calling multiple times `TcpClient::pinCertificate` will add multiple SSL validators. This is quite useful if you have one private key, that is currently used on the server, and another backup key, just in case the previous key gets compromised. In that case one can do the following:
```
MqttClient mqttClient; 
// ...
mqttClient.pinCertificate(fingerprintPublicKeyCurrent, eSFT_PkSha256); // first fingeprint
mqttClient.pinCertificate(fingerprintPublicKeyEmergencyBackup, eSFT_PkSha256); // second fingerprint
```

In the example above the first fingerprint will be checked. If it is valid no further checks will be done. If the first one fails then the next will be validated. If none of the fingerprints was valid then the connection will be rejected.
