### PR TITLE
SmingCore/Timer: Mark 'const' methods

### DIFF
--- a/Sming/SmingCore/Timer.cpp
+++ b/Sming/SmingCore/Timer.cpp
@@ -92,12 +92,12 @@ void Timer::restart()
 	start();
 }
 
-bool Timer::isStarted()
+bool Timer::isStarted() const
 {
 	return started;
 }
 
-uint64_t Timer::getIntervalUs()
+uint64_t Timer::getIntervalUs() const
 {
 	if(long_intvl_cntr_lim > 0) {
 		return interval * long_intvl_cntr_lim;
@@ -106,7 +106,7 @@ uint64_t Timer::getIntervalUs()
 	return interval;
 }
 
-uint32_t Timer::getIntervalMs()
+uint32_t Timer::getIntervalMs() const
 {
 	return (uint32_t)getIntervalUs() / 1000;
 }

--- a/Sming/SmingCore/Timer.h
+++ b/Sming/SmingCore/Timer.h
@@ -108,17 +108,17 @@ public:
     /** @brief  Check if timer is started
      *  @retval bool True if timer is running
      */
-	bool isStarted();
+	bool isStarted() const;
 
     /** @brief  Get timer interval
      *  @retval uint64_t Timer interval in microseconds
      */
-	uint64_t getIntervalUs();
+	uint64_t getIntervalUs() const;
 
     /** @brief  Get timer interval
      *  @retval uint32_t Timer interval in milliseconds
      */
-	uint32_t getIntervalMs();
+	uint32_t getIntervalMs() const;
 
     /** @brief  Set timer interval
      *  @param  microseconds Interval in microseconds. (Default: 1ms)


### PR DESCRIPTION
Timer methods `isStarted()`, `getIntervalUs()` and `getIntervalMs()` are marked with **const** modifier.