### PR TITLE
Fix/mqtt protocol

### DIFF
--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -77,6 +77,10 @@ bool MqttClient::setWill(const String& topic, const String& message, int QoS, bo
 bool MqttClient::connect(const URL& url, const String& clientName, uint32_t sslOptions)
 {
 	this->url = url;
+	if (not (url.Protocol == "mqtt" || url.Protocol == "mqtts")) {
+		debug_e("Invalid protocol");
+		return false;
+	}
 	waitingSize = 0;
 	posHeader = 0;
 	current = NULL;

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -78,7 +78,7 @@ bool MqttClient::connect(const URL& url, const String& clientName, uint32_t sslO
 {
 	this->url = url;
 	if (not (url.Protocol == "mqtt" || url.Protocol == "mqtts")) {
-		debug_e("Invalid protocol");
+		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
 	waitingSize = 0;

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -55,7 +55,7 @@ public:
 	bool setWill(const String& topic, const String& message, int QoS, bool retained = false);
 
 	/** @brief  Connect to a MQTT server
-	*  @param  url, in the form "mttqs://user:password@server:port"
+	*  @param  url, in the form "mqtt://user:password@server:port" or "mqtts://user:password@server:port"
 	*  @param  client name
 	*/
 	bool connect(const URL& url, const String& uniqueClientName, uint32_t sslOptions = 0);


### PR DESCRIPTION
We allow a URL of the form "mqtts://user:password@server:port"
but we (currently) never check the protocol bit