### PR TITLE
Replace strncpy and strcpy instances with memcpy in String class.

### DIFF
--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -186,7 +186,7 @@ String & String::copy(const char *cstr, unsigned int length)
     return *this;
   }
   len = length;
-  strncpy(buffer, cstr, length);
+  memcpy(buffer, cstr, length);
   buffer[length] = 0;
   return *this;
 }
@@ -252,7 +252,7 @@ unsigned char String::concat(const char *cstr, unsigned int length)
   if (!cstr) return 0;
   if (length == 0) return 1;
   if (!reserve(newlen)) return 0;
-  strcpy(buffer + len, cstr);
+  memcpy(buffer + len, cstr, length + 1); // Copy null terminator.
   len = newlen;
   return 1;
 }
@@ -514,7 +514,7 @@ void String::getBytes(unsigned char *buf, unsigned int bufsize, unsigned int ind
   }
   unsigned int n = bufsize - 1;
   if (n > len - index) n = len - index;
-  strncpy((char *)buf, buffer + index, n);
+  memcpy((char *)buf, buffer + index, n);
   buf[n] = 0;
 }
 


### PR DESCRIPTION
During testing with more binary MQTT payloads, it was found that the String class implementation in WString.cpp is unable to handle null bytes in binary strings, instead always assuming that a null byte must be a string terminator.

This is a problem because it makes it impossible to pass comm binary payloads such as measurement values and small files over MQTT and similar APIs which use the String class, as well as internally in application code.

Replacing the strcpy() and strncpy() instances with memcpy() solves this problem. As the length parameter is already explicitly being passed, one can assume that it is correct.