### PR TITLE
Rewrite base64 support using libb64 routines. Improvements to String class and adding support for non-ASCII data.

### DIFF
--- a/Sming/Services/WebHelpers/base64.cpp
+++ b/Sming/Services/WebHelpers/base64.cpp
@@ -1,8 +1,13 @@
-/*
- * 29/7/2018 (mikee47)
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * 	Rewritten as wrapper around libb64 encode/decode routines.
- */
+ *
+ * @author: 2018 - Mikee47 <mike@sillyhouse.net>
+ *
+ ****/
 
 #include "base64.h"
 
@@ -21,7 +26,7 @@ int base64_encode(size_t in_len, const unsigned char* in, size_t out_len, char* 
 		return -1;
 
 	base64_encodestate state;
-	base64_init_encodestate(&state);
+	base64_init_encodestate(&state, 0); // Don't include any linebreaks
 	int codelength = base64_encode_block((const char*)in, in_len, out, &state);
 	codelength += base64_encode_blockend(out + codelength, &state);
 	return codelength;

--- a/Sming/Services/WebHelpers/base64.cpp
+++ b/Sming/Services/WebHelpers/base64.cpp
@@ -1,115 +1,70 @@
-/* base64.c : base-64 / MIME encode/decode */
-/* PUBLIC DOMAIN - Jon Mayo - November 13, 2003 */
-/* $Id: base64.c 156 2007-07-12 23:29:10Z orange $ */
+/*
+ * 29/7/2018 (mikee47)
+ *
+ * 	Rewritten as wrapper around libb64 encode/decode routines.
+ */
+
 #include "base64.h"
 
-#include <c_types.h>
-#include <ctype.h>
+#include "../libb64/cencode.h"
+#include "../libb64/cdecode.h"
 
+// Base-64 encoding produces 3 output bytes for every 2 input bytes
+#define MIN_ENCODE_LEN(_in_len) (((_in_len)*3 + 1) / 2)
+#define MIN_DECODE_LEN(_in_len) (((_in_len)*2 + 2) / 3)
 
-static const uint8_t base64enc_tab[]= "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-static const uint8_t base64dec_tab[256]= {
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255, 62,255,255,255, 63,
-	 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,255,255,255,  0,255,255,
-	255,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14,
-	 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,255,255,255,255,255,
-	255, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40,
-	 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-	255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,255,
-};
-
-void base64encode(const unsigned char in[3], unsigned char out[4], int count)
+int base64_encode(size_t in_len, const unsigned char* in, size_t out_len, char* out)
 {
-	out[0]=base64enc_tab[(in[0]>>2)];
-	out[1]=base64enc_tab[((in[0]&3)<<4)|(in[1]>>4)];
-	out[2]=count<2 ? '=' : base64enc_tab[((in[1]&15)<<2)|(in[2]>>6)];
-	out[3]=count<3 ? '=' : base64enc_tab[(in[2]&63)];
+	// Base-64 encoding produces 3 output bytes for every 2 input bytes
+	unsigned min_out_len = MIN_ENCODE_LEN(in_len);
+	if (out_len < min_out_len)
+		return -1;
+
+	base64_encodestate state;
+	base64_init_encodestate(&state);
+	int codelength = base64_encode_block((const char*)in, in_len, out, &state);
+	codelength += base64_encode_blockend(out + codelength, &state);
+	return codelength;
 }
 
-#ifndef ENABLE_SSL
-int base64decode(const char in[4], char out[3])
+String base64_encode(const unsigned char* in, size_t in_len)
 {
-	uint8_t v[4];
+	String s;
+	if (!s.setLength(MIN_ENCODE_LEN(in_len)))
+		return nullptr;
 
-	v[0]=base64dec_tab[(unsigned)in[0]];
-	v[1]=base64dec_tab[(unsigned)in[1]];
-	v[2]=base64dec_tab[(unsigned)in[2]];
-	v[3]=base64dec_tab[(unsigned)in[3]];
+	int len = base64_encode(in_len, in, s.length(), s.begin());
+	if (len < 0)
+		return nullptr;
 
-	out[0]=(v[0]<<2)|(v[1]>>4); 
-	out[1]=(v[1]<<4)|(v[2]>>2); 
-	out[2]=(v[2]<<6)|(v[3]); 
-	return (v[0]|v[1]|v[2]|v[3])!=255 ? in[3]=='=' ? in[2]=='=' ? 1 : 2 : 3 : 0;
+	s.setLength(len);
+	return s;
 }
 
 /* decode a base64 string in one shot */
-int base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out) {
-	unsigned ii, io;
-	uint_least32_t v;
-	unsigned rem;
+int base64_decode(size_t in_len, const char* in, size_t out_len, unsigned char* out)
+{
+	if (out_len < MIN_DECODE_LEN(in_len))
+		return -1;
 
-	for(io=0,ii=0,v=0,rem=0;ii<in_len;ii++) {
-		unsigned char ch;
-		if(isspace(in[ii])) continue;
-		if(in[ii]=='=') break; /* stop at = */
-		ch=base64dec_tab[(unsigned)in[ii]];
-		if(ch==255) break; /* stop at a parse error */
-		v=(v<<6)|ch;
-		rem+=6;
-		if(rem>=8) {
-			rem-=8;
-			if(io>=out_len) return -1; /* truncation is failure */
-			out[io++]=(v>>rem)&255;
-		}
-	}
-	if(rem>=8) {
-		rem-=8;
-		if(io>=out_len) return -1; /* truncation is failure */
-		out[io++]=(v>>rem)&255;
-	}
-	return io;
-}
-#endif
-
-int base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out) {
-	unsigned ii, io;
-	uint_least32_t v;
-	unsigned rem;
-
-	for(io=0,ii=0,v=0,rem=0;ii<in_len;ii++) {
-		unsigned char ch;
-		ch=in[ii];
-		v=(v<<8)|ch;
-		rem+=8;
-		while(rem>=6) {
-			rem-=6;
-			if(io>=out_len) return -1; /* truncation is failure */
-			out[io++]=base64enc_tab[(v>>rem)&63];
-		}
-	}
-	if(rem) {
-		v<<=(6-rem);
-		if(io>=out_len) return -1; /* truncation is failure */
-		out[io++]=base64enc_tab[v&63];
-	}
-	while(io&3) {
-		if(io>=out_len) return -1; /* truncation is failure */
-		out[io++]='=';
-	}
-	if(io>=out_len) return -1; /* no room for null terminator */
-	out[io]=0;
-	return io;
+	base64_decodestate _state;
+	base64_init_decodestate(&_state);
+	return base64_decode_block(in, in_len, (char*)out, &_state);
 }
 
-/* vim: ts=4 sts=0 noet sw=4
-*/
+
+String base64_decode(const char *in, size_t in_len)
+{
+	String s;
+	if (!s.setLength(MIN_DECODE_LEN(in_len)))
+		return nullptr;
+
+	int outlen = base64_decode(in_len, in, s.length(), (unsigned char*)s.begin());
+	if (outlen < 0)
+		return nullptr;
+
+	s.setLength(outlen);
+	return s;
+}
+
+

--- a/Sming/Services/WebHelpers/base64.h
+++ b/Sming/Services/WebHelpers/base64.h
@@ -60,5 +60,15 @@ int base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *
  */
 String base64_decode(const char *in, size_t in_len);
 
+/** @brief encode a block of data into base64, both input and output are String objects
+ *  @param in
+ *  @retval String
+ */
+static inline String base64_decode(const String& in)
+{
+	return base64_decode(in.c_str(), in.length());
+}
+
+
 
 #endif /* BASE64_H */

--- a/Sming/Services/WebHelpers/base64.h
+++ b/Sming/Services/WebHelpers/base64.h
@@ -1,28 +1,63 @@
-/*
- * 12/8/2018 (mikee47)
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * 	Additional functions added to work with String objects for ease of use.
- */
+ *
+ * @author: 2018 - Mikee47 <mike@sillyhouse.net>
+ *
+ * 	Functions added to work with String objects for ease of use.
+ *
+ ****/
 
 #ifndef BASE64_H
 #define BASE64_H
 
 #include "WString.h"
 
-/* encode binary data into base64 digits with MIME style === pads */
+/** @brief encode binary data into base64 digits with MIME style === pads
+ *  @param in_len quantity of characters to encode
+ *  @param in data to encode
+ *  @param out_len size of output buffer
+ *  @param out buffer for base64-encoded text
+ *  @retval int length of encoded text, or -1 if output buffer is too small
+ *  @note Output is broken by newline every 72 characters. Final terminating newline
+ *  is not included.
+ */
 int base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out);
 
+/** @brief encode a block of data into base64, stored in a String
+ *  @param in text to encode
+ *  @param in_len quantity of characters to encode
+ *  @retval String the base64-encoded text
+ */
 String base64_encode(const unsigned char *in, size_t in_len);
 
+/** @brief encode a block of data into base64, both input and output are String objects
+ *  @param in
+ *  @retval String
+ */
 static inline String base64_encode(const String& in)
 {
 	return base64_encode((unsigned char*)in.c_str(), in.length());
 }
 
 
-/* decode base64 digits with MIME style === pads into binary data */
+/** @brief decode base64 digits with MIME style === pads into binary data
+ *  @param in_len length of source base64 text in characters
+ *  @param in base64-encoded text
+ *  @param out_len size of output buffer
+ *  @param out buffer for decoded output
+ *  @retval int length of decoded output, or -1 if output buffer is too small
+ */
 int base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out);
 
+/** @brief decode base64 text into binary data
+ *  @param in source base64-encoded text
+ *  @param in_len length of input text in characters
+ *  @retval String the decoded text
+ */
 String base64_decode(const char *in, size_t in_len);
 
 

--- a/Sming/Services/WebHelpers/base64.h
+++ b/Sming/Services/WebHelpers/base64.h
@@ -1,31 +1,29 @@
-/* base64.h : base-64 / MIME encode/decode */
-/* PUBLIC DOMAIN - Jon Mayo - November 13, 2003 */
-/* $Id: base64.h 128 2007-04-20 08:20:40Z orange $ */
+/*
+ * 12/8/2018 (mikee47)
+ *
+ * 	Additional functions added to work with String objects for ease of use.
+ */
+
 #ifndef BASE64_H
 #define BASE64_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-#include <user_config.h>
-
-/* used to encode 3 bytes into 4 base64 digits */
-void base64encode(const unsigned char in[3], unsigned char out[4], int count);
-
-/* used to decode 4 base64 digits into 3 bytes */
-int base64decode(const char in[4], char out[3]);
+#include "WString.h"
 
 /* encode binary data into base64 digits with MIME style === pads */
 int base64_encode(size_t in_len, const unsigned char *in, size_t out_len, char *out);
 
-#ifndef ENABLE_SSL
+String base64_encode(const unsigned char *in, size_t in_len);
+
+static inline String base64_encode(const String& in)
+{
+	return base64_encode((unsigned char*)in.c_str(), in.length());
+}
+
+
 /* decode base64 digits with MIME style === pads into binary data */
 int base64_decode(size_t in_len, const char *in, size_t out_len, unsigned char *out);
-#endif
 
-#ifdef __cplusplus
-}
-#endif
+String base64_decode(const char *in, size_t in_len);
+
 
 #endif /* BASE64_H */

--- a/Sming/Services/libb64/cdecode.c
+++ b/Sming/Services/libb64/cdecode.c
@@ -1,0 +1,85 @@
+/*
+cdecoder.c - c source to a base64 decoding algorithm implementation
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#include "cdecode.h"
+
+int base64_decode_value(char value_in)
+{
+	static const char decoding[] = {62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1,
+									-1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
+									18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31,
+									32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51};
+	static const char decoding_size = sizeof(decoding);
+	value_in -= 43;
+	if(value_in < 0 || value_in >= decoding_size)
+		return -1;
+	return decoding[(int)value_in];
+}
+
+void base64_init_decodestate(base64_decodestate* state_in)
+{
+	state_in->step = step_a;
+	state_in->plainchar = 0;
+}
+
+int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
+{
+	const char* codechar = code_in;
+	char* plainchar = plaintext_out;
+	char fragment;
+
+	*plainchar = state_in->plainchar;
+
+	switch(state_in->step) {
+		while(1) {
+		case step_a:
+			do {
+				if(codechar == code_in + length_in) {
+					state_in->step = step_a;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while(fragment < 0);
+			*plainchar = (fragment & 0x03f) << 2;
+		case step_b:
+			do {
+				if(codechar == code_in + length_in) {
+					state_in->step = step_b;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while(fragment < 0);
+			*plainchar++ |= (fragment & 0x030) >> 4;
+			*plainchar = (fragment & 0x00f) << 4;
+		case step_c:
+			do {
+				if(codechar == code_in + length_in) {
+					state_in->step = step_c;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while(fragment < 0);
+			*plainchar++ |= (fragment & 0x03c) >> 2;
+			*plainchar = (fragment & 0x003) << 6;
+		case step_d:
+			do {
+				if(codechar == code_in + length_in) {
+					state_in->step = step_d;
+					state_in->plainchar = *plainchar;
+					return plainchar - plaintext_out;
+				}
+				fragment = (char)base64_decode_value(*codechar++);
+			} while(fragment < 0);
+			*plainchar++ |= (fragment & 0x03f);
+		}
+	}
+	/* control should not reach here */
+	return plainchar - plaintext_out;
+}

--- a/Sming/Services/libb64/cdecode.c
+++ b/Sming/Services/libb64/cdecode.c
@@ -9,14 +9,10 @@ For details, see http://sourceforge.net/projects/libb64
 
 int base64_decode_value(char value_in)
 {
-	static const char decoding[] = {62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1,
-									-1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
-									18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31,
-									32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51};
+	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
 	static const char decoding_size = sizeof(decoding);
 	value_in -= 43;
-	if(value_in < 0 || value_in >= decoding_size)
-		return -1;
+	if (value_in < 0 || value_in >= decoding_size) return -1;
 	return decoding[(int)value_in];
 }
 
@@ -26,7 +22,7 @@ void base64_init_decodestate(base64_decodestate* state_in)
 	state_in->plainchar = 0;
 }
 
-int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
+unsigned base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in)
 {
 	const char* codechar = code_in;
 	char* plainchar = plaintext_out;
@@ -34,52 +30,59 @@ int base64_decode_block(const char* code_in, const int length_in, char* plaintex
 
 	*plainchar = state_in->plainchar;
 
-	switch(state_in->step) {
-		while(1) {
-		case step_a:
+	switch (state_in->step)
+	{
+		while (1)
+		{
+	case step_a:
 			do {
-				if(codechar == code_in + length_in) {
+				if (codechar == code_in+length_in)
+				{
 					state_in->step = step_a;
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
 				fragment = (char)base64_decode_value(*codechar++);
-			} while(fragment < 0);
-			*plainchar = (fragment & 0x03f) << 2;
-		case step_b:
+			} while (fragment < 0);
+			*plainchar    = (fragment & 0x03f) << 2;
+	case step_b:
 			do {
-				if(codechar == code_in + length_in) {
+				if (codechar == code_in+length_in)
+				{
 					state_in->step = step_b;
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
 				fragment = (char)base64_decode_value(*codechar++);
-			} while(fragment < 0);
+			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x030) >> 4;
-			*plainchar = (fragment & 0x00f) << 4;
-		case step_c:
+			*plainchar    = (fragment & 0x00f) << 4;
+	case step_c:
 			do {
-				if(codechar == code_in + length_in) {
+				if (codechar == code_in+length_in)
+				{
 					state_in->step = step_c;
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
 				fragment = (char)base64_decode_value(*codechar++);
-			} while(fragment < 0);
+			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x03c) >> 2;
-			*plainchar = (fragment & 0x003) << 6;
-		case step_d:
+			*plainchar    = (fragment & 0x003) << 6;
+	case step_d:
 			do {
-				if(codechar == code_in + length_in) {
+				if (codechar == code_in+length_in)
+				{
 					state_in->step = step_d;
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
 				fragment = (char)base64_decode_value(*codechar++);
-			} while(fragment < 0);
-			*plainchar++ |= (fragment & 0x03f);
+			} while (fragment < 0);
+			*plainchar++   |= (fragment & 0x03f);
 		}
 	}
 	/* control should not reach here */
 	return plainchar - plaintext_out;
 }
+

--- a/Sming/Services/libb64/cdecode.h
+++ b/Sming/Services/libb64/cdecode.h
@@ -12,18 +12,30 @@ For details, see http://sourceforge.net/projects/libb64
 extern "C" {
 #endif
 
-typedef enum { step_a, step_b, step_c, step_d } base64_decodestep;
+typedef enum
+{
+	step_a, step_b, step_c, step_d
+} base64_decodestep;
 
-typedef struct {
+typedef struct
+{
 	base64_decodestep step;
 	char plainchar;
 } base64_decodestate;
 
+/** @brief Call first to initialise decoder
+ *  @param state_in
+ */
 void base64_init_decodestate(base64_decodestate* state_in);
 
-int base64_decode_value(char value_in);
-
-int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in);
+/** @brief Call as many times as required to decode text
+ *  @param code_in
+ *  @param length_in
+ *  @param plaintext_out may use same buffer as code_in if required
+ *  @param state_in
+ *  @retval unsigned number of bytes output
+ */
+unsigned base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in);
 
 #ifdef __cplusplus
 }

--- a/Sming/Services/libb64/cdecode.h
+++ b/Sming/Services/libb64/cdecode.h
@@ -1,0 +1,32 @@
+/*
+cdecode.h - c header for a base64 decoding algorithm
+
+This is part of the libb64 project, and has been placed in the public domain.
+For details, see http://sourceforge.net/projects/libb64
+*/
+
+#ifndef BASE64_CDECODE_H
+#define BASE64_CDECODE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum { step_a, step_b, step_c, step_d } base64_decodestep;
+
+typedef struct {
+	base64_decodestep step;
+	char plainchar;
+} base64_decodestate;
+
+void base64_init_decodestate(base64_decodestate* state_in);
+
+int base64_decode_value(char value_in);
+
+int base64_decode_block(const char* code_in, const int length_in, char* plaintext_out, base64_decodestate* state_in);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BASE64_CDECODE_H */

--- a/Sming/Services/libb64/cencode.c
+++ b/Sming/Services/libb64/cencode.c
@@ -19,11 +19,12 @@ void base64_init_encodestate(base64_encodestate* state_in)
 char base64_encode_value(char value_in)
 {
 	static const char* encoding = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-	if (value_in > 63) return '=';
+	if(value_in > 63)
+		return '=';
 	return encoding[(int)value_in];
 }
 
-int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in)
+unsigned base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in)
 {
 	const char* plainchar = plaintext_in;
 	const char* const plaintextend = plaintext_in + length_in;
@@ -33,13 +34,10 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 
 	result = state_in->result;
 
-	switch (state_in->step)
-	{
-		while (1)
-		{
-	case step_A:
-			if (plainchar == plaintextend)
-			{
+	switch(state_in->step) {
+		while(1) {
+		case step_A:
+			if(plainchar == plaintextend) {
 				state_in->result = result;
 				state_in->step = step_A;
 				return codechar - code_out;
@@ -48,9 +46,8 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			result = (fragment & 0x0fc) >> 2;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x003) << 4;
-	case step_B:
-			if (plainchar == plaintextend)
-			{
+		case step_B:
+			if(plainchar == plaintextend) {
 				state_in->result = result;
 				state_in->step = step_B;
 				return codechar - code_out;
@@ -59,9 +56,8 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			result |= (fragment & 0x0f0) >> 4;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x00f) << 2;
-	case step_C:
-			if (plainchar == plaintextend)
-			{
+		case step_C:
+			if(plainchar == plaintextend) {
 				state_in->result = result;
 				state_in->step = step_C;
 				return codechar - code_out;
@@ -69,12 +65,11 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 			fragment = *plainchar++;
 			result |= (fragment & 0x0c0) >> 6;
 			*codechar++ = base64_encode_value(result);
-			result  = (fragment & 0x03f) >> 0;
+			result = (fragment & 0x03f) >> 0;
 			*codechar++ = base64_encode_value(result);
 
 			++(state_in->stepcount);
-			if (state_in->stepcount == CHARS_PER_LINE/4)
-			{
+			if(state_in->stepcount == CHARS_PER_LINE / 4) {
 				*codechar++ = '\n';
 				state_in->stepcount = 0;
 			}
@@ -84,12 +79,11 @@ int base64_encode_block(const char* plaintext_in, int length_in, char* code_out,
 	return codechar - code_out;
 }
 
-int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
+unsigned base64_encode_blockend(char* code_out, base64_encodestate* state_in)
 {
 	char* codechar = code_out;
 
-	switch (state_in->step)
-	{
+	switch(state_in->step) {
 	case step_B:
 		*codechar++ = base64_encode_value(state_in->result);
 		*codechar++ = '=';
@@ -102,7 +96,6 @@ int base64_encode_blockend(char* code_out, base64_encodestate* state_in)
 	case step_A:
 		break;
 	}
-	*codechar++ = '\n';
 
 	return codechar - code_out;
 }

--- a/Sming/Services/libb64/cencode.h
+++ b/Sming/Services/libb64/cencode.h
@@ -12,25 +12,33 @@ For details, see http://sourceforge.net/projects/libb64
 extern "C" {
 #endif
 
-typedef enum
-{
-	step_A, step_B, step_C
-} base64_encodestep;
+typedef enum { step_A, step_B, step_C } base64_encodestep;
 
-typedef struct
-{
+typedef struct {
 	base64_encodestep step;
 	char result;
 	int stepcount;
 } base64_encodestate;
 
+/** @brief Call first to initialise encoder
+ *  @param state_in
+ */
 void base64_init_encodestate(base64_encodestate* state_in);
 
-char base64_encode_value(char value_in);
+/** @brief Call as many times as required to encode text
+ *  @param plaintext_in
+ *  @param length_in
+ *  @param code_out buffer must be at least (4 * length_in / 3) bytes
+ *  @param state_in
+ *  @retval unsigned number of bytes output
+ */
+unsigned base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in);
 
-int base64_encode_block(const char* plaintext_in, int length_in, char* code_out, base64_encodestate* state_in);
-
-int base64_encode_blockend(char* code_out, base64_encodestate* state_in);
+/** @brief Call to finish encoding and return any remaining output bytes (maximum 2).
+ *  @note This function does NOT append any extraneous characters (such as a carriage return) to the
+ *  output text.
+ */
+unsigned base64_encode_blockend(char* code_out, base64_encodestate* state_in);
 
 #ifdef __cplusplus
 }

--- a/Sming/Services/libb64/cencode.h
+++ b/Sming/Services/libb64/cencode.h
@@ -12,18 +12,24 @@ For details, see http://sourceforge.net/projects/libb64
 extern "C" {
 #endif
 
-typedef enum { step_A, step_B, step_C } base64_encodestep;
+typedef enum
+{
+	step_A, step_B, step_C
+} base64_encodestep;
 
-typedef struct {
+typedef struct
+{
 	base64_encodestep step;
 	char result;
 	int stepcount;
+	unsigned steps_per_line; ///< Non-zero to limit encoded line lengths
 } base64_encodestate;
 
 /** @brief Call first to initialise encoder
  *  @param state_in
+ *  @param charsPerLine linebreaks added as required. Specify 0 to disable line breaking.
  */
-void base64_init_encodestate(base64_encodestate* state_in);
+void base64_init_encodestate(base64_encodestate* state_in, unsigned chars_per_line);
 
 /** @brief Call as many times as required to encode text
  *  @param plaintext_in

--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
@@ -10,11 +10,14 @@
 
 #include "Base64OutputStream.h"
 
+// Produce line breaks in output encodings
+const unsigned CHARS_PER_LINE = 72;
+
 Base64OutputStream::Base64OutputStream(ReadWriteStream* stream, size_t resultSize /* = 512 */)
 	: StreamTransformer(stream, nullptr, resultSize, (resultSize / 4))
 
 {
-	base64_init_encodestate(&state);
+	base64_init_encodestate(&state, CHARS_PER_LINE);
 
 	transformCallback = std::bind(&Base64OutputStream::encode, this, std::placeholders::_1, std::placeholders::_2,
 								  std::placeholders::_3, std::placeholders::_4);

--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
@@ -25,7 +25,6 @@ int Base64OutputStream::encode(uint8_t* source, size_t sourceLength, uint8_t* ta
 	int count = 0;
 	if(sourceLength == 0) {
 		count = base64_encode_blockend((char*)target, &state);
-		count--; // the last byte is a newline. we don't need it.
 	} else {
 		count = base64_encode_block((const char*)source, sourceLength, (char*)target, &state);
 	}

--- a/Sming/SmingCore/Data/Structures.h
+++ b/Sming/SmingCore/Data/Structures.h
@@ -14,9 +14,6 @@
 #include "../../Wiring/FILO.h"
 #include "../../Wiring/WString.h"
 #include "../../Wiring/WHashMap.h"
-extern "C" {
-int strcasecmp(const char*, const char*);
-}
 
 /**
  * WARNING: For the moment the name "SimpleConcurrentQueue" is very misleading.

--- a/Sming/SmingCore/Network/Http/HttpRequestAuth.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequestAuth.cpp
@@ -23,12 +23,7 @@ HttpBasicAuth::HttpBasicAuth(const String& username, const String& password)
 // Basic Auth
 void HttpBasicAuth::setRequest(HttpRequest* request)
 {
-	String clearText = username + ":" + password;
-	int hashLength = clearText.length() * 4;
-	char hash[hashLength];
-	base64_encode(clearText.length(), (const unsigned char*)clearText.c_str(), hashLength, hash);
-
-	request->setHeader("Authorization", "Basic " + String(hash));
+	request->setHeader("Authorization", "Basic " + base64_encode(username + ":" + password));
 }
 
 // Digest Auth

--- a/Sming/SmingCore/Network/Http/Websocket/WebSocketConnection.cpp
+++ b/Sming/SmingCore/Network/Http/Websocket/WebSocketConnection.cpp
@@ -31,17 +31,15 @@ bool WebSocketConnection::initialize(HttpRequest& request, HttpResponse& respons
 		return false;
 
 	state = eWSCS_Open;
-	String hash = request.getHeader("Sec-WebSocket-Key");
-	hash.trim();
-	hash = hash + secret;
-	unsigned char data[SHA1_SIZE];
-	char secure[SHA1_SIZE * 4];
-	sha1(data, hash.c_str(), hash.length());
-	base64_encode(SHA1_SIZE, data, SHA1_SIZE * 4, secure);
+	String token = request.getHeader("Sec-WebSocket-Key");
+	token.trim();
+	token = token + secret;
+	unsigned char hash[SHA1_SIZE];
+	sha1(hash, token.c_str(), token.length());
 	response.code = HTTP_STATUS_SWITCHING_PROTOCOLS;
 	response.setHeader("Connection", "Upgrade");
 	response.setHeader("Upgrade", "websocket");
-	response.setHeader("Sec-WebSocket-Accept", secure);
+	response.setHeader("Sec-WebSocket-Accept", base64_encode(hash, SHA1_SIZE));
 
 	delete stream;
 	stream = new EndlessMemoryStream();

--- a/Sming/SmingCore/Network/WebsocketClient.cpp
+++ b/Sming/SmingCore/Network/WebsocketClient.cpp
@@ -46,8 +46,9 @@ bool WebsocketClient::connect(String url, uint32_t sslOptions /* = 0 */)
 	_mode = wsMode::Connecting; // Server Connected / WS Upgrade request sent
 
 	uint8_t keyStart[16];
-	for(unsigned i = 0; i < sizeof(keyStart); ++i)
+	for(unsigned i = 0; i < sizeof(keyStart); ++i) {
 		keyStart[i] = 1 + os_random() % 255;
+	}
 	_key = base64_encode(keyStart, sizeof(keyStart));
 
 	String protocol = "chat";

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -17,92 +17,97 @@
 */
 
 #include "WiringFrameworkIncludes.h"
-#include <stdlib.h>
+
+/*
+ * Want memmem() to replace use of strstr() so we can search on byte strings.
+ * This is a GNU extension so not available with -std=c11
+ * Alternatively is to build using -std=gnu11
+ * Declare prototype instead so we can use it on other platforms
+ */
+extern "C" void *memmem (const void *__haystack, size_t __haystacklen, const void *__needle, size_t __needlelen);
 
 /*********************************************/
 /*  Constructors                             */
 /*********************************************/
 
-String::String(const char* cstr)
+String::String(const char *cstr)
 {
-	init();
-	if(cstr)
-		copy(cstr, strlen(cstr));
+  init();
+  if (cstr) copy(cstr, strlen(cstr));
 }
 
-String::String(const char* cstr, unsigned int length)
+String::String(const char *cstr, unsigned int length)
 {
-	init();
-	if(cstr)
-		copy(cstr, length);
+  init();
+  if (cstr) copy(cstr, length);
 }
 
-String::String(const String& value)
+String::String(const String &value)
 {
-	init();
-	*this = value;
+  init();
+  *this = value;
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String::String(String&& rval)
+String::String(String &&rval)
 {
-	init();
-	move(rval);
+  init();
+  move(rval);
 }
-String::String(StringSumHelper&& rval)
+String::String(StringSumHelper &&rval)
 {
-	init();
-	move(rval);
+  init();
+  move(rval);
 }
 #endif
 
 String::String(char c)
 {
-	init();
-	char buf[2];
-	buf[0] = c;
-	buf[1] = 0;
-	*this = buf;
+  init();
+  char buf[2];
+  buf[0] = c;
+  buf[1] = 0;
+  *this = buf;
 }
 
 String::String(unsigned char value, unsigned char base)
 {
-	init();
-	char buf[8 + 8 * sizeof(unsigned char)];
-	ultoa(value, buf, base);
-	*this = buf;
+  init();
+  char buf[8 + 8 * sizeof(unsigned char)];
+  ultoa(value, buf, base);
+  *this = buf;
 }
 
 String::String(int value, unsigned char base)
 {
-	init();
-	char buf[2 + 8 * sizeof(int)];
-	itoa(value, buf, base);
-	*this = buf;
+  init();
+  char buf[2 + 8 * sizeof(int)];
+  itoa(value, buf, base);
+  *this = buf;
 }
 
 String::String(unsigned int value, unsigned char base)
 {
-	init();
-	char buf[8 + 8 * sizeof(unsigned int)];
-	ultoa(value, buf, base);
-	*this = buf;
+  init();
+  char buf[8 + 8 * sizeof(unsigned int)];
+  ultoa(value, buf, base);
+  *this = buf;
 }
 
 String::String(long value, unsigned char base)
 {
-	init();
-	char buf[2 + 8 * sizeof(long)];
-	ltoa(value, buf, base);
-	*this = buf;
+  init();
+  char buf[2 + 8 * sizeof(long)];
+  ltoa(value, buf, base);
+  *this = buf;
 }
 
 String::String(unsigned long value, unsigned char base)
 {
-	init();
-	char buf[1 + 8 * sizeof(unsigned long)];
-	ultoa(value, buf, base);
-	*this = buf;
+  init();
+  char buf[1 + 8 * sizeof(unsigned long)];
+  ultoa(value, buf, base);
+  *this = buf;
 }
 
 String::String(float value, unsigned char decimalPlaces)
@@ -124,10 +129,11 @@ String::~String()
 	free(buffer);
 }
 
-void String::setString(const char* cstr, int length /* = -1 */)
+void String::setString(const char *cstr, int length /* = -1 */)
 {
-	if(cstr) {
-		if(length == -1)
+	if (cstr)
+	{
+		if (length == -1)
 			length = strlen(cstr);
 		copy(cstr, length);
 	}
@@ -139,30 +145,28 @@ void String::setString(const char* cstr, int length /* = -1 */)
 
 inline void String::init(void)
 {
-	buffer = NULL;
-	capacity = 0;
-	len = 0;
-	//flags = 0;
+  buffer = NULL;
+  capacity = 0;
+  len = 0;
+  //flags = 0;
 }
 
 void String::invalidate(void)
 {
-	if(buffer)
-		free(buffer);
-	buffer = NULL;
-	capacity = len = 0;
+  if (buffer) free(buffer);
+  buffer = NULL;
+  capacity = len = 0;
 }
 
 unsigned char String::reserve(unsigned int size)
 {
-	if(buffer && capacity >= size)
-		return 1;
-	if(changeBuffer(size)) {
-		if(len == 0)
-			buffer[0] = 0;
-		return 1;
-	}
-	return 0;
+  if (buffer && capacity >= size) return 1;
+  if (changeBuffer(size))
+  {
+    if (len == 0) buffer[0] = 0;
+    return 1;
+  }
+  return 0;
 }
 
 bool String::setLength(unsigned size)
@@ -179,156 +183,146 @@ bool String::setLength(unsigned size)
 
 unsigned char String::changeBuffer(unsigned int maxStrLen)
 {
-	char* newbuffer = (char*)realloc(buffer, maxStrLen + 1);
-	if(newbuffer) {
-		buffer = newbuffer;
-		capacity = maxStrLen;
-		return 1;
-	}
-	return 0;
+  char *newbuffer = (char *)realloc(buffer, maxStrLen + 1);
+  if (newbuffer)
+  {
+    buffer = newbuffer;
+    capacity = maxStrLen;
+    return 1;
+  }
+  return 0;
 }
 
 /*********************************************/
 /*  Copy and Move                            */
 /*********************************************/
 
-String& String::copy(const char* cstr, unsigned int length)
+String & String::copy(const char *cstr, unsigned int length)
 {
-	if(!reserve(length)) {
-		invalidate();
-		return *this;
-	}
-	len = length;
-	memmove(buffer, cstr, length);
-	buffer[length] = 0;
-	return *this;
+  if (!reserve(length))
+  {
+    invalidate();
+    return *this;
+  }
+  len = length;
+  memmove(buffer, cstr, length);
+  buffer[length] = 0;
+  return *this;
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-void String::move(String& rhs)
+void String::move(String &rhs)
 {
-	if(buffer)
-		free(buffer);
-	buffer = rhs.buffer;
-	capacity = rhs.capacity;
-	len = rhs.len;
-	rhs.buffer = NULL;
-	rhs.capacity = 0;
-	rhs.len = 0;
+  if (buffer)
+	  free(buffer);
+  buffer = rhs.buffer;
+  capacity = rhs.capacity;
+  len = rhs.len;
+  rhs.buffer = NULL;
+  rhs.capacity = 0;
+  rhs.len = 0;
 }
 #endif
 
-String& String::operator=(const String& rhs)
+String & String::operator = (const String &rhs)
 {
-	if(this == &rhs)
-		return *this;
+  if (this == &rhs) return *this;
 
-	if(rhs.buffer)
-		copy(rhs.buffer, rhs.len);
-	else
-		invalidate();
+  if (rhs.buffer) copy(rhs.buffer, rhs.len);
+  else invalidate();
 
-	return *this;
+  return *this;
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String& String::operator=(String&& rval)
+String & String::operator = (String && rval)
 {
-	if(this != &rval)
-		move(rval);
-	return *this;
+  if (this != &rval) move(rval);
+  return *this;
 }
 
-String& String::operator=(StringSumHelper&& rval)
+String & String::operator = (StringSumHelper && rval)
 {
-	if(this != &rval)
-		move(rval);
-	return *this;
+  if (this != &rval) move(rval);
+  return *this;
 }
 #endif
 
-String& String::operator=(const char* cstr)
+String & String::operator = (const char *cstr)
 {
-	if(cstr)
-		copy(cstr, strlen(cstr));
-	else
-		invalidate();
+  if (cstr) copy(cstr, strlen(cstr));
+  else invalidate();
 
-	return *this;
+  return *this;
 }
 
 /*********************************************/
 /*  concat                                   */
 /*********************************************/
 
-unsigned char String::concat(const String& s)
+unsigned char String::concat(const String &s)
 {
-	return concat(s.buffer, s.len);
+  return concat(s.buffer, s.len);
 }
 
-unsigned char String::concat(const char* cstr, unsigned int length)
+unsigned char String::concat(const char *cstr, unsigned int length)
 {
-	unsigned int newlen = len + length;
-	if(!cstr)
-		return 0;
-	if(length == 0)
-		return 1;
-	if(!reserve(newlen))
-		return 0;
-	memmove(buffer + len, cstr, length);
-	len = newlen;
-	buffer[len] = '\0';
-	return 1;
+  unsigned int newlen = len + length;
+  if (!cstr) return 0;
+  if (length == 0) return 1;
+  if (!reserve(newlen)) return 0;
+  memmove(buffer + len, cstr, length);
+  len = newlen;
+  return 1;
 }
 
-unsigned char String::concat(const char* cstr)
+unsigned char String::concat(const char *cstr)
 {
-	if(!cstr)
-		return 0;
-	return concat(cstr, strlen(cstr));
+  if (!cstr) return 0;
+  return concat(cstr, strlen(cstr));
 }
 
 unsigned char String::concat(char c)
 {
-	char buf[2];
-	buf[0] = c;
-	buf[1] = 0;
-	return concat(buf, 1);
+  char buf[2];
+  buf[0] = c;
+  buf[1] = 0;
+  return concat(buf, 1);
 }
 
 unsigned char String::concat(unsigned char num)
 {
-	char buf[1 + 3 * sizeof(unsigned char)];
-	itoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+  char buf[1 + 3 * sizeof(unsigned char)];
+  itoa(num, buf, 10);
+  return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(int num)
 {
-	char buf[2 + 3 * sizeof(int)];
-	itoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+  char buf[2 + 3 * sizeof(int)];
+  itoa(num, buf, 10);
+  return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(unsigned int num)
 {
-	char buf[8 + 3 * sizeof(unsigned int)];
-	ultoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+  char buf[8 + 3 * sizeof(unsigned int)];
+  ultoa(num, buf, 10);
+  return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(long num)
 {
-	char buf[2 + 3 * sizeof(long)];
-	ltoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+  char buf[2 + 3 * sizeof(long)];
+  ltoa(num, buf, 10);
+  return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(unsigned long num)
 {
-	char buf[1 + 3 * sizeof(unsigned long)];
-	ultoa(num, buf, 10);
-	return concat(buf, strlen(buf));
+  char buf[1 + 3 * sizeof(unsigned long)];
+  ultoa(num, buf, 10);
+  return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(float num)
@@ -349,83 +343,73 @@ unsigned char String::concat(double num)
 /*  Concatenate                              */
 /*********************************************/
 
-StringSumHelper& operator+(const StringSumHelper& lhs, const String& rhs)
+StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs)
 {
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!a.concat(rhs.buffer, rhs.len))
-		a.invalidate();
+  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+  if (!a.concat(rhs.buffer, rhs.len)) a.invalidate();
+  return a;
+}
+
+StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr)
+{
+  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+  if (!cstr || !a.concat(cstr, strlen(cstr))) a.invalidate();
+  return a;
+}
+
+StringSumHelper & operator + (const StringSumHelper &lhs, char c)
+{
+  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+  if (!a.concat(c)) a.invalidate();
+  return a;
+}
+
+StringSumHelper & operator + (const StringSumHelper &lhs, unsigned char num)
+{
+  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+  if (!a.concat(num)) a.invalidate();
+  return a;
+}
+
+StringSumHelper & operator + (const StringSumHelper &lhs, int num)
+{
+  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+  if (!a.concat(num)) a.invalidate();
+  return a;
+}
+
+StringSumHelper & operator + (const StringSumHelper &lhs, unsigned int num)
+{
+  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+  if (!a.concat(num)) a.invalidate();
+  return a;
+}
+
+StringSumHelper & operator + (const StringSumHelper &lhs, long num)
+{
+  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+  if (!a.concat(num)) a.invalidate();
+  return a;
+}
+
+StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long num)
+{
+  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+  if (!a.concat(num)) a.invalidate();
+  return a;
+}
+
+StringSumHelper & operator + (const StringSumHelper &lhs, float num)
+{
+	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+	if (!a.concat(num)) a.invalidate();
 	return a;
 }
 
-StringSumHelper& operator+(const StringSumHelper& lhs, const char* cstr)
+StringSumHelper & operator + (const StringSumHelper &lhs, double num)
 {
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!cstr || !a.concat(cstr, strlen(cstr)))
-		a.invalidate();
-	return a;
-}
-
-StringSumHelper& operator+(const StringSumHelper& lhs, char c)
-{
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!a.concat(c))
-		a.invalidate();
-	return a;
-}
-
-StringSumHelper& operator+(const StringSumHelper& lhs, unsigned char num)
-{
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!a.concat(num))
-		a.invalidate();
-	return a;
-}
-
-StringSumHelper& operator+(const StringSumHelper& lhs, int num)
-{
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!a.concat(num))
-		a.invalidate();
-	return a;
-}
-
-StringSumHelper& operator+(const StringSumHelper& lhs, unsigned int num)
-{
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!a.concat(num))
-		a.invalidate();
-	return a;
-}
-
-StringSumHelper& operator+(const StringSumHelper& lhs, long num)
-{
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!a.concat(num))
-		a.invalidate();
-	return a;
-}
-
-StringSumHelper& operator+(const StringSumHelper& lhs, unsigned long num)
-{
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!a.concat(num))
-		a.invalidate();
-	return a;
-}
-
-StringSumHelper& operator+(const StringSumHelper& lhs, float num)
-{
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!a.concat(num))
-		a.invalidate();
-	return a;
-}
-
-StringSumHelper& operator+(const StringSumHelper& lhs, double num)
-{
-	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
-	if(!a.concat(num))
-		a.invalidate();
+	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
+	if (!a.concat(num)) a.invalidate();
 	return a;
 }
 
@@ -433,88 +417,79 @@ StringSumHelper& operator+(const StringSumHelper& lhs, double num)
 /*  Comparison                               */
 /*********************************************/
 
-int String::compareTo(const String& s) const
+int String::compareTo(const String &s) const
 {
-	if(!buffer || !s.buffer) {
-		if(s.buffer && s.len > 0)
-			return 0 - *(unsigned char*)s.buffer;
-		if(buffer && len > 0)
-			return *(unsigned char*)buffer;
-		return 0;
-	}
-	return strcmp(buffer, s.buffer);
+  if (!buffer || !s.buffer)
+  {
+    if (s.buffer && s.len > 0) return 0 - *(unsigned char *)s.buffer;
+    if (buffer && len > 0) return *(unsigned char *)buffer;
+    return 0;
+  }
+  return strcmp(buffer, s.buffer);
 }
 
-unsigned char String::equals(const String& s2) const
+unsigned char String::equals(const String &s2) const
 {
-	return (len == s2.len && compareTo(s2) == 0);
+  return (len == s2.len && compareTo(s2) == 0);
 }
 
-unsigned char String::equals(const char* cstr) const
+unsigned char String::equals(const char *cstr) const
 {
-	if(len == 0)
-		return (cstr == NULL || *cstr == 0);
-	if(cstr == NULL)
-		return buffer[0] == 0;
-	return strcmp(buffer, cstr) == 0;
+  if (len == 0) return (cstr == NULL || *cstr == 0);
+  if (cstr == NULL) return buffer[0] == 0;
+  return strcmp(buffer, cstr) == 0;
 }
 
-unsigned char String::operator<(const String& rhs) const
+unsigned char String::operator<(const String &rhs) const
 {
-	return compareTo(rhs) < 0;
+  return compareTo(rhs) < 0;
 }
 
-unsigned char String::operator>(const String& rhs) const
+unsigned char String::operator>(const String &rhs) const
 {
-	return compareTo(rhs) > 0;
+  return compareTo(rhs) > 0;
 }
 
-unsigned char String::operator<=(const String& rhs) const
+unsigned char String::operator<=(const String &rhs) const
 {
-	return compareTo(rhs) <= 0;
+  return compareTo(rhs) <= 0;
 }
 
-unsigned char String::operator>=(const String& rhs) const
+unsigned char String::operator>=(const String &rhs) const
 {
-	return compareTo(rhs) >= 0;
+  return compareTo(rhs) >= 0;
 }
 
-unsigned char String::equalsIgnoreCase(const String& s2) const
+unsigned char String::equalsIgnoreCase(const String &s2) const
 {
-	if(this == &s2)
-		return 1;
-	if(len != s2.len)
-		return 0;
-	if(len == 0)
-		return 1;
-	const char* p1 = buffer;
-	const char* p2 = s2.buffer;
-	while(*p1) {
-		if(tolower(*p1++) != tolower(*p2++))
-			return 0;
-	}
-	return 1;
+  if (this == &s2) return 1;
+  if (len != s2.len) return 0;
+  if (len == 0) return 1;
+  const char *p1 = buffer;
+  const char *p2 = s2.buffer;
+  while (*p1)
+  {
+    if (tolower(*p1++) != tolower(*p2++)) return 0;
+  }
+  return 1;
 }
 
-unsigned char String::startsWith(const String& s2) const
+unsigned char String::startsWith(const String &s2) const
 {
-	if(len < s2.len)
-		return 0;
-	return startsWith(s2, 0);
+  if (len < s2.len) return 0;
+  return startsWith(s2, 0);
 }
 
-unsigned char String::startsWith(const String& s2, unsigned int offset) const
+unsigned char String::startsWith(const String &s2, unsigned int offset) const
 {
-	if(offset > len - s2.len || !buffer || !s2.buffer)
-		return 0;
-	return strncmp(&buffer[offset], s2.buffer, s2.len) == 0;
+  if (offset + s2.len > len || !buffer || !s2.buffer) return 0;
+  return memcmp(&buffer[offset], s2.buffer, s2.len) == 0;
 }
 
-unsigned char String::endsWith(const String& s2) const
+unsigned char String::endsWith(const String &s2) const
 {
-	if(len < s2.len || !buffer || !s2.buffer)
-		return 0;
-	return strcmp(&buffer[len - s2.len], s2.buffer) == 0;
+  if (len < s2.len || !buffer || !s2.buffer) return 0;
+  return memcmp(&buffer[len - s2.len], s2.buffer, s2.len) == 0;
 }
 
 /*********************************************/
@@ -523,45 +498,43 @@ unsigned char String::endsWith(const String& s2) const
 
 char String::charAt(unsigned int loc) const
 {
-	return operator[](loc);
+  return operator[](loc);
 }
 
 void String::setCharAt(unsigned int loc, char c)
 {
-	if(loc < len)
-		buffer[loc] = c;
+  if (loc < len) buffer[loc] = c;
 }
 
-char& String::operator[](unsigned int index)
+char & String::operator[](unsigned int index)
 {
-	static char dummy_writable_char;
-	if(index >= len || !buffer) {
-		dummy_writable_char = 0;
-		return dummy_writable_char;
-	}
-	return buffer[index];
+  static char dummy_writable_char;
+  if (index >= len || !buffer)
+  {
+    dummy_writable_char = 0;
+    return dummy_writable_char;
+  }
+  return buffer[index];
 }
 
 char String::operator[](unsigned int index) const
 {
-	if(index >= len || !buffer)
-		return 0;
-	return buffer[index];
+  if (index >= len || !buffer) return 0;
+  return buffer[index];
 }
 
-void String::getBytes(unsigned char* buf, unsigned int bufsize, unsigned int index) const
+void String::getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index) const
 {
-	if(!bufsize || !buf)
-		return;
-	if(index >= len) {
-		buf[0] = 0;
-		return;
-	}
-	unsigned int n = bufsize - 1;
-	if(n > len - index)
-		n = len - index;
-	memmove(buf, buffer + index, n);
-	buf[n] = 0;
+  if (!bufsize || !buf) return;
+  if (index >= len)
+  {
+    buf[0] = 0;
+    return;
+  }
+  unsigned int n = bufsize - 1;
+  if (n > len - index) n = len - index;
+  memmove((char *)buf, buffer + index, n);
+  buf[n] = 0;
 }
 
 /*********************************************/
@@ -570,91 +543,81 @@ void String::getBytes(unsigned char* buf, unsigned int bufsize, unsigned int ind
 
 int String::indexOf(char c) const
 {
-	return indexOf(c, 0);
+  return indexOf(c, 0);
 }
 
 int String::indexOf(char ch, unsigned int fromIndex) const
 {
-	if(fromIndex >= len)
-		return -1;
-	const char* temp = strchr(buffer + fromIndex, ch);
-	if(temp == NULL)
-		return -1;
-	return temp - buffer;
+  if (fromIndex >= len) return -1;
+  auto temp = (const char*)memchr(buffer + fromIndex, ch, len - fromIndex);
+  if (temp == NULL) return -1;
+  return temp - buffer;
 }
 
-int String::indexOf(const String& s2) const
+int String::indexOf(const String &s2) const
 {
-	return indexOf(s2, 0);
+  return indexOf(s2, 0);
 }
 
-int String::indexOf(const String& s2, unsigned int fromIndex) const
+int String::indexOf(const String &s2, unsigned int fromIndex) const
 {
-	if(fromIndex >= len)
-		return -1;
-	const char* found = strstr(buffer + fromIndex, s2.buffer);
-	if(found == NULL)
-		return -1;
-	return found - buffer;
+  if (fromIndex >= len) return -1;
+  auto found = (const char*)memmem(buffer + fromIndex, len - fromIndex, s2.buffer, s2.len);
+  if (found == NULL) return -1;
+  return found - buffer;
 }
 
 int String::lastIndexOf(char theChar) const
 {
-	return lastIndexOf(theChar, len - 1);
+  return lastIndexOf(theChar, len - 1);
 }
 
 int String::lastIndexOf(char ch, int fromIndex) const
 {
-	if(fromIndex >= len || fromIndex < 0)
-		return -1;
-	char tempchar = buffer[fromIndex + 1];
-	buffer[fromIndex + 1] = '\0';
-	char* temp = strrchr(buffer, ch);
-	buffer[fromIndex + 1] = tempchar;
-	if(temp == NULL)
-		return -1;
-	return temp - buffer;
+  if (fromIndex >= len || fromIndex < 0) return -1;
+  char tempchar = buffer[fromIndex + 1];
+  buffer[fromIndex + 1] = '\0';
+  char* temp = strrchr(buffer, ch);
+  buffer[fromIndex + 1] = tempchar;
+  if (temp == NULL) return -1;
+  return temp - buffer;
 }
 
-int String::lastIndexOf(const String& s2) const
+int String::lastIndexOf(const String &s2) const
 {
-	return lastIndexOf(s2, len - s2.len);
+  return lastIndexOf(s2, len - s2.len);
 }
 
-int String::lastIndexOf(const String& s2, int fromIndex) const
+int String::lastIndexOf(const String &s2, int fromIndex) const
 {
-	if(s2.len == 0 || len == 0 || s2.len > len || fromIndex < 0)
-		return -1;
-	if(fromIndex >= len)
-		fromIndex = len - 1;
-	int found = -1;
-	for(char* p = buffer; p <= buffer + fromIndex; p++) {
-		p = strstr(p, s2.buffer);
-		if(!p)
-			break;
-		if(p - buffer <= fromIndex)
-			found = p - buffer;
-	}
-	return found;
+  if (s2.len == 0 || len == 0 || s2.len > len || fromIndex < 0) return -1;
+  if (fromIndex >= len) fromIndex = len - 1;
+  int found = -1;
+  for (const char *p = buffer; p <= buffer + fromIndex; p++)
+  {
+	p = (const char*)memmem(p, buffer + len - p, s2.buffer, s2.len);
+    if (!p) break;
+    if (p - buffer <= fromIndex) found = p - buffer;
+  }
+  return found;
 }
 
 String String::substring(unsigned int left, unsigned int right) const
 {
-	if(left > right) {
-		unsigned int temp = right;
-		right = left;
-		left = temp;
-	}
-	String out;
-	if(left > len)
-		return out;
-	if(right > len)
-		right = len;
-	char temp = buffer[right]; // save the replaced character
-	buffer[right] = '\0';
-	out = buffer + left;  // pointer arithmetic
-	buffer[right] = temp; //restore character
-	return out;
+  if (left > right)
+  {
+    unsigned int temp = right;
+    right = left;
+    left = temp;
+  }
+  String out;
+  if (left > len) return out;
+  if (right > len) right = len;
+  char temp = buffer[right];  // save the replaced character
+  buffer[right] = '\0';
+  out = buffer + left;  // pointer arithmetic
+  buffer[right] = temp;  //restore character
+  return out;
 }
 
 /*********************************************/
@@ -663,117 +626,109 @@ String String::substring(unsigned int left, unsigned int right) const
 
 void String::replace(char find, char replace)
 {
-	if(!buffer)
-		return;
-	for(char* p = buffer; *p; p++) {
-		if(*p == find)
-			*p = replace;
-	}
+  if (!buffer) return;
+  for (char *p = buffer; *p; p++)
+  {
+    if (*p == find) *p = replace;
+  }
 }
 
 void String::replace(const String& find, const String& replace)
 {
-	if(len == 0 || find.len == 0)
-		return;
-	int diff = replace.len - find.len;
-	char* readFrom = buffer;
-	char* foundAt;
-	if(diff == 0) {
-		while((foundAt = strstr(readFrom, find.buffer)) != NULL) {
-			memmove(foundAt, replace.buffer, replace.len);
-			readFrom = foundAt + replace.len;
-		}
-	} else if(diff < 0) {
-		char* writeTo = buffer;
-		while((foundAt = strstr(readFrom, find.buffer)) != NULL) {
-			unsigned int n = foundAt - readFrom;
-			memmove(writeTo, readFrom, n);
-			writeTo += n;
-			memmove(writeTo, replace.buffer, replace.len);
-			writeTo += replace.len;
-			readFrom = foundAt + find.len;
-			len += diff;
-		}
-		strcpy(writeTo, readFrom);
-	} else {
-		unsigned int size = len; // compute size needed for result
-		while((foundAt = strstr(readFrom, find.buffer)) != NULL) {
-			readFrom = foundAt + find.len;
-			size += diff;
-		}
-		if(size == len)
-			return;
-		if(size > capacity && !changeBuffer(size))
-			return; // XXX: tell user!
-		int index = len - 1;
-		while((index = lastIndexOf(find, index)) >= 0) {
-			readFrom = buffer + index + find.len;
-			memmove(readFrom + diff, readFrom, len - (readFrom - buffer));
-			len += diff;
-			buffer[len] = 0;
-			memmove(buffer + index, replace.buffer, replace.len);
-			index--;
-		}
-	}
+  if (len == 0 || find.len == 0) return;
+  int diff = replace.len - find.len;
+  char *readFrom = buffer;
+  char *foundAt;
+  if (diff == 0)
+  {
+    while ((foundAt = (char*)memmem(readFrom, buffer + len - readFrom, find.buffer, find.len)) != NULL)
+    {
+      memcpy(foundAt, replace.buffer, replace.len);
+      readFrom = foundAt + replace.len;
+    }
+  }
+  else if (diff < 0)
+  {
+    char *writeTo = buffer;
+    while ((foundAt = (char*)memmem(readFrom, buffer + len - readFrom, find.buffer, find.len)) != NULL)
+    {
+      unsigned int n = foundAt - readFrom;
+      memcpy(writeTo, readFrom, n);
+      writeTo += n;
+      memcpy(writeTo, replace.buffer, replace.len);
+      writeTo += replace.len;
+      readFrom = foundAt + find.len;
+      len += diff;
+    }
+    memcpy(writeTo, readFrom, buffer + len - readFrom);
+  }
+  else
+  {
+    unsigned int size = len; // compute size needed for result
+    while ((foundAt = (char*)memmem(readFrom, buffer + len - readFrom, find.buffer, find.len)) != NULL)
+    {
+      readFrom = foundAt + find.len;
+      size += diff;
+    }
+    if (size == len) return;
+    if (size > capacity && !changeBuffer(size)) return; // XXX: tell user!
+    int index = len - 1;
+    while ((index = lastIndexOf(find, index)) >= 0)
+    {
+      readFrom = buffer + index + find.len;
+      memmove(readFrom + diff, readFrom, len - (readFrom - buffer));
+      len += diff;
+      buffer[len] = 0;
+      memcpy(buffer + index, replace.buffer, replace.len);
+      index--;
+    }
+  }
 }
 
-void String::remove(unsigned int index)
-{
-	if(index >= len) {
-		return;
-	}
+void String::remove(unsigned int index){
+	if (index >= len) { return; }
 	int count = len - index;
 	remove(index, count);
 }
 
-void String::remove(unsigned int index, unsigned int count)
-{
-	if(index >= len) {
-		return;
-	}
-	if(count <= 0) {
-		return;
-	}
-	if(index + count > len) {
-		count = len - index;
-	}
-	len -= count;
-	memmove(buffer + index, buffer + index + count, len - index);
+void String::remove(unsigned int index, unsigned int count){
+	if (index >= len) { return; }
+	if (count <= 0) { return; }
+	if (index + count > len) { count = len - index; }
+	char *writeTo = buffer + index;
+	len = len - count;
+	memcpy(writeTo, buffer + index + count, len - index);
 	buffer[len] = 0;
 }
 
 void String::toLowerCase(void)
 {
-	if(!buffer)
-		return;
-	for(char* p = buffer; *p; p++) {
-		*p = tolower(*p);
-	}
+  if (!buffer) return;
+  for (char *p = buffer; *p; p++)
+  {
+    *p = tolower(*p);
+  }
 }
 
 void String::toUpperCase(void)
 {
-	if(!buffer)
-		return;
-	for(char* p = buffer; *p; p++) {
-		*p = toupper(*p);
-	}
+  if (!buffer) return;
+  for (char *p = buffer; *p; p++)
+  {
+    *p = toupper(*p);
+  }
 }
 
 void String::trim(void)
 {
-	if(!buffer || len == 0)
-		return;
-	char* begin = buffer;
-	while(isspace(*begin))
-		begin++;
-	char* end = buffer + len - 1;
-	while(isspace(*end) && end >= begin)
-		end--;
-	len = end + 1 - begin;
-	if(begin > buffer)
-		memmove(buffer, begin, len);
-	buffer[len] = 0;
+  if (!buffer || len == 0) return;
+  char *begin = buffer;
+  while (isspace(*begin)) begin++;
+  char *end = buffer + len - 1;
+  while (isspace(*end) && end >= begin) end--;
+  len = end + 1 - begin;
+  if (begin > buffer) memmove(buffer, begin, len);
+  buffer[len] = 0;
 }
 
 /*********************************************/
@@ -782,19 +737,18 @@ void String::trim(void)
 
 long String::toInt(void) const
 {
-	if(buffer)
-		return atoi(buffer);
-	return 0;
+  if (buffer) return atoi(buffer);
+  return 0;
 }
 
 float String::toFloat(void) const
 {
-	if(buffer)
-		return (float)atof(buffer);
-	return 0;
+  if (buffer) return (float)atof(buffer);
+  return 0;
 }
 
 /*void String::printTo(Print &p) const
 {
   p.print(buffer);
 }*/
+

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -23,84 +23,86 @@
 /*  Constructors                             */
 /*********************************************/
 
-String::String(const char *cstr)
+String::String(const char* cstr)
 {
-  init();
-  if (cstr) copy(cstr, strlen(cstr));
+	init();
+	if(cstr)
+		copy(cstr, strlen(cstr));
 }
 
-String::String(const char *cstr, unsigned int length)
+String::String(const char* cstr, unsigned int length)
 {
-  init();
-  if (cstr) copy(cstr, length);
+	init();
+	if(cstr)
+		copy(cstr, length);
 }
 
-String::String(const String &value)
+String::String(const String& value)
 {
-  init();
-  *this = value;
+	init();
+	*this = value;
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String::String(String &&rval)
+String::String(String&& rval)
 {
-  init();
-  move(rval);
+	init();
+	move(rval);
 }
-String::String(StringSumHelper &&rval)
+String::String(StringSumHelper&& rval)
 {
-  init();
-  move(rval);
+	init();
+	move(rval);
 }
 #endif
 
 String::String(char c)
 {
-  init();
-  char buf[2];
-  buf[0] = c;
-  buf[1] = 0;
-  *this = buf;
+	init();
+	char buf[2];
+	buf[0] = c;
+	buf[1] = 0;
+	*this = buf;
 }
 
 String::String(unsigned char value, unsigned char base)
 {
-  init();
-  char buf[8 + 8 * sizeof(unsigned char)];
-  ultoa(value, buf, base);
-  *this = buf;
+	init();
+	char buf[8 + 8 * sizeof(unsigned char)];
+	ultoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(int value, unsigned char base)
 {
-  init();
-  char buf[2 + 8 * sizeof(int)];
-  itoa(value, buf, base);
-  *this = buf;
+	init();
+	char buf[2 + 8 * sizeof(int)];
+	itoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(unsigned int value, unsigned char base)
 {
-  init();
-  char buf[8 + 8 * sizeof(unsigned int)];
-  ultoa(value, buf, base);
-  *this = buf;
+	init();
+	char buf[8 + 8 * sizeof(unsigned int)];
+	ultoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(long value, unsigned char base)
 {
-  init();
-  char buf[2 + 8 * sizeof(long)];
-  ltoa(value, buf, base);
-  *this = buf;
+	init();
+	char buf[2 + 8 * sizeof(long)];
+	ltoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(unsigned long value, unsigned char base)
 {
-  init();
-  char buf[1 + 8 * sizeof(unsigned long)];
-  ultoa(value, buf, base);
-  *this = buf;
+	init();
+	char buf[1 + 8 * sizeof(unsigned long)];
+	ultoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(float value, unsigned char decimalPlaces)
@@ -122,11 +124,10 @@ String::~String()
 	free(buffer);
 }
 
-void String::setString(const char *cstr, int length /* = -1 */)
+void String::setString(const char* cstr, int length /* = -1 */)
 {
-	if (cstr)
-	{
-		if (length == -1)
+	if(cstr) {
+		if(length == -1)
 			length = strlen(cstr);
 		copy(cstr, length);
 	}
@@ -138,172 +139,196 @@ void String::setString(const char *cstr, int length /* = -1 */)
 
 inline void String::init(void)
 {
-  buffer = NULL;
-  capacity = 0;
-  len = 0;
-  //flags = 0;
+	buffer = NULL;
+	capacity = 0;
+	len = 0;
+	//flags = 0;
 }
 
 void String::invalidate(void)
 {
-  if (buffer) free(buffer);
-  buffer = NULL;
-  capacity = len = 0;
+	if(buffer)
+		free(buffer);
+	buffer = NULL;
+	capacity = len = 0;
 }
 
 unsigned char String::reserve(unsigned int size)
 {
-  if (buffer && capacity >= size) return 1;
-  if (changeBuffer(size))
-  {
-    if (len == 0) buffer[0] = 0;
-    return 1;
-  }
-  return 0;
+	if(buffer && capacity >= size)
+		return 1;
+	if(changeBuffer(size)) {
+		if(len == 0)
+			buffer[0] = 0;
+		return 1;
+	}
+	return 0;
+}
+
+bool String::setLength(unsigned size)
+{
+	if(!reserve(size))
+		return false;
+
+	len = size;
+	if(buffer)
+		buffer[len] = '\0';
+
+	return true;
 }
 
 unsigned char String::changeBuffer(unsigned int maxStrLen)
 {
-  char *newbuffer = (char *)realloc(buffer, maxStrLen + 1);
-  if (newbuffer)
-  {
-    buffer = newbuffer;
-    capacity = maxStrLen;
-    return 1;
-  }
-  return 0;
+	char* newbuffer = (char*)realloc(buffer, maxStrLen + 1);
+	if(newbuffer) {
+		buffer = newbuffer;
+		capacity = maxStrLen;
+		return 1;
+	}
+	return 0;
 }
 
 /*********************************************/
 /*  Copy and Move                            */
 /*********************************************/
 
-String & String::copy(const char *cstr, unsigned int length)
+String& String::copy(const char* cstr, unsigned int length)
 {
-  if (!reserve(length))
-  {
-    invalidate();
-    return *this;
-  }
-  len = length;
-  strncpy(buffer, cstr, length);
-  buffer[length] = 0;
-  return *this;
+	if(!reserve(length)) {
+		invalidate();
+		return *this;
+	}
+	len = length;
+	memmove(buffer, cstr, length);
+	buffer[length] = 0;
+	return *this;
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-void String::move(String &rhs)
+void String::move(String& rhs)
 {
-  if (buffer)
-	  free(buffer);
-  buffer = rhs.buffer;
-  capacity = rhs.capacity;
-  len = rhs.len;
-  rhs.buffer = NULL;
-  rhs.capacity = 0;
-  rhs.len = 0;
+	if(buffer)
+		free(buffer);
+	buffer = rhs.buffer;
+	capacity = rhs.capacity;
+	len = rhs.len;
+	rhs.buffer = NULL;
+	rhs.capacity = 0;
+	rhs.len = 0;
 }
 #endif
 
-String & String::operator = (const String &rhs)
+String& String::operator=(const String& rhs)
 {
-  if (this == &rhs) return *this;
+	if(this == &rhs)
+		return *this;
 
-  if (rhs.buffer) copy(rhs.buffer, rhs.len);
-  else invalidate();
+	if(rhs.buffer)
+		copy(rhs.buffer, rhs.len);
+	else
+		invalidate();
 
-  return *this;
+	return *this;
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String & String::operator = (String && rval)
+String& String::operator=(String&& rval)
 {
-  if (this != &rval) move(rval);
-  return *this;
+	if(this != &rval)
+		move(rval);
+	return *this;
 }
 
-String & String::operator = (StringSumHelper && rval)
+String& String::operator=(StringSumHelper&& rval)
 {
-  if (this != &rval) move(rval);
-  return *this;
+	if(this != &rval)
+		move(rval);
+	return *this;
 }
 #endif
 
-String & String::operator = (const char *cstr)
+String& String::operator=(const char* cstr)
 {
-  if (cstr) copy(cstr, strlen(cstr));
-  else invalidate();
+	if(cstr)
+		copy(cstr, strlen(cstr));
+	else
+		invalidate();
 
-  return *this;
+	return *this;
 }
 
 /*********************************************/
 /*  concat                                   */
 /*********************************************/
 
-unsigned char String::concat(const String &s)
+unsigned char String::concat(const String& s)
 {
-  return concat(s.buffer, s.len);
+	return concat(s.buffer, s.len);
 }
 
-unsigned char String::concat(const char *cstr, unsigned int length)
+unsigned char String::concat(const char* cstr, unsigned int length)
 {
-  unsigned int newlen = len + length;
-  if (!cstr) return 0;
-  if (length == 0) return 1;
-  if (!reserve(newlen)) return 0;
-  strcpy(buffer + len, cstr);
-  len = newlen;
-  return 1;
+	unsigned int newlen = len + length;
+	if(!cstr)
+		return 0;
+	if(length == 0)
+		return 1;
+	if(!reserve(newlen))
+		return 0;
+	memmove(buffer + len, cstr, length);
+	len = newlen;
+	buffer[len] = '\0';
+	return 1;
 }
 
-unsigned char String::concat(const char *cstr)
+unsigned char String::concat(const char* cstr)
 {
-  if (!cstr) return 0;
-  return concat(cstr, strlen(cstr));
+	if(!cstr)
+		return 0;
+	return concat(cstr, strlen(cstr));
 }
 
 unsigned char String::concat(char c)
 {
-  char buf[2];
-  buf[0] = c;
-  buf[1] = 0;
-  return concat(buf, 1);
+	char buf[2];
+	buf[0] = c;
+	buf[1] = 0;
+	return concat(buf, 1);
 }
 
 unsigned char String::concat(unsigned char num)
 {
-  char buf[1 + 3 * sizeof(unsigned char)];
-  itoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[1 + 3 * sizeof(unsigned char)];
+	itoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(int num)
 {
-  char buf[2 + 3 * sizeof(int)];
-  itoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[2 + 3 * sizeof(int)];
+	itoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(unsigned int num)
 {
-  char buf[8 + 3 * sizeof(unsigned int)];
-  ultoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[8 + 3 * sizeof(unsigned int)];
+	ultoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(long num)
 {
-  char buf[2 + 3 * sizeof(long)];
-  ltoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[2 + 3 * sizeof(long)];
+	ltoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(unsigned long num)
 {
-  char buf[1 + 3 * sizeof(unsigned long)];
-  ultoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[1 + 3 * sizeof(unsigned long)];
+	ultoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 unsigned char String::concat(float num)
@@ -324,73 +349,83 @@ unsigned char String::concat(double num)
 /*  Concatenate                              */
 /*********************************************/
 
-StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs)
+StringSumHelper& operator+(const StringSumHelper& lhs, const String& rhs)
 {
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(rhs.buffer, rhs.len)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!cstr || !a.concat(cstr, strlen(cstr))) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, char c)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(c)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, unsigned char num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, int num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, unsigned int num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, long num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, float num)
-{
-	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-	if (!a.concat(num)) a.invalidate();
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(rhs.buffer, rhs.len))
+		a.invalidate();
 	return a;
 }
 
-StringSumHelper & operator + (const StringSumHelper &lhs, double num)
+StringSumHelper& operator+(const StringSumHelper& lhs, const char* cstr)
 {
-	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-	if (!a.concat(num)) a.invalidate();
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!cstr || !a.concat(cstr, strlen(cstr)))
+		a.invalidate();
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, char c)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(c))
+		a.invalidate();
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, unsigned char num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num))
+		a.invalidate();
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, int num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num))
+		a.invalidate();
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, unsigned int num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num))
+		a.invalidate();
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, long num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num))
+		a.invalidate();
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, unsigned long num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num))
+		a.invalidate();
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, float num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num))
+		a.invalidate();
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, double num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num))
+		a.invalidate();
 	return a;
 }
 
@@ -398,79 +433,88 @@ StringSumHelper & operator + (const StringSumHelper &lhs, double num)
 /*  Comparison                               */
 /*********************************************/
 
-int String::compareTo(const String &s) const
+int String::compareTo(const String& s) const
 {
-  if (!buffer || !s.buffer)
-  {
-    if (s.buffer && s.len > 0) return 0 - *(unsigned char *)s.buffer;
-    if (buffer && len > 0) return *(unsigned char *)buffer;
-    return 0;
-  }
-  return strcmp(buffer, s.buffer);
+	if(!buffer || !s.buffer) {
+		if(s.buffer && s.len > 0)
+			return 0 - *(unsigned char*)s.buffer;
+		if(buffer && len > 0)
+			return *(unsigned char*)buffer;
+		return 0;
+	}
+	return strcmp(buffer, s.buffer);
 }
 
-unsigned char String::equals(const String &s2) const
+unsigned char String::equals(const String& s2) const
 {
-  return (len == s2.len && compareTo(s2) == 0);
+	return (len == s2.len && compareTo(s2) == 0);
 }
 
-unsigned char String::equals(const char *cstr) const
+unsigned char String::equals(const char* cstr) const
 {
-  if (len == 0) return (cstr == NULL || *cstr == 0);
-  if (cstr == NULL) return buffer[0] == 0;
-  return strcmp(buffer, cstr) == 0;
+	if(len == 0)
+		return (cstr == NULL || *cstr == 0);
+	if(cstr == NULL)
+		return buffer[0] == 0;
+	return strcmp(buffer, cstr) == 0;
 }
 
-unsigned char String::operator<(const String &rhs) const
+unsigned char String::operator<(const String& rhs) const
 {
-  return compareTo(rhs) < 0;
+	return compareTo(rhs) < 0;
 }
 
-unsigned char String::operator>(const String &rhs) const
+unsigned char String::operator>(const String& rhs) const
 {
-  return compareTo(rhs) > 0;
+	return compareTo(rhs) > 0;
 }
 
-unsigned char String::operator<=(const String &rhs) const
+unsigned char String::operator<=(const String& rhs) const
 {
-  return compareTo(rhs) <= 0;
+	return compareTo(rhs) <= 0;
 }
 
-unsigned char String::operator>=(const String &rhs) const
+unsigned char String::operator>=(const String& rhs) const
 {
-  return compareTo(rhs) >= 0;
+	return compareTo(rhs) >= 0;
 }
 
-unsigned char String::equalsIgnoreCase(const String &s2) const
+unsigned char String::equalsIgnoreCase(const String& s2) const
 {
-  if (this == &s2) return 1;
-  if (len != s2.len) return 0;
-  if (len == 0) return 1;
-  const char *p1 = buffer;
-  const char *p2 = s2.buffer;
-  while (*p1)
-  {
-    if (tolower(*p1++) != tolower(*p2++)) return 0;
-  }
-  return 1;
+	if(this == &s2)
+		return 1;
+	if(len != s2.len)
+		return 0;
+	if(len == 0)
+		return 1;
+	const char* p1 = buffer;
+	const char* p2 = s2.buffer;
+	while(*p1) {
+		if(tolower(*p1++) != tolower(*p2++))
+			return 0;
+	}
+	return 1;
 }
 
-unsigned char String::startsWith(const String &s2) const
+unsigned char String::startsWith(const String& s2) const
 {
-  if (len < s2.len) return 0;
-  return startsWith(s2, 0);
+	if(len < s2.len)
+		return 0;
+	return startsWith(s2, 0);
 }
 
-unsigned char String::startsWith(const String &s2, unsigned int offset) const
+unsigned char String::startsWith(const String& s2, unsigned int offset) const
 {
-  if (offset > len - s2.len || !buffer || !s2.buffer) return 0;
-  return strncmp(&buffer[offset], s2.buffer, s2.len) == 0;
+	if(offset > len - s2.len || !buffer || !s2.buffer)
+		return 0;
+	return strncmp(&buffer[offset], s2.buffer, s2.len) == 0;
 }
 
-unsigned char String::endsWith(const String &s2) const
+unsigned char String::endsWith(const String& s2) const
 {
-  if (len < s2.len || !buffer || !s2.buffer) return 0;
-  return strcmp(&buffer[len - s2.len], s2.buffer) == 0;
+	if(len < s2.len || !buffer || !s2.buffer)
+		return 0;
+	return strcmp(&buffer[len - s2.len], s2.buffer) == 0;
 }
 
 /*********************************************/
@@ -479,43 +523,45 @@ unsigned char String::endsWith(const String &s2) const
 
 char String::charAt(unsigned int loc) const
 {
-  return operator[](loc);
+	return operator[](loc);
 }
 
 void String::setCharAt(unsigned int loc, char c)
 {
-  if (loc < len) buffer[loc] = c;
+	if(loc < len)
+		buffer[loc] = c;
 }
 
-char & String::operator[](unsigned int index)
+char& String::operator[](unsigned int index)
 {
-  static char dummy_writable_char;
-  if (index >= len || !buffer)
-  {
-    dummy_writable_char = 0;
-    return dummy_writable_char;
-  }
-  return buffer[index];
+	static char dummy_writable_char;
+	if(index >= len || !buffer) {
+		dummy_writable_char = 0;
+		return dummy_writable_char;
+	}
+	return buffer[index];
 }
 
 char String::operator[](unsigned int index) const
 {
-  if (index >= len || !buffer) return 0;
-  return buffer[index];
+	if(index >= len || !buffer)
+		return 0;
+	return buffer[index];
 }
 
-void String::getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index) const
+void String::getBytes(unsigned char* buf, unsigned int bufsize, unsigned int index) const
 {
-  if (!bufsize || !buf) return;
-  if (index >= len)
-  {
-    buf[0] = 0;
-    return;
-  }
-  unsigned int n = bufsize - 1;
-  if (n > len - index) n = len - index;
-  strncpy((char *)buf, buffer + index, n);
-  buf[n] = 0;
+	if(!bufsize || !buf)
+		return;
+	if(index >= len) {
+		buf[0] = 0;
+		return;
+	}
+	unsigned int n = bufsize - 1;
+	if(n > len - index)
+		n = len - index;
+	memmove(buf, buffer + index, n);
+	buf[n] = 0;
 }
 
 /*********************************************/
@@ -524,81 +570,91 @@ void String::getBytes(unsigned char *buf, unsigned int bufsize, unsigned int ind
 
 int String::indexOf(char c) const
 {
-  return indexOf(c, 0);
+	return indexOf(c, 0);
 }
 
 int String::indexOf(char ch, unsigned int fromIndex) const
 {
-  if (fromIndex >= len) return -1;
-  const char* temp = strchr(buffer + fromIndex, ch);
-  if (temp == NULL) return -1;
-  return temp - buffer;
+	if(fromIndex >= len)
+		return -1;
+	const char* temp = strchr(buffer + fromIndex, ch);
+	if(temp == NULL)
+		return -1;
+	return temp - buffer;
 }
 
-int String::indexOf(const String &s2) const
+int String::indexOf(const String& s2) const
 {
-  return indexOf(s2, 0);
+	return indexOf(s2, 0);
 }
 
-int String::indexOf(const String &s2, unsigned int fromIndex) const
+int String::indexOf(const String& s2, unsigned int fromIndex) const
 {
-  if (fromIndex >= len) return -1;
-  const char *found = strstr(buffer + fromIndex, s2.buffer);
-  if (found == NULL) return -1;
-  return found - buffer;
+	if(fromIndex >= len)
+		return -1;
+	const char* found = strstr(buffer + fromIndex, s2.buffer);
+	if(found == NULL)
+		return -1;
+	return found - buffer;
 }
 
 int String::lastIndexOf(char theChar) const
 {
-  return lastIndexOf(theChar, len - 1);
+	return lastIndexOf(theChar, len - 1);
 }
 
 int String::lastIndexOf(char ch, int fromIndex) const
 {
-  if (fromIndex >= len || fromIndex < 0) return -1;
-  char tempchar = buffer[fromIndex + 1];
-  buffer[fromIndex + 1] = '\0';
-  char* temp = strrchr(buffer, ch);
-  buffer[fromIndex + 1] = tempchar;
-  if (temp == NULL) return -1;
-  return temp - buffer;
+	if(fromIndex >= len || fromIndex < 0)
+		return -1;
+	char tempchar = buffer[fromIndex + 1];
+	buffer[fromIndex + 1] = '\0';
+	char* temp = strrchr(buffer, ch);
+	buffer[fromIndex + 1] = tempchar;
+	if(temp == NULL)
+		return -1;
+	return temp - buffer;
 }
 
-int String::lastIndexOf(const String &s2) const
+int String::lastIndexOf(const String& s2) const
 {
-  return lastIndexOf(s2, len - s2.len);
+	return lastIndexOf(s2, len - s2.len);
 }
 
-int String::lastIndexOf(const String &s2, int fromIndex) const
+int String::lastIndexOf(const String& s2, int fromIndex) const
 {
-  if (s2.len == 0 || len == 0 || s2.len > len || fromIndex < 0) return -1;
-  if (fromIndex >= len) fromIndex = len - 1;
-  int found = -1;
-  for (char *p = buffer; p <= buffer + fromIndex; p++)
-  {
-    p = strstr(p, s2.buffer);
-    if (!p) break;
-    if (p - buffer <= fromIndex) found = p - buffer;
-  }
-  return found;
+	if(s2.len == 0 || len == 0 || s2.len > len || fromIndex < 0)
+		return -1;
+	if(fromIndex >= len)
+		fromIndex = len - 1;
+	int found = -1;
+	for(char* p = buffer; p <= buffer + fromIndex; p++) {
+		p = strstr(p, s2.buffer);
+		if(!p)
+			break;
+		if(p - buffer <= fromIndex)
+			found = p - buffer;
+	}
+	return found;
 }
 
 String String::substring(unsigned int left, unsigned int right) const
 {
-  if (left > right)
-  {
-    unsigned int temp = right;
-    right = left;
-    left = temp;
-  }
-  String out;
-  if (left > len) return out;
-  if (right > len) right = len;
-  char temp = buffer[right];  // save the replaced character
-  buffer[right] = '\0';
-  out = buffer + left;  // pointer arithmetic
-  buffer[right] = temp;  //restore character
-  return out;
+	if(left > right) {
+		unsigned int temp = right;
+		right = left;
+		left = temp;
+	}
+	String out;
+	if(left > len)
+		return out;
+	if(right > len)
+		right = len;
+	char temp = buffer[right]; // save the replaced character
+	buffer[right] = '\0';
+	out = buffer + left;  // pointer arithmetic
+	buffer[right] = temp; //restore character
+	return out;
 }
 
 /*********************************************/
@@ -607,109 +663,117 @@ String String::substring(unsigned int left, unsigned int right) const
 
 void String::replace(char find, char replace)
 {
-  if (!buffer) return;
-  for (char *p = buffer; *p; p++)
-  {
-    if (*p == find) *p = replace;
-  }
+	if(!buffer)
+		return;
+	for(char* p = buffer; *p; p++) {
+		if(*p == find)
+			*p = replace;
+	}
 }
 
 void String::replace(const String& find, const String& replace)
 {
-  if (len == 0 || find.len == 0) return;
-  int diff = replace.len - find.len;
-  char *readFrom = buffer;
-  char *foundAt;
-  if (diff == 0)
-  {
-    while ((foundAt = strstr(readFrom, find.buffer)) != NULL)
-    {
-      memcpy(foundAt, replace.buffer, replace.len);
-      readFrom = foundAt + replace.len;
-    }
-  }
-  else if (diff < 0)
-  {
-    char *writeTo = buffer;
-    while ((foundAt = strstr(readFrom, find.buffer)) != NULL)
-    {
-      unsigned int n = foundAt - readFrom;
-      memcpy(writeTo, readFrom, n);
-      writeTo += n;
-      memcpy(writeTo, replace.buffer, replace.len);
-      writeTo += replace.len;
-      readFrom = foundAt + find.len;
-      len += diff;
-    }
-    strcpy(writeTo, readFrom);
-  }
-  else
-  {
-    unsigned int size = len; // compute size needed for result
-    while ((foundAt = strstr(readFrom, find.buffer)) != NULL)
-    {
-      readFrom = foundAt + find.len;
-      size += diff;
-    }
-    if (size == len) return;
-    if (size > capacity && !changeBuffer(size)) return; // XXX: tell user!
-    int index = len - 1;
-    while ((index = lastIndexOf(find, index)) >= 0)
-    {
-      readFrom = buffer + index + find.len;
-      memmove(readFrom + diff, readFrom, len - (readFrom - buffer));
-      len += diff;
-      buffer[len] = 0;
-      memcpy(buffer + index, replace.buffer, replace.len);
-      index--;
-    }
-  }
+	if(len == 0 || find.len == 0)
+		return;
+	int diff = replace.len - find.len;
+	char* readFrom = buffer;
+	char* foundAt;
+	if(diff == 0) {
+		while((foundAt = strstr(readFrom, find.buffer)) != NULL) {
+			memmove(foundAt, replace.buffer, replace.len);
+			readFrom = foundAt + replace.len;
+		}
+	} else if(diff < 0) {
+		char* writeTo = buffer;
+		while((foundAt = strstr(readFrom, find.buffer)) != NULL) {
+			unsigned int n = foundAt - readFrom;
+			memmove(writeTo, readFrom, n);
+			writeTo += n;
+			memmove(writeTo, replace.buffer, replace.len);
+			writeTo += replace.len;
+			readFrom = foundAt + find.len;
+			len += diff;
+		}
+		strcpy(writeTo, readFrom);
+	} else {
+		unsigned int size = len; // compute size needed for result
+		while((foundAt = strstr(readFrom, find.buffer)) != NULL) {
+			readFrom = foundAt + find.len;
+			size += diff;
+		}
+		if(size == len)
+			return;
+		if(size > capacity && !changeBuffer(size))
+			return; // XXX: tell user!
+		int index = len - 1;
+		while((index = lastIndexOf(find, index)) >= 0) {
+			readFrom = buffer + index + find.len;
+			memmove(readFrom + diff, readFrom, len - (readFrom - buffer));
+			len += diff;
+			buffer[len] = 0;
+			memmove(buffer + index, replace.buffer, replace.len);
+			index--;
+		}
+	}
 }
 
-void String::remove(unsigned int index){
-	if (index >= len) { return; }
+void String::remove(unsigned int index)
+{
+	if(index >= len) {
+		return;
+	}
 	int count = len - index;
 	remove(index, count);
 }
 
-void String::remove(unsigned int index, unsigned int count){
-	if (index >= len) { return; }
-	if (count <= 0) { return; }
-	if (index + count > len) { count = len - index; }
-	char *writeTo = buffer + index;
-	len = len - count;
-	strncpy(writeTo, buffer + index + count,len - index);
+void String::remove(unsigned int index, unsigned int count)
+{
+	if(index >= len) {
+		return;
+	}
+	if(count <= 0) {
+		return;
+	}
+	if(index + count > len) {
+		count = len - index;
+	}
+	len -= count;
+	memmove(buffer + index, buffer + index + count, len - index);
 	buffer[len] = 0;
 }
 
 void String::toLowerCase(void)
 {
-  if (!buffer) return;
-  for (char *p = buffer; *p; p++)
-  {
-    *p = tolower(*p);
-  }
+	if(!buffer)
+		return;
+	for(char* p = buffer; *p; p++) {
+		*p = tolower(*p);
+	}
 }
 
 void String::toUpperCase(void)
 {
-  if (!buffer) return;
-  for (char *p = buffer; *p; p++)
-  {
-    *p = toupper(*p);
-  }
+	if(!buffer)
+		return;
+	for(char* p = buffer; *p; p++) {
+		*p = toupper(*p);
+	}
 }
 
 void String::trim(void)
 {
-  if (!buffer || len == 0) return;
-  char *begin = buffer;
-  while (isspace(*begin)) begin++;
-  char *end = buffer + len - 1;
-  while (isspace(*end) && end >= begin) end--;
-  len = end + 1 - begin;
-  if (begin > buffer) memmove(buffer, begin, len);
-  buffer[len] = 0;
+	if(!buffer || len == 0)
+		return;
+	char* begin = buffer;
+	while(isspace(*begin))
+		begin++;
+	char* end = buffer + len - 1;
+	while(isspace(*end) && end >= begin)
+		end--;
+	len = end + 1 - begin;
+	if(begin > buffer)
+		memmove(buffer, begin, len);
+	buffer[len] = 0;
 }
 
 /*********************************************/
@@ -718,18 +782,19 @@ void String::trim(void)
 
 long String::toInt(void) const
 {
-  if (buffer) return atoi(buffer);
-  return 0;
+	if(buffer)
+		return atoi(buffer);
+	return 0;
 }
 
 float String::toFloat(void) const
 {
-  if (buffer) return (float)atof(buffer);
-  return 0;
+	if(buffer)
+		return (float)atof(buffer);
+	return 0;
 }
 
 /*void String::printTo(Print &p) const
 {
   p.print(buffer);
 }*/
-

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -429,7 +429,7 @@ int String::compareTo(const String &s) const
 
 unsigned char String::equals(const String &s2) const
 {
-  return (len == s2.len && compareTo(s2) == 0);
+  return (len == s2.len && memcmp(buffer, s2.buffer, len) == 0);
 }
 
 unsigned char String::equals(const char *cstr) const
@@ -603,6 +603,8 @@ int String::lastIndexOf(const String &s2, int fromIndex) const
 
 String String::substring(unsigned int left, unsigned int right) const
 {
+  if (!buffer) return nullptr;
+
   if (left > right)
   {
     unsigned int temp = right;
@@ -679,10 +681,10 @@ void String::replace(const String& find, const String& replace)
       readFrom = buffer + index + find.len;
       memmove(readFrom + diff, readFrom, len - (readFrom - buffer));
       len += diff;
-      buffer[len] = 0;
       memcpy(buffer + index, replace.buffer, replace.len);
       index--;
     }
+    buffer[len] = '\0';
   }
 }
 

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -18,14 +18,6 @@
 
 #include "WiringFrameworkIncludes.h"
 
-/*
- * Want memmem() to replace use of strstr() so we can search on byte strings.
- * This is a GNU extension so not available with -std=c11
- * Alternatively is to build using -std=gnu11
- * Declare prototype instead so we can use it on other platforms
- */
-extern "C" void *memmem (const void *__haystack, size_t __haystacklen, const void *__needle, size_t __needlelen);
-
 /*********************************************/
 /*  Constructors                             */
 /*********************************************/
@@ -459,18 +451,17 @@ unsigned char String::operator>=(const String &rhs) const
   return compareTo(rhs) >= 0;
 }
 
+unsigned char String::equalsIgnoreCase(const char* cstr) const
+{
+  if(buffer == cstr) return 1;
+  return strcasecmp(cstr, buffer) == 0;
+}
+
 unsigned char String::equalsIgnoreCase(const String &s2) const
 {
-  if (this == &s2) return 1;
   if (len != s2.len) return 0;
   if (len == 0) return 1;
-  const char *p1 = buffer;
-  const char *p2 = s2.buffer;
-  while (*p1)
-  {
-    if (tolower(*p1++) != tolower(*p2++)) return 0;
-  }
-  return 1;
+  return equalsIgnoreCase(s2.buffer);
 }
 
 unsigned char String::startsWith(const String &prefix) const

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -116,7 +116,7 @@ String::String(double value, unsigned char decimalPlaces)
 
 String::~String()
 {
-	if (buffer) free(buffer);
+	free(buffer);
 }
 
 void String::setString(const char *cstr, int length /* = -1 */)
@@ -585,7 +585,7 @@ int String::lastIndexOf(const String &s2, int fromIndex) const
   int found = -1;
   for (char *p = buffer; p <= buffer + fromIndex; p++)
   {
-	p = (char*)memmem(p, buffer + len - p, s2.buffer, s2.len);
+    p = (char*)memmem(p, buffer + len - p, s2.buffer, s2.len);
     if (!p) break;
     if (p - buffer <= fromIndex) found = p - buffer;
   }

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -41,44 +41,42 @@ class StringSumHelper;
 // The string class
 class String
 {
-	// use a function pointer to allow for "if (s)" without the
-	// complications of an operator bool(). for more information, see:
-	// http://www.artima.com/cppsource/safebool.html
-	typedef void (String::*StringIfHelperType)() const;
-	void IRAM_ATTR StringIfHelper() const
-	{
-	}
+    // use a function pointer to allow for "if (s)" without the
+    // complications of an operator bool(). for more information, see:
+    // http://www.artima.com/cppsource/safebool.html
+    typedef void (String::*StringIfHelperType)() const;
+    void IRAM_ATTR StringIfHelper() const {}
 
-public:
-	// constructors
-	// creates a copy of the initial value.
-	// if the initial value is null or invalid, or if memory allocation
-	// fails, the string will be marked as invalid (i.e. "if (s)" will
-	// be false).
-	IRAM_ATTR String(const char* cstr = "");
-	IRAM_ATTR String(const char* cstr, unsigned int length);
-	IRAM_ATTR String(const String& str);
+  public:
+    // constructors
+    // creates a copy of the initial value.
+    // if the initial value is null or invalid, or if memory allocation
+    // fails, the string will be marked as invalid (i.e. "if (s)" will
+    // be false).
+    IRAM_ATTR String(const char *cstr = "");
+    IRAM_ATTR String(const char *cstr, unsigned int length);
+    IRAM_ATTR String(const String &str);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-	IRAM_ATTR String(String&& rval);
-	IRAM_ATTR String(StringSumHelper&& rval);
+    IRAM_ATTR String(String && rval);
+    IRAM_ATTR String(StringSumHelper && rval);
 #endif
-	explicit String(char c);
-	explicit String(unsigned char, unsigned char base = 10);
-	explicit String(int, unsigned char base = 10);
-	explicit String(unsigned int, unsigned char base = 10);
-	explicit String(long, unsigned char base = 10);
-	explicit String(unsigned long, unsigned char base = 10);
-	explicit String(float, unsigned char decimalPlaces = 2);
-	explicit String(double, unsigned char decimalPlaces = 2);
-	~String(void);
+    explicit String(char c);
+    explicit String(unsigned char, unsigned char base = 10);
+    explicit String(int, unsigned char base = 10);
+    explicit String(unsigned int, unsigned char base = 10);
+    explicit String(long, unsigned char base = 10);
+    explicit String(unsigned long, unsigned char base = 10);
+    explicit String(float, unsigned char decimalPlaces=2);
+    explicit String(double, unsigned char decimalPlaces=2);
+    ~String(void);
 
-	void setString(const char* cstr, int length = -1);
+    void setString(const char *cstr, int length = -1);
 
-	// memory management
-	// return true on success, false on failure (in which case, the string
-	// is left unchanged).  reserve(0), if successful, will validate an
-	// invalid string (i.e., "if (s)" will be true afterwards)
-	unsigned char reserve(unsigned int size);
+    // memory management
+    // return true on success, false on failure (in which case, the string
+    // is left unchanged).  reserve(0), if successful, will validate an
+    // invalid string (i.e., "if (s)" will be true afterwards)
+    unsigned char reserve(unsigned int size);
 
 	/** @brief set the string length accordingly, expanding if necessary
 	 *  @param length required for string (nul terminator additional)
@@ -88,251 +86,214 @@ public:
 	bool setLength(unsigned length);
 
 	inline unsigned int length(void) const
-	{
-		return len;
-	}
+    {
+      return len;
+    }
 
-	// creates a copy of the assigned value.  if the value is null or
-	// invalid, or if the memory allocation fails, the string will be
-	// marked as invalid ("if (s)" will be false).
-	String& IRAM_ATTR operator=(const String& rhs);
-	String& IRAM_ATTR operator=(const char* cstr);
+    // creates a copy of the assigned value.  if the value is null or
+    // invalid, or if the memory allocation fails, the string will be
+    // marked as invalid ("if (s)" will be false).
+    String & IRAM_ATTR operator = (const String &rhs);
+    String & IRAM_ATTR operator = (const char *cstr);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-	String& operator=(String&& rval);
-	String& operator=(StringSumHelper&& rval);
+    String & operator = (String && rval);
+    String & operator = (StringSumHelper && rval);
 #endif
 
-	// concatenate (works w/ built-in types)
+    // concatenate (works w/ built-in types)
 
-	// returns true on success, false on failure (in which case, the string
-	// is left unchanged).  if the argument is null or invalid, the
-	// concatenation is considered unsucessful.
-	unsigned char concat(const String& str);
-	unsigned char concat(const char* cstr);
-	unsigned char concat(char c);
-	unsigned char concat(unsigned char c);
-	unsigned char concat(int num);
-	unsigned char concat(unsigned int num);
-	unsigned char concat(long num);
-	unsigned char concat(unsigned long num);
-	unsigned char concat(float num);
-	unsigned char concat(double num);
+    // returns true on success, false on failure (in which case, the string
+    // is left unchanged).  if the argument is null or invalid, the
+    // concatenation is considered unsucessful.
+    unsigned char concat(const String &str);
+    unsigned char concat(const char *cstr);
+    unsigned char concat(char c);
+    unsigned char concat(unsigned char c);
+    unsigned char concat(int num);
+    unsigned char concat(unsigned int num);
+    unsigned char concat(long num);
+    unsigned char concat(unsigned long num);
+    unsigned char concat(float num);
+    unsigned char concat(double num);
+  
+    // if there's not enough memory for the concatenated value, the string
+    // will be left unchanged (but this isn't signalled in any way)
+    String & operator += (const String &rhs)
+    {
+      concat(rhs);
+      return (*this);
+    }
+    String & operator += (const char *cstr)
+    {
+      concat(cstr);
+      return (*this);
+    }
+    String & operator += (char c)
+    {
+      concat(c);
+      return (*this);
+    }
+    String & operator += (unsigned char num)
+    {
+      concat(num);
+      return (*this);
+    }
+    String & operator += (int num)
+    {
+      concat(num);
+      return (*this);
+    }
+    String & operator += (unsigned int num)
+    {
+      concat(num);
+      return (*this);
+    }
+    String & operator += (long num)
+    {
+      concat(num);
+      return (*this);
+    }
+    String & operator += (unsigned long num)
+    {
+      concat(num);
+      return (*this);
+    }
+    String & operator += (float num)
+    {
+      concat(num);
+      return (*this);
+    }
+    String & operator += (double num)
+    {
+      concat(num);
+      return (*this);
+    }
 
-	// if there's not enough memory for the concatenated value, the string
-	// will be left unchanged (but this isn't signalled in any way)
-	String& operator+=(const String& rhs)
-	{
-		concat(rhs);
-		return (*this);
-	}
-	String& operator+=(const char* cstr)
-	{
-		concat(cstr);
-		return (*this);
-	}
-	String& operator+=(char c)
-	{
-		concat(c);
-		return (*this);
-	}
-	String& operator+=(unsigned char num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(int num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(unsigned int num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(long num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(unsigned long num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(float num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(double num)
-	{
-		concat(num);
-		return (*this);
-	}
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, char c);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned char num);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, int num);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned int num);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, long num);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long num);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, float num);
+    friend StringSumHelper & operator + (const StringSumHelper &lhs, double num);
 
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, const String& rhs);
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, const char* cstr);
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, char c);
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned char num);
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, int num);
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned int num);
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, long num);
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned long num);
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, float num);
-	friend StringSumHelper& operator+(const StringSumHelper& lhs, double num);
+    // comparison (only works w/ Strings and "strings")
+    operator StringIfHelperType() const
+    {
+      return buffer ? &String::StringIfHelper : 0;
+    }
+    int IRAM_ATTR compareTo(const String &s) const;
+    unsigned char IRAM_ATTR equals(const String &s) const;
+    unsigned char IRAM_ATTR equals(const char *cstr) const;
+    unsigned char IRAM_ATTR operator == (const String &rhs) const
+    {
+      return equals(rhs);
+    }
+    unsigned char IRAM_ATTR operator == (const char *cstr) const
+    {
+      return equals(cstr);
+    }
+    unsigned char IRAM_ATTR operator != (const String &rhs) const
+    {
+      return !equals(rhs);
+    }
+    unsigned char IRAM_ATTR operator != (const char *cstr) const
+    {
+      return !equals(cstr);
+    }
+    unsigned char operator < (const String &rhs) const;
+    unsigned char operator > (const String &rhs) const;
+    unsigned char operator <= (const String &rhs) const;
+    unsigned char operator >= (const String &rhs) const;
+    unsigned char equalsIgnoreCase(const String &s) const;
+    unsigned char startsWith(const String &prefix) const;
+    unsigned char startsWith(const String &prefix, unsigned int offset) const;
+    unsigned char endsWith(const String &suffix) const;
 
-	// comparison (only works w/ Strings and "strings")
-	operator StringIfHelperType() const
-	{
-		return buffer ? &String::StringIfHelper : 0;
-	}
-	int IRAM_ATTR compareTo(const String& s) const;
-	unsigned char IRAM_ATTR equals(const String& s) const;
-	unsigned char IRAM_ATTR equals(const char* cstr) const;
-	unsigned char IRAM_ATTR operator==(const String& rhs) const
-	{
-		return equals(rhs);
-	}
-	unsigned char IRAM_ATTR operator==(const char* cstr) const
-	{
-		return equals(cstr);
-	}
-	unsigned char IRAM_ATTR operator!=(const String& rhs) const
-	{
-		return !equals(rhs);
-	}
-	unsigned char IRAM_ATTR operator!=(const char* cstr) const
-	{
-		return !equals(cstr);
-	}
-	unsigned char operator<(const String& rhs) const;
-	unsigned char operator>(const String& rhs) const;
-	unsigned char operator<=(const String& rhs) const;
-	unsigned char operator>=(const String& rhs) const;
-	unsigned char equalsIgnoreCase(const String& s) const;
-	unsigned char startsWith(const String& prefix) const;
-	unsigned char startsWith(const String& prefix, unsigned int offset) const;
-	unsigned char endsWith(const String& suffix) const;
+    // character acccess
+    char IRAM_ATTR charAt(unsigned int index) const;
+    void IRAM_ATTR setCharAt(unsigned int index, char c);
+    char IRAM_ATTR operator [](unsigned int index) const;
+    char& IRAM_ATTR operator [](unsigned int index);
+    void getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index = 0) const;
+    void toCharArray(char *buf, unsigned int bufsize, unsigned int index = 0) const
+    {
+      getBytes((unsigned char *)buf, bufsize, index);
+    }
+    const char* c_str() const { return buffer; }
+    char* begin() { return buffer; }
+    char* end() { return buffer + length(); }
+    const char* begin() const { return c_str(); }
+    const char* end() const { return c_str() + length(); }
+  
+    // search
+    int IRAM_ATTR indexOf(char ch) const;
+    int indexOf(char ch, unsigned int fromIndex) const;
+    int IRAM_ATTR indexOf(const String &str) const;
+    int indexOf(const String &str, unsigned int fromIndex) const;
+    int lastIndexOf(char ch) const;
+    int lastIndexOf(char ch, int fromIndex) const;
+    int lastIndexOf(const String &str) const;
+    int lastIndexOf(const String &str, int fromIndex) const;
+    String substring(unsigned int beginIndex) const { return substring(beginIndex, len); };
+    String substring(unsigned int beginIndex, unsigned int endIndex) const;
 
-	// character acccess
-	char IRAM_ATTR charAt(unsigned int index) const;
-	void IRAM_ATTR setCharAt(unsigned int index, char c);
-	char IRAM_ATTR operator[](unsigned int index) const;
-	char& IRAM_ATTR operator[](unsigned int index);
-	void getBytes(unsigned char* buf, unsigned int bufsize, unsigned int index = 0) const;
-	void toCharArray(char* buf, unsigned int bufsize, unsigned int index = 0) const
-	{
-		getBytes((unsigned char*)buf, bufsize, index);
-	}
-	const char* c_str() const
-	{
-		return buffer;
-	}
-	char* begin()
-	{
-		return buffer;
-	}
-	char* end()
-	{
-		return buffer + length();
-	}
-	const char* begin() const
-	{
-		return c_str();
-	}
-	const char* end() const
-	{
-		return c_str() + length();
-	}
+    // modification
+    void replace(char find, char replace);
+    void replace(const String& find, const String& replace);
+    void remove(unsigned int index);
+    void remove(unsigned int index, unsigned int count);
+    void toLowerCase(void);
+    void toUpperCase(void);
+    void trim(void);
 
-	// search
-	int IRAM_ATTR indexOf(char ch) const;
-	int indexOf(char ch, unsigned int fromIndex) const;
-	int IRAM_ATTR indexOf(const String& str) const;
-	int indexOf(const String& str, unsigned int fromIndex) const;
-	int lastIndexOf(char ch) const;
-	int lastIndexOf(char ch, int fromIndex) const;
-	int lastIndexOf(const String& str) const;
-	int lastIndexOf(const String& str, int fromIndex) const;
-	String substring(unsigned int beginIndex) const
-	{
-		return substring(beginIndex, len);
-	};
-	String substring(unsigned int beginIndex, unsigned int endIndex) const;
+    // parsing/conversion
+    long toInt(void) const;
+    float toFloat(void) const;
+  
+    friend int splitString(String &what, int delim, Vector<long> &splits);
+    friend int splitString(String &what, int delim, Vector<int> &splits);
+    friend int splitString(String &what, int delim, Vector<String> &splits);
 
-	// modification
-	void replace(char find, char replace);
-	void replace(const String& find, const String& replace);
-	void remove(unsigned int index);
-	void remove(unsigned int index, unsigned int count);
-	void toLowerCase(void);
-	void toUpperCase(void);
-	void trim(void);
+    //void printTo(Print &p) const;
 
-	// parsing/conversion
-	long toInt(void) const;
-	float toFloat(void) const;
 
-	friend int splitString(String& what, int delim, Vector<long>& splits);
-	friend int splitString(String& what, int delim, Vector<int>& splits);
-	friend int splitString(String& what, int delim, Vector<String>& splits);
+  protected:
+    char *buffer;	        // the actual char array
+    uint16_t capacity;  // the array length minus one (for the '\0')
+    uint16_t len;       // the String length (not counting the '\0')
+    //unsigned char flags;    // unused, for future features
+  protected:
+    void IRAM_ATTR init(void);
+    void IRAM_ATTR invalidate(void);
+    unsigned char IRAM_ATTR changeBuffer(unsigned int maxStrLen);
+    unsigned char IRAM_ATTR concat(const char *cstr, unsigned int length);
 
-	//void printTo(Print &p) const;
-
-protected:
-	char* buffer;	  // the actual char array
-	uint16_t capacity; // the array length minus one (for the '\0')
-	uint16_t len;	  // the String length (not counting the '\0')
-					   //unsigned char flags;    // unused, for future features
-protected:
-	void IRAM_ATTR init(void);
-	void IRAM_ATTR invalidate(void);
-	unsigned char IRAM_ATTR changeBuffer(unsigned int maxStrLen);
-	unsigned char IRAM_ATTR concat(const char* cstr, unsigned int length);
-
-	// copy and move
-	String& copy(const char* cstr, unsigned int length);
+    // copy and move
+    String & copy(const char *cstr, unsigned int length);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-	void move(String& rhs);
+    void move(String &rhs);
 #endif
 };
 
 class StringSumHelper : public String
 {
-public:
-	StringSumHelper(const String& s) : String(s)
-	{
-	}
-	StringSumHelper(const char* p) : String(p)
-	{
-	}
-	StringSumHelper(char c) : String(c)
-	{
-	}
-	StringSumHelper(unsigned char num) : String(num)
-	{
-	}
-	StringSumHelper(int num) : String(num)
-	{
-	}
-	StringSumHelper(unsigned int num) : String(num)
-	{
-	}
-	StringSumHelper(long num) : String(num)
-	{
-	}
-	StringSumHelper(unsigned long num) : String(num)
-	{
-	}
-	StringSumHelper(float num) : String(num)
-	{
-	}
-	StringSumHelper(double num) : String(num)
-	{
-	}
+  public:
+    StringSumHelper(const String &s) : String(s) {}
+    StringSumHelper(const char *p) : String(p) {}
+    StringSumHelper(char c) : String(c) {}
+    StringSumHelper(unsigned char num) : String(num) {}
+    StringSumHelper(int num) : String(num) {}
+    StringSumHelper(unsigned int num) : String(num) {}
+    StringSumHelper(long num) : String(num) {}
+    StringSumHelper(unsigned long num) : String(num) {}
+    StringSumHelper(float num) : String(num) {}
+    StringSumHelper(double num) : String(num) {}
 };
 
-#endif // __cplusplus
+#endif  // __cplusplus
 #endif
 // WSTRING_H

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -41,251 +41,298 @@ class StringSumHelper;
 // The string class
 class String
 {
-    // use a function pointer to allow for "if (s)" without the
-    // complications of an operator bool(). for more information, see:
-    // http://www.artima.com/cppsource/safebool.html
-    typedef void (String::*StringIfHelperType)() const;
-    void IRAM_ATTR StringIfHelper() const {}
+	// use a function pointer to allow for "if (s)" without the
+	// complications of an operator bool(). for more information, see:
+	// http://www.artima.com/cppsource/safebool.html
+	typedef void (String::*StringIfHelperType)() const;
+	void IRAM_ATTR StringIfHelper() const
+	{
+	}
 
-  public:
-    // constructors
-    // creates a copy of the initial value.
-    // if the initial value is null or invalid, or if memory allocation
-    // fails, the string will be marked as invalid (i.e. "if (s)" will
-    // be false).
-    IRAM_ATTR String(const char *cstr = "");
-    IRAM_ATTR String(const char *cstr, unsigned int length);
-    IRAM_ATTR String(const String &str);
+public:
+	// constructors
+	// creates a copy of the initial value.
+	// if the initial value is null or invalid, or if memory allocation
+	// fails, the string will be marked as invalid (i.e. "if (s)" will
+	// be false).
+	IRAM_ATTR String(const char* cstr = "");
+	IRAM_ATTR String(const char* cstr, unsigned int length);
+	IRAM_ATTR String(const String& str);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    IRAM_ATTR String(String && rval);
-    IRAM_ATTR String(StringSumHelper && rval);
+	IRAM_ATTR String(String&& rval);
+	IRAM_ATTR String(StringSumHelper&& rval);
 #endif
-    explicit String(char c);
-    explicit String(unsigned char, unsigned char base = 10);
-    explicit String(int, unsigned char base = 10);
-    explicit String(unsigned int, unsigned char base = 10);
-    explicit String(long, unsigned char base = 10);
-    explicit String(unsigned long, unsigned char base = 10);
-    explicit String(float, unsigned char decimalPlaces=2);
-    explicit String(double, unsigned char decimalPlaces=2);
-    ~String(void);
+	explicit String(char c);
+	explicit String(unsigned char, unsigned char base = 10);
+	explicit String(int, unsigned char base = 10);
+	explicit String(unsigned int, unsigned char base = 10);
+	explicit String(long, unsigned char base = 10);
+	explicit String(unsigned long, unsigned char base = 10);
+	explicit String(float, unsigned char decimalPlaces = 2);
+	explicit String(double, unsigned char decimalPlaces = 2);
+	~String(void);
 
-    void setString(const char *cstr, int length = -1);
+	void setString(const char* cstr, int length = -1);
 
-    // memory management
-    // return true on success, false on failure (in which case, the string
-    // is left unchanged).  reserve(0), if successful, will validate an
-    // invalid string (i.e., "if (s)" will be true afterwards)
-    unsigned char reserve(unsigned int size);
-    inline unsigned int length(void) const
-    {
-      return len;
-    }
+	// memory management
+	// return true on success, false on failure (in which case, the string
+	// is left unchanged).  reserve(0), if successful, will validate an
+	// invalid string (i.e., "if (s)" will be true afterwards)
+	unsigned char reserve(unsigned int size);
 
-    // creates a copy of the assigned value.  if the value is null or
-    // invalid, or if the memory allocation fails, the string will be
-    // marked as invalid ("if (s)" will be false).
-    String & IRAM_ATTR operator = (const String &rhs);
-    String & IRAM_ATTR operator = (const char *cstr);
+	/** @brief set the string length accordingly, expanding if necessary
+	 *  @param length required for string (nul terminator additional)
+	 *  @retval true on success, false on failure
+	 *  @note extra characters are undefined
+	 */
+	bool setLength(unsigned length);
+
+	inline unsigned int length(void) const
+	{
+		return len;
+	}
+
+	// creates a copy of the assigned value.  if the value is null or
+	// invalid, or if the memory allocation fails, the string will be
+	// marked as invalid ("if (s)" will be false).
+	String& IRAM_ATTR operator=(const String& rhs);
+	String& IRAM_ATTR operator=(const char* cstr);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    String & operator = (String && rval);
-    String & operator = (StringSumHelper && rval);
+	String& operator=(String&& rval);
+	String& operator=(StringSumHelper&& rval);
 #endif
 
-    // concatenate (works w/ built-in types)
+	// concatenate (works w/ built-in types)
 
-    // returns true on success, false on failure (in which case, the string
-    // is left unchanged).  if the argument is null or invalid, the
-    // concatenation is considered unsucessful.
-    unsigned char concat(const String &str);
-    unsigned char concat(const char *cstr);
-    unsigned char concat(char c);
-    unsigned char concat(unsigned char c);
-    unsigned char concat(int num);
-    unsigned char concat(unsigned int num);
-    unsigned char concat(long num);
-    unsigned char concat(unsigned long num);
-    unsigned char concat(float num);
-    unsigned char concat(double num);
-  
-    // if there's not enough memory for the concatenated value, the string
-    // will be left unchanged (but this isn't signalled in any way)
-    String & operator += (const String &rhs)
-    {
-      concat(rhs);
-      return (*this);
-    }
-    String & operator += (const char *cstr)
-    {
-      concat(cstr);
-      return (*this);
-    }
-    String & operator += (char c)
-    {
-      concat(c);
-      return (*this);
-    }
-    String & operator += (unsigned char num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (int num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (unsigned int num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (long num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (unsigned long num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (float num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (double num)
-    {
-      concat(num);
-      return (*this);
-    }
+	// returns true on success, false on failure (in which case, the string
+	// is left unchanged).  if the argument is null or invalid, the
+	// concatenation is considered unsucessful.
+	unsigned char concat(const String& str);
+	unsigned char concat(const char* cstr);
+	unsigned char concat(char c);
+	unsigned char concat(unsigned char c);
+	unsigned char concat(int num);
+	unsigned char concat(unsigned int num);
+	unsigned char concat(long num);
+	unsigned char concat(unsigned long num);
+	unsigned char concat(float num);
+	unsigned char concat(double num);
 
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, char c);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned char num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, int num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned int num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, long num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, float num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, double num);
+	// if there's not enough memory for the concatenated value, the string
+	// will be left unchanged (but this isn't signalled in any way)
+	String& operator+=(const String& rhs)
+	{
+		concat(rhs);
+		return (*this);
+	}
+	String& operator+=(const char* cstr)
+	{
+		concat(cstr);
+		return (*this);
+	}
+	String& operator+=(char c)
+	{
+		concat(c);
+		return (*this);
+	}
+	String& operator+=(unsigned char num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(int num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(unsigned int num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(long num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(unsigned long num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(float num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(double num)
+	{
+		concat(num);
+		return (*this);
+	}
 
-    // comparison (only works w/ Strings and "strings")
-    operator StringIfHelperType() const
-    {
-      return buffer ? &String::StringIfHelper : 0;
-    }
-    int IRAM_ATTR compareTo(const String &s) const;
-    unsigned char IRAM_ATTR equals(const String &s) const;
-    unsigned char IRAM_ATTR equals(const char *cstr) const;
-    unsigned char IRAM_ATTR operator == (const String &rhs) const
-    {
-      return equals(rhs);
-    }
-    unsigned char IRAM_ATTR operator == (const char *cstr) const
-    {
-      return equals(cstr);
-    }
-    unsigned char IRAM_ATTR operator != (const String &rhs) const
-    {
-      return !equals(rhs);
-    }
-    unsigned char IRAM_ATTR operator != (const char *cstr) const
-    {
-      return !equals(cstr);
-    }
-    unsigned char operator < (const String &rhs) const;
-    unsigned char operator > (const String &rhs) const;
-    unsigned char operator <= (const String &rhs) const;
-    unsigned char operator >= (const String &rhs) const;
-    unsigned char equalsIgnoreCase(const String &s) const;
-    unsigned char startsWith(const String &prefix) const;
-    unsigned char startsWith(const String &prefix, unsigned int offset) const;
-    unsigned char endsWith(const String &suffix) const;
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, const String& rhs);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, const char* cstr);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, char c);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned char num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, int num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned int num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, long num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned long num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, float num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, double num);
 
-    // character acccess
-    char IRAM_ATTR charAt(unsigned int index) const;
-    void IRAM_ATTR setCharAt(unsigned int index, char c);
-    char IRAM_ATTR operator [](unsigned int index) const;
-    char& IRAM_ATTR operator [](unsigned int index);
-    void getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index = 0) const;
-    void toCharArray(char *buf, unsigned int bufsize, unsigned int index = 0) const
-    {
-      getBytes((unsigned char *)buf, bufsize, index);
-    }
-    const char* c_str() const { return buffer; }
-    char* begin() { return buffer; }
-    char* end() { return buffer + length(); }
-    const char* begin() const { return c_str(); }
-    const char* end() const { return c_str() + length(); }
-  
-    // search
-    int IRAM_ATTR indexOf(char ch) const;
-    int indexOf(char ch, unsigned int fromIndex) const;
-    int IRAM_ATTR indexOf(const String &str) const;
-    int indexOf(const String &str, unsigned int fromIndex) const;
-    int lastIndexOf(char ch) const;
-    int lastIndexOf(char ch, int fromIndex) const;
-    int lastIndexOf(const String &str) const;
-    int lastIndexOf(const String &str, int fromIndex) const;
-    String substring(unsigned int beginIndex) const { return substring(beginIndex, len); };
-    String substring(unsigned int beginIndex, unsigned int endIndex) const;
+	// comparison (only works w/ Strings and "strings")
+	operator StringIfHelperType() const
+	{
+		return buffer ? &String::StringIfHelper : 0;
+	}
+	int IRAM_ATTR compareTo(const String& s) const;
+	unsigned char IRAM_ATTR equals(const String& s) const;
+	unsigned char IRAM_ATTR equals(const char* cstr) const;
+	unsigned char IRAM_ATTR operator==(const String& rhs) const
+	{
+		return equals(rhs);
+	}
+	unsigned char IRAM_ATTR operator==(const char* cstr) const
+	{
+		return equals(cstr);
+	}
+	unsigned char IRAM_ATTR operator!=(const String& rhs) const
+	{
+		return !equals(rhs);
+	}
+	unsigned char IRAM_ATTR operator!=(const char* cstr) const
+	{
+		return !equals(cstr);
+	}
+	unsigned char operator<(const String& rhs) const;
+	unsigned char operator>(const String& rhs) const;
+	unsigned char operator<=(const String& rhs) const;
+	unsigned char operator>=(const String& rhs) const;
+	unsigned char equalsIgnoreCase(const String& s) const;
+	unsigned char startsWith(const String& prefix) const;
+	unsigned char startsWith(const String& prefix, unsigned int offset) const;
+	unsigned char endsWith(const String& suffix) const;
 
-    // modification
-    void replace(char find, char replace);
-    void replace(const String& find, const String& replace);
-    void remove(unsigned int index);
-    void remove(unsigned int index, unsigned int count);
-    void toLowerCase(void);
-    void toUpperCase(void);
-    void trim(void);
+	// character acccess
+	char IRAM_ATTR charAt(unsigned int index) const;
+	void IRAM_ATTR setCharAt(unsigned int index, char c);
+	char IRAM_ATTR operator[](unsigned int index) const;
+	char& IRAM_ATTR operator[](unsigned int index);
+	void getBytes(unsigned char* buf, unsigned int bufsize, unsigned int index = 0) const;
+	void toCharArray(char* buf, unsigned int bufsize, unsigned int index = 0) const
+	{
+		getBytes((unsigned char*)buf, bufsize, index);
+	}
+	const char* c_str() const
+	{
+		return buffer;
+	}
+	char* begin()
+	{
+		return buffer;
+	}
+	char* end()
+	{
+		return buffer + length();
+	}
+	const char* begin() const
+	{
+		return c_str();
+	}
+	const char* end() const
+	{
+		return c_str() + length();
+	}
 
-    // parsing/conversion
-    long toInt(void) const;
-    float toFloat(void) const;
-  
-    friend int splitString(String &what, int delim, Vector<long> &splits);
-    friend int splitString(String &what, int delim, Vector<int> &splits);
-    friend int splitString(String &what, int delim, Vector<String> &splits);
+	// search
+	int IRAM_ATTR indexOf(char ch) const;
+	int indexOf(char ch, unsigned int fromIndex) const;
+	int IRAM_ATTR indexOf(const String& str) const;
+	int indexOf(const String& str, unsigned int fromIndex) const;
+	int lastIndexOf(char ch) const;
+	int lastIndexOf(char ch, int fromIndex) const;
+	int lastIndexOf(const String& str) const;
+	int lastIndexOf(const String& str, int fromIndex) const;
+	String substring(unsigned int beginIndex) const
+	{
+		return substring(beginIndex, len);
+	};
+	String substring(unsigned int beginIndex, unsigned int endIndex) const;
 
-    //void printTo(Print &p) const;
+	// modification
+	void replace(char find, char replace);
+	void replace(const String& find, const String& replace);
+	void remove(unsigned int index);
+	void remove(unsigned int index, unsigned int count);
+	void toLowerCase(void);
+	void toUpperCase(void);
+	void trim(void);
 
+	// parsing/conversion
+	long toInt(void) const;
+	float toFloat(void) const;
 
-  protected:
-    char *buffer;	        // the actual char array
-    uint16_t capacity;  // the array length minus one (for the '\0')
-    uint16_t len;       // the String length (not counting the '\0')
-    //unsigned char flags;    // unused, for future features
-  protected:
-    void IRAM_ATTR init(void);
-    void IRAM_ATTR invalidate(void);
-    unsigned char IRAM_ATTR changeBuffer(unsigned int maxStrLen);
-    unsigned char IRAM_ATTR concat(const char *cstr, unsigned int length);
+	friend int splitString(String& what, int delim, Vector<long>& splits);
+	friend int splitString(String& what, int delim, Vector<int>& splits);
+	friend int splitString(String& what, int delim, Vector<String>& splits);
 
-    // copy and move
-    String & copy(const char *cstr, unsigned int length);
+	//void printTo(Print &p) const;
+
+protected:
+	char* buffer;	  // the actual char array
+	uint16_t capacity; // the array length minus one (for the '\0')
+	uint16_t len;	  // the String length (not counting the '\0')
+					   //unsigned char flags;    // unused, for future features
+protected:
+	void IRAM_ATTR init(void);
+	void IRAM_ATTR invalidate(void);
+	unsigned char IRAM_ATTR changeBuffer(unsigned int maxStrLen);
+	unsigned char IRAM_ATTR concat(const char* cstr, unsigned int length);
+
+	// copy and move
+	String& copy(const char* cstr, unsigned int length);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    void move(String &rhs);
+	void move(String& rhs);
 #endif
 };
 
 class StringSumHelper : public String
 {
-  public:
-    StringSumHelper(const String &s) : String(s) {}
-    StringSumHelper(const char *p) : String(p) {}
-    StringSumHelper(char c) : String(c) {}
-    StringSumHelper(unsigned char num) : String(num) {}
-    StringSumHelper(int num) : String(num) {}
-    StringSumHelper(unsigned int num) : String(num) {}
-    StringSumHelper(long num) : String(num) {}
-    StringSumHelper(unsigned long num) : String(num) {}
-    StringSumHelper(float num) : String(num) {}
-    StringSumHelper(double num) : String(num) {}
+public:
+	StringSumHelper(const String& s) : String(s)
+	{
+	}
+	StringSumHelper(const char* p) : String(p)
+	{
+	}
+	StringSumHelper(char c) : String(c)
+	{
+	}
+	StringSumHelper(unsigned char num) : String(num)
+	{
+	}
+	StringSumHelper(int num) : String(num)
+	{
+	}
+	StringSumHelper(unsigned int num) : String(num)
+	{
+	}
+	StringSumHelper(long num) : String(num)
+	{
+	}
+	StringSumHelper(unsigned long num) : String(num)
+	{
+	}
+	StringSumHelper(float num) : String(num)
+	{
+	}
+	StringSumHelper(double num) : String(num)
+	{
+	}
 };
 
-#endif  // __cplusplus
+#endif // __cplusplus
 #endif
 // WSTRING_H

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -208,6 +208,7 @@ class String
     unsigned char operator > (const String &rhs) const;
     unsigned char operator <= (const String &rhs) const;
     unsigned char operator >= (const String &rhs) const;
+    unsigned char equalsIgnoreCase(const char* cstr) const;
     unsigned char equalsIgnoreCase(const String &s2) const;
     unsigned char startsWith(const String &prefix) const;
     unsigned char startsWith(const String &prefix, unsigned int offset) const;

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -83,7 +83,7 @@ class String
 	 *  @retval true on success, false on failure
 	 *  @note extra characters are undefined
 	 */
-	bool setLength(unsigned length);
+	bool setLength(unsigned int length);
 
 	inline unsigned int length(void) const
     {
@@ -208,7 +208,7 @@ class String
     unsigned char operator > (const String &rhs) const;
     unsigned char operator <= (const String &rhs) const;
     unsigned char operator >= (const String &rhs) const;
-    unsigned char equalsIgnoreCase(const String &s) const;
+    unsigned char equalsIgnoreCase(const String &s2) const;
     unsigned char startsWith(const String &prefix) const;
     unsigned char startsWith(const String &prefix, unsigned int offset) const;
     unsigned char endsWith(const String &suffix) const;

--- a/Sming/system/include/stringutil.h
+++ b/Sming/system/include/stringutil.h
@@ -14,12 +14,25 @@
 extern "C" {
 #endif
 
-  /** Return pointer to occurence of substring in string. Case insensitive.
+#include "c_types.h"
+
+/** Return pointer to occurence of substring in string. Case insensitive.
    * \param[in] pString string to work with
    * \param[in] pToken string to locate
    * \return pointer to first occurence in of pToken in pString or NULL if not found
    */
 const char* strstri(const char* pString, const char* pToken);
+
+/** @brief A case-insensitive @code{strcmp}.
+	@note non-ANSI GNU C library extension
+*/
+int strcasecmp(const char* s1, const char* s2);
+
+/** @brief Returns a pointer to the first occurrence of @var{needle} (length @var{needle_len}) in @var{haystack} (length @var{haystack_len}).
+	@retval void* @code{NULL} if not found.
+	@note non-ANSI GNU C library extension
+*/
+void* memmem(const void* haystack, size_t haystacklen, const void* needle, size_t needlelen);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Add additional functions to encode/decode using Strings
Add String::setLength to allow direct buffer resizing and avoid double-copy operations
Make String objects useable with non-ASCII data by replacing strcpy/memcpy calls with memmove. An example of this is nul-separated text segments.

Closes #1436.
Closes #1435.