### PR TITLE
Allow the use of multiple DS18S20 sensors

### DIFF
--- a/Sming/Libraries/DS18S20/ds18s20.cpp
+++ b/Sming/Libraries/DS18S20/ds18s20.cpp
@@ -21,17 +21,19 @@
 
 
 
-#define WORK_PIN 2 			// default DS1820 on GPIO2, can be changed by Init
-//OneWire ds(WORK_PIN);
+#define DS1820_WORK_PIN 2 			// default DS1820 on GPIO2, can be changed by Init
 
 
-DS18S20::DS18S20()
+
+DS18S20::DS18S20(uint8_t workPin = DS1820_WORK_PIN)
 {
-	ds = new OneWire(WORK_PIN);
+	ds = new OneWire(workPin);
 }
 
 DS18S20::~DS18S20()
 {
+	delete ds;
+	ds = nullptr;
 }
 
 void DS18S20::Init(uint8_t pinOneWire)

--- a/Sming/Libraries/DS18S20/ds18s20.h
+++ b/Sming/Libraries/DS18S20/ds18s20.h
@@ -127,6 +127,8 @@ private:
 
 
 	float celsius[MAX_SENSORS], fahrenheit[MAX_SENSORS];
+public:
+	OneWire* ds;
 };
 
 /** @} */

--- a/Sming/Libraries/DS18S20/ds18s20.h
+++ b/Sming/Libraries/DS18S20/ds18s20.h
@@ -41,7 +41,7 @@ class DS18S20
 public:
     /** @brief  Instantiate a DS18S20 object
     */
-    DS18S20();
+    DS18S20(uint8_t);
 
     /** @brief  Initiate communication on 1-wire bus
     *   @param  GPIO pin acting as 1-wire bus
@@ -127,8 +127,8 @@ private:
 
 
 	float celsius[MAX_SENSORS], fahrenheit[MAX_SENSORS];
-public:
-	OneWire* ds;
+
+	OneWire* ds = nullptr;
 };
 
 /** @} */


### PR DESCRIPTION
DS18S20 files changed so that if there are multiple instances of the DS18S20 class, each own has local instance of the OneWire class. This is to prevent false readings in case of using multiple DS18S20 sensors on different pins.