### PR TITLE
Fix make cs for windows

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -554,14 +554,18 @@ dist-clean: clean samples-clean third-party-clean libraries-clean tools-clean
  	done
 	$(Q) $(GIT) checkout $(USER_LIBDIR)
 
+# Recursive wildcard search
+rwildcard = $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subst *,%,$2),$d))
 
 # Files that should follow our coding standards
-CS_FILES=$(shell find SmingCore/ -name '*.cpp' -o  -name '*.h' -o -name '*.c') \
-         $(shell find ../samples -name '*.cpp' -o  -name '*.h' -o -name '*.c')
+CS_FILES := $(call rwildcard, SmingCore ../samples, *.cpp *.h *.c)
+
+# Unless overridden in platform-specific makefile
+CLANG_FORMAT ?= clang-format
 
 cs:
 	$(Q) for FILE in $(CS_FILES); do \
-		clang-format -i -style=file $$FILE; \
+		$(CLANG_FORMAT) -verbose -i -style=file $$FILE; \
 	done
 
 

--- a/Sming/Makefile-windows.mk
+++ b/Sming/Makefile-windows.mk
@@ -14,3 +14,4 @@ KILL_TERM    ?= taskkill.exe -f -im Terminal.exe || exit 0
 GET_FILESIZE ?= stat --printf="%s"
 TERMINAL     ?= $(SDK_TOOLS)/Terminal.exe $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
 MEMANALYZER  ?= python $(SMING_HOME)/../tools/memanalyzer.py $(OBJDUMP).exe
+CLANG_FORMAT ?= ""C:\\Program\ Files\\LLVM\\bin\\clang-format.exe""


### PR DESCRIPTION
mingw 'find' conflicts with windows version, re-written using make constructs
Path to clang-format required for windows builds