### PR TITLE
Microsoft Visual SourceSafe status files added to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ nbproject
 GTAGS
 GRTAGS
 GPATH
+
+# Microsoft Visual SourceSafe files
 vssver2.scc

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ nbproject
 GTAGS
 GRTAGS
 GPATH
+vssver2.scc


### PR DESCRIPTION
Microsoft Visual SourceSafe creates status files named "vssver2.scc" that should be ignored.