### PR TITLE
HardwareSerial: expose internal uart object

### DIFF
--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -254,6 +254,12 @@ public:
 	 */
 	size_t indexOf(char c);
 
+	/*
+	 * @brief Returns a pointer to the internal uart object. Use with care.
+	 * @retval pointer to uart_t
+	 */
+	uart_t* getUart() { return uart; }
+
 private:
 	int uartNr;
 	static HWSerialMemberData memberData[NUMBER_UARTS];

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -258,7 +258,10 @@ public:
 	 * @brief Returns a pointer to the internal uart object. Use with care.
 	 * @retval pointer to uart_t
 	 */
-	uart_t* getUart() { return uart; }
+	uart_t* getUart()
+	{
+		return uart;
+	}
 
 private:
 	int uartNr;


### PR DESCRIPTION
Other uses of the UART hardware (e. g. fast WS2812 output) require access to the uart_t object.