### PR TITLE
Remove m_print dependency on serial port.

### DIFF
--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -98,16 +98,6 @@ int HardwareSerial::available()
 	return result;
 }
 
-size_t HardwareSerial::write(uint8_t oneChar)
-{
-	if(!uart || !uart_tx_enabled(uart)) {
-		return 0;
-	}
-
-	uart_write_char(uart, oneChar);
-	return 1;
-}
-
 int HardwareSerial::read()
 {
 	return uart_read_char(uart);

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -156,13 +156,14 @@ void HardwareSerial::systemDebugOutput(bool enabled)
 	if(enabled) {
 		if(uart_tx_enabled(uart)) {
 			uart_set_debug(uartNr);
-			m_setPuts(reinterpret_cast<nputs_callback_t>(uart_write), uart);
+			using namespace std::placeholders;
+			m_setPuts(std::bind(&uart_write, uart, _1, _2));
 		} else {
 			uart_set_debug(UART_NO);
 		}
 	} else {
 		// don't print debugf() data at all
-		m_setPuts(nullptr, nullptr);
+		m_setPuts(nullptr);
 		// and disable system debug messages on this interface
 		if(uart_get_debug() == uartNr) {
 			uart_set_debug(UART_NO);

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -18,9 +18,6 @@ HWSerialMemberData HardwareSerial::memberData[NUMBER_UARTS];
 os_event_t* HardwareSerial::serialQueue = nullptr;
 bool HardwareSerial::init = false;
 
-//set m_printf callback
-extern void setMPrintfPrinterCbc(void (*callback)(uart_t*, char), uart_t* uart);
-
 HardwareSerial::HardwareSerial(const int uartPort) : uartNr(uartPort), rxSize(256)
 {
 }
@@ -159,13 +156,13 @@ void HardwareSerial::systemDebugOutput(bool enabled)
 	if(enabled) {
 		if(uart_tx_enabled(uart)) {
 			uart_set_debug(uartNr);
-			setMPrintfPrinterCbc(uart_write_char, uart);
+			m_setPuts(reinterpret_cast<nputs_callback_t>(uart_write), uart);
 		} else {
 			uart_set_debug(UART_NO);
 		}
 	} else {
 		// don't print debugf() data at all
-		setMPrintfPrinterCbc(NULL, NULL);
+		m_setPuts(nullptr, nullptr);
 		// and disable system debug messages on this interface
 		if(uart_get_debug() == uartNr) {
 			uart_set_debug(UART_NO);

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -197,9 +197,20 @@ public:
 	 *  @param  oneChar Character to write to the serial port
 	 *  @retval size_t Quantity of characters written (always 1)
 	 */
-	size_t write(uint8_t oneChar);
+	size_t write(uint8_t oneChar) override
+	{
+		return uart_write_char(uart, oneChar);
+	}
 
-	using Stream::write;
+	/** @brief  write multiple characters to serial port
+	 *  @param buffer data to write
+	 *  @param size number of characters to write
+	 *  @retval size_t Quantity of characters written, may be less than size
+	 */
+	size_t write(const uint8_t* buffer, size_t size) override
+	{
+		return uart_write(uart, buffer, size);
+	}
 
 	/** @brief  Configure serial port for system debug output and redirect output from debugf
 	 *  @param  enabled True to enable this port for system debug output

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -197,17 +197,19 @@ public:
 	 *  @param  oneChar Character to write to the serial port
 	 *  @retval size_t Quantity of characters written (always 1)
 	 */
-	size_t write(uint8_t oneChar) override
+	virtual size_t write(uint8_t oneChar)
 	{
 		return uart_write_char(uart, oneChar);
 	}
+
+	using Stream::write;
 
 	/** @brief  write multiple characters to serial port
 	 *  @param buffer data to write
 	 *  @param size number of characters to write
 	 *  @retval size_t Quantity of characters written, may be less than size
 	 */
-	size_t write(const uint8_t* buffer, size_t size) override
+	virtual size_t write(const uint8_t* buffer, size_t size)
 	{
 		return uart_write(uart, buffer, size);
 	}

--- a/Sming/system/include/espinc/uart.h
+++ b/Sming/system/include/espinc/uart.h
@@ -119,8 +119,16 @@ int uart_get_baudrate(uart_t* uart);
 
 size_t uart_resize_rx_buffer(uart_t* uart, size_t new_size);
 
-void uart_write_char(uart_t* uart, char c);
-void uart_write(uart_t* uart, const char* buf, size_t size);
+size_t uart_write_char(uart_t* uart, char c);
+
+/** @brief write a block of data
+ *  @param uart
+ *  @param buffer
+ *  @param size
+ *  @retval size_t number of bytes buffered for transmission
+ */
+size_t uart_write(uart_t* uart, const void* buffer, size_t size);
+
 int uart_read_char(uart_t* uart);
 int uart_peek_char(uart_t* uart);
 size_t uart_rx_available(uart_t* uart);

--- a/Sming/system/include/m_printf.h
+++ b/Sming/system/include/m_printf.h
@@ -62,21 +62,17 @@ static inline size_t m_puts(const char* str)
 }
 
 #ifdef __cplusplus
-#define M_PRINTHEX_BYTESPERLINE = 16
-#else
-#define M_PRINTHEX_BYTESPERLINE
-#endif
 
 /** @brief output a block of data in hex format
- *  @param tag brief name to display with the data block
+ *  @param tag brief name to display with the data block. Specify nullptr if not required.
  *  @param data
  *  @param len
+ *  @param addr Prefix lines with addresses starting at the given value, use -1 if not required.
  *  @param bytesPerLine If non-zero, data will be output in block separated by carriage return
  *  @note intended for debugging
  */
-void m_printHex(const char* tag, const void* data, size_t len, size_t bytesPerLine M_PRINTHEX_BYTESPERLINE);
+void m_printHex(const char* tag, const void* data, size_t len, int addr = -1, size_t bytesPerLine = 16);
 
-#ifdef __cplusplus
 }
 #endif
 

--- a/Sming/system/include/m_printf.h
+++ b/Sming/system/include/m_printf.h
@@ -13,8 +13,10 @@ Descr: embedded very simple version of printf with float support
 #include <string.h>
 
 #ifdef __cplusplus
-extern "C" {
-#endif
+
+extern "C++" {
+
+#include <functional>
 
 /** @brief callback type to output a string of data
  *  @param param
@@ -23,13 +25,17 @@ extern "C" {
  *  @retval number of characters written, which may be less than the requested size
  *  @note data does not need to be nul terminated and may contain any 8-bit values including nul
  */
-typedef size_t (*nputs_callback_t)(void* param, const char* str, size_t length);
+typedef std::function<size_t(const char* str, size_t length)> nputs_callback_t;
 
 /** @brief set the character output routine
  *  @param callback
- *  @param param
  */
-void m_setPuts(nputs_callback_t callback, void* param);
+void m_setPuts(nputs_callback_t callback);
+
+} // extern "C++"
+
+extern "C" {
+#endif
 
 int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args);
 int m_snprintf(char* buf, int length, const char *fmt, ...);

--- a/Sming/system/include/m_printf.h
+++ b/Sming/system/include/m_printf.h
@@ -9,16 +9,66 @@ Descr: embedded very simple version of printf with float support
 #define _M_PRINTF_
 
 #include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+/** @brief callback type to output a string of data
+ *  @param param
+ *  @param str data to send
+ *  @param length number of characters to write
+ *  @retval number of characters written, which may be less than the requested size
+ *  @note data does not need to be nul terminated and may contain any 8-bit values including nul
+ */
+typedef size_t (*nputs_callback_t)(void* param, const char* str, size_t length);
+
+/** @brief set the character output routine
+ *  @param callback
+ *  @param param
+ */
+void m_setPuts(nputs_callback_t callback, void* param);
+
 int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args);
 int m_snprintf(char* buf, int length, const char *fmt, ...);
 int m_printf(char const*, ...);
 int m_vprintf ( const char * format, va_list arg );
-void m_putc(char c);
+
+/** @brief output a single character
+ *  @param c
+ *  @retval size_t 1 on success, 0 if the character could not be output
+ */
+size_t m_putc(char c);
+
+/** @brief output a text string
+ *  @param str the text
+ *  @param length length of text, excluding nul terminator
+ *  @retval size_t number of characters actually output
+ *  @note nul terminator is optional
+ */
+size_t m_nputs(const char* str, size_t length);
+
+static inline size_t m_puts(const char* str)
+{
+	return m_nputs(str, strlen(str));
+}
+
+#ifdef __cplusplus
+#define M_PRINTHEX_BYTESPERLINE = 16
+#else
+#define M_PRINTHEX_BYTESPERLINE
+#endif
+
+/** @brief output a block of data in hex format
+ *  @param tag brief name to display with the data block
+ *  @param data
+ *  @param len
+ *  @param bytesPerLine If non-zero, data will be output in block separated by carriage return
+ *  @note intended for debugging
+ */
+void m_printHex(const char* tag, const void* data, size_t len, size_t bytesPerLine M_PRINTHEX_BYTESPERLINE);
 
 #ifdef __cplusplus
 }

--- a/Sming/system/include/stringutil.h
+++ b/Sming/system/include/stringutil.h
@@ -34,6 +34,16 @@ int strcasecmp(const char* s1, const char* s2);
 */
 void* memmem(const void* haystack, size_t haystacklen, const void* needle, size_t needlelen);
 
+static inline signed char hexchar(unsigned char c)
+{
+	if(c < 10)
+		return '0' + c;
+	else if(c <= 15)
+		return 'a' + c - 10;
+	else
+		return '\0';
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/system/include/stringutil.h
+++ b/Sming/system/include/stringutil.h
@@ -14,7 +14,7 @@
 extern "C" {
 #endif
 
-#include "c_types.h"
+#include "stddef.h"
 
 /** Return pointer to occurence of substring in string. Case insensitive.
    * \param[in] pString string to work with

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -223,44 +223,55 @@ size_t m_nputs(const char* str, size_t length)
 }
 
 
-void m_printHex(const char* tag, const void* data, size_t len, size_t bytesPerLine)
+void m_printHex(const char* tag, const void* data, size_t len, int addr, size_t bytesPerLine)
 {
 	auto buf = static_cast<const unsigned char*>(data);
 
-	auto taglen = strlen(tag);
+	unsigned taglen = tag ? strlen(tag) : 0;
 	size_t offset = 0;
 	while (offset < len) {
-		if (offset == 0) {
-			m_nputs(tag, taglen);
-			m_putc(':');
+		if (taglen) {
+			if (offset == 0) {
+				m_nputs(tag, taglen);
+				m_putc(':');
+			}
+			else {
+				for (size_t  i = 0; i <= taglen; ++i)
+					m_putc(' ');
+			}
+			m_putc(' ');
 		}
-		else {
-			for (size_t  i = 0; i <= taglen; ++i)
-				m_putc(' ');
-		}
+
+		if (addr >= 0)
+			m_printf("%08X ", addr);
 
 		size_t n = len - offset;
 		if (bytesPerLine && n > bytesPerLine)
 			n = bytesPerLine;
 
 		for (size_t i = 0; i < n; ++i) {
-			m_putc(' ');
 			m_putc(hexchar(buf[offset + i] >> 4));
 			m_putc(hexchar(buf[offset + i] & 0x0f));
+			m_putc(' ');
 		}
-		m_putc('\n');
 
-		// Output ASCII on line below
-		for (size_t  i = 0; i <= taglen; ++i)
+		// Output ASCII
+		unsigned spaces = 1;
+		if (bytesPerLine)
+			spaces += 3 * (bytesPerLine - n);
+		while (spaces--)
 			m_putc(' ');
+
 		for (size_t i = 0; i < n; ++i) {
-			m_putc(' ');
-			m_putc(' ');
 			char c = buf[offset + i];
-			m_putc(is_print(c) ? c : ' ');
+			m_putc(is_print(c) ? c : '.');
 		}
+
 		m_putc('\n');
 
 		offset += n;
+
+		if (addr >= 0)
+			addr += n;
 	}
 }

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -7,7 +7,6 @@ Descr: embedded very simple version of printf with float support
 */
 
 #include "m_printf.h"
-#include "c_types.h"
 #include "stringconversion.h"
 #include "stringutil.h"
 #include <algorithm>

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -20,11 +20,7 @@ Descr: embedded very simple version of printf with float support
  * By default, output is disabled here.
  * Startup behaviour is defined in user_init() in user_main.cpp.
  */
-static struct
-{
-	nputs_callback_t callback;
-	void* param;
-} _puts;
+static nputs_callback_t _puts_callback;
 
 
 #define is_digit(c) ((c) >= '0' && (c) <= '9')
@@ -38,14 +34,14 @@ static int skip_atoi(const char **s)
 	return i;
 }
 
-void m_setPuts(nputs_callback_t callback, void* param)
+void m_setPuts(nputs_callback_t callback)
 {
-	_puts = { callback, param };
+	_puts_callback = callback;
 }
 
 size_t m_putc(char c)
 {
-	return _puts.callback ? _puts.callback(_puts.param, &c, 1) : 0;
+	return _puts_callback ? _puts_callback(&c, 1) : 0;
 }
 
 
@@ -71,14 +67,14 @@ int m_snprintf(char* buf, int length, const char *fmt, ...)
 
 int m_vprintf ( const char * format, va_list arg )
 {
-	if (!_puts.callback)
+	if (!_puts_callback)
 	{
 		return 0;
 	}
 
 	char buf[MPRINTF_BUF_SIZE];
 	int len = m_vsnprintf(buf, sizeof(buf), format, arg);
-	return _puts.callback(_puts.param, buf, std::min((size_t)len, sizeof(buf)));
+	return _puts_callback(buf, std::min((size_t)len, sizeof(buf)));
 }
 
 
@@ -91,7 +87,7 @@ int m_vprintf ( const char * format, va_list arg )
  */
 int m_printf(const char* fmt, ...)
 {
-	if (!_puts.callback || !fmt)
+	if (!_puts_callback || !fmt)
 		return 0;
 
 	va_list args;
@@ -223,7 +219,7 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
 
 size_t m_nputs(const char* str, size_t length)
 {
-	return _puts.callback ? _puts.callback(_puts.param, str, length) : 0;
+	return _puts_callback ? _puts_callback(str, length) : 0;
 }
 
 

--- a/Sming/system/stringconversion.cpp
+++ b/Sming/system/stringconversion.cpp
@@ -1,7 +1,8 @@
 #include <user_config.h>
 #include <math.h>
 #include <stdlib.h>
-#include "../include/stringconversion.h"
+#include "stringconversion.h"
+#include "stringutil.h"
 
 //Since C does not support default func parameters, keep this function as used by framework
 //and create extended _w funct to handle width
@@ -23,7 +24,7 @@ char* ltoa_wp(long val, char* buffer, int base, int width, char pad)
 	if (ngt) val = -val;
 
 	for(; val && i ; --i, p++, val /= base)
-		buf[i] = "0123456789abcdef"[val % base];
+		buf[i] = hexchar(val % base);
 	if (p == 0) buf[i--] = '0'; // case for zero
 
 	if (ngt)
@@ -60,7 +61,7 @@ char* ultoa_wp(unsigned long val, char* buffer, unsigned int base, int width, ch
 	char buf[40] = {0};
 
 	for(; val && i ; --i, p++, val /= base)
-		buf[i] = "0123456789abcdef"[val % base];
+		buf[i] = hexchar(val % base);
 	if (p == 0) buf[i--] = '0'; // case for zero
 
 	if(width != 0)
@@ -92,10 +93,8 @@ char *dtostrf_p(double floatVar, int minStringWidthIncDecimalPoint, int numDigit
 	if(processedFracLen < 0)
 		processedFracLen = 9;
 
-	double remainder;
-
-	if (outputBuffer == NULL)
-		return NULL ;
+	if (outputBuffer == nullptr)
+		return nullptr;
 
 	char *buf = outputBuffer, *s;
 

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -156,23 +156,27 @@ void uart_stop_isr(uart_t* uart)
 }
 
 
-void uart_write_char(uart_t* uart, char c)
+size_t uart_write_char(uart_t* uart, char c)
 {
     if(uart == NULL || !uart->tx_enabled) {
-        return;
+        return 0;
     }
     while((USS(uart->uart_nr) >> USTXC) >= 0x7f);
     USF(uart->uart_nr) = c;
+    return 1;
 }
 
-void uart_write(uart_t* uart, const char* buf, size_t size)
+size_t uart_write(uart_t* uart, const void* buf, size_t size)
 {
     if(uart == NULL || !uart->tx_enabled) {
-        return;
+        return 0;
     }
+    size_t written = 0;
+    auto p = static_cast<const char*>(buf);
     while(size--) {
-        uart_write_char(uart, *buf++);
+        written += uart_write_char(uart, *p++);
     }
+    return written;
 }
 
 size_t uart_tx_free(uart_t* uart)

--- a/samples/Basic_ProgMem/app/TestProgmem.cpp
+++ b/samples/Basic_ProgMem/app/TestProgmem.cpp
@@ -53,6 +53,7 @@ void testPSTR(Print& out)
 	out.print('"');
 	out.write(buf, sizeof(buf) - 1);
 	out.println('"');
+	m_printHex("hex", buf, sizeof(buf)); // show the actual data
 
 	// PSR defined in another module - we don't know its size! so have to guess,
 	// and of course nuls don't get included
@@ -70,6 +71,7 @@ void testPSTR(Print& out)
 	out.print('"');
 	out.write(psarr, sizeof(psarr) - 1);
 	out.println('"');
+	m_printHex("hex", psarr, sizeof(psarr));
 
 	//
 	out.println("< testPSTR() end\n");


### PR DESCRIPTION
* There's no apparent reason for the dependency.
* Change output callback to handle multiple characters instead of just one (efficiency).
* Output routines return character count, so caller can determine if output was actually performed. This is for consistency with return values from m_printf, etc. and also in support of a forthcoming uart driver update which includes extended transmit buffering and interrupt servicing.
* Change default behaviour for m_printf() so it doesn't output anything, i.e. no callback set.
* Add m_printHex() function, mainly as a debugging aid.