### PR TITLE
Optimise HashMap to use pass-by-reference where possible.

### DIFF
--- a/Sming/SmingCore/Data/Structures.h
+++ b/Sming/SmingCore/Data/Structures.h
@@ -47,7 +47,7 @@ public:
 	}
 };
 
-static bool headerKeyCompare(String a, String b)
+static bool headerKeyCompare(const String& a, const String& b)
 {
 	return (strcasecmp(a.c_str(), b.c_str()) == 0);
 }

--- a/Sming/Wiring/WHashMap.h
+++ b/Sming/Wiring/WHashMap.h
@@ -117,6 +117,11 @@ class HashMap
     || | An indexer for accessing and assigning a value to a key
     || | If a key is used that exists, it returns the value for that key
     || | If there exists no value for that key, a nil value is returned
+    || |
+    || | Note that if the HashMap object is not const, the non-const version
+    || | of this operator will be called which will create a default value
+    || | for this key. If that behaviour is not desired, then check for the
+    || | existence of the key first, using either contains() or indexOf().
     || #
     ||
     || @parameter key the key to get the value for

--- a/Sming/Wiring/WHashMap.h
+++ b/Sming/Wiring/WHashMap.h
@@ -39,12 +39,21 @@ class HashMap
 
     /*
     || @constructor
+    || | Default constructor
+    || #
+    */
+    HashMap()
+    {
+    }
+
+    /*
+    || @constructor
     || | Initialize this HashMap
     || #
     ||
     || @parameter compare optional function for comparing a key against another (for complex types)
     */
-    HashMap(comparator compare = nullptr) : cb_comparator(compare)
+    HashMap(comparator compare) : cb_comparator(compare)
     {
     }
 
@@ -297,7 +306,7 @@ class HashMap
     V nil;
     uint16_t currentIndex = 0;
     uint16_t size = 0;
-    comparator cb_comparator;
+    comparator cb_comparator = nullptr;
 
   private:
     HashMap(const HashMap<K, V>& that);


### PR DESCRIPTION
* When used with Strings, most operations result in duplicate objects being created. Changing methods to use references (const or otherwise) avoids this and improves performance considerably for lookups and modifications.
* Requires change to comparator callback arguments - should provide significant performance improvement as callback invoked multiple times during a search - see HttpHeaders class.
* Change use of int to unsigned where appropriate
* Initialise member variables directly, rather than in constructor (except for _nil_ - could be a primitive or an object)