### PR TITLE
Optimise url escaping / unescaping

### DIFF
--- a/Sming/Services/WebHelpers/escape.cpp
+++ b/Sming/Services/WebHelpers/escape.cpp
@@ -6,13 +6,10 @@
 #include <ctype.h>
 #include <math.h>
 
-/* WARNING : none of the code has been tested properly */
-
-static const char tohex[] = "0123456789ABCDEF";
-
+// Append str to dest with checks
 static unsigned safe_append(char *dest, size_t len, const char *str) {
 	unsigned len2;
-	len2=strlen((const char*)str);
+	len2=strlen(str);
 	if(len2>len) {
 		return 0; /* refuse to append */
 	}
@@ -21,60 +18,32 @@ static unsigned safe_append(char *dest, size_t len, const char *str) {
 }
 
 /* return true if 2 characters are valid hexidecimal */
-static int ishex(const char code[2]) {
+static bool ishex(const char code[2]) {
 	return isxdigit(code[0]) && isxdigit(code[1]);
 }
 
 /* verify with ishex() before calling */
-static char unhex(const char code[2]) {
-	unsigned char a = code[0];
-	unsigned char b = code[1];
-	if (isdigit(a))
-		a -= '0';
-	else
-		a = a - 'A' + 10;
-	if (isdigit(b))
-		b -= '0';
-	else
-		b = b - 'A' + 10;
+static uint8_t unhex(const char code[2])
+{
+	return (unhex(code[0]) << 4) | unhex(code[1]);
+}
 
-	return a*16 + b;
+// These characters are escaped
+static bool must_escape(char c) {
+	return c == '\r' || c == '\n' || c == '+' || c == '~' || c == '!'
+			|| c == '#' || c == '$' || c == '%' || c == '^' || c == '&'
+			|| c == '(' || c == ')' || c == '{' || c == '}' || c == '['
+			|| c == ']' || c == '=' || c == ':' || c == ',' || c == ';'
+			|| c == '?' || c == '\'' || c == '"' || c == '\\';
 }
 
 unsigned uri_escape_len(const char *s, size_t len) {
-	/* TODO: implement this */
 	unsigned ret;
 	for(ret=0;len>0;len--,s++) {
-		switch(*s) {
-			case '\r':
-			case '\n':
-			case '+':
-			case '~':
-			case '!':
-			case '#':
-			case '$':
-			case '%':
-			case '^':
-			case '&':
-			case '(':
-			case ')':
-			case '{':
-			case '}':
-			case '[':
-			case ']':
-			case '=':
-			case ':':
-			case ',':
-			case ';':
-			case '?':
-			case '\'':
-			case '"':
-			case '\\':
-				ret+=3;
-				break;
-			default:
-				ret++;
-		}
+		if (must_escape(*s))
+			ret+=3;
+		else
+			ret++;
 	}
 	return ret;
 }
@@ -87,68 +56,42 @@ unsigned uri_escape_len(const char *s, size_t len) {
  *  dest or allocated pointer on success
  *  destination string will always be null terminated
  */
-char *uri_escape(char *dest, size_t dest_len, const char *src, int src_len) {
-	char *ret;
-	int ret_is_allocated;
-	assert(src!=NULL);
+char *uri_escape(char *dest, size_t dest_len, const char *src, int src_len)
+{
+	assert(src != nullptr);
+
 	if(src_len<0) {
 		src_len=strlen(src);
 	}
-	ret_is_allocated=!dest;
+	bool ret_is_allocated=!dest;
 	if(ret_is_allocated) {
 		/* src_len is non-negative because of earlier condition */
 		assert(src_len>=0);
-		dest_len=uri_escape_len(src, (unsigned)src_len)+1;
+		dest_len=uri_escape_len(src, src_len)+1;
 		dest=(char*)malloc(dest_len);
 		if(!dest) {
 			return 0; /* allocation failure */
 		}
 	}
-	ret=dest;
+	char* ret=dest;
 	/* escape these values ~!#$%^&(){}[]=:,;?'"\
 	 * make sure there is room in dest for a '\0' */
 	for(;src_len>0 && dest_len>1;src++,src_len--) {
-		switch(*src) {
-			case '\r':
-			case '\n':
-			case '+':
-			case '~':
-			case '!':
-			case '#':
-			case '$':
-			case '%':
-			case '^':
-			case '&':
-			case '(':
-			case ')':
-			case '{':
-			case '}':
-			case '[':
-			case ']':
-			case '=':
-			case ':':
-			case ',':
-			case ';':
-			case '?':
-			case '\'':
-			case '"':
-			case '\\':
-				/* check that there is room for "%XX\0" in dest */
-				if(dest_len<=3) {
-					if(ret_is_allocated) {
-						free(ret);
-					}
-					return 0;
-				}
-				dest[0]='%';
-				dest[1]=tohex[(((unsigned char)*src)/16)%16];
-				dest[2]=tohex[((unsigned char)*src)%16];
-				dest+=3;
-				dest_len-=3;
-				break;
-			default:
-				*(dest++)=*src;
-				dest_len--;
+		if(must_escape(*src)) {
+			/* check that there is room for "%XX\0" in dest */
+			if(dest_len<=3) {
+				if(ret_is_allocated)
+					free(ret);
+				return 0;
+			}
+			dest[0] = '%';
+			dest[1] = hexchar(*src >> 4);
+			dest[2] = hexchar(*src & 0x0f);
+			dest+=3;
+			dest_len-=3;
+		} else {
+			*(dest++)=*src;
+			dest_len--;
 		}
 	}
 	/* check for errors - src was not fully consumed */
@@ -159,7 +102,7 @@ char *uri_escape(char *dest, size_t dest_len, const char *src, int src_len) {
 		return 0;
 	}
 	assert(dest_len>=1);
-	*dest=0;
+	*dest='\0';
 
 	return ret;
 }
@@ -173,14 +116,11 @@ char *uri_escape(char *dest, size_t dest_len, const char *src, int src_len) {
  */
 char *uri_unescape(char *dest, size_t dest_len, const char *src, int src_len)
 {
-	assert(src!=NULL);
-	char *ret;
-	int ret_is_allocated;
-	assert(src!=NULL);
+	assert(src!=nullptr);
 	if(src_len<0) {
-		src_len=strlen((const char *)src);
+		src_len=strlen(src);
 	}
-	ret_is_allocated=!dest;
+	bool ret_is_allocated=!dest;
 	if(ret_is_allocated) {
 		dest_len=src_len+1; /* TODO: calculate the exact needed size? */
 		dest=(char*)malloc(dest_len);
@@ -188,7 +128,7 @@ char *uri_unescape(char *dest, size_t dest_len, const char *src, int src_len)
 			return 0; /* allocation failure */
 		}
 	}
-	ret=dest;
+	char* ret=dest;
 	for(;dest_len>1 && src_len>0;dest_len--,dest++) {
 		if(*src=='%' && src_len>=3 && ishex(src+1)) {
 			*dest=(char)unhex(src+1);
@@ -219,16 +159,21 @@ char *uri_unescape(char *dest, size_t dest_len, const char *src, int src_len)
 /* calculates the required length for html_escape */
 unsigned html_escape_len(const char *s, size_t len) {
 	unsigned ret;
-	for(ret=0;len && *s;len--,s++) {
-		switch(*s) {
-			case '<': ret+=4; break; /* &lt; */
-			case '>': ret+=4; break; /* &gt; */
-			case '&': ret+=5; break; /* &amp; */
-			case '"': ret+=6; break; /* &quot; */
-			case '\'': ret+=6; break; /* &apos; */
-			default:
-				ret++;
-		}
+	for(ret=0;len && *s;len--, s++) {
+		char c = *s;
+
+		if(c == '<')
+			ret+=4;  /* &lt; */
+		else if(c == '>')
+			ret+=4;  /* &gt; */
+		else if(c == '&')
+			ret+=5;  /* &amp; */
+		else if(c == '"')
+			ret+=6;  /* &quot; */
+		else if(c == '\'')
+			ret += 6; /* &apos; */
+		else
+			ret++;
 	}
 	return ret;
 }
@@ -237,28 +182,47 @@ unsigned html_escape_len(const char *s, size_t len) {
  * BUG: silently drops entities if there is no room
  */
 void html_escape(char *dest, size_t len, const char *s) {
-	unsigned i;
-
-	for(i=0;i<len && *s;s++) {
-		switch(*s) {
-			case '<':
-				i+=safe_append(dest+i,len-i, "&lt;");
-				break;
-			case '>':
-				i+=safe_append(dest+i,len-i, "&gt;");
-				break;
-			case '&':
-				i+=safe_append(dest+i,len-i, "&amp;");
-				break;
-			case '"':
-				i+=safe_append(dest+i,len-i, "&quot;");
-				break;
-			case '\'':
-				i+=safe_append(dest+i,len-i, "&apos;");
-				break;
-			default:
-				dest[i++]=*s;
-		}
+	unsigned i=0;
+	for(;i<len && *s;s++) {
+		char c = *s;
+		if (c == '<')
+			i += safe_append(dest+i,len-i, "&lt;");
+		else if (c == '>')
+			i += safe_append(dest+i,len-i, "&gt;");
+		else if (c == '&')
+			i += safe_append(dest+i,len-i, "&amp;");
+		else if (c == '"')
+			i += safe_append(dest+i,len-i, "&quot;");
+		else if (c == '\'')
+			i += safe_append(dest+i,len-i, "&apos;");
+		else
+			dest[i++]=*s;
 	}
-	dest[i]=0;
+	dest[i]='\0';
 }
+
+
+
+
+String uri_escape(const char *src, int src_len)
+{
+	char* p = uri_escape(nullptr, 0, src, src_len);
+	String s(p);
+	if (p)
+		free(p);
+	return s;
+}
+
+int uri_unescape_inplace(String& s)
+{
+	// If string is invalid, ensure result remains invalid
+	if (!s)
+		return 0;
+
+	char* p = s.begin();
+	uri_unescape(p, s.length(), p, s.length());
+	s.setLength(strlen(p));
+	return s.length();
+}
+
+

--- a/Sming/Services/WebHelpers/escape.h
+++ b/Sming/Services/WebHelpers/escape.h
@@ -1,11 +1,8 @@
 #ifndef ESCAPE_H
 #define ESCAPE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include <user_config.h>
+#include "WString.h"
 
 unsigned uri_escape_len(const char *s, size_t len);
 char *uri_escape(char *dest, size_t dest_len, const char *src, int src_len);
@@ -13,8 +10,34 @@ char *uri_unescape(char *dest, size_t dest_len, const char *src, int src_len);
 unsigned html_escape_len(const char *s, size_t len);
 void html_escape(char *dest, size_t len, const char *s);
 
-#ifdef __cplusplus
+/** @brief escape the given URI string
+ *  @param src
+ *  @param src_len
+ *  @retval String the escaped string
+ *  @note escaping may increase text size (but not always)
+ */
+String uri_escape(const char *src, int src_len);
+
+static inline String uri_escape(const String& src)
+{
+	return src ? uri_escape(src.c_str(), src.length()) : src;
 }
-#endif
+
+
+/** @brief replace the given uri by its unescaped version
+ *  @retval int length of result
+ *  @note unescaped string is never longer than escaped version
+ */
+int uri_unescape_inplace(String& s);
+
+/** @brief return the unescaped version of a string
+ *  @retval String unescaped string
+ */
+static inline String uri_unescape(const String& s)
+{
+	String ret = s;
+	uri_unescape_inplace(ret);
+	return ret;
+}
 
 #endif

--- a/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.cpp
@@ -9,32 +9,20 @@
  ****/
 
 #include "UrlencodedOutputStream.h"
+#include "../Services/WebHelpers/escape.h"
 
-#include "../../../Services/WebHelpers/escape.h"
+/*
+ * @todo Revise this so stream produces encoded output line-by-line, rather than all at once.
+ */
 
 UrlencodedOutputStream::UrlencodedOutputStream(const HttpParams& params)
 {
-	int maxLength = 0;
-	for(int i = 0; i < params.count(); i++) {
-		int kLength = params.keyAt(i).length();
-		int vLength = params.valueAt(i).length();
-		if(maxLength < vLength || maxLength < kLength) {
-			maxLength = (kLength < vLength ? vLength : kLength);
-		}
-	}
+	for(unsigned i = 0; i < params.count(); i++) {
+		if(i > 0)
+			stream.write('&');
 
-	char buffer[maxLength * 4 + 1];
-	for(int i = 0, max = params.count(); i < max; i++) {
-		String key = params.keyAt(i);
-		String value = params.valueAt(i);
-
-		char* temp = uri_escape(buffer, maxLength + 1, value.c_str(), value.length());
-		String write = params.keyAt(i) + "=" + String(temp);
-		if(i + 1 != max) {
-			write += "&";
-		}
-		if(stream.write((uint8_t*)write.c_str(), write.length()) != write.length()) {
-			break;
-		}
+		stream.print(uri_escape(params.keyAt(i)));
+		stream.print('=');
+		stream.print(uri_escape(params.valueAt(i)));
 	}
 }

--- a/Sming/SmingCore/Network/Http/HttpBodyParser.h
+++ b/Sming/SmingCore/Network/Http/HttpBodyParser.h
@@ -16,17 +16,17 @@
 #include "HttpCommon.h"
 #include "HttpRequest.h"
 
+/** @brief special length values passed to parse functions */
+#define PARSE_DATASTART -1
+#define PARSE_DATAEND -2
+
 typedef Delegate<void(HttpRequest&, const char* at, int length)> HttpBodyParserDelegate;
 typedef HashMap<String, HttpBodyParserDelegate> BodyParsers;
 
 typedef struct {
 	char searchChar = '=';
-	String postName = "";
+	String postName;
 } FormUrlParserState;
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * @brief Parses application/x-www-form-urlencoded body data
@@ -48,9 +48,5 @@ void formUrlParser(HttpRequest& request, const char* at, int length);
  * 				-2 - end of incoming data
  */
 void bodyToStringParser(HttpRequest& request, const char* at, int length);
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* _SMING_CORE_HTTP_BODY_PARSER_H_ */

--- a/Sming/SmingCore/Network/Http/HttpCommon.cpp
+++ b/Sming/SmingCore/Network/Http/HttpCommon.cpp
@@ -1,0 +1,69 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * @author: 2018 - Mikee47 <mike@sillyhouse.net>
+ *
+ * 	httpGetErrnoName() and httpGetStatusText() functions added
+ *
+ ****/
+
+#include "HttpCommon.h"
+
+// Define flash strings and lookup table for HTTP error names
+#define XX(_n, _s) static DEFINE_FSTR(__hpename_##_n, "HPE_" #_n);
+HTTP_ERRNO_MAP(XX)
+#undef XX
+
+static const FlashString* const __hpenames[] PROGMEM = {
+#define XX(_n, _s) FSTR_PTR(__hpename_##_n),
+	HTTP_ERRNO_MAP(XX)
+#undef XX
+};
+
+String httpGetErrnoName(enum http_errno err)
+{
+	if(err > HPE_UNKNOWN)
+		return F("HPE_#") + String(err);
+
+	return *__hpenames[err];
+}
+
+// Define flash strings and lookup table for HTTP error descriptions
+#define XX(_n, _s) static DEFINE_FSTR(__hpedesc_##_n, _s);
+HTTP_ERRNO_MAP(XX)
+#undef XX
+
+static const FlashString* const __hpedescriptions[] PROGMEM = {
+#define XX(_n, _s) FSTR_PTR(__hpedesc_##_n),
+	HTTP_ERRNO_MAP(XX)
+#undef XX
+};
+
+String httpGetErrnoDescription(enum http_errno err)
+{
+	if(err > HPE_UNKNOWN)
+		return F("HPE_#") + String(err);
+
+	return *__hpedescriptions[err];
+}
+
+// Define flash strings for HTTP status codes
+#define XX(_num, _name, _string) static DEFINE_FSTR(__hpstext##_num, #_string);
+HTTP_STATUS_MAP(XX)
+#undef XX
+
+String httpGetStatusText(enum http_status code)
+{
+	switch(code) {
+#define XX(_num, _name, _string)                                                                                       \
+	case _num:                                                                                                         \
+		return __hpstext##_num;
+		HTTP_STATUS_MAP(XX)
+#undef XX
+	default:
+		return F("<unknown_") + String(code) + '>';
+	}
+}

--- a/Sming/SmingCore/Network/Http/HttpCommon.h
+++ b/Sming/SmingCore/Network/Http/HttpCommon.h
@@ -44,4 +44,36 @@ enum HttpConnectionState {
 	eHCS_Sent
 };
 
+/**
+ * @brief Return a string name of the given error
+ * @param err
+ * @retval String
+ * @note This replaces the one in http_parser module which uses a load of RAM
+ */
+String httpGetErrnoName(enum http_errno err);
+
+/**
+ * @brief Return a descriptive string for the given error
+ * @param err
+ * @retval String
+ */
+String httpGetErrnoDescription(enum http_errno err);
+
+/**
+ * @brief Return a descriptive string for an HTTP status code
+ * @param code
+ * @retval String
+ */
+String httpGetStatusText(enum http_status code);
+
+/**
+ * @brief Return a descriptive string for an HTTP status code
+ * @param code
+ * @retval String
+ */
+static inline String httpGetStatusText(unsigned code)
+{
+	return httpGetStatusText((enum http_status)code);
+}
+
 #endif /* _SMING_CORE_HTTP_COMMON_H_ */

--- a/Sming/SmingCore/Network/Http/HttpConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpConnection.cpp
@@ -563,7 +563,7 @@ err_t HttpConnection::onReceive(pbuf* buf)
 		parsedBytes += http_parser_execute(&parser, &parserSettings, (char*)cur->payload, cur->len);
 		if(HTTP_PARSER_ERRNO(&parser) != HPE_OK) {
 			// we ran into trouble - abort the connection
-			debug_e("HTTP parser error: %s", http_errno_name(HTTP_PARSER_ERRNO(&parser)));
+			debug_e("HTTP parser error: %s", httpGetErrnoName(HTTP_PARSER_ERRNO(&parser)).c_str());
 			cleanup();
 			TcpConnection::onReceive(NULL);
 			return ERR_ABRT;

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.h
@@ -53,10 +53,8 @@ public:
 protected:
 	virtual err_t onReceive(pbuf* buf);
 	virtual void onReadyToSendData(TcpConnectionEvent sourceEvent);
-	virtual void sendError(const char* message = NULL, enum http_status code = HTTP_STATUS_BAD_REQUEST);
+	virtual void sendError(const String& message = nullptr, enum http_status code = HTTP_STATUS_BAD_REQUEST);
 	virtual void onError(err_t err);
-
-	const char* getStatus(enum http_status s);
 
 private:
 	static int staticOnMessageBegin(http_parser* parser);

--- a/Sming/system/include/stringutil.h
+++ b/Sming/system/include/stringutil.h
@@ -44,6 +44,22 @@ static inline signed char hexchar(unsigned char c)
 		return '\0';
 }
 
+static inline signed char unhex(char c)
+{
+	if(c >= '0' && c <= '9')
+		return c - '0';
+	else if(c >= 'a' && c <= 'f')
+		return 10 + c - 'a';
+	else if(c >= 'A' && c <= 'F')
+		return 10 + c - 'A';
+	else
+		return -1;
+}
+
+#ifndef ARRAY_SIZE
+#define ARRAY_SIZE(a) (sizeof(a) / sizeof((a)[0]))
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/third-party/.patches/http-parser.patch
+++ b/Sming/third-party/.patches/http-parser.patch
@@ -133,7 +133,7 @@ index 678f555..0000000
 -  }
 -}
 diff --git a/http_parser.c b/http_parser.c
-index 5b5657b..e7a2b3d 100644
+index 5b5657b..b7541a5 100644
 --- a/http_parser.c
 +++ b/http_parser.c
 @@ -19,12 +19,22 @@
@@ -153,7 +153,7 @@ index 5b5657b..e7a2b3d 100644
 +    #include <stdarg.h>
 +    #include "m_printf.h"
 +    #undef assert
-+    #define assert(condition) if (!(condition)) m_printf("ASSERT: %s %d", __FUNCTION__, __LINE__)
++    #define assert(condition) if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__)
 +#else
 +    #include <assert.h>
 +#endif
@@ -166,20 +166,32 @@ index 5b5657b..e7a2b3d 100644
   *                    | "{" | "}" | SP | HT
   */
 -static const char tokens[256] = {
-+static const char tokens[256] PROGMEM_L32 = {
++static const char __flash_tokens[256] PROGMEM = {
  /*   0 nul    1 soh    2 stx    3 etx    4 eot    5 enq    6 ack    7 bel  */
          0,       0,       0,       0,       0,       0,       0,       0,
  /*   8 bs     9 ht    10 nl    11 vt    12 np    13 cr    14 so    15 si   */
-@@ -217,7 +227,7 @@ static const char tokens[256] = {
+@@ -217,6 +227,12 @@ static const char tokens[256] = {
         'x',     'y',     'z',      0,      '|',      0,      '~',       0 };
  
  
--static const int8_t unhex[256] =
-+static const int8_t unhex[256] PROGMEM_L32 =
++static inline char get_token(char c)
++{
++	return (char)pgm_read_byte(&__flash_tokens[(uint8_t)c]);
++}
++
++/*
+ static const int8_t unhex[256] =
    {-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1
    ,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1
+@@ -227,6 +243,7 @@ static const int8_t unhex[256] =
+   ,-1,10,11,12,13,14,15,-1,-1,-1,-1,-1,-1,-1,-1,-1
    ,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1,-1
-@@ -236,7 +246,7 @@ static const int8_t unhex[256] =
+   };
++*/
+ 
+ 
+ #if HTTP_PARSER_STRICT
+@@ -236,7 +253,7 @@ static const int8_t unhex[256] =
  #endif
  
  
@@ -188,6 +200,74 @@ index 5b5657b..e7a2b3d 100644
  /*   0 nul    1 soh    2 stx    3 etx    4 eot    5 enq    6 ack    7 bel  */
          0    |   0    |   0    |   0    |   0    |   0    |   0    |   0,
  /*   8 bs     9 ht    10 nl    11 vt    12 np    13 cr    14 so    15 si   */
+@@ -417,14 +434,14 @@ enum http_host_state
+   (c) == ';' || (c) == ':' || (c) == '&' || (c) == '=' || (c) == '+' || \
+   (c) == '$' || (c) == ',')
+ 
+-#define STRICT_TOKEN(c)     (tokens[(unsigned char)c])
++#define STRICT_TOKEN(c)     get_token(c)
+ 
+ #if HTTP_PARSER_STRICT
+-#define TOKEN(c)            (tokens[(unsigned char)c])
++#define TOKEN(c)            get_token(c)
+ #define IS_URL_CHAR(c)      (BIT_AT(normal_url_char, (unsigned char)c))
+ #define IS_HOST_CHAR(c)     (IS_ALPHANUM(c) || (c) == '.' || (c) == '-')
+ #else
+-#define TOKEN(c)            ((c == ' ') ? ' ' : tokens[(unsigned char)c])
++#define TOKEN(c)            ((c == ' ') ? ' ' : get_token(c)
+ #define IS_URL_CHAR(c)                                                         \
+   (BIT_AT(normal_url_char, (unsigned char)c) || ((c) & 0x80))
+ #define IS_HOST_CHAR(c)                                                        \
+@@ -457,6 +474,7 @@ do {                                                                 \
+ 
+ 
+ /* Map errno values to strings for human-readable output */
++/*
+ #define HTTP_STRERROR_GEN(n, s) { "HPE_" #n, s },
+ static struct {
+   const char *name;
+@@ -465,6 +483,7 @@ static struct {
+   HTTP_ERRNO_MAP(HTTP_STRERROR_GEN)
+ };
+ #undef HTTP_STRERROR_GEN
++*/
+ 
+ int http_message_needs_eof(const http_parser *parser);
+ 
+@@ -1874,7 +1893,7 @@ reexecute:
+         assert(parser->nread == 1);
+         assert(parser->flags & F_CHUNKED);
+ 
+-        unhex_val = unhex[(unsigned char)ch];
++        unhex_val = unhex(ch);
+         if (UNLIKELY(unhex_val == -1)) {
+           SET_ERRNO(HPE_INVALID_CHUNK_SIZE);
+           goto error;
+@@ -1896,7 +1915,7 @@ reexecute:
+           break;
+         }
+ 
+-        unhex_val = unhex[(unsigned char)ch];
++        unhex_val = unhex(ch);
+ 
+         if (unhex_val == -1) {
+           if (ch == ';' || ch == ' ') {
+@@ -2096,6 +2115,7 @@ http_parser_settings_init(http_parser_settings *settings)
+   memset(settings, 0, sizeof(*settings));
+ }
+ 
++/*
+ const char *
+ http_errno_name(enum http_errno err) {
+   assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
+@@ -2107,6 +2127,7 @@ http_errno_description(enum http_errno err) {
+   assert(((size_t) err) < ARRAY_SIZE(http_strerror_tab));
+   return http_strerror_tab[err].description;
+ }
++*/
+ 
+ static enum http_host_state
+ http_parse_host_char(enum http_host_state s, const char ch) {
 diff --git a/test.c b/test.c
 deleted file mode 100644
 index bc4e664..0000000


### PR DESCRIPTION
http-parser - patch update
* place tokens[] into flash memory and use get_token() function instead - doesn't rely on mforce32 compiler support to save RAM
* Use unhex() function in stringutils.h, comment out unhex[] array
* Comment-out http_errno_name() - replaced with httpGetErrnoName() defined in HttpCommon.cpp. Note the replacement returns a String, not a const char*
* Replace m_printf() with SYSTEM_ERROR()

WebHelpers/escape
* Use hexchar() function instead of static array - saves a little RAM but also safer and avoids code duplication, at the expense of a little speed
* Use unhex() function defined in stringutil.h - also used by http-parser
* Add must_escape() function to remove duplication of code
* Add uri_escape() and uri_unescape() methods to work with Strings, simplifying user code and taking care of buffer allocations

HttpBodyParser
* Replace magic numbers -1 and -2 with definitions
* Simplify and eliminate String copy operations using uri_unescape_inplace() and revised HashMap to modify string content in-situ

UrlEncodedOutputStream
* Simplify

HttpCommon
* Add httpGetErrnoName(), httpGetErrnoDescription() and httpGetStatusText() functions - saves RAM by storing text strings in flash

HttpServerConnection
* getStatus() method removed, superseded by httpGetStatusText() function. The _message_ parameter is now a const String&, instead of const char*. As the default value is nullptr, if () statement works as expected.