### PR TITLE
Move ContentType text into flash and revise functions

### DIFF
--- a/Sming/SmingCore/Network/Http/HttpResponse.cpp
+++ b/Sming/SmingCore/Network/Http/HttpResponse.cpp
@@ -101,8 +101,8 @@ bool HttpResponse::sendFile(String fileName, bool allowGzipFileCheck /* = true*/
 	}
 
 	if(!hasHeader("Content-Type")) {
-		const char* mime = ContentType::fromFullFileName(fileName);
-		if(mime != NULL)
+		String mime = ContentType::fromFullFileName(fileName);
+		if(mime)
 			setContentType(mime);
 	}
 
@@ -126,8 +126,8 @@ bool HttpResponse::sendTemplate(TemplateFileStream* newTemplateInstance)
 	}
 
 	if(!hasHeader("Content-Type")) {
-		const char* mime = ContentType::fromFullFileName(newTemplateInstance->fileName());
-		if(mime != NULL)
+		String mime = ContentType::fromFullFileName(newTemplateInstance->fileName());
+		if(mime)
 			setContentType(mime);
 	}
 

--- a/Sming/SmingCore/Network/WebConstants.cpp
+++ b/Sming/SmingCore/Network/WebConstants.cpp
@@ -26,7 +26,7 @@ static FSTR_TABLE(mimeStrings) = {
 MIME_TYPE_MAP(XX)
 #undef XX
 
-static FSTR_TABLE(extStrings) = {
+static FSTR_TABLE(extensionStrings) = {
 #define XX(_name, _ext, _mime) FSTR_PTR(extstr_##_name),
 	MIME_TYPE_MAP(XX)
 #undef XX
@@ -38,8 +38,8 @@ String fromFileExtension(const char* extension)
 	if(strcasecmp(extension, _F("htm")) == 0)
 		return mimestr_HTML;
 
-	for(unsigned i = 0; i < ARRAY_SIZE(extStrings); ++i) {
-		if(*extStrings[i] == extension)
+	for(unsigned i = 0; i < ARRAY_SIZE(extensionStrings); ++i) {
+		if(*extensionStrings[i] == extension)
 			return *mimeStrings[i];
 	}
 
@@ -60,9 +60,9 @@ String fromFullFileName(const char* fileName)
 	if(!fileName)
 		return nullptr;
 
-	const char* pExt = strrchr(fileName, '.');
+	const char* extension = strrchr(fileName, '.');
 
-	return pExt ? fromFileExtension(pExt + 1) : nullptr;
+	return extension ? fromFileExtension(extension + 1) : nullptr;
 }
 
 }; // namespace ContentType

--- a/Sming/SmingCore/Network/WebConstants.cpp
+++ b/Sming/SmingCore/Network/WebConstants.cpp
@@ -1,0 +1,68 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ ****/
+
+#include "WebConstants.h"
+#include "FakePgmSpace.h"
+
+namespace ContentType
+{
+// MIME type strings
+#define XX(_name, _ext, _mime) static DEFINE_FSTR(mimestr_##_name, _mime);
+MIME_TYPE_MAP(XX)
+#undef XX
+
+static FSTR_TABLE(mimeStrings) = {
+#define XX(_name, _ext, _mime) FSTR_PTR(mimestr_##_name),
+	MIME_TYPE_MAP(XX)
+#undef XX
+};
+
+// File extensions
+#define XX(_name, _ext, _mime) static DEFINE_FSTR(extstr_##_name, _ext);
+MIME_TYPE_MAP(XX)
+#undef XX
+
+static FSTR_TABLE(extStrings) = {
+#define XX(_name, _ext, _mime) FSTR_PTR(extstr_##_name),
+	MIME_TYPE_MAP(XX)
+#undef XX
+};
+
+String fromFileExtension(const char* extension)
+{
+	// We accept 'htm' or 'html', but the latter is preferred
+	if(strcasecmp(extension, _F("htm")) == 0)
+		return mimestr_HTML;
+
+	for(unsigned i = 0; i < ARRAY_SIZE(extStrings); ++i) {
+		if(*extStrings[i] == extension)
+			return *mimeStrings[i];
+	}
+
+	// Type undefined - if (String) will return false
+	return nullptr;
+}
+
+String toString(enum MimeType m)
+{
+	if(m >= ARRAY_SIZE(mimeStrings))
+		return nullptr;
+
+	return *mimeStrings[m];
+}
+
+String fromFullFileName(const char* fileName)
+{
+	if(!fileName)
+		return nullptr;
+
+	const char* pExt = strrchr(fileName, '.');
+
+	return pExt ? fromFileExtension(pExt + 1) : nullptr;
+}
+
+}; // namespace ContentType

--- a/Sming/SmingCore/Network/WebConstants.h
+++ b/Sming/SmingCore/Network/WebConstants.h
@@ -15,11 +15,17 @@
 #ifndef _SMING_CORE_NETWORK_WEBCONSTANTS_H_
 #define _SMING_CORE_NETWORK_WEBCONSTANTS_H_
 
+#include "WString.h"
+
+/** @brief Basic MIME types and file extensions
+ *  @note Each MIME type can have only one associated file extension. Where other extensions
+ *  @todo Consider using sz-strings for file extension to enable matching to alternative file extensions
+ */
 #define MIME_TYPE_MAP(XX)                                                                                              \
 	/* Type, extension start, Mime type */                                                                             \
                                                                                                                        \
 	/* Texts */                                                                                                        \
-	XX(HTML, "htm", "text/html")                                                                                       \
+	XX(HTML, "html", "text/html")                                                                                      \
 	XX(TEXT, "txt", "text/plain")                                                                                      \
 	XX(JS, "js", "text/javascript")                                                                                    \
 	XX(CSS, "css", "text/css")                                                                                         \
@@ -50,47 +56,43 @@ enum MimeType {
 
 namespace ContentType
 {
-static const char* fromFileExtension(const String extension)
+/** @brief Obtain content type string from file extension
+ *  @param extension excluding '.' separator (e.g. "htm", "json")
+ *  @retval String
+ */
+String fromFileExtension(const char* extension);
+
+/** @brief Obtain content type string from file extension
+ *  @param extension
+ *  @retval String
+ */
+static inline String fromFileExtension(const String& extension)
 {
-	String ext = extension;
-	ext.toLowerCase();
-
-#define XX(name, extensionStart, mime)                                                                                 \
-	if(ext.startsWith(extensionStart)) {                                                                               \
-		return mime;                                                                                                   \
-	}
-	MIME_TYPE_MAP(XX)
-#undef XX
-
-	// Unknown
-	return "<unknown>";
+	return fromFileExtension(extension.c_str());
 }
 
-static const char* toString(enum MimeType m)
-{
-#define XX(name, extensionStart, mime)                                                                                 \
-	if(MIME_##name == m) {                                                                                             \
-		return mime;                                                                                                   \
-	}
-	MIME_TYPE_MAP(XX)
-#undef XX
+/** @brief Get textual representation for a MIME type
+ *  @param m the MIME type
+ *  @retval String
+ */
+String toString(enum MimeType m);
 
-	// Unknown
-	return "<unknown>";
+/** @brief Obtain content type string from file name or path, with extension
+ *  @param fileName
+ *  @retval String
+ */
+String fromFullFileName(const char* fileName);
+
+/** @brief Obtain content type string from file name or path, with extension
+ *  @param fileName
+ *  @retval String
+ */
+static inline String fromFullFileName(const String& fileName)
+{
+	return fromFullFileName(fileName.c_str());
 }
 
-static const char* fromFullFileName(const String fileName)
-{
-	int p = fileName.lastIndexOf('.');
-	if(p != -1) {
-		String ext = fileName.substring(p + 1);
-		const char* mime = ContentType::fromFileExtension(ext);
-		return mime;
-	}
-
-	return NULL;
-}
-};
+}; // namespace ContentType
 
 /** @} */
 #endif /* _SMING_CORE_NETWORK_WEBCONSTANTS_H_ */


### PR DESCRIPTION
* fromFileExtension() and fromFullFileName() return String instead of const char*
* Code moved into new file, WebConstants.cpp
* Bugfix: File extension matching is now done on entire extension, not just the start; this caused a mis-interpretation of 'json' as 'js'.
* MIME_TYPE_MAP performs a 1:1 mapping between file extension and MIME type. For HTML files the extension has been changed to .html as this appears to be the generally preferred format. The alternative, .htm, is checked in the code when mapping to MIME type.
* toString() returns an invalid String so the caller can use if() to check for validity. The function previously returned "<unknown>", which is a rather strange string to be embedding in an HTML header.