### PR TITLE
WebSocketConnection: make getActiveWebSockets() static

### DIFF
--- a/Sming/SmingCore/Network/Http/Websocket/WebSocketConnection.h
+++ b/Sming/SmingCore/Network/Http/Websocket/WebSocketConnection.h
@@ -52,7 +52,7 @@ public:
 	// @deprecated
 	bool operator==(const WebSocketConnection& rhs) const;
 
-	WebSocketsList& getActiveWebSockets();
+	static WebSocketsList& getActiveWebSockets();
 	// @end deprecated
 
 	void setConnectionHandler(WebSocketDelegate handler);


### PR DESCRIPTION
IMHO getActiveWebSockets() should be declared static. This it allows it to be used with and without an object reference.

BTW: It is marked deprecated, what method should be used instead?
