### PR TITLE
Add method which should have been part of #1461 and #1463

### DIFF
--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -492,6 +492,13 @@ bool String::equalsIgnoreCase(const String &s2) const
   return equalsIgnoreCase(s2.buffer);
 }
 
+bool String::equalsIgnoreCase(const FlashString& fstr) const
+{
+  if (len != fstr.length()) return false;
+  LOAD_FSTR(buf, fstr);
+  return strcasecmp(buf, buffer) == 0;
+}
+
 bool String::startsWith(const String &prefix) const
 {
   if (len < prefix.len) return false;

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -288,6 +288,7 @@ class String
     bool operator >= (const String &rhs) const;
     bool equalsIgnoreCase(const char* cstr) const;
     bool equalsIgnoreCase(const String &s2) const;
+    bool equalsIgnoreCase(const FlashString& fstr) const;
     bool startsWith(const String &prefix) const;
     bool startsWith(const String &prefix, unsigned int offset) const;
     bool endsWith(const String &suffix) const;


### PR DESCRIPTION
* Comparison accomplished using stack, avoids allocating temporary String variable on heap