### PR TITLE
Implement global task queue

### DIFF
--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -194,7 +194,7 @@ void HardwareSerial::callbackHandler(uart_t* uart)
 							.uartNr = static_cast<uint8_t>(uart_nr)}};
 
 		if(m.HWSDelegate)
-			System.deferCallback(
+			System.queueCallback(
 				[](os_param_t param) {
 					SerialParam ser = {.param = param};
 					auto& m = memberData[ser.uartNr];
@@ -205,7 +205,7 @@ void HardwareSerial::callbackHandler(uart_t* uart)
 
 #if ENABLE_CMD_EXECUTOR
 		if(m.commandExecutor)
-			System.deferCallback(
+			System.queueCallback(
 				[](os_param_t param) {
 					SerialParam ser = {.param = param};
 					auto& m = memberData[ser.uartNr];

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -7,18 +7,16 @@
 
 // HardwareSerial based on Espressif Systems code
 
-#include "../SmingCore/HardwareSerial.h"
-#include "../Wiring/WiringFrameworkIncludes.h"
+#include "HardwareSerial.h"
 #include <cstdarg>
 
 #include "../SmingCore/Clock.h"
 #include "../SmingCore/Interrupts.h"
 
 HWSerialMemberData HardwareSerial::memberData[NUMBER_UARTS];
-os_event_t* HardwareSerial::serialQueue = nullptr;
 bool HardwareSerial::init = false;
 
-HardwareSerial::HardwareSerial(const int uartPort) : uartNr(uartPort), rxSize(256)
+HardwareSerial::HardwareSerial(const int uartPort) : uartNr(uartPort), rxSize(DEFAULT_RX_BUFFER_SIZE)
 {
 }
 
@@ -41,7 +39,7 @@ void HardwareSerial::end()
 
 	if(uart) {
 		uart_uninit(uart);
-		uart = NULL;
+		uart = nullptr;
 	} else if(!init) {
 		uart_detach(uartNr);
 		init = true;
@@ -84,12 +82,12 @@ void HardwareSerial::pins(uint8_t tx, uint8_t rx)
 
 bool HardwareSerial::isTxEnabled(void)
 {
-	return uart && uart_tx_enabled(uart);
+	return uart_tx_enabled(uart);
 }
 
 bool HardwareSerial::isRxEnabled(void)
 {
-	return uart && uart_rx_enabled(uart);
+	return uart_rx_enabled(uart);
 }
 
 int HardwareSerial::available()
@@ -103,9 +101,10 @@ int HardwareSerial::read()
 	return uart_read_char(uart);
 }
 
+// @todo This does not comply with spec. as it affects stream position; we cannot seek on the stream without some trouble
 int HardwareSerial::readMemoryBlock(char* buf, int max_len)
 {
-	if(uart != 0 && uart_rx_enabled(uart)) {
+	if(uart_rx_enabled(uart)) {
 		int size = 0;
 		char c;
 		for(int i = 0; i < max_len; i++) {
@@ -130,7 +129,7 @@ int HardwareSerial::peek()
 
 void HardwareSerial::flush()
 {
-	if(!uart || !uart_tx_enabled(uart)) {
+	if(!uart_tx_enabled(uart)) {
 		return;
 	}
 
@@ -163,53 +162,71 @@ void HardwareSerial::systemDebugOutput(bool enabled)
 
 void HardwareSerial::callbackHandler(uart_t* uart)
 {
-	if(uart == NULL) {
+	if(uart == nullptr || uart->uart_nr < 0) {
 		return;
 	}
+
+	int uart_nr = uart->uart_nr;
+	auto& m = memberData[uart_nr];
 
 	uint8_t lastPos = uart->rx_buffer->wpos;
 	if(!lastPos) {
 		lastPos = uart->rx_buffer->size;
 	}
 	uint8_t receivedChar = uart->rx_buffer->buffer[lastPos - 1];
-	if((memberData[uart->uart_nr].HWSDelegate)
+	if((m.HWSDelegate)
 #if ENABLE_CMD_EXECUTOR
-	   || (memberData[uart->uart_nr].commandExecutor)
+	   || (m.commandExecutor)
 #endif
 	) {
-		uint32 serialQueueParameter;
-		uint16 cc = uart_rx_available(uart);
-		serialQueueParameter = (cc * 256) + receivedChar; // can be done by bitlogic, avoid casting to ETSParam
-		serialQueueParameter +=
-			(uart->uart_nr << 25); // the left most byte contains the uart_nr. Up to 256 uarts are supported
+		// Pack parameters for callback into a single word
+		union __packed SerialParam {
+			struct {
+				uint16_t charCount;
+				uint8_t receivedChar;
+				uint8_t uartNr;
+			};
+			os_param_t param;
+		};
 
-		if(memberData[uart->uart_nr].HWSDelegate) {
-			system_os_post(USER_TASK_PRIO_0, SERIAL_SIGNAL_DELEGATE, serialQueueParameter);
-		}
+		SerialParam ser = {{.charCount = static_cast<uint16_t>(uart_rx_available(uart)),
+							.receivedChar = receivedChar,
+							.uartNr = static_cast<uint8_t>(uart_nr)}};
+
+		if(m.HWSDelegate)
+			System.deferCallback(
+				[](os_param_t param) {
+					SerialParam ser = {.param = param};
+					auto& m = memberData[ser.uartNr];
+					if(m.HWSDelegate)
+						m.HWSDelegate(Serial, ser.receivedChar, ser.charCount);
+				},
+				ser.param);
+
 #if ENABLE_CMD_EXECUTOR
-		if(memberData[uart->uart_nr].commandExecutor) {
-			system_os_post(USER_TASK_PRIO_0, SERIAL_SIGNAL_COMMAND, serialQueueParameter);
-		}
+		if(m.commandExecutor)
+			System.deferCallback(
+				[](os_param_t param) {
+					SerialParam ser = {.param = param};
+					auto& m = memberData[ser.uartNr];
+					if(m.commandExecutor)
+						m.commandExecutor->executorReceive(ser.receivedChar);
+				},
+				ser.param);
+
 #endif
 	}
 }
 
 bool HardwareSerial::setCallback(StreamDataReceivedDelegate reqDelegate)
 {
-	if(!uart || !uart_rx_enabled(uart)) {
+	if(!uart_rx_enabled(uart)) {
 		return false;
 	}
 
 	uart->callback = callbackHandler;
 
 	memberData[uartNr].HWSDelegate = reqDelegate;
-
-	// Start Serial task
-	if(!serialQueue) {
-		serialQueue = (os_event_t*)malloc(sizeof(os_event_t) * SERIAL_QUEUE_LEN);
-		system_os_task(delegateTask, USER_TASK_PRIO_0, serialQueue, SERIAL_QUEUE_LEN);
-	}
-
 	return true;
 }
 
@@ -217,7 +234,7 @@ void HardwareSerial::resetCallback()
 {
 	memberData[uartNr].HWSDelegate = nullptr;
 
-	uart->callback = 0;
+	uart->callback = nullptr;
 }
 
 void HardwareSerial::commandProcessing(bool reqEnable)
@@ -234,34 +251,6 @@ void HardwareSerial::commandProcessing(bool reqEnable)
 #endif
 }
 
-void HardwareSerial::delegateTask(os_event_t* inputEvent)
-{
-	int uartNr = inputEvent->par >> 25;				// the uart_nr is in the last byte
-	inputEvent->par = inputEvent->par & 0x00FFFFFF; // clear the last byte
-	uint8 rcvChar = inputEvent->par % 256;			// can be done by bitlogic, avoid casting from ETSParam
-	uint16 charCount = inputEvent->par / 256;
-
-	switch(inputEvent->sig) {
-	case SERIAL_SIGNAL_DELEGATE:
-
-		if(memberData[uartNr].HWSDelegate) {
-			memberData[uartNr].HWSDelegate(Serial, rcvChar, charCount);
-		}
-		break;
-
-	case SERIAL_SIGNAL_COMMAND:
-#if ENABLE_CMD_EXECUTOR
-		if(memberData[uartNr].commandExecutor) {
-			memberData[uartNr].commandExecutor->executorReceive(rcvChar);
-		}
-#endif
-		break;
-
-	default:
-		break;
-	}
-}
-
 int HardwareSerial::baudRate(void)
 {
 	// Null pointer on _uart is checked by SDK
@@ -270,7 +259,7 @@ int HardwareSerial::baudRate(void)
 
 HardwareSerial::operator bool() const
 {
-	return uart != 0;
+	return uart != nullptr;
 }
 
 size_t HardwareSerial::indexOf(char c)

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -10,8 +10,10 @@
 #include "HardwareSerial.h"
 #include <cstdarg>
 
-#include "../SmingCore/Clock.h"
-#include "../SmingCore/Interrupts.h"
+#include "System.h"
+#include "Interrupts.h"
+
+#include "m_printf.h"
 
 HWSerialMemberData HardwareSerial::memberData[NUMBER_UARTS];
 bool HardwareSerial::init = false;

--- a/Sming/SmingCore/Interrupts.cpp
+++ b/Sming/SmingCore/Interrupts.cpp
@@ -5,13 +5,20 @@
  * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#include "../SmingCore/Interrupts.h"
-#include "../SmingCore/Digital.h"
-#include "../Wiring/WiringFrameworkIncludes.h"
+#include "Interrupts.h"
+#include "Digital.h"
+#include "WiringFrameworkIncludes.h"
+#include "System.h"
 
-InterruptCallback _gpioInterruptsList[16] = {0};
-Delegate<void()> _delegateFunctionList[16];
-bool _gpioInterruptsInitialied = false;
+static InterruptCallback _gpioInterruptsList[16] = {0};
+static InterruptDelegate _delegateFunctionList[16];
+static bool _gpioInterruptsInitialied = false;
+
+/** @brief  Interrupt handler
+ *  @param  intr_mask Interrupt mask
+ *  @param  arg pointer to array of arguments
+ */
+static void interruptHandler(uint32 intr_mask, void* arg);
 
 void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode)
 {
@@ -38,7 +45,7 @@ void attachInterrupt(uint8_t pin, Delegate<void()> delegateFunction, GPIO_INT_TY
 {
 	if(pin >= 16)
 		return; // WTF o_O
-	_gpioInterruptsList[pin] = NULL;
+	_gpioInterruptsList[pin] = nullptr;
 	_delegateFunctionList[pin] = delegateFunction;
 	attachInterruptHandler(pin, mode);
 }
@@ -48,7 +55,7 @@ void attachInterruptHandler(uint8_t pin, GPIO_INT_TYPE mode)
 	ETS_GPIO_INTR_DISABLE();
 
 	if(!_gpioInterruptsInitialied) {
-		ETS_GPIO_INTR_ATTACH((ets_isr_t)interruptHandler, NULL); // Register interrupt handler
+		ETS_GPIO_INTR_ATTACH((ets_isr_t)interruptHandler, nullptr); // Register interrupt handler
 		_gpioInterruptsInitialied = true;
 	}
 
@@ -61,7 +68,7 @@ void attachInterruptHandler(uint8_t pin, GPIO_INT_TYPE mode)
 
 void detachInterrupt(uint8_t pin)
 {
-	_gpioInterruptsList[pin] = NULL;
+	_gpioInterruptsList[pin] = nullptr;
 	_delegateFunctionList[pin] = nullptr;
 	attachInterruptHandler(pin, GPIO_PIN_INTR_DISABLE);
 }
@@ -120,18 +127,27 @@ static void IRAM_ATTR interruptHandler(uint32 intr_mask, void* arg)
 	do {
 		gpio_status = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
 		processed = false;
-		for(uint8 i = 0; i < ESP_MAX_INTERRUPTS; i++, gpio_status << 1) {
-			if((gpio_status & BIT(i)) && (_gpioInterruptsList[i] || _delegateFunctionList[i])) {
-				//clear interrupt status
-				GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status & BIT(i));
-
-				if(_gpioInterruptsList[i])
-					_gpioInterruptsList[i]();
-				else if(_delegateFunctionList[i])
-					_delegateFunctionList[i]();
-
-				processed = true;
+		for(uint8 i = 0; i < ESP_MAX_INTERRUPTS; i++) {
+			if(!bitRead(gpio_status, i)) {
+				continue;
 			}
+
+			// clear interrupt status
+			GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status & _BV(i));
+
+			if(_gpioInterruptsList[i]) {
+				_gpioInterruptsList[i]();
+			} else if(_delegateFunctionList[i]) {
+				System.queueCallback(
+					[](uint32_t interruptNumber) {
+						auto& delegate = _delegateFunctionList[interruptNumber];
+						if(delegate)
+							delegate();
+					},
+					i);
+			}
+
+			processed = true;
 		}
 	} while(processed);
 }

--- a/Sming/SmingCore/Interrupts.cpp
+++ b/Sming/SmingCore/Interrupts.cpp
@@ -18,7 +18,38 @@ static bool _gpioInterruptsInitialied = false;
  *  @param  intr_mask Interrupt mask
  *  @param  arg pointer to array of arguments
  */
-static void interruptHandler(uint32 intr_mask, void* arg);
+static void IRAM_ATTR interruptHandler(uint32 intr_mask, void* arg)
+{
+	boolean processed;
+	uint32 gpio_status;
+
+	do {
+		gpio_status = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
+		processed = false;
+		for(uint8 i = 0; i < ESP_MAX_INTERRUPTS; i++) {
+			if(!bitRead(gpio_status, i)) {
+				continue;
+			}
+
+			// clear interrupt status
+			GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status & _BV(i));
+
+			if(_gpioInterruptsList[i]) {
+				_gpioInterruptsList[i]();
+			} else if(_delegateFunctionList[i]) {
+				System.queueCallback(
+					[](uint32_t interruptNumber) {
+						auto& delegate = _delegateFunctionList[interruptNumber];
+						if(delegate)
+							delegate();
+					},
+					i);
+			}
+
+			processed = true;
+		}
+	} while(processed);
+}
 
 void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode)
 {

--- a/Sming/SmingCore/Interrupts.cpp
+++ b/Sming/SmingCore/Interrupts.cpp
@@ -21,18 +21,18 @@ static bool gpioInterruptsInitialied = false;
 static void IRAM_ATTR interruptHandler(uint32 intr_mask, void* arg)
 {
 	boolean processed;
-	uint32 gpio_status;
+	uint32 gpioStatus;
 
 	do {
-		gpio_status = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
+		gpioStatus = GPIO_REG_READ(GPIO_STATUS_ADDRESS);
 		processed = false;
 		for(uint8 i = 0; i < ESP_MAX_INTERRUPTS; i++) {
-			if(!bitRead(gpio_status, i)) {
+			if(!bitRead(gpioStatus, i)) {
 				continue;
 			}
 
 			// clear interrupt status
-			GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpio_status & _BV(i));
+			GPIO_REG_WRITE(GPIO_STATUS_W1TC_ADDRESS, gpioStatus & _BV(i));
 
 			if(gpioInterruptsList[i]) {
 				gpioInterruptsList[i]();
@@ -57,7 +57,7 @@ void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode)
 	attachInterrupt(pin, callback, type);
 }
 
-void attachInterrupt(uint8_t pin, Delegate<void()> delegateFunction, uint8_t mode)
+void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, uint8_t mode)
 {
 	GPIO_INT_TYPE type = ConvertArduinoInterruptMode(mode);
 	attachInterrupt(pin, delegateFunction, type);
@@ -72,7 +72,7 @@ void attachInterrupt(uint8_t pin, InterruptCallback callback, GPIO_INT_TYPE mode
 	attachInterruptHandler(pin, mode);
 }
 
-void attachInterrupt(uint8_t pin, Delegate<void()> delegateFunction, GPIO_INT_TYPE mode)
+void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, GPIO_INT_TYPE mode)
 {
 	if(pin >= 16)
 		return; // WTF o_O

--- a/Sming/SmingCore/Interrupts.h
+++ b/Sming/SmingCore/Interrupts.h
@@ -12,20 +12,20 @@
 #ifndef _SMING_CORE_INTERRUPTS_H_
 #define _SMING_CORE_INTERRUPTS_H_
 
-#include "../Wiring/WiringFrameworkDependencies.h"
-#include "../SmingCore/Delegate.h"
+#include "WiringFrameworkDependencies.h"
+#include "Delegate.h"
 
 #define ESP_MAX_INTERRUPTS 16
 
 typedef void (*InterruptCallback)(void);
-extern InterruptCallback _gpioInterruptsList[ESP_MAX_INTERRUPTS];
-extern bool _gpioInterruptsInitialied;
+typedef Delegate<void()> InterruptDelegate;
 
 /** @brief  Attach a function to a GPIO interrupt
  *  @param  pin GPIO to configure
  *  @param  callback Function to call when interrupt occurs on GPIO
  *  @param  mode Arduino type interrupt mode
- *  @note   Traditional c-type callback function method
+ *  @note   Traditional c-type callback function method, MUST use IRAM_ATTR
+ *  Use this type of interrupt handler for timing-sensitive applications.
  */
 void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode);
 
@@ -33,7 +33,9 @@ void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode);
  *  @param  pin GPIO to configure
  *  @param  delegateFunction Function to call when interrupt occurs on GPIO
  *  @param  mode Arduino type interrupt mode
- *  @note   Delegate function method
+ *  @note   Delegate function method, can be a regular function, method, etc.
+ *  The delegate function is called via the system task queue so does not need any special consideration.
+ *  Note that this type of interrupt handler is not suitable for timing-sensitive applications.
  */
 void attachInterrupt(uint8_t pin, Delegate<void()> delegateFunction, uint8_t mode);
 
@@ -85,12 +87,6 @@ void interruptMode(uint8_t pin, GPIO_INT_TYPE type);
  *  @retval GPIO_INT_TYPE Sming interrupt mode type
  */
 GPIO_INT_TYPE ConvertArduinoInterruptMode(uint8_t mode);
-
-/** @brief  Interrupt handler
- *  @param  intr_mask Interrupt mask
- *  @param  arg pointer to array of arguments
- */
-static void interruptHandler(uint32 intr_mask, void* arg);
 
 /** @brief  Disable interrupts
  */

--- a/Sming/SmingCore/Platform/System.cpp
+++ b/Sming/SmingCore/Platform/System.cpp
@@ -25,7 +25,7 @@ void SystemClass::taskHandler(os_event_t* event)
 		// If we get interrupt during adjustment of the counter, do it again
 		uint8_t oldCount = taskCount;
 		--taskCount;
-		if (taskCount != oldCount - 1)
+		if(taskCount != oldCount - 1)
 			--taskCount;
 		callback(event->par);
 	}

--- a/Sming/SmingCore/Platform/System.cpp
+++ b/Sming/SmingCore/Platform/System.cpp
@@ -20,7 +20,7 @@ volatile uint8_t SystemClass::maxTaskCount;
  */
 void SystemClass::taskHandler(os_event_t* event)
 {
-	auto callback = reinterpret_cast<TaskCallback*>(event->sig);
+	auto callback = reinterpret_cast<TaskCallback>(event->sig);
 	if(callback) {
 		/*
 		 * @todo how to guarantee atomic operation?
@@ -31,8 +31,7 @@ void SystemClass::taskHandler(os_event_t* event)
 		 *
 		 */
 		--taskCount;
-		(*callback)(event->par);
-		delete callback;
+		callback(event->par);
 	}
 }
 
@@ -48,7 +47,7 @@ void SystemClass::initialize()
 	system_init_done_cb(staticReadyHandler);
 }
 
-bool SystemClass::queueCallback(TaskCallback callback, os_param_t param)
+bool SystemClass::queueCallback(TaskCallback callback, uint32_t param)
 {
 	if(callback == nullptr) {
 		return false;
@@ -58,7 +57,7 @@ bool SystemClass::queueCallback(TaskCallback callback, os_param_t param)
 		maxTaskCount = taskCount;
 	}
 
-	return system_os_post(USER_TASK_PRIO_1, reinterpret_cast<os_signal_t>(new TaskCallback(callback)), param);
+	return system_os_post(USER_TASK_PRIO_1, reinterpret_cast<os_signal_t>(callback), param);
 }
 
 void SystemClass::restart()

--- a/Sming/SmingCore/Platform/System.cpp
+++ b/Sming/SmingCore/Platform/System.cpp
@@ -22,7 +22,11 @@ void SystemClass::taskHandler(os_event_t* event)
 {
 	auto callback = reinterpret_cast<TaskCallback>(event->sig);
 	if(callback) {
+		// If we get interrupt during adjustment of the counter, do it again
+		uint8_t oldCount = taskCount;
 		--taskCount;
+		if (taskCount != oldCount - 1)
+			--taskCount;
 		callback(event->par);
 	}
 }

--- a/Sming/SmingCore/Platform/System.cpp
+++ b/Sming/SmingCore/Platform/System.cpp
@@ -22,15 +22,9 @@ void SystemClass::taskHandler(os_event_t* event)
 {
 	auto callback = reinterpret_cast<TaskCallback>(event->sig);
 	if(callback) {
-		/*
-		 * @todo how to guarantee atomic operation?
-		 *
-		 * I suspect atomics aren't available in the SDK library as linker fails with this:
-		 *
-		 * __atomic_fetch_sub(&taskCount, 1, __ATOMIC_RELAXED);
-		 *
-		 */
+		noInterrupts();
 		--taskCount;
+		interrupts();
 		callback(event->par);
 	}
 }

--- a/Sming/SmingCore/Platform/System.cpp
+++ b/Sming/SmingCore/Platform/System.cpp
@@ -22,9 +22,7 @@ void SystemClass::taskHandler(os_event_t* event)
 {
 	auto callback = reinterpret_cast<TaskCallback>(event->sig);
 	if(callback) {
-		noInterrupts();
 		--taskCount;
-		interrupts();
 		callback(event->par);
 	}
 }

--- a/Sming/SmingCore/Platform/System.h
+++ b/Sming/SmingCore/Platform/System.h
@@ -29,7 +29,7 @@
  * 	@note Callback code does not need to be in IRAM
  *  @todo Integrate delegation into callbacks
  */
-typedef std::function<void(os_param_t param)> TaskCallback;
+typedef void (*TaskCallback)(uint32_t param);
 
 /// @ingroup event_handlers
 typedef Delegate<void()> SystemReadyDelegate; ///< Handler function for system ready
@@ -130,8 +130,10 @@ public:
 	 * @retval bool false if callback could not be queued
 	 * @note It is important to check the return value to avoid memory leaks and other issues,
 	 * for example if memory is allocated and relies on the callback to free it again.
+	 * Note also that this method is typically called from interrupt context so must avoid things
+	 * like heap allocation, etc.
 	 */
-	static bool IRAM_ATTR queueCallback(TaskCallback callback, os_param_t param = 0);
+	static bool IRAM_ATTR queueCallback(TaskCallback callback, uint32_t param = 0);
 
 	/** @brief Get number of tasks currently on queue
 	 *  @retval unsigned

--- a/Sming/SmingCore/Platform/System.h
+++ b/Sming/SmingCore/Platform/System.h
@@ -29,7 +29,7 @@
  * 	@note Callback code does not need to be in IRAM
  *  @todo Integrate delegation into callbacks
  */
-typedef void (*task_callback_t)(os_param_t param);
+typedef std::function<void(os_param_t param)> TaskCallback;
 
 /// @ingroup event_handlers
 typedef Delegate<void()> SystemReadyDelegate; ///< Handler function for system ready
@@ -128,10 +128,7 @@ public:
 	 * @param callback The function to be called
 	 * @param param Parameter passed to the callback
 	*/
-	static __forceinline bool IRAM_ATTR deferCallback(task_callback_t callback, os_param_t param = 0)
-	{
-		return callback ? system_os_post(USER_TASK_PRIO_1, (os_signal_t)callback, param) : false;
-	}
+	static bool IRAM_ATTR queueCallback(TaskCallback callback, os_param_t param = 0);
 
 private:
 	static void staticReadyHandler();

--- a/Sming/SmingCore/Platform/System.h
+++ b/Sming/SmingCore/Platform/System.h
@@ -127,18 +127,42 @@ public:
 	 * @brief Queue a deferred callback.
 	 * @param callback The function to be called
 	 * @param param Parameter passed to the callback
-	*/
+	 * @retval bool false if callback could not be queued
+	 * @note It is important to check the return value to avoid memory leaks and other issues,
+	 * for example if memory is allocated and relies on the callback to free it again.
+	 */
 	static bool IRAM_ATTR queueCallback(TaskCallback callback, os_param_t param = 0);
+
+	/** @brief Get number of tasks currently on queue
+	 *  @retval unsigned
+	 */
+	static unsigned getTaskCount()
+	{
+		return taskCount;
+	}
+
+	/** @brief Get maximum number of tasks seen on queue at any one time
+	 *  @retval unsigned
+	 *  @note If return value is higher than maximum task queue TASK_QUEUE_LENGTH then
+	 *  the queue has overflowed at some point and tasks have been left un-executed.
+	 */
+	static unsigned getMaxTaskCount()
+	{
+		return maxTaskCount;
+	}
 
 private:
 	static void staticReadyHandler();
+	static void taskHandler(os_event_t* event);
 	void readyHandler();
 
 private:
 	Vector<SystemReadyDelegate> readyHandlers;
 	Vector<ISystemReadyHandler*> readyInterfaces;
 	SystemState state = eSS_None;
-	static os_event_t taskQueue[]; ///< OS task queue
+	static os_event_t taskQueue[];		  ///< OS task queue
+	static volatile uint8_t taskCount;	///< Number of tasks on queue
+	static volatile uint8_t maxTaskCount; ///< Profiling to establish appropriate queue size
 };
 
 /**	@brief	Global instance of system object

--- a/samples/Basic_Interrupts/app/application.cpp
+++ b/samples/Basic_Interrupts/app/application.cpp
@@ -1,20 +1,73 @@
 #include <user_config.h>
 #include <SmingCore/SmingCore.h>
 
-#define INT_PIN 0 // GPIO0
-#define say(a) (Serial.print(a))
+// Input pin for demonstrating a call to a low-level interrupt handler callback
+#define INT_PIN_A 0 // GPIO0
 
+// Input pin for demonstrating a call to an InterruptDelegate function
+#define INT_PIN_B 4  // GPIO4
+#define TOGGLE_PIN 5 // GPIO5
+
+#define say(a) (Serial.print(a))
+#define newline() (Serial.println())
+
+/** @brief Low-level interrupt handler
+ *  @note An interrupt handling callback must have the IRAM_ATTR attribute.
+ *  Interrupt processing code should be as short as possible.
+ *  You could perhaps set a flag, then check it in your main code (timers, etc) or read actual
+ *  pin state and save it to a global variable.
+ *  Avoid doing things like calling malloc(), new(), reading Flash memory.
+ *  If your application is not timing-critical, then use an InterruptDelegate callback instead.
+ */
 void IRAM_ATTR interruptHandler()
 {
-	// This is not very good idea - make actions in interrupt handler (it's just an example)
-	// Better set some flag and check it in main code (timers and etc) or read actual pins state and save it to variable
-	// Interrupt processing code should be as short as possible.
-	// flagInterruptOccurred = true;
+	// For this example, we just toggle the state of an output pin.
+	bool state = digitalRead(TOGGLE_PIN);
+	digitalWrite(TOGGLE_PIN, !state);
+}
 
+/** @brief Example of an InterruptDelegate function
+ *  @note Unlike interruptHandler() above, this function is not called directly from an interrupt so there
+ *  are no restrictions on what you can do here, and you don't need to use IRAM_ATTR.
+ */
+void interruptDelegate()
+{
+	// For this example, we write some stuff out of the serial port.
 	say(micros());
 	say("   Pin changed, now   ");
-	say(digitalRead(INT_PIN));
-	Serial.println();
+	say(digitalRead(INT_PIN_A));
+	newline();
+
+	// Interrupt delegates work by queueing your callback routine, so let's just show you how many requests got queued
+	say("Max tasks queued: ");
+	say(System.getMaxTaskCount());
+	newline();
+
+	/* OK, so you probably got a number which hit 255 pretty quickly! It stays there to indicate the task queue
+	 * overflowed, which happens because we're getting way more interrupts than we can process in a timely manner, so
+	 * lots of them get dropped.
+	 *
+	 * So what's happening?
+	 *
+	 * In our example, if you use a jumper wire to ground the input pin then it will bounce around as contact is made
+	 * and then broken; this is known as 'contact bounce'. This means you'll get multiple outputs instead of a clean
+	 * signal. If your circuit uses a push switch, reed switch, etc. then you'll need a 'debounce circuit'.
+	 *
+	 * If you want to try a very simple debounce circuit to see what happens, try this:
+	 *
+	 *                3v3
+	 *                _|_
+	 *                ___ 100nF
+	 *                 |
+	 *                 |
+	 * INPUT   >--------------> GPIO PIN
+	 *
+	 * You'll need to hit the reset button to get the task counter back to 0. Now try toggling the input again...
+	 * I'll leave it to you to work out why this helps. Hint: We've enabled pullups on the input pins, so there
+	 * will be another resistor in the circuit.
+	 *
+	 * There is plenty of information available on this subject. Just search the internet for 'debounce circuit'.
+	 */
 }
 
 void init()
@@ -23,9 +76,20 @@ void init()
 
 	delay(3000);
 	say("======= Bring GPIO");
-	say(INT_PIN);
+	say(INT_PIN_A);
 	say(" low to trigger interrupt(s) =======");
-	Serial.println();
+	newline();
 
-	attachInterrupt(INT_PIN, interruptHandler, CHANGE);
+	// Note we enable pullup on our test pin so it will stay high when not connected
+	attachInterrupt(INT_PIN_A, interruptHandler, CHANGE);
+	pinMode(INT_PIN_A, INPUT_PULLUP);
+	say("Interrupt A attached");
+	newline();
+
+	// For an interrupt delegate callback, we simply cast our function or method using InterruptDelegate()
+	pinMode(TOGGLE_PIN, OUTPUT);
+	attachInterrupt(INT_PIN_B, InterruptDelegate(interruptDelegate), CHANGE);
+	pinMode(INT_PIN_B, INPUT_PULLUP);
+	say("Interrupt B attached");
+	newline();
 }

--- a/samples/Basic_Interrupts/app/application.cpp
+++ b/samples/Basic_Interrupts/app/application.cpp
@@ -24,6 +24,33 @@ void IRAM_ATTR interruptHandler()
 	// For this example, we just toggle the state of an output pin.
 	bool state = digitalRead(TOGGLE_PIN);
 	digitalWrite(TOGGLE_PIN, !state);
+
+	// Example of how you can queue a callback from inside a regular interrupt handler
+	const unsigned MAX_TOGGLE_COUNTS = 10;
+	static unsigned toggleCount;
+	++toggleCount;
+	if(toggleCount > MAX_TOGGLE_COUNTS) {
+		/*
+		 * Using a 'lambda function' we can easily include any code to be executed by the callback
+		 * without having to define a function elsewhere.
+		 * You could also pass a function pointer to queueCallback().
+		 */
+		System.queueCallback(
+			[&](uint32_t interruptToggleCount) {
+				say("Toggle count hit ");
+				say(interruptToggleCount);
+				say(", current value is ");
+				say(toggleCount);
+				say("!");
+				newline();
+				say("Max tasks queued: ");
+				say(System.getMaxTaskCount());
+				newline();
+			},
+			toggleCount);
+
+		toggleCount = 0;
+	}
 }
 
 /** @brief Example of an InterruptDelegate function
@@ -35,7 +62,7 @@ void interruptDelegate()
 	// For this example, we write some stuff out of the serial port.
 	say(micros());
 	say("   Pin changed, now   ");
-	say(digitalRead(INT_PIN_A));
+	say(digitalRead(INT_PIN_B));
 	newline();
 
 	// Interrupt delegates work by queueing your callback routine, so let's just show you how many requests got queued

--- a/samples/Gesture_APDS-9960/app/application.cpp
+++ b/samples/Gesture_APDS-9960/app/application.cpp
@@ -10,7 +10,7 @@ SparkFun_APDS9960 apds = SparkFun_APDS9960();
 //
 #define APDS9960_INT 4 // Needs to be an interrupt pin
 
-void IRAM_ATTR handleGesture()
+void handleGesture()
 {
 	if(apds.isGestureAvailable()) {
 		switch(apds.readGesture()) {
@@ -38,11 +38,11 @@ void IRAM_ATTR handleGesture()
 	}
 }
 
-void IRAM_ATTR interruptRoutine()
+void interruptRoutine()
 {
 	detachInterrupt(APDS9960_INT);
 	handleGesture();
-	attachInterrupt(APDS9960_INT, interruptRoutine, FALLING);
+	attachInterrupt(APDS9960_INT, InterruptDelegate(interruptRoutine), FALLING);
 }
 
 void init()
@@ -75,5 +75,5 @@ void init()
 
 	// Initialize interrupt service routine
 	pinMode(APDS9960_INT, (GPIO_INT_TYPE)GPIO_PIN_INTR_ANYEDGE);
-	attachInterrupt(APDS9960_INT, interruptRoutine, FALLING);
+	attachInterrupt(APDS9960_INT, InterruptDelegate(interruptRoutine), FALLING);
 }

--- a/samples/PortExpander_MCP23017/app/application.cpp
+++ b/samples/PortExpander_MCP23017/app/application.cpp
@@ -37,5 +37,5 @@ void init()
 	mcp.pinMode(mcpPinA, INPUT);
 	mcp.pullUp(mcpPinA, HIGH);
 	mcp.setupInterruptPin(mcpPinA, FALLING);
-	attachInterrupt(interruptPin, interruptCallback, FALLING);
+	attachInterrupt(interruptPin, InterruptDelegate(interruptCallback), FALLING);
 }


### PR DESCRIPTION
* Move out of HardwareSerial into SystemClass, making queue available for applications and other framework code.
* SDK has two priority queues, this is a simple implementation of one of them. If the situation arises where some tasks need to be elevated then a second task queue could be added, but this would consume more RAM. The API can be extended with a second parameter to support this.