### PR TITLE
Improvements to SystemClock

### DIFF
--- a/Sming/SmingCore/AtClient.cpp
+++ b/Sming/SmingCore/AtClient.cpp
@@ -5,7 +5,8 @@
  *      Author: slavey
  */
 
-#include <AtClient.h>
+#include "AtClient.h"
+#include "Clock.h"
 
 #ifndef debugf
 #define debugf(fmt, ...)

--- a/Sming/SmingCore/SmingCore.h
+++ b/Sming/SmingCore/SmingCore.h
@@ -28,6 +28,7 @@
 #include "SPISoft.h"
 #include "SPI.h"
 
+#include "Platform/RTC.h"
 #include "Platform/System.h"
 #include "Platform/WifiEvents.h"
 #include "Platform/Station.h"

--- a/Sming/SmingCore/SystemClock.cpp
+++ b/Sming/SmingCore/SystemClock.cpp
@@ -1,37 +1,53 @@
-#include "SystemClock.h"
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ ****/
 
-DateTime SystemClockClass::now(TimeZone timeType /* = eTZ_Local */)
+#include "SystemClock.h"
+#include "Platform/RTC.h"
+
+SystemClockClass SystemClock;
+
+time_t SystemClockClass::now(TimeZone timeType /* = eTZ_Local */)
 {
 	uint32_t systemTime = RTC.getRtcSeconds();
 
-	if((timeType == eTZ_Local) || (status == eSCS_Initial)) {
-		return DateTime(systemTime); // local time
-	} else {
-		return DateTime(systemTime - (timezoneDiff * SECS_PER_HOUR)); // utc time
+	if(timeType == eTZ_UTC) {
+		systemTime -= timeZoneOffsetSecs;
 	}
+
+	return systemTime;
 }
 
-void SystemClockClass::setTime(time_t time, TimeZone timeType /* = eTZ_Local */)
+bool SystemClockClass::setTime(time_t time, TimeZone timeType /* = eTZ_Local */)
 {
-	bool timeSet =
-		(timeType == eTZ_UTC) ? RTC.setRtcSeconds((time + (timezoneDiff * SECS_PER_HOUR))) : RTC.setRtcSeconds(time);
+	if(timeType == eTZ_UTC) {
+		time += timeZoneOffsetSecs;
+	}
+
+	bool timeSet = RTC.setRtcSeconds(time);
+	if(timeSet) {
+		status = eSCS_Set;
+	}
+
 	debugf("time updated? %d", timeSet);
-	status = eSCS_Set;
+
+	return timeSet;
 }
 
 String SystemClockClass::getSystemTimeString(TimeZone timeType /* = eTZ_Local */)
 {
-	dateTime.setTime(now(timeType));
-	return dateTime.toFullDateTimeString();
+	DateTime dt(now(timeType));
+	return DateTime(now(timeType)).toFullDateTimeString();
 }
 
-bool SystemClockClass::setTimeZone(double localTimezone)
+bool SystemClockClass::setTimeZoneOffset(int tzOffsetSecs)
 {
-	if((localTimezone >= -12) && (localTimezone <= 12)) {
-		timezoneDiff = localTimezone;
+	if((unsigned)abs(tzOffsetSecs) < (12 * SECS_PER_HOUR)) {
+		timeZoneOffsetSecs = tzOffsetSecs;
 		return true;
 	}
 	return false;
 }
-
-SystemClockClass SystemClock;

--- a/Sming/SmingCore/SystemClock.cpp
+++ b/Sming/SmingCore/SystemClock.cpp
@@ -43,10 +43,10 @@ String SystemClockClass::getSystemTimeString(TimeZone timeType /* = eTZ_Local */
 	return DateTime(now(timeType)).toFullDateTimeString();
 }
 
-bool SystemClockClass::setTimeZoneOffset(int tzOffsetSecs)
+bool SystemClockClass::setTimeZoneOffset(int seconds)
 {
-	if((unsigned)abs(tzOffsetSecs) < (12 * SECS_PER_HOUR)) {
-		timeZoneOffsetSecs = tzOffsetSecs;
+	if((unsigned)abs(seconds) < (12 * SECS_PER_HOUR)) {
+		timeZoneOffsetSecs = seconds;
 		return true;
 	}
 	return false;

--- a/Sming/SmingCore/SystemClock.h
+++ b/Sming/SmingCore/SystemClock.h
@@ -10,8 +10,8 @@
  *  @brief      Provides system clock functions
 */
 
-#ifndef APP_SYSTEMCLOCK_H_
-#define APP_SYSTEMCLOCK_H_
+#ifndef SMINGCORE_SYSTEMCLOCK_H_
+#define SMINGCORE_SYSTEMCLOCK_H_
 
 #include "../Services/DateTime/DateTime.h"
 #include "WString.h"
@@ -65,14 +65,14 @@ public:
      *  @todo   Why does this need to be set to 2 for UK during winter?
      *  @note   Supports whole hour and fraction of hour offsets from -12 hours to +12 hours
      */
-	bool setTimeZoneOffset(int tzOffsetSecs);
+	bool setTimeZoneOffset(int seconds);
 
 	bool setTimeZone(float localTimezoneOffset)
 	{
 		return setTimeZoneOffset(localTimezoneOffset * SECS_PER_HOUR);
 	}
 
-	int tzOffsetSecs()
+	int getTimeZoneOffset()
 	{
 		return timeZoneOffsetSecs;
 	}
@@ -91,4 +91,4 @@ private:
 extern SystemClockClass SystemClock;
 
 /** @} */
-#endif /* APP_SYSTEMCLOCK_H_ */
+#endif /* SMINGCORE_SYSTEMCLOCK_H_ */

--- a/Sming/SmingCore/SystemClock.h
+++ b/Sming/SmingCore/SystemClock.h
@@ -1,3 +1,10 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ ****/
+
 /** @defgroup   systemclock System clock functions
  *  @ingroup    datetime
  *  @brief      Provides system clock functions
@@ -6,11 +13,8 @@
 #ifndef APP_SYSTEMCLOCK_H_
 #define APP_SYSTEMCLOCK_H_
 
-#include "Clock.h"
-#include "../../Services/DateTime/DateTime.h"
-#include "../../Wiring/WString.h"
-#include "../SmingCore/Network/NtpClient.h"
-#include "../SmingCore/Platform/RTC.h"
+#include "../Services/DateTime/DateTime.h"
+#include "WString.h"
 
 /** @addtogroup constants
  *  @{
@@ -28,8 +32,6 @@ enum SystemClockStatus {
 };
 /** @} */
 
-class NtpClient;
-
 /** @brief  System clock class
  *  @addtogroup systemclock
  *  @{
@@ -41,14 +43,14 @@ public:
      *  @param  timeType Time zone to use (UTC / local)
      *  @retval DateTime Current date and time
      */
-	DateTime now(TimeZone timeType = eTZ_Local);
+	time_t now(TimeZone timeType = eTZ_Local);
 
 	/** @brief  Set the system clock's time
      *  @param  time Unix time to set clock to (quantity of seconds since 00:00:00 1970-01-01)
      *  @param  timeType Time zone of Unix time, i.e. is time provided as local or UTC?
      *  @note   System time is always stored as local timezone time
      */
-	void setTime(time_t time, TimeZone timeType = eTZ_Local);
+	bool setTime(time_t time, TimeZone timeType = eTZ_Local);
 
 	/** @brief  Get current time as a string
      *  @param  timeType Time zone to present time as, i.e. return local or UTC time
@@ -63,11 +65,20 @@ public:
      *  @todo   Why does this need to be set to 2 for UK during winter?
      *  @note   Supports whole hour and fraction of hour offsets from -12 hours to +12 hours
      */
-	bool setTimeZone(double localTimezoneOffset);
+	bool setTimeZoneOffset(int tzOffsetSecs);
+
+	bool setTimeZone(float localTimezoneOffset)
+	{
+		return setTimeZoneOffset(localTimezoneOffset * SECS_PER_HOUR);
+	}
+
+	int tzOffsetSecs()
+	{
+		return timeZoneOffsetSecs;
+	}
 
 private:
-	double timezoneDiff = 0.0;
-	DateTime dateTime;
+	int timeZoneOffsetSecs = 0;
 	SystemClockStatus status = eSCS_Initial;
 };
 


### PR DESCRIPTION
* Modify to use int instead of double for timeZone offset. AFAIK the little old ESP8266 doesn't have hardware FP... though it's big brother does :-)
* Use time_t as return value for now(). Shouldn't break anything as DateTime has implicit constructor for that.
* Tidy up `#includes` - various unrelated headers removed.