### PR TITLE
Change HardwareTimer to use NMI (Non-Maskable Interrupts)

### DIFF
--- a/Sming/SmingCore/HardwareTimer.h
+++ b/Sming/SmingCore/HardwareTimer.h
@@ -12,11 +12,11 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_HWTIMER_H_
-#define _SMING_CORE_HWTIMER_H_
+#ifndef _SMING_CORE_HARDWARE_TIMER_H_
+#define _SMING_CORE_HARDWARE_TIMER_H_
 
-#include "../SmingCore/Interrupts.h"
-#include "../SmingCore/Delegate.h"
+#include "Interrupts.h"
+#include "Delegate.h"
 
 #define MAX_HW_TIMER_INTERVAL_US 0x7fffff ///< Maximum timer interval in microseconds
 #define MIN_HW_TIMER_INTERVAL_US 0x32	 ///< Minimum hardware interval in microseconds
@@ -30,10 +30,6 @@ uint32_t IRAM_ATTR usToTimerTicks(uint32_t us);
  *  @note accounts for current timer prescale setting
  */
 uint32_t IRAM_ATTR timerTicksToUs(uint32_t ticks);
-
-/** @brief  Delegate callback type for timer trigger
- */
-typedef Delegate<void()> TimerDelegate;
 
 /// Hardware timer class
 class HardwareTimer
@@ -50,7 +46,7 @@ public:
      *  @retval HardwareTimer& Reference to timer
      */
 	HardwareTimer& IRAM_ATTR initializeUs(uint32_t microseconds,
-										  InterruptCallback callback = NULL); // Init in Microseconds.
+										  InterruptCallback callback = nullptr); // Init in Microseconds.
 
 	/** @brief  Initialise hardware timer
      *  @param  milliseconds Timer interval in milliseconds
@@ -58,7 +54,7 @@ public:
      *  @retval HardwareTimer& Reference to timer
      */
 	HardwareTimer& IRAM_ATTR initializeMs(uint32_t milliseconds,
-										  InterruptCallback callback = NULL); // Init in Milliseconds.
+										  InterruptCallback callback = nullptr); // Init in Milliseconds.
 
 	/** @brief  Start timer running
      *  @param  repeating True to restart timer when it triggers, false for one-shot (Default: true)
@@ -76,10 +72,8 @@ public:
 	}
 
 	/** @brief  Stops timer
-	 *  @retval bool Always false
-	 *  @todo   Why always return false from Hardware_timer::stop()?
 	 */
-	bool IRAM_ATTR stop();
+	void IRAM_ATTR stop();
 
 	/** @brief  Restart timer
 	 *  @retval bool True if timer started
@@ -90,27 +84,39 @@ public:
 	/** @brief  Check if timer is started
 	 *  @retval bool True if started
 	 */
-	bool isStarted();
+	bool isStarted()
+	{
+		return started;
+	}
 
 	/** @brief  Get timer interval
      *  @retval uint32_t Timer interval in microseconds
      */
-	uint32_t getIntervalUs();
+	uint32_t getIntervalUs()
+	{
+		return interval;
+	}
 
 	/** @brief  Get timer interval
      *  @retval uint32_t Timer interval in milliseconds
      */
-	uint32_t getIntervalMs();
+	uint32_t getIntervalMs()
+	{
+		return getIntervalUs() / 1000;
+	}
 
 	/** @brief  Set timer interval
      *  @param  microseconds Interval time in microseconds (Default: 1ms)
      */
-	bool IRAM_ATTR setIntervalUs(uint32_t microseconds = 1000000);
+	bool IRAM_ATTR setIntervalUs(uint32_t microseconds);
 
 	/** @brief  Set timer interval
-     *  @param  milliseconds Interval time in milliseconds (Default: 1s)
+     *  @param  milliseconds Interval time in milliseconds
      */
-	bool IRAM_ATTR setIntervalMs(uint32_t milliseconds = 1000000);
+	__forceinline bool IRAM_ATTR setIntervalMs(uint32_t milliseconds)
+	{
+		return setIntervalUs(milliseconds * 1000);
+	}
 
 	/** @brief  Set timer trigger callback
      *  @param  callback Function to call when timer triggers
@@ -142,4 +148,4 @@ class Hardware_Timer : public HardwareTimer
 };
 
 /** @} */
-#endif /* _SMING_CORE_HWTIMER_H_ */
+#endif /* _SMING_CORE_HARDWARE_TIMER_H_ */

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -41,8 +41,11 @@
 #else
 #define debugf debug_i
 #endif
-#define assert(condition) if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__)
-#define SYSTEM_ERROR(fmt, ...) m_printf("ERROR: " fmt "\r\n", ##__VA_ARGS__)
+#define assert(condition) \
+	do {\
+		if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__); \
+	} while(0)
+#define SYSTEM_ERROR(fmt, ...) debug_e("ERROR: " fmt "\r\n", ##__VA_ARGS__)
 
 #ifndef SDK_INTERNAL
 extern void ets_timer_arm_new(ETSTimer *ptimer, uint32_t milliseconds, bool repeat_flag, int isMstimer);
@@ -97,6 +100,9 @@ extern void uart_tx_one_char(char ch);
 
 extern void ets_intr_lock();
 extern void ets_intr_unlock();
+
+// Missing from SDK 1.5.x
+extern void NmiTimSetFunc(void (*func)(void));
 
 #endif /* SDK_INTERNAL */
 

--- a/samples/Basic_Debug/app/application.cpp
+++ b/samples/Basic_Debug/app/application.cpp
@@ -1,9 +1,16 @@
 #include <user_config.h>
-#include <SmingCore/SmingCore.h>
+#include "SmingCore.h"
+#include "HardwareTimer.h"
 
 #define LED_PIN 2 // GPIO2
 
-Timer procTimer;
+/*
+ * This example uses the hardware timer for best timing accuracy. There is only one of these on the ESP8266,
+ * so it may not be available if another module requires it.
+ * Most timing applicatons can use a SimpleTimer, which is good for intervals of up to about 268 seconds.
+ * For longer intervals, use a Timer.
+ */
+HardwareTimer procTimer;
 bool state = true;
 
 /*


### PR DESCRIPTION
Prevents other interrupts causing timing jitter.

* Move trivial code into header to improve performance
* Fix #include guard naming
* Change return type for stop() to void - meaningless
* Change SYSTEM_ERROR() to emit using debug_e so it uses flash instead of RAM for format strings
* Remove default parameter values - no point

Samples/Basic_Debug

* Change to use HardwareTimer and add a note about using SimpleTimer and Timer