### PR TITLE
Various improvements to NtpClient class

### DIFF
--- a/Sming/SmingCore/Network/NtpClient.cpp
+++ b/Sming/SmingCore/Network/NtpClient.cpp
@@ -99,8 +99,7 @@ void NtpClient::internalRequestTime(IPAddress serverIp)
 	packet[1] = 0;						   // Stratum, or type of clock, unspecified.
 
 	// Start timer to retry if no response received
-	timer.setIntervalMs(NTP_RESPONSE_TIMEOUT_MS);
-	timer.startOnce();
+	startTimer(NTP_RESPONSE_TIMEOUT_MS);
 
 	// Send to server, serverAddress & port is set in connect
 	NtpClient::send(packet, NTP_PACKET_SIZE);

--- a/Sming/SmingCore/Network/NtpClient.h
+++ b/Sming/SmingCore/Network/NtpClient.h
@@ -1,18 +1,25 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ ****/
+
 /** @defgroup   ntp Network Time Protocol client
  *  @brief      Provides NTP client
  *  @ingroup    datetime
  *  @ingroup    udp
  *  @{
  */
-#ifndef APP_NTPCLIENT_H_
-#define APP_NTPCLIENT_H_
+#ifndef _SMING_CORE_NETWORK_NTPCLIENT_H_
+#define _SMING_CORE_NETWORK_NTPCLIENT_H_
 
 #include "UdpConnection.h"
-#include "../Platform/System.h"
-#include "../Timer.h"
-#include "../SystemClock.h"
-#include "../Platform/Station.h"
-#include "../Delegate.h"
+#include "Platform/System.h"
+#include "Timer.h"
+#include "../Services/DateTime/DateTime.h"
+#include "Delegate.h"
 
 #define NTP_PORT 123
 #define NTP_PACKET_SIZE 48
@@ -20,9 +27,9 @@
 #define NTP_MODE_CLIENT 3
 #define NTP_MODE_SERVER 4
 
-#define NTP_DEFAULT_SERVER "pool.ntp.org"
-#define NTP_DEFAULT_QUERY_INTERVAL_SECONDS 600 // 10 minutes
-#define NTP_RESPONSE_TIMEOUT_MS 20000		   // 20 seconds
+#define NTP_DEFAULT_SERVER F("pool.ntp.org")
+#define NTP_DEFAULT_QUERY_INTERVAL_SECONDS (10 * SECS_PER_MIN)
+#define NTP_RESPONSE_TIMEOUT_MS (20 * 1000)
 
 class NtpClient;
 
@@ -47,9 +54,11 @@ public:
      *  @param  reqIntervalSeconds Quantity of seconds between NTP requests
      *  @param  onTimeReceivedCb Callback delegate to be called when NTP time result is received (Default: None)
      */
-	NtpClient(String reqServer, int reqIntervalSeconds, NtpTimeResultDelegate onTimeReceivedCb = nullptr);
+	NtpClient(const String& reqServer, int reqIntervalSeconds, NtpTimeResultDelegate onTimeReceivedCb = nullptr);
 
-	virtual ~NtpClient();
+	virtual ~NtpClient()
+	{
+	}
 
 	/** @brief  Request time from NTP server
      *  @note   Instigates request. Result is handled by NTP result handler function if defined
@@ -59,12 +68,21 @@ public:
 	/** @brief  Set the NTP server
      *  @param  server IP address or hostname of NTP server
      */
-	void setNtpServer(String server);
+	void setNtpServer(const String& server)
+	{
+		this->server = server;
+	}
 
 	/** @brief  Enable / disable periodic query
      *  @param  autoQuery True to enable periodic query of NTP server
      */
-	void setAutoQuery(bool autoQuery);
+	void setAutoQuery(bool autoQuery)
+	{
+		if(autoQuery)
+			autoUpdateTimer.start();
+		else
+			autoUpdateTimer.stop();
+	}
 
 	/** @brief  Set query period
      *  @param  seconds Period in seconds between periodic queries
@@ -90,23 +108,15 @@ protected:
 	void internalRequestTime(IPAddress serverIp);
 
 protected:
-	String server = NTP_DEFAULT_SERVER; ///< IP address or Hostname of NTP server
+	String server; ///< IP address or Hostname of NTP server
 
 	NtpTimeResultDelegate delegateCompleted = nullptr; ///< NTP result handler delegate
 	bool autoUpdateSystemClock = false;				   ///< True to update system clock with NTP time
 
-	Timer autoUpdateTimer; ///< Periodic query timer
-	Timer timeoutTimer;	///< NTP message timeout timer
-	Timer connectionTimer; ///< Wait for WiFi connection timer
-
-	/** @brief  Handle DNS response
-     *  @param  name Pointer to c-string containing hostname
-     *  @param  ip Ponter to IP address
-     *  @param  arg Pointer to the NTP client object that made the DNS request
-     *  @note   This function is called when a DNS query is serviced
-     */
-	static void staticDnsResponse(const char* name, LWIP_IP_ADDR_T* ip, void* arg);
+	Timer autoUpdateTimer;		 ///< Periodic query timer
+	SimpleTimer timeoutTimer;	///< NTP message timeout timer
+	SimpleTimer connectionTimer; ///< Wait for WiFi connection timer
 };
 
 /** @} */
-#endif /* APP_NTPCLIENT_H_ */
+#endif /* _SMING_CORE_NETWORK_NTPCLIENT_H_ */


### PR DESCRIPTION
Tested with SystemClock_NTP sample, but note that time will be wrong as we don't yet have any timezone management in place. The sample also sets local time, but NTP provides time in UTC. No point in fixing that yet as without timezone it just makes things worse.

* Fix #include guard name
* Tidy #includes
* Put NTP_DEFAULT_SERVER into Flash
* Use const String& for parameters
* Use SimpleTimer instead of Timer as appropriate (efficiency, saves RAM)
* timeoutTimer doesn't need to be initialised until a request has been queued, so moved out of constructor
* Replace staticDnsResponse() with lambda
* Tidy extraction of timestamp from received packet using LWIP macro

Closes: #1449 