### PR TITLE
Fix dodgy expressions, tidy up code in SPI

### DIFF
--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -16,17 +16,17 @@
 
 #include "SPI.h"
 
-#include <SmingCore.h>
 #include <stdlib.h>
 #include "eagle_soc.h"
 #include "espinc/spi_register.h"
 #include "c_types.h"
+
 // define the static singleton
 SPIClass SPI;
 
 SPIClass::SPIClass()
 {
-	_SPISettings = this->SPIDefaultSettings;
+	spiSettings = this->SPIDefaultSettings;
 }
 
 SPIClass::~SPIClass()
@@ -75,7 +75,7 @@ void SPIClass::beginTransaction(SPISettings mySettings)
 	debugf("SPIhw::beginTransaction(SPISettings mySettings)");
 #endif
 	// check if we need to change settings
-	if(this->_SPISettings == mySettings)
+	if(this->spiSettings == mySettings)
 		return;
 
 	// prepare SPI settings
@@ -119,8 +119,8 @@ uint32 SPIClass::transfer32(uint32 data, uint8 bits)
 	regvalue |= SPI_USR_MOSI | SPI_DOUTDIN | SPI_CK_I_EDGE;
 	WRITE_PERI_REG(SPI_USER(SPI_NO), regvalue);
 
-	WRITE_PERI_REG(SPI_USER1(SPI_NO), ((bits - 1 & SPI_USR_MOSI_BITLEN) << SPI_USR_MOSI_BITLEN_S) |
-										  ((bits - 1 & SPI_USR_MISO_BITLEN) << SPI_USR_MISO_BITLEN_S));
+	WRITE_PERI_REG(SPI_USER1(SPI_NO), (((bits - 1) & SPI_USR_MOSI_BITLEN) << SPI_USR_MOSI_BITLEN_S) |
+										  (((bits - 1) & SPI_USR_MISO_BITLEN) << SPI_USR_MISO_BITLEN_S));
 
 	// copy data to W0
 	if(READ_PERI_REG(SPI_USER(SPI_NO)) & SPI_WR_BYTE_ORDER) {
@@ -212,8 +212,8 @@ void SPIClass::transfer(uint8* buffer, size_t numberBytes)
 		WRITE_PERI_REG(SPI_USER(SPI_NO), regvalue);
 
 		// setup bit lenght
-		WRITE_PERI_REG(SPI_USER1(SPI_NO), ((num_bits - 1 & SPI_USR_MOSI_BITLEN) << SPI_USR_MOSI_BITLEN_S) |
-											  ((num_bits - 1 & SPI_USR_MISO_BITLEN) << SPI_USR_MISO_BITLEN_S));
+		WRITE_PERI_REG(SPI_USER1(SPI_NO), (((num_bits - 1) & SPI_USR_MOSI_BITLEN) << SPI_USR_MOSI_BITLEN_S) |
+											  (((num_bits - 1) & SPI_USR_MISO_BITLEN) << SPI_USR_MISO_BITLEN_S));
 
 		// copy the registers starting from last index position
 		memcpy((void*)SPI_W0(SPI_NO), &buffer[bufIndx], bufLenght);
@@ -251,24 +251,24 @@ void SPIClass::prepare(SPISettings mySettings)
 #endif
 
 	// check if we need to change settings
-	if(_init & _SPISettings == mySettings)
+	if(initialised && spiSettings == mySettings)
 		return;
 
 	//  setup clock
-	setFrequency(mySettings._speed);
+	setFrequency(mySettings.speed);
 
 	//	set byte order
-	this->spi_byte_order(mySettings._byteOrder);
+	this->spi_byte_order(mySettings.byteOrder);
 
 	//	set spi mode
-	spi_mode(mySettings._dataMode);
+	spi_mode(mySettings.dataMode);
 
 #ifdef SPI_DEBUG
 	debugf("SPIhw::prepare(SPISettings mySettings) -> updated settings");
 #endif
 
-	_SPISettings = mySettings;
-	_init = true;
+	spiSettings = mySettings;
+	initialised = true;
 };
 
 /** @brief  spi_mode Configures SPI mode parameters for clock edge and clock polarity.
@@ -345,9 +345,9 @@ void SPIClass::spi_byte_order(uint8 byte_order)
 void SPIClass::setClock(uint8 prediv, uint8 cntdiv)
 {
 #ifdef SPI_DEBUG
-	debugf("SPIClass::setClock(prediv %d, cntdiv %d) for target %d", prediv, cntdiv, _SPISettings._speed);
+	debugf("SPIClass::setClock(prediv %d, cntdiv %d) for target %d", prediv, cntdiv, spiSettings.speed);
 #endif
-	debugf("SPIClass::setClock(prediv %d, cntdiv %d) for target %d", prediv, cntdiv, _SPISettings._speed);
+	debugf("SPIClass::setClock(prediv %d, cntdiv %d) for target %d", prediv, cntdiv, spiSettings.speed);
 
 	if((prediv == 0) | (cntdiv == 0)) {
 		// go full speed = SYSTEMCLOCK
@@ -430,17 +430,17 @@ void SPIClass::setFrequency(int freq)
 	int _CPU_freq = system_get_cpu_freq() * 10000000UL;
 
 	// dont run code if there are no changes
-	if(_init & freq == _SPISettings._speed)
+	if(initialised && freq == spiSettings.speed)
 		return;
 
 	if(freq == _CPU_freq) {
-		_SPISettings._speed = freq;
+		spiSettings.speed = freq;
 		setClock(0, 0);
 		return;
 	}
 
 	freq = std::min(freq, _CPU_freq / 2);
-	_SPISettings._speed = freq;
+	spiSettings.speed = freq;
 
 	int pre2;
 	int f2 = getFrequency(freq, pre2, 2);

--- a/Sming/SmingCore/SPI.h
+++ b/Sming/SmingCore/SPI.h
@@ -13,8 +13,8 @@
  *  @brief    Provides hardware SPI support
  */
 
-#ifndef SMINGCORE_SPI_H_
-#define SMINGCORE_SPI_H_
+#ifndef _SMING_CORE_SPI_H_
+#define _SMING_CORE_SPI_H_
 
 #include "SPIBase.h"
 #include "SPISettings.h"
@@ -177,12 +177,12 @@ private:
 	uint32_t getFrequency(int freq, int& pre, int clk);
 	void setFrequency(int freq);
 
-	SPISettings _SPISettings;
-	uint8 _isTX = false;
-	uint8 _init = false;
+	SPISettings spiSettings;
+	bool isTX = false;
+	bool initialised = false;
 };
 
 /** @brief  Global instance of SPI class */
 extern SPIClass SPI;
 
-#endif /* SMINGCORE_SPI_H_ */
+#endif /* _SMING_CORE_SPI_H_ */

--- a/Sming/SmingCore/SPISettings.cpp
+++ b/Sming/SmingCore/SPISettings.cpp
@@ -18,9 +18,6 @@ SPISettings::SPISettings()
 #ifdef SPI_DEBUG
 	debugf("SPISettings::SPISettings() default");
 #endif
-	_speed = 4000000;
-	_byteOrder = MSBFIRST;
-	_dataMode = SPI_MODE0;
 }
 
 /*
@@ -34,9 +31,9 @@ SPISettings::SPISettings(int speed, uint8 byteOrder, uint8 dataMode)
 	debugf("SPISettings::SPISettings(int %i, uint8 %d, uint8 %d)", speed, byteOrder, dataMode);
 #endif
 
-	_speed = speed;
-	_byteOrder = byteOrder;
-	_dataMode = dataMode;
+	this->speed = speed;
+	this->byteOrder = byteOrder;
+	this->dataMode = dataMode;
 }
 
 SPISettings::~SPISettings()
@@ -45,13 +42,13 @@ SPISettings::~SPISettings()
 
 bool SPISettings::operator==(const SPISettings& other) const
 {
-	int res = _speed == other._speed & _byteOrder == other._byteOrder & _dataMode == other._dataMode;
+	int res = speed == other.speed && byteOrder == other.byteOrder && dataMode == other.dataMode;
 	return res;
 }
 
 #ifdef SPI_DEBUG
 void SPISettings::print(const char* s)
 {
-	debugf("->  %s -> SPISettings::print(int %i, uint8 %d, uint8 %d)", s, _speed, _byteOrder, _dataMode);
+	debugf("->  %s -> SPISettings::print(int %i, uint8 %d, uint8 %d)", s, speed, byteOrder, dataMode);
 }
 #endif

--- a/Sming/SmingCore/SPISettings.h
+++ b/Sming/SmingCore/SPISettings.h
@@ -8,8 +8,8 @@
  *  @brief    Provides SPI support
  */
 
-#ifndef SMINGCORE_SPISETTINGS_H_
-#define SMINGCORE_SPISETTINGS_H_
+#ifndef _SMING_CORE_SPI_SETTINGS_H_
+#define _SMING_CORE_SPI_SETTINGS_H_
 
 #include "Digital.h"
 
@@ -63,7 +63,7 @@ public:
 
 	inline uint8 getDataMode()
 	{
-		return _dataMode;
+		return dataMode;
 	};
 
 	// overload operator to check wheter the settings are equal
@@ -74,9 +74,9 @@ public:
 	friend class SPIClass;
 
 private:
-	int _speed;
-	uint8 _byteOrder;
-	uint8 _dataMode;
+	int speed = 4000000;
+	uint8_t byteOrder = MSBFIRST;
+	uint8_t dataMode = SPI_MODE0;
 };
 
-#endif /* SMINGCORE_SPISETTINGS_H_ */
+#endif /* _SMING_CORE_SPI_SETTINGS_H_ */


### PR DESCRIPTION
* Fix #include guard name
* Fix variable names to comply with coding style
* Tidy #includes (don't include SmingCore.h)
* Parenthesis required around some expressions to satisfy compiler
* Replace incorrect use of & with &&