### PR TITLE
Added support for more silent rBoot

### DIFF
--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -198,6 +198,7 @@ FW_MEMINFO_SAVED = out/fwMeminfo
 
 RBOOT_ROM_0  := $(addprefix $(FW_BASE)/,$(RBOOT_ROM_0).bin)
 RBOOT_ROM_1  := $(addprefix $(FW_BASE)/,$(RBOOT_ROM_1).bin)
+RBOOT_SILENT ?= 0
 
 # name for the target project
 TARGET		= app
@@ -514,7 +515,7 @@ endef
 all: $(USER_LIBDIR)/lib$(LIBSMING).a checkdirs $(LIBMAIN_DST) $(RBOOT_BIN) $(RBOOT_ROM_0) $(RBOOT_ROM_1) $(SPIFF_BIN_OUT) $(FW_FILE_1) $(FW_FILE_2) 
 
 $(RBOOT_BIN):
-	$(MAKE) -C $(THIRD_PARTY_DIR)/rboot RBOOT_GPIO_ENABLED=$(RBOOT_GPIO_ENABLED)
+	$(MAKE) -C $(THIRD_PARTY_DIR)/rboot RBOOT_GPIO_ENABLED=$(RBOOT_GPIO_ENABLED) RBOOT_SILENT=$(RBOOT_SILENT)
 
 $(LIBMAIN_DST): $(LIBMAIN_SRC)
 	@echo "OC $@"

--- a/Sming/third-party/.patches/rboot.patch
+++ b/Sming/third-party/.patches/rboot.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile b/Makefile
-index ca234de..08b0fba 100644
+index ca234de..f76fbaa 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -55,6 +55,12 @@ endif
+@@ -55,6 +55,16 @@ endif
  ifeq ($(RBOOT_IROM_CHKSUM),1)
  	CFLAGS += -DBOOT_IROM_CHKSUM
  endif
@@ -12,11 +12,15 @@ index ca234de..08b0fba 100644
 +ifneq ($(RBOOT_ROM2_ADDR),)
 +	CFLAGS += -DBOOT_ROM2_ADDR=$(RBOOT_ROM2_ADDR)
 +endif
++ifeq ($(RBOOT_SILENT),1)
++	CFLAGS += -DBOOT_SILENT=$(RBOOT_SILENT)
++endif
++
  ifneq ($(RBOOT_EXTRA_INCDIR),)
  	CFLAGS += $(addprefix -I,$(RBOOT_EXTRA_INCDIR))
  endif
 diff --git a/rboot.c b/rboot.c
-index 6e10a2f..7ac60a8 100644
+index 6e10a2f..03cc87b 100644
 --- a/rboot.c
 +++ b/rboot.c
 @@ -250,7 +250,25 @@ static uint8 calc_chksum(uint8 *start, uint8 *end) {
@@ -45,6 +49,128 @@ index 6e10a2f..7ac60a8 100644
  #ifdef BOOT_GPIO_ENABLED
  	romconf->mode = MODE_GPIO_ROM;
  #endif
+@@ -291,86 +309,94 @@ uint32 NOINLINE find_image(void) {
+ 	ets_delay_us(BOOT_DELAY_MICROS);
+ #endif
+ 
+-	ets_printf("\r\nrBoot v1.4.2 - richardaburton@gmail.com\r\n");
++#ifndef BOOT_SILENT
++#define echof(fmt, ...) ets_printf(fmt, ##__VA_ARGS__)
++#else
++#define echof(fmt, ...)
++#endif
++
++	echof("\r\nrBoot v1.4.2 - richardaburton@gmail.com\r\n");
+ 
+ 	// read rom header
+ 	SPIRead(0, header, sizeof(rom_header));
+ 
+ 	// print and get flash size
+-	ets_printf("Flash Size:   ");
++	echof("Flash Size:   ");
+ 	flag = header->flags2 >> 4;
+ 	if (flag == 0) {
+-		ets_printf("4 Mbit\r\n");
++		echof("4 Mbit\r\n");
+ 		flashsize = 0x80000;
+ 	} else if (flag == 1) {
+-		ets_printf("2 Mbit\r\n");
++		echof("2 Mbit\r\n");
+ 		flashsize = 0x40000;
+ 	} else if (flag == 2) {
+-		ets_printf("8 Mbit\r\n");
++		echof("8 Mbit\r\n");
+ 		flashsize = 0x100000;
+ 	} else if (flag == 3) {
+-		ets_printf("16 Mbit\r\n");
++		echof("16 Mbit\r\n");
+ #ifdef BOOT_BIG_FLASH
+ 		flashsize = 0x200000;
+ #else
+ 		flashsize = 0x100000; // limit to 8Mbit
+ #endif
+ 	} else if (flag == 4) {
+-		ets_printf("32 Mbit\r\n");
++		echof("32 Mbit\r\n");
+ #ifdef BOOT_BIG_FLASH
+ 		flashsize = 0x400000;
+ #else
+ 		flashsize = 0x100000; // limit to 8Mbit
+ #endif
+ 	} else {
+-		ets_printf("unknown\r\n");
++		echof("unknown\r\n");
+ 		// assume at least 4mbit
+ 		flashsize = 0x80000;
+ 	}
+ 
+ 	// print spi mode
+-	ets_printf("Flash Mode:   ");
++	echof("Flash Mode:   ");
+ 	if (header->flags1 == 0) {
+-		ets_printf("QIO\r\n");
++		echof("QIO\r\n");
+ 	} else if (header->flags1 == 1) {
+-		ets_printf("QOUT\r\n");
++		echof("QOUT\r\n");
+ 	} else if (header->flags1 == 2) {
+-		ets_printf("DIO\r\n");
++		echof("DIO\r\n");
+ 	} else if (header->flags1 == 3) {
+-		ets_printf("DOUT\r\n");
++		echof("DOUT\r\n");
+ 	} else {
+-		ets_printf("unknown\r\n");
++		echof("unknown\r\n");
+ 	}
+ 
+ 	// print spi speed
+-	ets_printf("Flash Speed:  ");
++	echof("Flash Speed:  ");
+ 	flag = header->flags2 & 0x0f;
+-	if (flag == 0) ets_printf("40 MHz\r\n");
+-	else if (flag == 1) ets_printf("26.7 MHz\r\n");
+-	else if (flag == 2) ets_printf("20 MHz\r\n");
+-	else if (flag == 0x0f) ets_printf("80 MHz\r\n");
+-	else ets_printf("unknown\r\n");
++	if (flag == 0) echof("40 MHz\r\n");
++	else if (flag == 1) echof("26.7 MHz\r\n");
++	else if (flag == 2) echof("20 MHz\r\n");
++	else if (flag == 0x0f) echof("80 MHz\r\n");
++	else echof("unknown\r\n");
+ 
+ 	// print enabled options
+ #ifdef BOOT_BIG_FLASH
+-	ets_printf("rBoot Option: Big flash\r\n");
++	echof("rBoot Option: Big flash\r\n");
+ #endif
+ #ifdef BOOT_CONFIG_CHKSUM
+-	ets_printf("rBoot Option: Config chksum\r\n");
++	echof("rBoot Option: Config chksum\r\n");
+ #endif
+ #ifdef BOOT_GPIO_ENABLED
+-	ets_printf("rBoot Option: GPIO rom mode (%d)\r\n", BOOT_GPIO_NUM);
++	echof("rBoot Option: GPIO rom mode (%d)\r\n", BOOT_GPIO_NUM);
+ #endif
+ #ifdef BOOT_GPIO_SKIP_ENABLED
+-	ets_printf("rBoot Option: GPIO skip mode (%d)\r\n", BOOT_GPIO_NUM);
++	echof("rBoot Option: GPIO skip mode (%d)\r\n", BOOT_GPIO_NUM);
+ #endif
+ #ifdef BOOT_RTC_ENABLED
+-	ets_printf("rBoot Option: RTC data\r\n");
++	echof("rBoot Option: RTC data\r\n");
+ #endif
+ #ifdef BOOT_IROM_CHKSUM
+-	ets_printf("rBoot Option: irom chksum\r\n");
++	echof("rBoot Option: irom chksum\r\n");
+ #endif
+-	ets_printf("\r\n");
++	echof("\r\n");
++
++#undef echof
+ 
+ 	// read boot config
+ 	SPIRead(BOOT_CONFIG_SECTOR * SECTOR_SIZE, buffer, SECTOR_SIZE);
 diff --git a/rboot.h b/rboot.h
 index 93ae317..bd3ad6d 100644
 --- a/rboot.h


### PR DESCRIPTION
When communication with another slower MCU it is important to decrease the unnecessary communication to minimum. This PR adds a directive RBOOT_SILENT that can be used to disable the initial boot messages from rBoot.