### PR TITLE
Added code that allows programmatically to manage the phy data.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -71,7 +71,8 @@ This feature is still **experimental** which means that we do not recommend it i
 - **Debug information for custom LWIP**: If you use custom LWIP (see above) some debug information will be printed for critical errors and situations. You can enable all debug information printing using `ENABLE_LWIPDEBUG=1`. To increase debugging for certain areas you can modify debug options in `third-party/esp-open-lwip/include/lwipopts.h`.
 - **Interactive debugging on the device**: (default: OFF) In order to be able to debug live directly on the ESP8266 microcontroller you should re-compile the Sming library and your application with `ENABLE_GDB=1` directive. See [Basic_Debug](https://github.com/SmingHub/Sming/tree/develop/samples/Basic_Debug) sample for more details.
 - **CommandExecutor feature**: (default: ON) This feature enables execution of certain commands by registering token handlers for text received via serial, websocket or telnet connection. If this feature is not used additional RAM/Flash can be obtained by setting `ENABLE_CMD_EXECUTOR=0`. This will save ~1KB RAM and ~3KB of flash memory.
-- **SDK 2.1.0+**: (default: OFF) In order to use SDK 2.1 you should set one environment variable before (re)compiling Sming AND applications based on it.  The variable is SDK_BASE and it should point to `$SMING_HOME/third-party/ESP8266_NONOS_SDK`.
+- **SDK 3.0.+**: (default: OFF) In order to use SDK 3.0+ you should set one environment variable before (re)compiling Sming AND applications based on it.  The variable is SDK_BASE and it should point to `$SMING_HOME/third-party/ESP8266_NONOS_SDK`.
+- **Custom Phy data**: (default OFF) Allows programatical control over the initial physical data. This feature can be enabled by recompiling the Sming library and application with `ENABLE_CUSTOM_PHY=1`.
 
 For Windows you need to do:
 ```

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -264,6 +264,8 @@ ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	CFLAGS += -DSDK_PWM_PERIOD_COMPAT_MODE=1
 endif
 
+ENABLE_CUSTOM_PHY ?= 0
+
 MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
 
 # compiler flags using during compilation of source files. Add '-pg' for debugging
@@ -286,6 +288,11 @@ ifneq ($(MFORCE32),)
 else 
     CFLAGS += -DPROGMEM_L32=""
 endif
+
+ifeq ($(ENABLE_CUSTOM_PHY),1)
+	CFLAGS += -DENABLE_CUSTOM_PHY=$(ENABLE_CUSTOM_PHY)
+endif
+
 #Append debug options
 CFLAGS += -DCUST_FILE_BASE=$$* -DDEBUG_VERBOSE_LEVEL=$(DEBUG_VERBOSE_LEVEL) -DDEBUG_PRINT_FILENAME_AND_LINE=$(DEBUG_PRINT_FILENAME_AND_LINE)
 

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -320,7 +320,7 @@ endif
 
 # linker flags used to generate the main object file
 LDFLAGS		= -nostdlib -u call_user_start -u custom_crash_callback -Wl,-static -Wl,--gc-sections -Wl,-Map=$(FW_BASE)/firmware.map -Wl,-wrap,system_restart_local 
-ifeq ($(ENABLE_CUSTOM_PHY)), 1)
+ifeq ($(ENABLE_CUSTOM_PHY), 1)
 	LDFLAGS += -Wl,-wrap,register_chipv6_phy -u custom_register_chipv6_phy -u get_adc_mode
 endif
 

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -250,6 +250,8 @@ ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	CUSTOM_TARGETS += $(USER_LIBDIR)/lib$(LIBPWM).a
 endif
 
+ENABLE_CUSTOM_PHY ?= 0
+
 # libraries used in this project, mainly provided by the SDK
 LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa $(LIBSMING) $(LIBMAIN) crypto $(LIBPWM) smartconfig $(EXTRA_LIBS)
 ifeq ($(ENABLE_WPS),1)
@@ -278,6 +280,10 @@ else
 endif
 ifeq ($(ENABLE_WPS),1)
 	CFLAGS += -DENABLE_WPS=1
+endif
+
+ifeq ($(ENABLE_CUSTOM_PHY),1)
+	CFLAGS += -DENABLE_CUSTOM_PHY=$(ENABLE_CUSTOM_PHY)
 endif
 
 #Append debug options
@@ -314,6 +320,9 @@ endif
 
 # linker flags used to generate the main object file
 LDFLAGS		= -nostdlib -u call_user_start -u custom_crash_callback -Wl,-static -Wl,--gc-sections -Wl,-Map=$(FW_BASE)/firmware.map -Wl,-wrap,system_restart_local 
+ifeq ($(ENABLE_CUSTOM_PHY)), 1)
+	LDFLAGS += -Wl,-wrap,register_chipv6_phy -u custom_register_chipv6_phy -u get_adc_mode
+endif
 
 # linker script used for the above linkier step
 LD_PATH     = $(SMING_HOME)/compiler/ld

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -259,6 +259,10 @@ ifeq ($(ENABLE_WPS),1)
    CFLAGS += -DENABLE_WPS=1
 endif
 
+ifeq ($(ENABLE_CUSTOM_PHY),1)
+	CFLAGS += -DENABLE_CUSTOM_PHY=$(ENABLE_CUSTOM_PHY)
+endif
+
 #Append debug options
 CFLAGS  += -DCUST_FILE_BASE=$$* -DDEBUG_VERBOSE_LEVEL=$(DEBUG_VERBOSE_LEVEL) -DDEBUG_PRINT_FILENAME_AND_LINE=$(DEBUG_PRINT_FILENAME_AND_LINE)
 CXXFLAGS = $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11 -felide-constructors
@@ -312,6 +316,8 @@ ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	CUSTOM_TARGETS += $(USER_LIBDIR)/lib$(LIBPWM).a
 endif
 
+ENABLE_CUSTOM_PHY ?= 0
+
 LIBS		= microc microgcc hal phy pp net80211 $(LIBLWIP) wpa $(LIBSMING) $(LIBMAIN) crypto $(LIBPWM) smartconfig $(EXTRA_LIBS)
 ifeq ($(ENABLE_WPS),1)
    LIBS += wps
@@ -354,6 +360,9 @@ endif
 
 # linker flags used to generate the main object file
 LDFLAGS		= -nostdlib -u call_user_start -u Cache_Read_Enable_New -u spiffs_get_storage_config -u custom_crash_callback -Wl,-static -Wl,--gc-sections -Wl,-Map=$(basename $@).map -Wl,-wrap,system_restart_local 
+ifeq ($(ENABLE_CUSTOM_PHY)), 1)
+	LDFLAGS += -Wl,-wrap,register_chipv6_phy -u custom_register_chipv6_phy -u get_adc_mode
+endif
 
 ifeq ($(SPI_SPEED), 26)
 	flashimageoptions = -ff 26m

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -360,7 +360,7 @@ endif
 
 # linker flags used to generate the main object file
 LDFLAGS		= -nostdlib -u call_user_start -u Cache_Read_Enable_New -u spiffs_get_storage_config -u custom_crash_callback -Wl,-static -Wl,--gc-sections -Wl,-Map=$(basename $@).map -Wl,-wrap,system_restart_local 
-ifeq ($(ENABLE_CUSTOM_PHY)), 1)
+ifeq ($(ENABLE_CUSTOM_PHY), 1)
 	LDFLAGS += -Wl,-wrap,register_chipv6_phy -u custom_register_chipv6_phy -u get_adc_mode
 endif
 

--- a/Sming/system/esp8266_phy.c
+++ b/Sming/system/esp8266_phy.c
@@ -22,14 +22,14 @@
 
 #include <user_config.h>
 
-#ifndef F_CRYSTAL
-#define F_CRYSTAL 40000000
+#ifndef ICACHE_RAM_ATTR
+#define ICACHE_RAM_ATTR __attribute__((section(".iram.text")))
 #endif
 
-static const uint8_t phyInitData[128] =
+static const uint8_t ICACHE_FLASH_ATTR phyInitData[128] =
 {
     [0] = 5,  // Reserved, do not change
-    [1] = 8,  // Reserved, do not change
+    [1] = 0,  // Reserved, do not change
     [2] = 4,  // Reserved, do not change
     [3] = 2,  // Reserved, do not change
     [4] = 5,  // Reserved, do not change
@@ -66,11 +66,11 @@ static const uint8_t phyInitData[128] =
     [32] = 0xf8, // Reserved, do not change
     [33] = 0xf8, // Reserved, do not change
 
-    [34] = 78, // target_power_qdb_0, target power is 78/4=19.5dbm
-    [35] = 74, // target_power_qdb_1, target power is 74/4=18.5dbm
-    [36] = 70, // target_power_qdb_2, target power is 70/4=17.5dbm
-    [37] = 64, // target_power_qdb_3, target power is 64/4=16dbm
-    [38] = 60, // target_power_qdb_4, target power is 60/4=15dbm
+    [34] = 0x52, // target_power_qdb_0, target power is 78/4=19.5dbm
+    [35] = 0x4e, // target_power_qdb_1, target power is 74/4=18.5dbm
+    [36] = 0x4a, // target_power_qdb_2, target power is 70/4=17.5dbm
+    [37] = 0x44, // target_power_qdb_3, target power is 64/4=16dbm
+    [38] = 0x40, // target_power_qdb_4, target power is 60/4=15dbm
     [39] = 56, // target_power_qdb_5, target power is 56/4=14dbm
 
     [40] = 0, // target_power_index_mcs0
@@ -86,11 +86,7 @@ static const uint8_t phyInitData[128] =
     // 0: 40MHz
     // 1: 26MHz
     // 2: 24MHz
-    #if F_CRYSTAL == 40000000
-      [48] = 0,
-    #else
-      [48] = 1,
-    #endif
+    [48] = 1,
 
     // sdio_configure
     // 0: Auto by pin strapping
@@ -229,7 +225,7 @@ static const uint8_t phyInitData[128] =
     // 3: auto measure frequency offset and correct it,  bbpll is 160M, it only can correct + frequency offset.
     // 5: use 113 byte force_freq_offset to correct frequency offset, bbpll is 168M, it can correct + and - frequency offset.
     // 7: use 113 byte force_freq_offset to correct frequency offset, bbpll is 160M , it only can correct + frequency offset.
-    [112] = 0,
+    [112] = 3,
 
     // force_freq_offset
     // signed, unit is 8kHz
@@ -243,21 +239,17 @@ static const uint8_t phyInitData[128] =
     [114] = 1
 };
 
-#ifndef F_CRYSTAL
-#define F_CRYSTAL 40000000
-#endif
-
 extern int __real_register_chipv6_phy(uint8_t* initData);
 
-int __attribute__((weak)) get_adc_mode()
+int ICACHE_RAM_ATTR __attribute__((weak)) get_adc_mode()
 {
 	return 33;
 }
 
-int ICACHE_FLASH_ATTR __attribute__((weak)) custom_register_chipv6_phy(uint8_t* initData)
+int ICACHE_RAM_ATTR __attribute__((weak)) custom_register_chipv6_phy(uint8_t* initData)
 {
 	if (initData != NULL) {
-	  memcpy(initData, phyInitData, sizeof(phyInitData));
+	  memcpy_P(initData, phyInitData, sizeof(phyInitData));
 	  initData[107] = get_adc_mode();
 	}
 	return __real_register_chipv6_phy(initData);

--- a/Sming/system/esp8266_phy.c
+++ b/Sming/system/esp8266_phy.c
@@ -1,0 +1,268 @@
+/*
+ Adapted from Arduino for Sming.
+ Original copyright note is kept below.
+
+ phy.c - ESP8266 PHY initialization data
+ Copyright (c) 2015 Ivan Grokhotkov. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifdef ENABLE_CUSTOM_PHY
+
+#include <user_config.h>
+
+#ifndef F_CRYSTAL
+#define F_CRYSTAL 40000000
+#endif
+
+static const uint8_t ICACHE_FLASH_ATTR phyInitData[128] =
+{
+    [0] = 5,  // Reserved, do not change
+    [1] = 8,  // Reserved, do not change
+    [2] = 4,  // Reserved, do not change
+    [3] = 2,  // Reserved, do not change
+    [4] = 5,  // Reserved, do not change
+    [5] = 5,  // Reserved, do not change
+    [6] = 5,  // Reserved, do not change
+    [7] = 2,  // Reserved, do not change
+    [8] = 5,  // Reserved, do not change
+    [9] = 0,  // Reserved, do not change
+    [10] = 4,  // Reserved, do not change
+    [11] = 5,  // Reserved, do not change
+    [12] = 5,  // Reserved, do not change
+    [13] = 4,  // Reserved, do not change
+    [14] = 5,  // Reserved, do not change
+    [15] = 5,  // Reserved, do not change
+    [16] = 4,  // Reserved, do not change
+    [17] = -2, // Reserved, do not change
+    [18] = -3, // Reserved, do not change
+    [19] = -1, // Reserved, do not change
+    [20] = -16, // Reserved, do not change
+    [21] = -16, // Reserved, do not change
+    [22] = -16, // Reserved, do not change
+    [23] = -32, // Reserved, do not change
+    [24] = -32, // Reserved, do not change
+    [25] = -32, // Reserved, do not change
+
+    [26] = 225, // spur_freq_cfg, spur_freq=spur_freq_cfg/spur_freq_cfg_div
+    [27] = 10,  // spur_freq_cfg_div
+    // each bit for 1 channel, 1 to select the spur_freq if in band, else 40
+    [28] = 0xff,   // spur_freq_en_h
+    [29] = 0xff,   // spur_freq_en_l
+
+    [30] = 0xf8, // Reserved, do not change
+    [31] = 0,    // Reserved, do not change
+    [32] = 0xf8, // Reserved, do not change
+    [33] = 0xf8, // Reserved, do not change
+
+    [34] = 78, // target_power_qdb_0, target power is 78/4=19.5dbm
+    [35] = 74, // target_power_qdb_1, target power is 74/4=18.5dbm
+    [36] = 70, // target_power_qdb_2, target power is 70/4=17.5dbm
+    [37] = 64, // target_power_qdb_3, target power is 64/4=16dbm
+    [38] = 60, // target_power_qdb_4, target power is 60/4=15dbm
+    [39] = 56, // target_power_qdb_5, target power is 56/4=14dbm
+
+    [40] = 0, // target_power_index_mcs0
+    [41] = 0, // target_power_index_mcs1
+    [42] = 1, // target_power_index_mcs2
+    [43] = 1, // target_power_index_mcs3
+    [44] = 2, // target_power_index_mcs4
+    [45] = 3, // target_power_index_mcs5
+    [46] = 4, // target_power_index_mcs6
+    [47] = 5, // target_power_index_mcs7
+
+    // crystal_26m_en
+    // 0: 40MHz
+    // 1: 26MHz
+    // 2: 24MHz
+    #if F_CRYSTAL == 40000000
+      [48] = 0,
+    #else
+      [48] = 1,
+    #endif
+
+    // sdio_configure
+    // 0: Auto by pin strapping
+    // 1: SDIO dataoutput is at negative edges (SDIO V1.1)
+    // 2: SDIO dataoutput is at positive edges (SDIO V2.0)
+    [50] = 0,
+
+    // bt_configure
+    // 0: None,no bluetooth
+    // 1: GPIO0 -> WLAN_ACTIVE/ANT_SEL_WIFI
+    //    MTMS -> BT_ACTIVE
+    //    MTCK  -> BT_PRIORITY
+    //    U0RXD -> ANT_SEL_BT
+    // 2: None, have bluetooth
+    // 3: GPIO0 -> WLAN_ACTIVE/ANT_SEL_WIFI
+    //    MTMS -> BT_PRIORITY
+    //    MTCK  -> BT_ACTIVE
+    //    U0RXD -> ANT_SEL_BT
+    [51] = 0,
+
+    // bt_protocol
+    // 0: WiFi-BT are not enabled. Antenna is for WiFi
+    // 1: WiFi-BT are not enabled. Antenna is for BT
+    // 2: WiFi-BT 2-wire are enabled, (only use BT_ACTIVE), independent ant
+    // 3: WiFi-BT 3-wire are enabled, (when BT_ACTIVE = 0, BT_PRIORITY must be 0), independent ant
+    // 4: WiFi-BT 2-wire are enabled, (only use BT_ACTIVE), share ant
+    // 5: WiFi-BT 3-wire are enabled, (when BT_ACTIVE = 0, BT_PRIORITY must be 0), share ant
+    [52] = 0,
+
+    // dual_ant_configure
+    // 0: None
+    // 1: dual_ant (antenna diversity for WiFi-only): GPIO0 + U0RXD
+    // 2: T/R switch for External PA/LNA:  GPIO0 is high and U0RXD is low during Tx
+    // 3: T/R switch for External PA/LNA:  GPIO0 is low and U0RXD is high during Tx
+    [53] = 0,
+
+    [54] = 2, // Reserved, do not change
+
+    // share_xtal
+    // This option is to share crystal clock for BT
+    // The state of Crystal during sleeping
+    // 0: Off
+    // 1: Forcely On
+    // 2: Automatically On according to XPD_DCDC
+    // 3: Automatically On according to GPIO2
+    [55] = 0,
+
+    [64] = 225, // spur_freq_cfg_2, spur_freq_2=spur_freq_cfg_2/spur_freq_cfg_div_2
+    [65] = 10,  // spur_freq_cfg_div_2
+    [66] = 0,   // spur_freq_en_h_2
+    [67] = 0,   // spur_freq_en_l_2
+    [68] = 0,   // spur_freq_cfg_msb
+    [69] = 0,   // spur_freq_cfg_2_msb
+    [70] = 0,   // spur_freq_cfg_3_low
+    [71] = 0,   // spur_freq_cfg_3_high
+    [72] = 0,   // spur_freq_cfg_4_low
+    [73] = 0,   // spur_freq_cfg_4_high
+
+    [74] = 1,   // Reserved, do not change
+    [75] = 0x93,   // Reserved, do not change
+    [76] = 0x43,   // Reserved, do not change
+    [77] = 0x00,   // Reserved, do not change
+
+    // low_power_en
+    // 0: disable low power mode
+    // 1: enable low power mode
+    [93] = 0,
+
+    // lp_rf_stg10
+    // the attenuation of RF gain stage 0 and 1,
+    // 0xf: 0db,
+    // 0xe: -2.5db,
+    // 0xd: -6db,
+    // 0x9: -8.5db,
+    // 0xc: -11.5db,
+    // 0x8: -14db,
+    // 0x4: -17.5,
+    // 0x0: -23
+    [94] = 0x00,
+
+    // lp_bb_att_ext
+    // the attenuation of BB gain,
+    // 0: 0db,
+    // 1: -0.25db,
+    // 2: -0.5db,
+    // 3: -0.75db,
+    // 4: -1db,
+    // 5: -1.25db,
+    // 6: -1.5db,
+    // 7: -1.75db,
+    // 8: -2db
+    // max valve is 24(-6db)
+    [95] = 0,
+
+    // pwr_ind_11b_en
+    // 0: 11b power is same as mcs0 and 6m
+    // 1: enable 11b power different with ofdm
+    [96] = 0,
+
+    // pwr_ind_11b_0
+    // 1m, 2m power index [0~5]
+    [97] = 0,
+
+    // pwr_ind_11b_1
+    // 5.5m, 11m power index [0~5]
+    [98] = 0,
+
+    // vdd33_const
+    // the voltage of PA_VDD
+    // x=0xff: it can measure VDD33,
+    // 18<=x<=36: use input voltage,
+    // the value is voltage*10, 33 is 3.3V, 30 is 3.0V,
+    // x<18 or x>36: default voltage is 3.3V
+    //
+    // the value of this byte depend from the TOUT pin usage (1 or 2):
+    // 1)
+    // analogRead function (system_adc_read()):
+    // is only available when wire TOUT pin17 to external circuitry, Input Voltage Range restricted to 0 ~ 1.0V.
+    // For this function the vdd33_const must be set as real power voltage of VDD3P3 pin 3 and 4
+    // The range of operating voltage of ESP8266 is 1.8V~3.6V，the unit of vdd33_const is 0.1V，so effective value range of vdd33_const is [18,36]
+    // 2)
+    // getVcc function (system_get_vdd33):
+    // is only available when TOUT pin17 is suspended (floating), this function measure the power voltage of VDD3P3 pin 3 and 4
+    // For this function the vdd33_const must be set to 255 (0xFF).
+    [107] = 33,
+
+    // disable RF calibration for certain number of times
+    [108] = 0,
+
+    // freq_correct_en
+    // bit[0]:0->do not correct frequency offset, 1->correct frequency offset.
+    // bit[1]:0->bbpll is 168M, it can correct + and - frequency offset,  1->bbpll is 160M, it only can correct + frequency offset
+    // bit[2]:0->auto measure frequency offset and correct it, 1->use 113 byte force_freq_offset to correct frequency offset.
+    // 0: do not correct frequency offset.
+    // 1: auto measure frequency offset and correct it,  bbpll is 168M, it can correct + and - frequency offset.
+    // 3: auto measure frequency offset and correct it,  bbpll is 160M, it only can correct + frequency offset.
+    // 5: use 113 byte force_freq_offset to correct frequency offset, bbpll is 168M, it can correct + and - frequency offset.
+    // 7: use 113 byte force_freq_offset to correct frequency offset, bbpll is 160M , it only can correct + frequency offset.
+    [112] = 0,
+
+    // force_freq_offset
+    // signed, unit is 8kHz
+    [113] = 0,
+
+    // rf_cal_use_flash
+    // 0: RF init no RF CAL, using all RF CAL data in flash, it takes about 2ms for RF init
+    // 1: RF init only do TX power control CAL, others using RF CAL data in flash, it takes about 20ms for RF init
+    // 2: RF init no RF CAL, using all RF CAL data in flash, it takes about 2ms for RF init  (same as 0?!)
+    // 3: RF init do all RF CAL, it takes about 200ms for RF init
+    [114] = 1
+};
+
+#ifndef F_CRYSTAL
+#define F_CRYSTAL 40000000
+#endif
+
+extern int __real_register_chipv6_phy(uint8_t* initData);
+
+int __attribute__((weak)) get_adc_mode()
+{
+	return 33;
+}
+
+int ICACHE_FLASH_ATTR __attribute__((weak)) custom_register_chipv6_phy(uint8_t* initData)
+{
+	if (initData != NULL) {
+	  memcpy(initData, phyInitData, sizeof(phyInitData));
+	  initData[107] = get_adc_mode();
+	}
+	return __real_register_chipv6_phy(initData);
+}
+
+int __wrap_register_chipv6_phy(uint8_t* initData) __attribute__ ((alias("custom_register_chipv6_phy")));
+
+#endif /* ENABLE_CUSTOM_PHY */

--- a/Sming/system/esp8266_phy.c
+++ b/Sming/system/esp8266_phy.c
@@ -26,7 +26,7 @@
 #define F_CRYSTAL 40000000
 #endif
 
-static const uint8_t ICACHE_FLASH_ATTR phyInitData[128] =
+static const uint8_t phyInitData[128] =
 {
     [0] = 5,  // Reserved, do not change
     [1] = 8,  // Reserved, do not change


### PR DESCRIPTION
The initial physical data is used initialize an ESP8266 chip and controls its behaviour. Sometimes you may want to change that data for a certain ROM on the device without changing it for all ROMs on the device. 
This PR introduces a new feature that allows programmatically to control and change the initial physical data.

That option is not enabled by default but can be enabled with ENABLE_CUSTOM_PHY=1 directive.

Closes #985.