### PR TITLE
General changes to Stream classes

### DIFF
--- a/Sming/SmingCore/Data/CircularBuffer.cpp
+++ b/Sming/SmingCore/Data/CircularBuffer.cpp
@@ -13,20 +13,6 @@
 
 #include "CircularBuffer.h"
 
-CircularBuffer::CircularBuffer(int size) : buffer(new char[size]), readPos(buffer), writePos(buffer), size(size)
-{
-}
-
-CircularBuffer::~CircularBuffer()
-{
-	delete[] buffer;
-}
-
-StreamType CircularBuffer::getStreamType()
-{
-	return StreamType::eSST_Memory;
-}
-
 uint16_t CircularBuffer::readMemoryBlock(char* data, int bufSize)
 {
 	size_t bytesAvailable = available();
@@ -62,11 +48,6 @@ bool CircularBuffer::seek(int len)
 	return true;
 }
 
-bool CircularBuffer::isFinished()
-{
-	return (available() < 1);
-}
-
 int CircularBuffer::available()
 {
 	if(writePos >= readPos) {
@@ -81,12 +62,6 @@ size_t CircularBuffer::room() const
 		return size - (writePos - readPos) - 1;
 	}
 	return readPos - writePos - 1;
-}
-
-String CircularBuffer::id()
-{
-	// TODO: check if that is printing the address of the buffer...
-	return String((char*)&buffer);
 }
 
 size_t CircularBuffer::write(uint8_t charToWrite)

--- a/Sming/SmingCore/Data/CircularBuffer.h
+++ b/Sming/SmingCore/Data/CircularBuffer.h
@@ -27,15 +27,23 @@
 class CircularBuffer : public ReadWriteStream
 {
 public:
-	CircularBuffer(int size);
+	CircularBuffer(int size) : buffer(new char[size]), readPos(buffer), writePos(buffer), size(size)
+	{
+	}
 
-	virtual ~CircularBuffer();
+	virtual ~CircularBuffer()
+	{
+		delete[] buffer;
+	}
 
 	/** @brief  Get the stream type
      *  @retval StreamType The stream type.
      *  @todo   Return value of IDataSourceStream:getStreamType base class function should be of type StreamType, e.g. eSST_User
      */
-	virtual StreamType getStreamType();
+	virtual StreamType getStreamType()
+	{
+		return StreamType::eSST_Memory;
+	}
 
 	/** @brief  Read a block of memory
      *  @param  data Pointer to the data to be read
@@ -52,9 +60,12 @@ public:
 	virtual bool seek(int len);
 
 	/** @brief  Check if stream is finished
-     *  @retval bool True on success.
-     */
-	virtual bool isFinished();
+	 *  @retval bool true on success.
+	 */
+	virtual bool isFinished()
+	{
+		return available() < 1;
+	}
 
 	/**
 	 * @brief Return the total length of the stream
@@ -66,7 +77,10 @@ public:
 	 * @brief Returns unique id of the resource.
 	 * @retval String the unique id of the stream.
 	 */
-	virtual String id();
+	virtual String id()
+	{
+		return String(reinterpret_cast<uint32_t>(&buffer), HEX);
+	}
 
 	virtual size_t write(uint8_t charToWrite);
 
@@ -75,8 +89,11 @@ public:
      *  @param  size Quantity of chars to writen
      *  @retval size_t Quantity of chars written to stream
      */
-	virtual size_t write(const uint8_t* buffer, size_t size);
+	virtual size_t write(const uint8_t* data, size_t size);
 
+	/** @brief Get the maximum number of bytes for which write() will succeed
+		@retval size_t
+	*/
 	size_t room() const;
 
 	inline void flush()
@@ -92,9 +109,9 @@ private:
 	}
 
 private:
-	char* buffer = NULL;
-	char* readPos = NULL;
-	char* writePos = NULL;
+	char* buffer = nullptr;
+	char* readPos = nullptr;
+	char* writePos = nullptr;
 	int size = 0;
 };
 

--- a/Sming/SmingCore/Data/Stream/DataSourceStream.h
+++ b/Sming/SmingCore/Data/Stream/DataSourceStream.h
@@ -85,6 +85,14 @@ public:
 		return -1;
 	}
 
+	/*
+	 * From Stream class: We don't write using this stream
+	 */
+	virtual size_t write(uint8_t charToWrite)
+	{
+		return 0;
+	}
+
 	/**
 	 * @brief Return the total length of the stream
 	 * @retval int -1 is returned when the size cannot be determined
@@ -110,7 +118,7 @@ public:
 	 */
 	virtual String id()
 	{
-		return String();
+		return nullptr;
 	}
 };
 

--- a/Sming/SmingCore/Data/Stream/EndlessMemoryStream.cpp
+++ b/Sming/SmingCore/Data/Stream/EndlessMemoryStream.cpp
@@ -7,61 +7,26 @@
 
 #include "EndlessMemoryStream.h"
 
-EndlessMemoryStream::~EndlessMemoryStream()
-{
-	delete stream;
-	stream = NULL;
-}
-
-StreamType EndlessMemoryStream::getStreamType()
-{
-	return eSST_Memory;
-}
-
-uint16_t EndlessMemoryStream::readMemoryBlock(char* data, int bufSize)
-{
-	if(stream == NULL) {
-		return 0;
-	}
-
-	return stream->readMemoryBlock(data, bufSize);
-}
-
-//Use base class documentation
 bool EndlessMemoryStream::seek(int len)
 {
-	if(stream == NULL) {
+	if(stream == nullptr) {
 		return false;
 	}
 
 	int res = stream->seek(len);
 	if(stream->isFinished()) {
 		delete stream;
-		stream = NULL;
+		stream = nullptr;
 	}
 
 	return res;
 }
 
-size_t EndlessMemoryStream::write(uint8_t charToWrite)
-{
-	if(stream == NULL) {
-		stream = new MemoryDataStream();
-	}
-
-	return stream->write(charToWrite);
-}
-
 size_t EndlessMemoryStream::write(const uint8_t* buffer, size_t size)
 {
-	if(stream == NULL) {
+	if(stream == nullptr) {
 		stream = new MemoryDataStream();
 	}
 
 	return stream->write(buffer, size);
-}
-
-bool EndlessMemoryStream::isFinished()
-{
-	return false;
 }

--- a/Sming/SmingCore/Data/Stream/EndlessMemoryStream.h
+++ b/Sming/SmingCore/Data/Stream/EndlessMemoryStream.h
@@ -25,21 +25,22 @@
 class EndlessMemoryStream : public ReadWriteStream
 {
 public:
-	virtual ~EndlessMemoryStream();
+	virtual ~EndlessMemoryStream()
+	{
+		delete stream;
+	}
 
-	//Use base class documentation
-	virtual StreamType getStreamType();
+	virtual StreamType getStreamType()
+	{
+		return eSST_Memory;
+	}
 
-	virtual uint16_t readMemoryBlock(char* data, int bufSize);
+	virtual uint16_t readMemoryBlock(char* data, int bufSize)
+	{
+		return stream ? stream->readMemoryBlock(data, bufSize) : 0;
+	}
 
-	//Use base class documentation
 	virtual bool seek(int len);
-
-	/** @brief  Write a single char to stream
-	 *  @param  charToWrite Char to write to the stream
-	 *  @retval size_t Quantity of chars written to stream (always 1)
-	 */
-	virtual size_t write(uint8_t charToWrite);
 
 	/** @brief  Write chars to stream
 	 *  @param  buffer Pointer to buffer to write to the stream
@@ -48,10 +49,16 @@ public:
 	 */
 	virtual size_t write(const uint8_t* buffer, size_t size);
 
-	virtual bool isFinished();
+	/** @todo is this behaviour consistent with DataSourceStream ?
+	 * It might be desirable to return true when _stream is null.
+	 */
+	virtual bool isFinished()
+	{
+		return false;
+	}
 
 private:
-	MemoryDataStream* stream = NULL;
+	MemoryDataStream* stream = nullptr;
 };
 
 /** @} */

--- a/Sming/SmingCore/Data/Stream/EndlessMemoryStream.h
+++ b/Sming/SmingCore/Data/Stream/EndlessMemoryStream.h
@@ -49,9 +49,6 @@ public:
 	 */
 	virtual size_t write(const uint8_t* buffer, size_t size);
 
-	/** @todo is this behaviour consistent with DataSourceStream ?
-	 * It might be desirable to return true when _stream is null.
-	 */
 	virtual bool isFinished()
 	{
 		return false;

--- a/Sming/SmingCore/Data/Stream/JsonObjectStream.cpp
+++ b/Sming/SmingCore/Data/Stream/JsonObjectStream.cpp
@@ -7,34 +7,12 @@
 
 #include "JsonObjectStream.h"
 
-JsonObjectStream::JsonObjectStream() : rootNode(buffer.createObject()), send(true)
-{
-}
-
-JsonObjectStream::~JsonObjectStream()
-{
-}
-
-JsonObject& JsonObjectStream::getRoot()
-{
-	return rootNode;
-}
-
 uint16_t JsonObjectStream::readMemoryBlock(char* data, int bufSize)
 {
-	if(rootNode != JsonObject::invalid() && send) {
+	if(send && rootNode.success()) {
 		rootNode.printTo(*this);
 		send = false;
 	}
 
 	return MemoryDataStream::readMemoryBlock(data, bufSize);
-}
-
-int JsonObjectStream::available()
-{
-	if(rootNode == JsonObject::invalid()) {
-		return 0;
-	}
-
-	return rootNode.measureLength();
 }

--- a/Sming/SmingCore/Data/Stream/JsonObjectStream.h
+++ b/Sming/SmingCore/Data/Stream/JsonObjectStream.h
@@ -22,8 +22,13 @@ class JsonObjectStream : public MemoryDataStream
 public:
 	/** @brief  Create a JSON object stream
     */
-	JsonObjectStream();
-	virtual ~JsonObjectStream();
+	JsonObjectStream() : rootNode(buffer.createObject())
+	{
+	}
+
+	virtual ~JsonObjectStream()
+	{
+	}
 
 	//Use base class documentation
 	virtual StreamType getStreamType()
@@ -34,7 +39,10 @@ public:
 	/** @brief  Get the JSON root node
      *  @retval JsonObject Reference to the root node
      */
-	JsonObject& getRoot();
+	JsonObject& getRoot()
+	{
+		return rootNode;
+	}
 
 	//Use base class documentation
 	virtual uint16_t readMemoryBlock(char* data, int bufSize);
@@ -43,12 +51,15 @@ public:
 	 * @brief Return the total length of the stream
 	 * @retval int -1 is returned when the size cannot be determined
 	 */
-	int available();
+	int available()
+	{
+		return rootNode.success() ? rootNode.measureLength() : 0;
+	}
 
 private:
 	DynamicJsonBuffer buffer;
 	JsonObject& rootNode;
-	bool send;
+	bool send = true;
 };
 
 /** @} */

--- a/Sming/SmingCore/Data/Stream/LimitedMemoryStream.h
+++ b/Sming/SmingCore/Data/Stream/LimitedMemoryStream.h
@@ -57,7 +57,7 @@ public:
 	virtual bool isFinished();
 
 private:
-	uint8_t* buffer = NULL;
+	uint8_t* buffer = nullptr;
 	size_t writePos = 0;
 	size_t readPos = 0;
 	size_t length = 0;

--- a/Sming/SmingCore/Data/Stream/MemoryDataStream.cpp
+++ b/Sming/SmingCore/Data/Stream/MemoryDataStream.cpp
@@ -9,38 +9,12 @@
 
 /* MemoryDataStream */
 
-MemoryDataStream::MemoryDataStream()
-{
-	buf = NULL;
-	pos = NULL;
-	size = 0;
-	capacity = 0;
-}
-
-MemoryDataStream::~MemoryDataStream()
-{
-	free(buf);
-	buf = NULL;
-	pos = NULL;
-	size = 0;
-}
-
-int MemoryDataStream::available()
-{
-	return size - (pos - buf);
-}
-
-size_t MemoryDataStream::write(uint8_t charToWrite)
-{
-	return write(&charToWrite, 1);
-}
-
 size_t MemoryDataStream::write(const uint8_t* data, size_t len)
 {
 	//TODO: add queued buffers without full copy
-	if(buf == NULL) {
+	if(buf == nullptr) {
 		buf = (char*)malloc(len + 1);
-		if(buf == NULL)
+		if(buf == nullptr)
 			return 0;
 		buf[len] = '\0';
 		memcpy(buf, data, len);
@@ -81,9 +55,4 @@ bool MemoryDataStream::seek(int len)
 
 	pos += len;
 	return true;
-}
-
-bool MemoryDataStream::isFinished()
-{
-	return size == (pos - buf);
 }

--- a/Sming/SmingCore/Data/Stream/MemoryDataStream.h
+++ b/Sming/SmingCore/Data/Stream/MemoryDataStream.h
@@ -28,8 +28,14 @@ class MemoryDataStream : public ReadWriteStream
 public:
 	/** @brief Memory data stream base class
     */
-	MemoryDataStream();
-	virtual ~MemoryDataStream();
+	MemoryDataStream()
+	{
+	}
+
+	virtual ~MemoryDataStream()
+	{
+		free(buf);
+	}
 
 	//Use base class documentation
 	virtual StreamType getStreamType()
@@ -40,7 +46,7 @@ public:
 	/** @brief  Get a pointer to the current position
 	 *  @retval "const char*" Pointer to current cursor position within the data stream
 	 */
-	const char* getStreamPointer()
+	const char* getStreamPointer() const
 	{
 		return pos;
 	}
@@ -49,15 +55,14 @@ public:
 	 * @brief Return the total length of the stream
 	 * @retval int -1 is returned when the size cannot be determined
 	*/
-	int available();
+	int available()
+	{
+		return size - (pos - buf);
+	}
 
-	/** @brief  Write a single char to stream
-     *  @param  charToWrite Char to write to the stream
-     *  @retval size_t Quantity of chars written to stream (always 1)
-     */
-	virtual size_t write(uint8_t charToWrite);
+	using ReadWriteStream::write;
 
-	/** @brief  Write chars to stream
+	/** @brief  Write chars to end of stream
      *  @param  buffer Pointer to buffer to write to the stream
      *  @param  size Quantity of chars to write
      *  @retval size_t Quantity of chars written to stream
@@ -71,13 +76,16 @@ public:
 	virtual bool seek(int len);
 
 	//Use base class documentation
-	virtual bool isFinished();
+	virtual bool isFinished()
+	{
+		return size == (pos - buf);
+	}
 
 private:
-	char* buf;
-	char* pos;
-	int size;
-	int capacity;
+	char* buf = nullptr;
+	char* pos = nullptr;
+	int size = 0;
+	int capacity = 0;
 };
 
 /** @} */

--- a/Sming/SmingCore/Data/Stream/ReadWriteStream.h
+++ b/Sming/SmingCore/Data/Stream/ReadWriteStream.h
@@ -24,7 +24,10 @@ public:
 	{
 	}
 
-	virtual size_t write(uint8_t charToWrite) = 0;
+	virtual size_t write(uint8_t charToWrite)
+	{
+		return write(&charToWrite, 1);
+	}
 
 	/** @brief  Write chars to stream
      *  @param  buffer Pointer to buffer to write to the stream


### PR DESCRIPTION
* Move trivial code into header
* Use member variable initialisers instead of setting defaults in constructor
* Change int to unsigned/size_t as appropriate
* Change appropriate methods to const (except where there's a risk of breaking other code)
* Amend comments to clarify operation
* Mark inherited methods with virtual (if not already)
* Add ReadWriteStream::write(uint8_t) implementation to call write(const char*, size_t) method by default