### PR TITLE
HttpRequest improvements and move HttpParams into separate module

### DIFF
--- a/Sming/Services/WebHelpers/escape.h
+++ b/Sming/Services/WebHelpers/escape.h
@@ -4,11 +4,49 @@
 #include <user_config.h>
 #include "WString.h"
 
+/** @brief Obtain number of characters required to escape the given text
+ *  @param s source text
+ *  @param len Number of characters in source text
+ *  @retval unsigned number of characters for output, NOT including nul terminator
+ */
 unsigned uri_escape_len(const char *s, size_t len);
+
+static inline unsigned uri_escape_len(const String& str)
+{
+	return uri_escape_len(str.c_str(), str.length());
+}
+
+/** @brief Escape text
+ *  @param dest buffer to store result
+ *  @param dest_len available space in dest; requires +1 extra character for nul terminator,
+ *                  so at least uri_escape_len() + 1
+ *  @param src source text to escape
+ *  @param src_len number of characters in source
+ *  @retval char* points to start of dest
+ *  @note destination and source MUST be different buffers
+ */
 char *uri_escape(char *dest, size_t dest_len, const char *src, int src_len);
+
+/** @brief unescape text
+ *  @param dest buffer to store result
+ *  @param dest_len available space in dest; requires +1 extra character for nul terminator
+ *  @param src source text to un-escape
+ *  @param src_len number of characters in source
+ *  @retval char* points to start of dest
+ *  @note destination and source may be the same buffer
+ */
 char *uri_unescape(char *dest, size_t dest_len, const char *src, int src_len);
+
 unsigned html_escape_len(const char *s, size_t len);
 void html_escape(char *dest, size_t len, const char *s);
+
+
+/** @brief Replace a nul-terminated string with its unescaped version
+ *  @param str the string to un-escape
+ *  @retval char* the result, a copy of str
+ *  @note unescaped string is never longer than escaped version
+ */
+char* uri_unescape_inplace(char *str);
 
 /** @brief escape the given URI string
  *  @param src
@@ -24,18 +62,19 @@ static inline String uri_escape(const String& src)
 }
 
 
-/** @brief replace the given uri by its unescaped version
- *  @retval int length of result
+/** @brief replace the given text by its unescaped version
+ *  @param str the string to unescape
+ *  @retval reference to str, unescaped
  *  @note unescaped string is never longer than escaped version
  */
-int uri_unescape_inplace(String& s);
+String& uri_unescape_inplace(String& str);
 
 /** @brief return the unescaped version of a string
  *  @retval String unescaped string
  */
-static inline String uri_unescape(const String& s)
+static inline String uri_unescape(const String& str)
 {
-	String ret = s;
+	String ret = str;
 	uri_unescape_inplace(ret);
 	return ret;
 }

--- a/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.cpp
@@ -13,16 +13,10 @@
 
 /*
  * @todo Revise this so stream produces encoded output line-by-line, rather than all at once.
+ * Can use StreamTransformer to do this.
  */
 
 UrlencodedOutputStream::UrlencodedOutputStream(const HttpParams& params)
 {
-	for(unsigned i = 0; i < params.count(); i++) {
-		if(i > 0)
-			stream.write('&');
-
-		stream.print(uri_escape(params.keyAt(i)));
-		stream.print('=');
-		stream.print(uri_escape(params.valueAt(i)));
-	}
+	stream.print(params);
 }

--- a/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.h
+++ b/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.h
@@ -12,16 +12,14 @@
 #define _SMING_CORE_DATA_URL_ENCODDED_OUTPUT_STREAM_H_
 
 #include "MemoryDataStream.h"
-#include "WHashMap.h"
+#include "Network/Http/HttpParams.h"
 
 /**
  * @brief      UrlEncoded Stream
  * @ingroup    stream data
  *
  *  @{
-*/
-
-typedef HashMap<String, String> HttpParams;
+ */
 
 class UrlencodedOutputStream : public ReadWriteStream
 {

--- a/Sming/SmingCore/Data/Structures.h
+++ b/Sming/SmingCore/Data/Structures.h
@@ -47,6 +47,4 @@ public:
 	}
 };
 
-typedef HashMap<String, String> HttpParams;
-
 #endif /* _SMING_CORE_DATA_STRUCTURES_H_ */

--- a/Sming/SmingCore/Network/Http/HttpParams.cpp
+++ b/Sming/SmingCore/Network/Http/HttpParams.cpp
@@ -1,0 +1,27 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * @author: 2018 - Mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#include "HttpParams.h"
+#include "../Services/WebHelpers/escape.h"
+#include "Print.h"
+
+size_t HttpParams::printTo(Print& p) const
+{
+	size_t charsPrinted = 0;
+	for(unsigned i = 0; i < count(); i++) {
+		if(i > 0)
+			charsPrinted += p.print('&');
+		charsPrinted += p.print(uri_escape(keyAt(i)));
+		charsPrinted += p.print('=');
+		charsPrinted += p.print(uri_escape(valueAt(i)));
+	}
+
+	return charsPrinted;
+}

--- a/Sming/SmingCore/Network/Http/HttpParams.h
+++ b/Sming/SmingCore/Network/Http/HttpParams.h
@@ -1,0 +1,37 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * @author: 2018 - Mikee47 <mike@sillyhouse.net>
+ *
+ * 	Class to manage HTTP URI query parameters
+ *
+ *  The HttpParams class was an empty HashMap class living in 'Structures.h'.
+ *  It has been expanded to incorporate escaping and unescaping.
+ *  Custom URL parsing code has been replaced with the yuarel library https://github.com/jacketizer/libyuarel
+ *
+ ****/
+
+#ifndef _SMINGCORE_HTTP_HTTP_PARAMS_H_
+#define _SMINGCORE_HTTP_HTTP_PARAMS_H_
+
+#include "WString.h"
+#include "WHashMap.h"
+#include "Printable.h"
+
+/** @brief
+ *
+ *  @todo values stored in escaped form, unescape return value and escape provided values.
+ *  Revise HttpBodyParser.cpp as it will no longer do this job.
+ *
+ */
+class HttpParams : public HashMap<String, String>, public Printable
+{
+public:
+	// Printable
+	virtual size_t printTo(Print& p) const;
+};
+
+#endif // _SMINGCORE_HTTP_HTTP_PARAMS_H_

--- a/Sming/SmingCore/Network/Http/HttpParams.h
+++ b/Sming/SmingCore/Network/Http/HttpParams.h
@@ -30,6 +30,10 @@
 class HttpParams : public HashMap<String, String>, public Printable
 {
 public:
+	virtual ~HttpParams()
+	{
+	}
+
 	// Printable
 	virtual size_t printTo(Print& p) const;
 };

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -159,15 +159,15 @@ String HttpRequest::getQueryParameter(const String& parameterName, const String&
 
 String HttpRequest::getBody()
 {
-	if(stream == nullptr) {
+	if(bodyStream == nullptr) {
 		return "";
 	}
 
 	String ret;
-	if(stream->available() != -1 && stream->getStreamType() == eSST_Memory) {
-		MemoryDataStream* memory = (MemoryDataStream*)stream;
+	if(bodyStream->available() != -1 && bodyStream->getStreamType() == eSST_Memory) {
+		MemoryDataStream* memory = (MemoryDataStream*)bodyStream;
 		char buf[1024];
-		while(stream->available() > 0) {
+		while(bodyStream->available() > 0) {
 			int available = memory->readMemoryBlock(buf, 1024);
 			memory->seek(available);
 			ret += String(buf, available);
@@ -181,7 +181,7 @@ String HttpRequest::getBody()
 
 ReadWriteStream* HttpRequest::getBodyStream()
 {
-	return stream;
+	return bodyStream;
 }
 
 HttpRequest* HttpRequest::setResponseStream(ReadWriteStream* stream)
@@ -240,13 +240,13 @@ HttpRequest* HttpRequest::setBody(uint8_t* rawData, size_t length)
 
 HttpRequest* HttpRequest::setBody(ReadWriteStream* stream)
 {
-	if(this->stream != nullptr) {
+	if(this->bodyStream != nullptr) {
 		debug_e("HttpRequest::setBody: Discarding already set stream!");
-		delete this->stream;
-		this->stream = nullptr;
+		delete this->bodyStream;
+		this->bodyStream = nullptr;
 	}
 
-	this->stream = stream;
+	this->bodyStream = stream;
 	return this;
 }
 
@@ -271,10 +271,10 @@ HttpRequest* HttpRequest::onRequestComplete(RequestCompletedDelegate delegateFun
 void HttpRequest::reset()
 {
 	delete queryParams;
-	delete stream;
+	delete bodyStream;
 	delete responseStream;
 	queryParams = nullptr;
-	stream = nullptr;
+	bodyStream = nullptr;
 	responseStream = nullptr;
 
 	postParams.clear();
@@ -307,8 +307,8 @@ String HttpRequest::toString()
 		content += headers[i];
 	}
 
-	if(stream != nullptr && stream->available() >= 0) {
-		content += headers.toString(HTTP_HEADER_CONTENT_LENGTH, String(stream->available()));
+	if(bodyStream != nullptr && bodyStream->available() >= 0) {
+		content += headers.toString(HTTP_HEADER_CONTENT_LENGTH, String(bodyStream->available()));
 	}
 
 	return content;

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -169,7 +169,7 @@ protected:
 	RequestBodyDelegate requestBodyDelegate;
 	RequestCompletedDelegate requestCompletedDelegate;
 
-	ReadWriteStream* stream = nullptr;
+	ReadWriteStream* bodyStream = nullptr;
 	ReadWriteStream* responseStream = nullptr;
 
 #ifdef ENABLE_HTTP_REQUEST_AUTH

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -21,6 +21,7 @@
 #include "Data/Stream/DataSourceStream.h"
 #include "Data/Stream/MultipartStream.h"
 #include "Network/Http/HttpHeaders.h"
+#include "HttpParams.h"
 
 class HttpClient;
 class HttpServerConnection;

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -87,9 +87,9 @@ public:
 		return this;
 	}
 
-	/** @deprecated this replaces existing post parameter set, which is different to
-	 * behaviour of setHeaders which only replaces specified values.
-	 * Better to use appropriate method of postParams for consistency.
+	/**
+	 * @deprecated This method is deprecated and will be removed in the coming versions.
+	 * 			   Please set postParams directly, i.e. request.postParams = params
 	 */
 	HttpRequest* setPostParameters(const HttpParams& params)
 	{
@@ -181,7 +181,7 @@ public:
 	 *
 	 * @retval HttpRequest*
 	 *
-	 * @note The response to this message will be stored in the user-provided stream.
+	 * @note The response to this request will be stored in the user-provided stream.
 	 */
 	HttpRequest* setResponseStream(ReadWriteStream* stream);
 


### PR DESCRIPTION
* Rename HttpRequest::stream to bodyStream
* Move trivial code into headers
* Simplify getHeader() and getPostParameter() methods by calling `HashMap[] const` method, thus ensuring missing values aren't added. Also more efficient as doesn't require two lookups (one for contains(), another for operator[]).
* Simplify and optimise HttpRequest::getBody() by reading content directly into pre-allocated String

WebHelpers/escape
* bugfix: encoding of space as '+' added
* uri_escape(const char*, int) rewritten without using heap
* add uri_unescape_inplace(char*, int)
* bugfix: output buffer must account for nul terminator in uri_unescape_inplace(String&)

structures.h
* Move HttpParams definition into separate module

UrlencodedOutputStream
* Remove (duplicate) definition of HttpParams
* Move output code into HttpParams::printTo() method