### PR TITLE
Simplified TCP timeouts. 

### DIFF
--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -17,7 +17,7 @@
 
 HttpServer::HttpServer()
 {
-	settings.keepAliveSeconds = 0;
+	settings.keepAliveSeconds = 2;
 	configure(settings);
 }
 
@@ -37,7 +37,7 @@ void HttpServer::configure(HttpServerSettings settings)
 		setBodyParser(ContentType::toString(MIME_FORM_URL_ENCODED), formUrlParser);
 	}
 
-	setTimeOut(settings.keepAliveSeconds);
+	setKeepAlive(settings.keepAliveSeconds);
 #ifdef ENABLE_SSL
 	sslSessionCacheSize = settings.sslSessionCacheSize;
 #endif

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -13,10 +13,12 @@ TcpClient::TcpClient(tcp_pcb* clientTcp, TcpClientDataDelegate clientReceive, Tc
 {
 	completed = onCompleted;
 	receive = clientReceive;
+	timeOut = TCP_CLIENT_TIMEOUT;
 }
 
 TcpClient::TcpClient(bool autoDestruct) : TcpConnection(autoDestruct), state(eTCS_Ready)
 {
+	timeOut = TCP_CLIENT_TIMEOUT;
 }
 
 TcpClient::TcpClient(TcpClientCompleteDelegate onCompleted, TcpClientEventDelegate onReadyToSend /* = NULL*/,
@@ -26,6 +28,7 @@ TcpClient::TcpClient(TcpClientCompleteDelegate onCompleted, TcpClientEventDelega
 	completed = onCompleted;
 	ready = onReadyToSend;
 	receive = onReceive;
+	timeOut = TCP_CLIENT_TIMEOUT;
 }
 
 TcpClient::TcpClient(TcpClientCompleteDelegate onCompleted, TcpClientDataDelegate onReceive /* = NULL*/)
@@ -33,11 +36,13 @@ TcpClient::TcpClient(TcpClientCompleteDelegate onCompleted, TcpClientDataDelegat
 {
 	completed = onCompleted;
 	receive = onReceive;
+	timeOut = TCP_CLIENT_TIMEOUT;
 }
 
 TcpClient::TcpClient(TcpClientDataDelegate onReceive) : TcpConnection(false), state(eTCS_Ready)
 {
 	receive = onReceive;
+	timeOut = TCP_CLIENT_TIMEOUT;
 }
 
 TcpClient::~TcpClient()

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -35,6 +35,9 @@ typedef Delegate<bool(TcpClient& client, char* data, int size)> TcpClientDataDel
 
 enum TcpClientState { eTCS_Ready, eTCS_Connecting, eTCS_Connected, eTCS_Successful, eTCS_Failed };
 
+// By default a TCP client connection has 70 seconds timeout
+#define TCP_CLIENT_TIMEOUT 70
+
 class TcpClient : public TcpConnection
 {
 public:

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -15,12 +15,12 @@
 
 #include <algorithm>
 
-TcpConnection::TcpConnection(bool autoDestruct) : autoSelfDestruct(autoDestruct), sleep(0), canSend(true), timeOut(70)
+TcpConnection::TcpConnection(bool autoDestruct) : autoSelfDestruct(autoDestruct), sleep(0), canSend(true)
 {
 }
 
 TcpConnection::TcpConnection(tcp_pcb* connection, bool autoDestruct)
-	: autoSelfDestruct(autoDestruct), sleep(0), canSend(true), timeOut(70)
+	: autoSelfDestruct(autoDestruct), sleep(0), canSend(true)
 {
 	initialize(connection);
 }

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -248,7 +248,7 @@ private:
 protected:
 	tcp_pcb* tcp = NULL;
 	uint16_t sleep;
-	uint16_t timeOut;
+	uint16_t timeOut = USHRT_MAX; // << By default a TCP connection does not have a time out
 	bool canSend;
 	bool autoSelfDestruct;
 #ifdef ENABLE_SSL

--- a/Sming/SmingCore/Network/TcpServer.cpp
+++ b/Sming/SmingCore/Network/TcpServer.cpp
@@ -15,8 +15,7 @@ int16_t TcpServer::totalConnections = 0;
 
 TcpServer::TcpServer() : TcpConnection(false)
 {
-	timeOut = 40;
-	TcpConnection::setTimeOut(USHRT_MAX);
+	timeOut = TCP_SERVER_TIMEOUT;
 }
 
 TcpServer::TcpServer(TcpClientConnectDelegate onClientHandler, TcpClientDataDelegate clientReceiveDataHandler,
@@ -24,23 +23,20 @@ TcpServer::TcpServer(TcpClientConnectDelegate onClientHandler, TcpClientDataDele
 	: TcpConnection(false), clientConnectDelegate(onClientHandler), clientReceiveDelegate(clientReceiveDataHandler),
 	  clientCompleteDelegate(clientCompleteHandler)
 {
-	timeOut = 40;
-	TcpConnection::setTimeOut(USHRT_MAX);
+	timeOut = TCP_SERVER_TIMEOUT;
 }
 
 TcpServer::TcpServer(TcpClientDataDelegate clientReceiveDataHandler, TcpClientCompleteDelegate clientCompleteHandler)
 	: TcpConnection(false), clientReceiveDelegate(clientReceiveDataHandler),
 	  clientCompleteDelegate(clientCompleteHandler)
 {
-	timeOut = 40;
-	TcpConnection::setTimeOut(USHRT_MAX);
+	timeOut = TCP_SERVER_TIMEOUT;
 }
 
 TcpServer::TcpServer(TcpClientDataDelegate clientReceiveDataHandler)
 	: TcpConnection(false), clientReceiveDelegate(clientReceiveDataHandler)
 {
-	timeOut = 40;
-	TcpConnection::setTimeOut(USHRT_MAX);
+	timeOut = TCP_SERVER_TIMEOUT;
 }
 
 TcpServer::~TcpServer()
@@ -73,10 +69,10 @@ void list_mem()
 	debug_d("Free heap size=%d, K=%d", system_get_free_heap_size(), TcpServer::totalConnections);
 }
 
-void TcpServer::setTimeOut(uint16_t waitTimeOut)
+void TcpServer::setKeepAlive(uint16_t seconds)
 {
-	debug_d("Server timeout updating: %d -> %d", timeOut, waitTimeOut);
-	timeOut = waitTimeOut;
+	debug_d("Server keep-alive updating: %d -> %d", keepAlive, seconds);
+	keepAlive = seconds;
 }
 
 bool TcpServer::listen(int port, bool useSsl /*= false */)
@@ -148,7 +144,7 @@ err_t TcpServer::onAccept(tcp_pcb* clientTcp, err_t err)
 	TcpConnection* client = createClient(clientTcp);
 	if(client == NULL)
 		return ERR_MEM;
-	client->setTimeOut(timeOut);
+	client->setTimeOut(keepAlive);
 
 #ifdef ENABLE_SSL
 	if(useSsl) {

--- a/Sming/SmingCore/Network/TcpServer.h
+++ b/Sming/SmingCore/Network/TcpServer.h
@@ -20,6 +20,9 @@
 
 typedef Delegate<void(TcpClient* client)> TcpClientConnectDelegate;
 
+// By default a TCP server will wait for a new remote client connection to get established for 20 seconds
+#define TCP_SERVER_TIMEOUT 20
+
 class TcpServer : public TcpConnection
 {
 public:
@@ -32,7 +35,7 @@ public:
 
 public:
 	virtual bool listen(int port, bool useSsl = false);
-	void setTimeOut(uint16_t waitTimeOut);
+	void setKeepAlive(uint16_t seconds);
 
 	void shutdown();
 
@@ -79,7 +82,8 @@ protected:
 	Vector<TcpConnection*> connections;
 
 private:
-	uint16_t timeOut;
+	uint16_t keepAlive = 70; // << The time to wait after the connection is established. If there is no data
+							 //  coming or going to the client within that period the client connection will be closed
 	TcpClientDataDelegate clientReceiveDelegate = NULL;
 	TcpClientCompleteDelegate clientCompleteDelegate = NULL;
 	TcpClientConnectDelegate clientConnectDelegate = NULL;


### PR DESCRIPTION
With the new code:
- a new TCP connection has no timeout
- a TCP client connection has 70 seconds timeout
- a TCP server connection has 20 seconds for wait until a new TCP client connection is established.
- and a TCP server can set keep-alive timeout that specify how long the TCP server will wait for an established TCP client connection to be closed after the last sending or receiving of data.