### PR TITLE
Streaming support for flash data

### DIFF
--- a/Sming/SmingCore/Data/Stream/FlashMemoryStream.cpp
+++ b/Sming/SmingCore/Data/Stream/FlashMemoryStream.cpp
@@ -1,0 +1,30 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * @author: 23 Oct 2018 - mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#include "FlashMemoryStream.h"
+#include "FlashString.h"
+
+uint16_t FlashMemoryStream::readMemoryBlock(char* data, int bufSize)
+{
+	int count = std::min(available(), bufSize);
+	memcpy_P(data, &flashString.flashData[readPos], count);
+	return count;
+}
+
+bool FlashMemoryStream::seek(int len)
+{
+	size_t newPos = static_cast<size_t>(readPos + len);
+	if(newPos <= flashString.length()) {
+		readPos = newPos;
+		return true;
+	} else {
+		return false;
+	}
+}

--- a/Sming/SmingCore/Data/Stream/FlashMemoryStream.h
+++ b/Sming/SmingCore/Data/Stream/FlashMemoryStream.h
@@ -1,0 +1,62 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * @author: 23 Oct 2018 - mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#ifndef _SMING_CORE_DATA_FLASH_MEMORY_STREAM_H_
+#define _SMING_CORE_DATA_FLASH_MEMORY_STREAM_H_
+
+#include "DataSourceStream.h"
+
+/** @addtogroup stream
+ *  @{
+ */
+
+/*
+ * FlashMemoryDataStream
+ *
+ * Provides a stream buffer on flash storage, so it's read-only
+ *
+ */
+class FlashMemoryStream : public IDataSourceStream
+{
+public:
+	FlashMemoryStream(const FlashString& flashString) : flashString(flashString)
+	{
+	}
+
+	virtual StreamType getStreamType() const
+	{
+		return eSST_Memory;
+	}
+
+	/**
+	 * @brief Return the total length of the stream
+	 * @retval int -1 is returned when the size cannot be determined
+	*/
+	int available()
+	{
+		return flashString.length() - readPos;
+	}
+
+	virtual uint16_t readMemoryBlock(char* data, int bufSize);
+
+	virtual bool seek(int len);
+
+	virtual bool isFinished()
+	{
+		return readPos >= flashString.length();
+	}
+
+private:
+	const FlashString& flashString;
+	size_t readPos = 0;
+};
+
+/** @} */
+#endif /* _SMING_CORE_DATA_FLASH_MEMORY_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/TemplateFlashMemoryStream.h
+++ b/Sming/SmingCore/Data/Stream/TemplateFlashMemoryStream.h
@@ -1,0 +1,37 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * @author: 23 Oct 2018 - mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#ifndef _SMING_CORE_DATA_TEMPLATE_FLASH_MEMORY_STREAM_H_
+#define _SMING_CORE_DATA_TEMPLATE_FLASH_MEMORY_STREAM_H_
+
+#include "FlashMemoryStream.h"
+#include "TemplateStream.h"
+
+/**
+  * @brief      Template Flash memory stream class
+  * @ingroup    stream data
+  *
+  *  @{
+ */
+
+class TemplateFlashMemoryStream : public TemplateStream
+{
+public:
+	/** @brief Create a template stream on top of a flash memory stream
+     *  @param  flashString Source data for the stream
+     */
+	TemplateFlashMemoryStream(const FlashString& flashString) : TemplateStream(new FlashMemoryStream(flashString))
+	{
+	}
+};
+
+/** @} */
+
+#endif /* _SMING_CORE_DATA_TEMPLATE_FLASH_MEMORY_STREAM_H_ */

--- a/samples/HttpServer_ConfigNetwork/app/application.cpp
+++ b/samples/HttpServer_ConfigNetwork/app/application.cpp
@@ -1,6 +1,7 @@
 #include <user_config.h>
 #include <SmingCore/SmingCore.h>
 #include <AppSettings.h>
+#include "Data/Stream/TemplateFlashMemoryStream.h"
 
 HttpServer server;
 FTPServer ftp;
@@ -10,6 +11,9 @@ String network, password;
 Timer connectionTimer;
 
 String lastModified;
+
+// Instead of using a SPIFFS file, here we demonstrate usage of imported Flash Strings
+IMPORT_FSTR(flashSettings, "web/build/settings.html")
 
 void onIndex(HttpRequest& request, HttpResponse& response)
 {
@@ -35,7 +39,12 @@ int onIpConfig(HttpServerConnection& connection, HttpRequest& request, HttpRespo
 		AppSettings.save();
 	}
 
-	TemplateFileStream* tmpl = new TemplateFileStream("settings.html");
+	/*
+	 * We could use a regular SPIFFS file for this, but instead we demonstrate using a Flash String.
+	 *
+	 * 	TemplateFileStream* tmpl = new TemplateFileStream("settings.html");
+	 */
+	auto tmpl = new TemplateFlashMemoryStream(flashSettings);
 	auto& vars = tmpl->variables();
 
 	bool dhcp = WifiStation.isEnabledDHCP();


### PR DESCRIPTION
* Add FlashMemoryStream class
* Add FlashTemplateStream class
* Add IMPORT_FSTR macro to bind a file into firmware image as FlashString object
* Demonstrate usage using HttpServer_ConfigNetwork sample application. Note behaviour is unchanged, but settings.html is statically linked rather than using SPIFFS.