### PR TITLE
Enable more compiler checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ GPATH
 # Microsoft Visual SourceSafe files
 vssver2.scc
 
-/.metadata
+.metadata

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ GPATH
 
 # Microsoft Visual SourceSafe files
 vssver2.scc
+
+/.metadata

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,12 +58,12 @@ script:
 - cd $SMING_HOME
 - if [ "$SDK_VERSION" == "2.0.0" ]; then ../.travis/tools/clang/format-pr.sh; fi
 - cd $SMING_HOME
-- make
+- make STRICT=1
 - make samples
 - make clean samples-clean
-- make ENABLE_CUSTOM_HEAP=1
+- make ENABLE_CUSTOM_HEAP=1 STRICT=1
 - make Basic_Blink ENABLE_CUSTOM_HEAP=1 DEBUG_VERBOSE_LEVEL=3
-- make dist-clean; make HttpServer_ConfigNetwork ENABLE_CUSTOM_LWIP=2
+- make dist-clean; make HttpServer_ConfigNetwork ENABLE_CUSTOM_LWIP=2 STRICT=1
 deploy:
   provider: script
   script: sh $TRAVIS_BUILD_DIR/.travis/deploy.sh $TRAVIS_TAG

--- a/Sming/Libraries/SI7021/SI7021.cpp
+++ b/Sming/Libraries/SI7021/SI7021.cpp
@@ -53,7 +53,7 @@ void SI7021::softReset(void)
 }
 
 int SI7021::getTemperature() {
-    byte tempbytes[2];
+    byte tempbytes[3];
     _command(TEMP_READ, tempbytes);
     long tempraw = (long)tempbytes[0] << 8 | tempbytes[1];
     if (_checkCRC8(tempraw) != tempbytes[2]){
@@ -71,7 +71,7 @@ int SI7021::_getTemperaturePostHumidity() {
 
 
 unsigned int SI7021::getHumidityPercent() {
-    byte humbytes[2];
+    byte humbytes[3];
     _command(RH_READ, humbytes);
     long humraw = (long)humbytes[0] << 8 | humbytes[1];
     if (_checkCRC8(humraw) != humbytes[2]){

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -267,9 +267,12 @@ endif
 MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
 
 # compiler flags using during compilation of source files. Add '-pg' for debugging
-CFLAGS += -Wall -Wno-comment \
+CFLAGS += -Wall -Wundef -Wpointer-arith -Wno-comment \
 			-Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
          	-D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1 -DSMING_INCLUDED=1 
+ifneq ($(STRICT),1)
+CFLAGS += -Werror -Wno-sign-compare -Wno-parentheses -Wno-unused-variable -Wno-unused-but-set-variable -Wno-strict-aliasing -Wno-return-type -Wno-maybe-uninitialized
+endif
 ifeq ($(SMING_RELEASE),1)
 	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
 	#      for full list of optimization options
@@ -291,6 +294,9 @@ endif
 CFLAGS += -DCUST_FILE_BASE=$$* -DDEBUG_VERBOSE_LEVEL=$(DEBUG_VERBOSE_LEVEL) -DDEBUG_PRINT_FILENAME_AND_LINE=$(DEBUG_PRINT_FILENAME_AND_LINE)
 
 CXXFLAGS	= $(CFLAGS) -fno-rtti -fno-exceptions -std=c++11 -felide-constructors
+ifneq ($(STRICT),1)
+CXXFLAGS += -Wno-reorder
+endif
 
 # linker flags used to generate the main object file
 LDFLAGS		= -nostdlib -u call_user_start -Wl,-static -Wl,--gc-sections -Wl,-wrap,system_restart_local 

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -140,7 +140,7 @@ COM_SPEED_SERIAL  ?= $(COM_SPEED)
 # By default `debugf` does not print file name and line number. If you want this enabled set the directive below to 1
 DEBUG_PRINT_FILENAME_AND_LINE ?= 0
 
-# Defaut debug verbose level is INFO, where DEBUG=3 INFO=2 WARNING=1 ERROR=0 
+# Default debug verbose level is INFO, where DEBUG=3 INFO=2 WARNING=1 ERROR=0 
 DEBUG_VERBOSE_LEVEL ?= 2
 
 # Disable CommandExecutor functionality if not used and save some ROM and RAM
@@ -267,12 +267,13 @@ endif
 MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
 
 # compiler flags using during compilation of source files. Add '-pg' for debugging
-CFLAGS += -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
-         -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1 -DSMING_INCLUDED=1 
+CFLAGS += -Wall -Wno-comment \
+			-Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
+         	-D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1 -DSMING_INCLUDED=1 
 ifeq ($(SMING_RELEASE),1)
 	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
 	#      for full list of optimization options
-	CFLAGS += -Os -DSMING_RELEASE=1
+	CFLAGS += -Os -DSMING_RELEASE=1 -DLWIP_NOASSERT
 else ifeq ($(ENABLE_GDB), 1)
 	CFLAGS += -Og -ggdb -DGDBSTUB_FREERTOS=0 -DENABLE_GDB=1
 else

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -269,7 +269,7 @@ MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
 # compiler flags using during compilation of source files. Add '-pg' for debugging
 CFLAGS += -Wall -Wundef -Wpointer-arith -Wno-comment \
 			-Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
-         	-D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1 -DSMING_INCLUDED=1 
+         	-D__ets__ -DICACHE_FLASH -DUSE_OPTIMIZE_PRINTF -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DESP8266=1 -DSMING_INCLUDED=1 
 ifneq ($(STRICT),1)
 CFLAGS += -Werror -Wno-sign-compare -Wno-parentheses -Wno-unused-variable -Wno-unused-but-set-variable -Wno-strict-aliasing -Wno-return-type -Wno-maybe-uninitialized
 endif

--- a/Sming/Services/CommandProcessing/CommandExecutor.cpp
+++ b/Sming/Services/CommandProcessing/CommandExecutor.cpp
@@ -71,6 +71,7 @@ int CommandExecutor::executorReceive(String recvString)
 			break;
 		}
 	}
+	return receiveReturn;
 }
 
 int CommandExecutor::executorReceive(char recvChar)

--- a/Sming/SmingCore/AtClient.cpp
+++ b/Sming/SmingCore/AtClient.cpp
@@ -75,8 +75,7 @@ void AtClient::processor(Stream& source, char arrivedChar, uint16_t availableCha
 	next();
 }
 
-void AtClient::send(const String& text, const String& altResponse /* ="" */, uint32_t timeoutMs /* = AT_TIMEOUT */,
-					int retries /* = 0 */)
+void AtClient::send(const String& text, const String& altResponse, uint32_t timeoutMs, unsigned retries)
 {
 	AtCommand atCommand;
 	atCommand.text = text;
@@ -87,8 +86,7 @@ void AtClient::send(const String& text, const String& altResponse /* ="" */, uin
 	send(atCommand);
 }
 
-void AtClient::send(const String& text, AtReceiveCallback onReceive, uint32_t timeoutMs /* = AT_TIMEOUT */,
-					int retries /* = 0 */)
+void AtClient::send(const String& text, AtReceiveCallback onReceive, uint32_t timeoutMs, unsigned retries)
 {
 	AtCommand atCommand;
 	atCommand.text = text;
@@ -99,8 +97,7 @@ void AtClient::send(const String& text, AtReceiveCallback onReceive, uint32_t ti
 	send(atCommand);
 }
 
-void AtClient::send(const String& text, AtCompleteCallback onComplete, uint32_t timeoutMs /* = AT_TIMEOUT */,
-					int retries /* = 0 */)
+void AtClient::send(const String& text, AtCompleteCallback onComplete, uint32_t timeoutMs, unsigned retries)
 {
 	AtCommand atCommand;
 	atCommand.text = text;

--- a/Sming/SmingCore/AtClient.h
+++ b/Sming/SmingCore/AtClient.h
@@ -13,10 +13,10 @@
 #ifndef _SMING_CORE_ATCLIENT_H_
 #define _SMING_CORE_ATCLIENT_H_
 
-#include "../SmingCore/HardwareSerial.h"
-#include "../Wiring/FILO.h"
-#include "../SmingCore/Delegate.h"
-#include "../SmingCore/Timer.h"
+#include "HardwareSerial.h"
+#include "FILO.h"
+#include "Delegate.h"
+#include "Timer.h"
 
 #define AT_REPLY_OK "OK"
 #ifndef AT_TIMEOUT
@@ -35,24 +35,14 @@ typedef Delegate<bool(AtClient& atClient, String& reply)> AtCompleteCallback;
 typedef struct {
 	String text;					   // << the actual AT command
 	String response2;				   // << alternative successful response
-	int timeout;					   // << timeout in milliseconds
-	int retries;					   // << number of retries before giving up
+	unsigned timeout;				   // << timeout in milliseconds
+	unsigned retries;				   // << number of retries before giving up
 	bool breakOnError = true;		   // << stop executing next command if that one has failed
 	AtReceiveCallback onReceive = 0;   // << if set you can process manually all incoming data in a callback
 	AtCompleteCallback onComplete = 0; // if set then you can process the complete response manually
 } AtCommand;
 
 typedef enum { eAtOK = 0, eAtRunning, eAtError } AtState;
-
-template <typename T, int rawSize> class SimpleQueue : public FIFO<T, rawSize>
-{
-	virtual const T& operator[](unsigned int) const
-	{
-	}
-	virtual T& operator[](unsigned int)
-	{
-	}
-};
 
 /**
  * @brief Class that facilitates the communication with an AT device.
@@ -70,9 +60,10 @@ public:
 	 * @param text String The actual AT command text. For example AT+CAMSTOP
 	 * @param altResponse String Expected response on success in addition to the default one which is OK
 	 * @param timeoutMs uint32_t Time in milliseconds to wait for response
-	 * @param retries int Retries on error
+	 * @param retries unsigned Retries on error
 	 */
-	void send(const String& text, const String& altResponse = "", uint32_t timeoutMs = AT_TIMEOUT, int retries = 0);
+	void send(const String& text, const String& altResponse = nullptr, uint32_t timeoutMs = AT_TIMEOUT,
+			  unsigned retries = 0);
 
 	/**
 	 * @brief Sends AT command
@@ -81,7 +72,7 @@ public:
 	 * @param timeoutMs uint32_t Time in milliseconds to wait for response
 	 * @param retries int Retries on error
 	 */
-	void send(const String& text, AtReceiveCallback onReceive, uint32_t timeoutMs = AT_TIMEOUT, int retries = 0);
+	void send(const String& text, AtReceiveCallback onReceive, uint32_t timeoutMs = AT_TIMEOUT, unsigned retries = 0);
 
 	/**
 	 * @brief Sends AT command
@@ -90,7 +81,7 @@ public:
 	 * @param timeoutMs uint32_t Time in milliseconds to wait for response
 	 * @param retries int Retries on error
 	 */
-	void send(const String& text, AtCompleteCallback onComplete, uint32_t timeoutMs = AT_TIMEOUT, int retries = 0);
+	void send(const String& text, AtCompleteCallback onComplete, uint32_t timeoutMs = AT_TIMEOUT, unsigned retries = 0);
 
 	// Low Level Functions
 
@@ -137,8 +128,8 @@ protected:
 	virtual void processor(Stream& source, char arrivedChar, uint16_t availableCharsCount);
 
 private:
-	SimpleQueue<AtCommand, 10> queue; // << Queue for the commands to be executed
-	HardwareSerial* stream;			  // << The main communication stream
+	FIFO<AtCommand, 10> queue;		  // << Queue for the commands to be executed
+	HardwareSerial* stream = nullptr; // << The main communication stream
 	Timer commandTimer;				  // timer used for commands with timeout
 	AtState state = eAtOK;
 

--- a/Sming/SmingCore/Data/Stream/TemplateStream.cpp
+++ b/Sming/SmingCore/Data/Stream/TemplateStream.cpp
@@ -24,7 +24,7 @@ uint16_t TemplateStream::readMemoryBlock(char* data, int bufSize)
 
 		// Return variable value
 		const String& value = templateData.valueAt(i);
-		if(bufSize < value.length()) {
+		if(unsigned(bufSize) < value.length()) {
 			debug_e("TemplateStream, buffer too small");
 			return 0;
 		}

--- a/Sming/SmingCore/Digital.cpp
+++ b/Sming/SmingCore/Digital.cpp
@@ -140,7 +140,7 @@ unsigned long pulseIn(uint16_t pin, uint8_t state, unsigned long timeout)
 	// pulse width measuring loop and achieve finer resolution.  calling
 	// digitalRead() instead yields much coarser resolution.
 	uint8_t bit = digitalPinToBitMask(pin);
-	uint8_t port = digitalPinToPort(pin);
+	// uint8_t port = digitalPinToPort(pin); // Does nothing in Sming, comment-out to prevent compiler warning
 	uint8_t stateMask = (state ? bit : 0);
 	unsigned long width = 0; // keep initialization out of time critical area
 

--- a/Sming/SmingCore/FileSystem.h
+++ b/Sming/SmingCore/FileSystem.h
@@ -29,7 +29,7 @@ enum FileOpenFlags {
 	eFO_CreateNewAlways = eFO_CreateIfNotExist | eFO_Truncate ///< Create new file even if file exists
 };
 
-static FileOpenFlags operator|(FileOpenFlags lhs, FileOpenFlags rhs)
+static inline FileOpenFlags operator|(FileOpenFlags lhs, FileOpenFlags rhs)
 {
 	return (FileOpenFlags)((int)lhs | (int)rhs);
 }

--- a/Sming/SmingCore/Network/FTPServerConnection.cpp
+++ b/Sming/SmingCore/Network/FTPServerConnection.cpp
@@ -367,5 +367,7 @@ void FTPServerConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 		this->writeString(_F("220 Welcome to Sming FTP\r\n"), 0);
 		state = eFCS_Authorization;
 		break;
+
+	default:; // Do nothing
 	}
 }

--- a/Sming/SmingCore/Network/Http/HttpConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpConnection.cpp
@@ -457,7 +457,9 @@ REENTER:
 			goto REENTER;
 		}
 	}
-	} // switch(state)
+
+	default:; // Do nothing
+	}		  // switch(state)
 
 	TcpClient::onReadyToSendData(sourceEvent);
 }

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
@@ -403,6 +403,8 @@ void HttpServerConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 		break;
 	}
 
+	default:; // Do nothing
+
 	} /* switch(state) */
 
 	TcpClient::onReadyToSendData(sourceEvent);

--- a/Sming/SmingCore/Network/SmtpClient.cpp
+++ b/Sming/SmingCore/Network/SmtpClient.cpp
@@ -188,6 +188,8 @@ void SmtpClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 		}
 
 		break;
+
+	default:; // Do nothing
 	}
 
 	case eSMTP_SendAuthResponse: {

--- a/Sming/SmingCore/Network/WebsocketClient.cpp
+++ b/Sming/SmingCore/Network/WebsocketClient.cpp
@@ -242,7 +242,7 @@ err_t WebsocketClient::onReceive(pbuf* buf)
 		}
 		break;
 
-	case wsMode::Connected:
+	case wsMode::Connected: {
 		WebsocketFrameClass wsFrame;
 		do {
 			if(wsFrame.decodeFrame(data, size)) {
@@ -297,6 +297,9 @@ err_t WebsocketClient::onReceive(pbuf* buf)
 		} while(wsFrame._nextReadOffset > 0);
 
 		break;
+	}
+
+	default:; // Do nothing
 	}
 
 	delete[] data;

--- a/Sming/SmingCore/Network/WebsocketFrame.cpp
+++ b/Sming/SmingCore/Network/WebsocketFrame.cpp
@@ -148,9 +148,7 @@ uint8_t WebsocketFrameClass::_getFrameSizes(uint8_t* buffer, size_t length)
 
 	if(payloadLength == 126) {
 		//next 2 bytes are length
-		payloadLength = buffer[2];
-		payloadLength << 8;
-		payloadLength |= buffer[3];
+		payloadLength = (buffer[2] << 8) | buffer[3];
 	}
 
 	_payloadLength = payloadLength;

--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -185,23 +185,25 @@ void SPIClass::transfer(uint8* buffer, size_t numberBytes)
 #define BLOCKSIZE 64 // the max length of the ESP SPI_W0 registers
 
 	uint16 bufIndx = 0;
-	uint8 bufLenght = 0;
+	uint8 bufLength = 0;
 	uint8 num_bits = 0;
 
 	int blocks = ((numberBytes - 1) / BLOCKSIZE) + 1;
+#ifdef SPI_DEBUG
 	int total = blocks;
+#endif
 
 	// loop number of blocks
 	while(blocks--) {
 		// get full BLOCKSIZE or number of remaining bytes
-		bufLenght = std::min(numberBytes - bufIndx, (unsigned int)BLOCKSIZE);
+		bufLength = std::min(numberBytes - bufIndx, (unsigned int)BLOCKSIZE);
 
 #ifdef SPI_DEBUG
-		debugf("Write/Read Block %d total %d bytes", total - blocks, bufLenght);
+		debugf("Write/Read Block %d total %d bytes", total - blocks, bufLength);
 #endif
 
 		// compute the number of bits to clock
-		num_bits = bufLenght * 8;
+		num_bits = bufLength * 8;
 
 		uint32_t regvalue = READ_PERI_REG(SPI_USER(SPI_NO)) & (SPI_WR_BYTE_ORDER | SPI_RD_BYTE_ORDER | SPI_CK_OUT_EDGE);
 
@@ -216,7 +218,7 @@ void SPIClass::transfer(uint8* buffer, size_t numberBytes)
 											  (((num_bits - 1) & SPI_USR_MISO_BITLEN) << SPI_USR_MISO_BITLEN_S));
 
 		// copy the registers starting from last index position
-		memcpy((void*)SPI_W0(SPI_NO), &buffer[bufIndx], bufLenght);
+		memcpy((void*)SPI_W0(SPI_NO), &buffer[bufIndx], bufLength);
 
 		// Begin SPI Transaction
 		SET_PERI_REG_MASK(SPI_CMD(SPI_NO), SPI_USR);
@@ -229,10 +231,10 @@ void SPIClass::transfer(uint8* buffer, size_t numberBytes)
 		//		delayMicroseconds(8);
 
 		// copy the registers starting from last index position
-		memcpy(&buffer[bufIndx], (void*)SPI_W0(SPI_NO), bufLenght);
+		memcpy(&buffer[bufIndx], (void*)SPI_W0(SPI_NO), bufLength);
 
 		// increment bufIndex
-		bufIndx += bufLenght;
+		bufIndx += bufLength;
 	}
 };
 

--- a/Sming/SmingCore/core_esp8266_si2c.cpp
+++ b/Sming/SmingCore/core_esp8266_si2c.cpp
@@ -102,7 +102,7 @@ static void twi_delay(unsigned char v)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
 	for(i = 0; i < v; i++)
-		unsigned int reg = GPI;
+		(void)GPI; // Suppress compiler warning for this read
 #pragma GCC diagnostic pop
 }
 

--- a/Sming/SmingCore/core_esp8266_si2c.cpp
+++ b/Sming/SmingCore/core_esp8266_si2c.cpp
@@ -101,9 +101,8 @@ static void twi_delay(unsigned char v)
 	unsigned int i;
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-but-set-variable"
-	unsigned int reg;
 	for(i = 0; i < v; i++)
-		reg = GPI;
+		unsigned int reg = GPI;
 #pragma GCC diagnostic pop
 }
 

--- a/Sming/Wiring/Print.cpp
+++ b/Sming/Wiring/Print.cpp
@@ -17,7 +17,8 @@
 */
 
 #include "Print.h"
-#include "WiringFrameworkIncludes.h"
+#include "WString.h"
+
 /*
 || @description
 || | Virtual method - may be redefined in derived class (polymorphic)
@@ -219,9 +220,10 @@ size_t Print::printf(const char *fmt, ...)
 			{
 				write(tempBuff,sz);
 			}
-			return sz;
+			break;
 		}
 	} while (retry);
+	return sz;
 }
 
 // private methods

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -31,7 +31,7 @@ class String;
 class Print
 {
   public:
-	Print() : write_error(0) {}
+	Print() {}
 	virtual ~Print() {}
   
     int getWriteError() { return write_error; }
@@ -89,7 +89,7 @@ class Print
     size_t printf(const char *fmt, ...);
 
   private:
-    int write_error;
+    int write_error = 0;
     size_t printNumber(unsigned long, uint8_t);
     size_t printFloat(double, uint8_t);
   protected:

--- a/Sming/Wiring/WVector.h
+++ b/Sming/Wiring/WVector.h
@@ -156,13 +156,13 @@ Vector<Element>::~Vector()
 {
   removeAllElements();
   delete [] _data;
-};
+}
 
 template <class Element>
 unsigned int Vector<Element>::capacity() const
 {
   return _capacity;
-};
+}
 
 template <class Element>
 boolean Vector<Element>::contains(const Element &elem) const
@@ -176,7 +176,7 @@ void Vector<Element>::copyInto(Element* array) const
   if (array != nullptr)
     for (unsigned int i = 0; i < _size; i++)
       array[i] = *_data[i];
-};
+}
 
 
 template <class Element>
@@ -237,7 +237,7 @@ const Element & Vector<Element>::lastElement() const
   }
 
   return *_data[ _size - 1 ];
-};
+}
 
 template <class Element>
 int Vector<Element>::lastIndexOf(const Element &elem) const
@@ -264,7 +264,7 @@ template <class Element>
 unsigned int Vector<Element>::size() const
 {
   return _size;
-};
+}
 
 template <class Element>
 void Vector<Element>::addElement(const Element &obj)
@@ -273,7 +273,7 @@ void Vector<Element>::addElement(const Element &obj)
     ensureCapacity(_capacity + _increment);
   if (_size < _capacity)
     _data[ _size++ ] = new Element(obj);
-};
+}
 
 template <class Element>
 void Vector<Element>::addElement(Element* objp)
@@ -282,7 +282,7 @@ void Vector<Element>::addElement(Element* objp)
     ensureCapacity(_capacity + _increment);
   if (_size < _capacity)
     _data[ _size++ ] = objp;
-};
+}
 
 template <class Element>
 void Vector<Element>::ensureCapacity(unsigned int minCapacity)
@@ -384,7 +384,7 @@ void Vector<Element>::setElementAt(const Element &obj, unsigned int index)
   // check for valid index
   if (index >= _size) return;
   *_data[ index ] = obj;
-};
+}
 
 template <class Element>
 void Vector<Element>::setSize(unsigned int newSize)
@@ -436,7 +436,7 @@ Element & Vector<Element>::operator[](unsigned int index)
 	  abort();
   }
   return *_data[ index ];
-};
+}
 
 template <class Element>
 void Vector<Element>::sort(Comparer compareFunction)

--- a/Sming/Wiring/WVector.h
+++ b/Sming/Wiring/WVector.h
@@ -19,8 +19,8 @@
 #define WVECTOR_H
 
 #include "Countable.h"
-#include "WiringFrameworkDependencies.h"
 #include <stdlib.h>
+#include <string.h>
 
 template <typename Element>
 class Vector : public Countable<Element>
@@ -119,14 +119,14 @@ Vector<Element>::Vector(unsigned int initialCapacity, unsigned int capacityIncre
   _capacity = initialCapacity;
   _data = new Element*[ _capacity ];
   _increment = capacityIncrement;
-  if (_data == NULL) _capacity = _increment = 0;
-};
+  if (_data == nullptr) _capacity = _increment = 0;
+}
 
 template <class Element>
 Vector<Element>::Vector(const Vector<Element>& rhv)
 {
 	copyFrom(rhv);
-};
+}
 
 template <class Element>
 void Vector<Element>::copyFrom(const Vector<Element>& rhv)
@@ -140,7 +140,7 @@ void Vector<Element>::copyFrom(const Vector<Element>& rhv)
   _capacity = rhv._capacity;
   _data = new Element*[ _capacity ];
   _increment = rhv._increment;
-  if (_data == NULL)
+  if (_data == nullptr)
   {
     _size = _capacity = _increment = 0;
   }
@@ -149,7 +149,7 @@ void Vector<Element>::copyFrom(const Vector<Element>& rhv)
   {
     _data[i] = new Element(*(rhv._data[i]));
   }
-};
+}
 
 template <class Element>
 Vector<Element>::~Vector()
@@ -167,19 +167,13 @@ unsigned int Vector<Element>::capacity() const
 template <class Element>
 boolean Vector<Element>::contains(const Element &elem) const
 {
-  for (unsigned int i = 0; i < _size; i++)
-  {
-    if (*_data[i] == elem)
-      return true;
-  }
-
-  return false;
-};
+	return indexOf(elem) >= 0;
+}
 
 template <class Element>
 void Vector<Element>::copyInto(Element* array) const
 {
-  if (array != NULL)
+  if (array != nullptr)
     for (unsigned int i = 0; i < _size; i++)
       array[i] = *_data[i];
 };
@@ -197,7 +191,7 @@ const Element & Vector<Element>::elementAt(unsigned int index) const
   }
   // add check for valid index
   return *_data[index];
-};
+}
 
 template <class Element>
 const Element & Vector<Element>::firstElement() const
@@ -211,7 +205,7 @@ const Element & Vector<Element>::firstElement() const
   }
 
   return *_data[ 0 ];
-};
+}
 
 template <class Element>
 int Vector<Element>::indexOf(const Element &elem) const
@@ -223,13 +217,13 @@ int Vector<Element>::indexOf(const Element &elem) const
   }
 
   return -1;
-};
+}
 
 template <class Element>
 boolean Vector<Element>::isEmpty() const
 {
   return _size == 0;
-};
+}
 
 template <class Element>
 const Element & Vector<Element>::lastElement() const
@@ -264,7 +258,7 @@ int Vector<Element>::lastIndexOf(const Element &elem) const
   while (i != 0);
 
   return -1;
-};
+}
 
 template <class Element>
 unsigned int Vector<Element>::size() const
@@ -295,11 +289,10 @@ void Vector<Element>::ensureCapacity(unsigned int minCapacity)
 {
   if (minCapacity > _capacity)
   {
-    unsigned int i;
     //_capacity = minCapacity;
     Element** temp = new Element*[ minCapacity ];
     // copy all elements
-    if (temp != NULL)
+    if (temp != nullptr)
     {
       _capacity = minCapacity;
       memcpy(temp, _data, sizeof(Element*) * _size);
@@ -307,7 +300,7 @@ void Vector<Element>::ensureCapacity(unsigned int minCapacity)
       _data = temp;
     }
   }
-};
+}
 
 template <class Element>
 void Vector<Element>::insertElementAt(const Element &obj, unsigned int index)
@@ -338,16 +331,13 @@ void Vector<Element>::insertElementAt(const Element &obj, unsigned int index)
       _size++;
     }
   }
-  //_size++;
-};
+}
 
 template <class Element>
 const void Vector<Element>::remove(unsigned int index)
 {
-  //const Element* retval = &get(index);
   removeElementAt(index);
-  //return (Element)*retval;
-};
+}
 
 template <class Element>
 void Vector<Element>::removeAllElements()
@@ -357,7 +347,7 @@ void Vector<Element>::removeAllElements()
     delete _data[i];
 
   _size = 0;
-};
+}
 
 template <class Element>
 boolean Vector<Element>::removeElement(const Element &obj)
@@ -371,7 +361,7 @@ boolean Vector<Element>::removeElement(const Element &obj)
     }
   }
   return false;
-};
+}
 
 template <class Element>
 void Vector<Element>::removeElementAt(unsigned int index)
@@ -385,9 +375,8 @@ void Vector<Element>::removeElementAt(unsigned int index)
   for (i = index + 1; i < _size; i++)
     _data[ i - 1 ] = _data[ i ];
 
-  _data[i];
   _size--;
-};
+}
 
 template <class Element>
 void Vector<Element>::setElementAt(const Element &obj, unsigned int index)
@@ -409,7 +398,7 @@ void Vector<Element>::setSize(unsigned int newSize)
 
     _size = newSize;
   }
-};
+}
 
 template <class Element>
 void Vector<Element>::trimToSize()
@@ -417,7 +406,7 @@ void Vector<Element>::trimToSize()
   if (_size != _capacity)
   {
     Element** temp = new Element*[ _size ];
-    if (temp == NULL) return;
+    if (temp == nullptr) return;
 
     for (unsigned int i = 0; i < _size; i++)
       temp[i] = _data[i];
@@ -427,13 +416,13 @@ void Vector<Element>::trimToSize()
     _data = temp;
     _capacity = _size;
   }
-};
+}
 
 template <class Element>
 const Element & Vector<Element>::operator[](unsigned int index) const
 {
   return elementAt(index);
-};
+}
 
 template <class Element>
 Element & Vector<Element>::operator[](unsigned int index)

--- a/Sming/Wiring/WVector.h
+++ b/Sming/Wiring/WVector.h
@@ -120,13 +120,13 @@ Vector<Element>::Vector(unsigned int initialCapacity, unsigned int capacityIncre
   _data = new Element*[ _capacity ];
   _increment = capacityIncrement;
   if (_data == nullptr) _capacity = _increment = 0;
-}
+};
 
 template <class Element>
 Vector<Element>::Vector(const Vector<Element>& rhv)
 {
 	copyFrom(rhv);
-}
+};
 
 template <class Element>
 void Vector<Element>::copyFrom(const Vector<Element>& rhv)
@@ -149,26 +149,26 @@ void Vector<Element>::copyFrom(const Vector<Element>& rhv)
   {
     _data[i] = new Element(*(rhv._data[i]));
   }
-}
+};
 
 template <class Element>
 Vector<Element>::~Vector()
 {
   removeAllElements();
   delete [] _data;
-}
+};
 
 template <class Element>
 unsigned int Vector<Element>::capacity() const
 {
   return _capacity;
-}
+};
 
 template <class Element>
 boolean Vector<Element>::contains(const Element &elem) const
 {
 	return indexOf(elem) >= 0;
-}
+};
 
 template <class Element>
 void Vector<Element>::copyInto(Element* array) const
@@ -176,7 +176,7 @@ void Vector<Element>::copyInto(Element* array) const
   if (array != nullptr)
     for (unsigned int i = 0; i < _size; i++)
       array[i] = *_data[i];
-}
+};
 
 
 template <class Element>
@@ -191,7 +191,7 @@ const Element & Vector<Element>::elementAt(unsigned int index) const
   }
   // add check for valid index
   return *_data[index];
-}
+};
 
 template <class Element>
 const Element & Vector<Element>::firstElement() const
@@ -205,7 +205,7 @@ const Element & Vector<Element>::firstElement() const
   }
 
   return *_data[ 0 ];
-}
+};
 
 template <class Element>
 int Vector<Element>::indexOf(const Element &elem) const
@@ -217,13 +217,13 @@ int Vector<Element>::indexOf(const Element &elem) const
   }
 
   return -1;
-}
+};
 
 template <class Element>
 boolean Vector<Element>::isEmpty() const
 {
   return _size == 0;
-}
+};
 
 template <class Element>
 const Element & Vector<Element>::lastElement() const
@@ -237,7 +237,7 @@ const Element & Vector<Element>::lastElement() const
   }
 
   return *_data[ _size - 1 ];
-}
+};
 
 template <class Element>
 int Vector<Element>::lastIndexOf(const Element &elem) const
@@ -258,13 +258,13 @@ int Vector<Element>::lastIndexOf(const Element &elem) const
   while (i != 0);
 
   return -1;
-}
+};
 
 template <class Element>
 unsigned int Vector<Element>::size() const
 {
   return _size;
-}
+};
 
 template <class Element>
 void Vector<Element>::addElement(const Element &obj)
@@ -273,7 +273,7 @@ void Vector<Element>::addElement(const Element &obj)
     ensureCapacity(_capacity + _increment);
   if (_size < _capacity)
     _data[ _size++ ] = new Element(obj);
-}
+};
 
 template <class Element>
 void Vector<Element>::addElement(Element* objp)
@@ -282,7 +282,7 @@ void Vector<Element>::addElement(Element* objp)
     ensureCapacity(_capacity + _increment);
   if (_size < _capacity)
     _data[ _size++ ] = objp;
-}
+};
 
 template <class Element>
 void Vector<Element>::ensureCapacity(unsigned int minCapacity)
@@ -300,7 +300,7 @@ void Vector<Element>::ensureCapacity(unsigned int minCapacity)
       _data = temp;
     }
   }
-}
+};
 
 template <class Element>
 void Vector<Element>::insertElementAt(const Element &obj, unsigned int index)
@@ -331,13 +331,13 @@ void Vector<Element>::insertElementAt(const Element &obj, unsigned int index)
       _size++;
     }
   }
-}
+};
 
 template <class Element>
 const void Vector<Element>::remove(unsigned int index)
 {
   removeElementAt(index);
-}
+};
 
 template <class Element>
 void Vector<Element>::removeAllElements()
@@ -347,7 +347,7 @@ void Vector<Element>::removeAllElements()
     delete _data[i];
 
   _size = 0;
-}
+};
 
 template <class Element>
 boolean Vector<Element>::removeElement(const Element &obj)
@@ -361,7 +361,7 @@ boolean Vector<Element>::removeElement(const Element &obj)
     }
   }
   return false;
-}
+};
 
 template <class Element>
 void Vector<Element>::removeElementAt(unsigned int index)
@@ -376,7 +376,7 @@ void Vector<Element>::removeElementAt(unsigned int index)
     _data[ i - 1 ] = _data[ i ];
 
   _size--;
-}
+};
 
 template <class Element>
 void Vector<Element>::setElementAt(const Element &obj, unsigned int index)
@@ -384,7 +384,7 @@ void Vector<Element>::setElementAt(const Element &obj, unsigned int index)
   // check for valid index
   if (index >= _size) return;
   *_data[ index ] = obj;
-}
+};
 
 template <class Element>
 void Vector<Element>::setSize(unsigned int newSize)
@@ -398,7 +398,7 @@ void Vector<Element>::setSize(unsigned int newSize)
 
     _size = newSize;
   }
-}
+};
 
 template <class Element>
 void Vector<Element>::trimToSize()
@@ -416,13 +416,13 @@ void Vector<Element>::trimToSize()
     _data = temp;
     _capacity = _size;
   }
-}
+};
 
 template <class Element>
 const Element & Vector<Element>::operator[](unsigned int index) const
 {
   return elementAt(index);
-}
+};
 
 template <class Element>
 Element & Vector<Element>::operator[](unsigned int index)
@@ -436,7 +436,7 @@ Element & Vector<Element>::operator[](unsigned int index)
 	  abort();
   }
   return *_data[ index ];
-}
+};
 
 template <class Element>
 void Vector<Element>::sort(Comparer compareFunction)

--- a/Sming/appinit/user_main.cpp
+++ b/Sming/appinit/user_main.cpp
@@ -119,11 +119,11 @@ extern "C" void ICACHE_FLASH_ATTR  __attribute__((weak)) user_pre_init(void)
 
 	enum flash_size_map sizeMap = system_get_flash_size_map();
 	if(!system_partition_table_regist(partitions, ARRAY_SIZE(partitions), sizeMap)) {
-		os_printf(_F("system_partition_table_regist: failed\n"));
-		os_printf(_F("size_map = %u\n"), sizeMap);
+		os_printf("system_partition_table_regist: failed\n");
+		os_printf("size_map = %u\n", sizeMap);
 		for (unsigned i = 0; i < ARRAY_SIZE(partitions); ++i) {
 			auto& part = partitions[i];
-			os_printf(_F("partition[%u]: %u, 0x%08x, 0x%08x\n"), i, part.type, part.addr, part.size);
+			os_printf("partition[%u]: %u, 0x%08x, 0x%08x\n", i, part.type, part.addr, part.size);
 		}
 		while(1) {
 			// Cannot proceed

--- a/Sming/gdb/gdbstub.c
+++ b/Sming/gdb/gdbstub.c
@@ -43,38 +43,37 @@ static unsigned int getaregval(int reg) {
 
 static void print_stack(uint32_t start, uint32_t end) {
   uint32_t pos = 0;
-  os_printf(_F("\nStack dump:\n"));
-  os_printf(_F("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n"));
-  os_printf(_F("and copy & paste the text enclosed in '===='.\n"));
-  os_printf(_F("================================================================\n"));
+  os_printf("\nStack dump:\n");
+  os_printf("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n");
+  os_printf("and copy & paste the text enclosed in '===='.\n");
+  os_printf("================================================================\n");
   for (pos = start; pos < end; pos += 0x10) {
     uint32_t* values = (uint32_t*)(pos);
     // rough indicator: stack frames usually have SP saved as the second word
     bool looksLikeStackFrame = (values[2] == pos + 0x10);
 
-    os_printf(_F("%08x:  %08x %08x %08x %08x %c\n"),
+    os_printf("%08x:  %08x %08x %08x %08x %c\n",
         pos, values[0], values[1], values[2], values[3], (looksLikeStackFrame)?'<':' ');
   }
   os_printf("\n");
-  os_printf(_F("================================================================\n"));
-  os_printf(_F("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n"));
-  os_printf(_F("and copy & paste the text enclosed in '===='.\n"));
+  os_printf("================================================================\n");
+  os_printf("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n");
+  os_printf("and copy & paste the text enclosed in '===='.\n");
 }
 
 void _xtos_set_exception_handler(int cause, void (exhandler)(struct XTensa_exception_frame_s *frame));
-int os_printf_plus(const char *format, ...)  __attribute__ ((format (printf, 1, 2)));
 
 // Print exception info to console
 static void printReason() {
   int i=0;
   //register uint32_t sp asm("a1");
   struct XTensa_exception_frame_s *reg = &gdbstub_savedRegs;
-  os_printf(_F("\n\n***** Fatal exception %u\n"), reg->reason);
-  os_printf(_F("pc=0x%08x sp=0x%08x excvaddr=0x%08x\n"), reg->pc, reg->a1, reg->excvaddr);
-  os_printf(_F("ps=0x%08x sar=0x%08x vpri=0x%08x\n"), reg->ps, reg->sar, reg->vpri);
+  os_printf("\n\n***** Fatal exception %u\n", reg->reason);
+  os_printf("pc=0x%08x sp=0x%08x excvaddr=0x%08x\n", reg->pc, reg->a1, reg->excvaddr);
+  os_printf("ps=0x%08x sar=0x%08x vpri=0x%08x\n", reg->ps, reg->sar, reg->vpri);
   for (i=0; i<16; i++) {
     unsigned int r = getaregval(i);
-    os_printf(_F("r%02d: 0x%08x=%10d "), i, r, r);
+    os_printf("r%02d: 0x%08x=%10d ", i, r, r);
     if (i%3 == 2) os_printf("\n");
   }
   os_printf("\n");

--- a/Sming/gdb/gdbstub.c
+++ b/Sming/gdb/gdbstub.c
@@ -43,22 +43,22 @@ static unsigned int getaregval(int reg) {
 
 static void print_stack(uint32_t start, uint32_t end) {
   uint32_t pos = 0;
-  os_printf("\nStack dump:\n");
-  os_printf("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n");
-  os_printf("and copy & paste the text enclosed in '===='.\n");
-  os_printf("================================================================\n");
+  os_printf(_F("\nStack dump:\n"));
+  os_printf(_F("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n"));
+  os_printf(_F("and copy & paste the text enclosed in '===='.\n"));
+  os_printf(_F("================================================================\n"));
   for (pos = start; pos < end; pos += 0x10) {
     uint32_t* values = (uint32_t*)(pos);
     // rough indicator: stack frames usually have SP saved as the second word
     bool looksLikeStackFrame = (values[2] == pos + 0x10);
 
-    os_printf("%08lx:  %08lx %08lx %08lx %08lx %c\n",
+    os_printf(_F("%08x:  %08x %08x %08x %08x %c\n"),
         pos, values[0], values[1], values[2], values[3], (looksLikeStackFrame)?'<':' ');
   }
   os_printf("\n");
-  os_printf("================================================================\n");
-  os_printf("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n");
-  os_printf("and copy & paste the text enclosed in '===='.\n");
+  os_printf(_F("================================================================\n"));
+  os_printf(_F("To decode the stack dump call from command line:\n   python $SMING_HOME/../tools/decode-stacktrace.py out/build/app.out\n"));
+  os_printf(_F("and copy & paste the text enclosed in '===='.\n"));
 }
 
 void _xtos_set_exception_handler(int cause, void (exhandler)(struct XTensa_exception_frame_s *frame));
@@ -69,12 +69,12 @@ static void printReason() {
   int i=0;
   //register uint32_t sp asm("a1");
   struct XTensa_exception_frame_s *reg = &gdbstub_savedRegs;
-  os_printf("\n\n***** Fatal exception %ld\n", reg->reason);
-  os_printf("pc=0x%08lx sp=0x%08lx excvaddr=0x%08lx\n", reg->pc, reg->a1, reg->excvaddr);
-  os_printf("ps=0x%08lx sar=0x%08lx vpri=0x%08lx\n", reg->ps, reg->sar, reg->vpri);
+  os_printf(_F("\n\n***** Fatal exception %u\n"), reg->reason);
+  os_printf(_F("pc=0x%08x sp=0x%08x excvaddr=0x%08x\n"), reg->pc, reg->a1, reg->excvaddr);
+  os_printf(_F("ps=0x%08x sar=0x%08x vpri=0x%08x\n"), reg->ps, reg->sar, reg->vpri);
   for (i=0; i<16; i++) {
     unsigned int r = getaregval(i);
-    os_printf("r%02d: 0x%08x=%10d ", i, r, r);
+    os_printf(_F("r%02d: 0x%08x=%10d "), i, r, r);
     if (i%3 == 2) os_printf("\n");
   }
   os_printf("\n");

--- a/Sming/system/crash_handler.c
+++ b/Sming/system/crash_handler.c
@@ -56,11 +56,11 @@ void __wrap_system_restart_local() {
     ets_install_putc1(&uart_write_char_d);
 
     if (rst_info.reason == REASON_EXCEPTION_RST) {
-        ets_printf(_F("\n\n***** Exception Reset (%d):\nepc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n"),
+        os_printf("\n\n***** Exception Reset (%d):\nepc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n",
             rst_info.exccause, rst_info.epc1, rst_info.epc2, rst_info.epc3, rst_info.excvaddr, rst_info.depc);
     }
     else if (rst_info.reason == REASON_SOFT_WDT_RST) {
-        ets_printf(_F("\n\n***** Software Watchdog Reset\n"));
+        os_printf("\n\n***** Software Watchdog Reset\n");
     }
 #endif
 
@@ -100,17 +100,17 @@ static void print_stack(uint32_t start, uint32_t end) {
 
     PSTR_ARRAY(separatorLine, "\n================================================================\n");
 
-    ets_printf(separatorLine);
+    os_printf_plus(separatorLine);
     for (pos = start; pos < end; pos += 0x10) {
         uint32_t* values = (uint32_t*)(pos);
 
         // rough indicator: stack frames usually have SP saved as the second word
         bool looksLikeStackFrame = (values[2] == pos + 0x10);
 
-        ets_printf(_F("%08x:  %08x %08x %08x %08x %c\n"),
+        os_printf("%08x:  %08x %08x %08x %08x %c\n",
             pos, values[0], values[1], values[2], values[3], (looksLikeStackFrame)?'<':' ');
     }
-    ets_printf(separatorLine);
+    os_printf_plus(separatorLine);
 }
 
 void uart_write_char_d(char c) {

--- a/Sming/system/crash_handler.c
+++ b/Sming/system/crash_handler.c
@@ -56,11 +56,11 @@ void __wrap_system_restart_local() {
     ets_install_putc1(&uart_write_char_d);
 
     if (rst_info.reason == REASON_EXCEPTION_RST) {
-        ets_printf("\n\n***** Exception Reset (%d):\nepc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n",
+        ets_printf(_F("\n\n***** Exception Reset (%d):\nepc1=0x%08x epc2=0x%08x epc3=0x%08x excvaddr=0x%08x depc=0x%08x\n"),
             rst_info.exccause, rst_info.epc1, rst_info.epc2, rst_info.epc3, rst_info.excvaddr, rst_info.depc);
     }
     else if (rst_info.reason == REASON_SOFT_WDT_RST) {
-        ets_printf("\n\n***** Software Watchdog Reset\n");
+        ets_printf(_F("\n\n***** Software Watchdog Reset\n"));
     }
 #endif
 
@@ -98,17 +98,19 @@ void __wrap_system_restart_local() {
 static void print_stack(uint32_t start, uint32_t end) {
     uint32_t pos = 0;
 
-    ets_printf("\n================================================================\n");
+    PSTR_ARRAY(separatorLine, "\n================================================================\n");
+
+    ets_printf(separatorLine);
     for (pos = start; pos < end; pos += 0x10) {
         uint32_t* values = (uint32_t*)(pos);
 
         // rough indicator: stack frames usually have SP saved as the second word
         bool looksLikeStackFrame = (values[2] == pos + 0x10);
 
-        ets_printf("%08x:  %08x %08x %08x %08x %c\n",
+        ets_printf(_F("%08x:  %08x %08x %08x %08x %c\n"),
             pos, values[0], values[1], values[2], values[3], (looksLikeStackFrame)?'<':' ');
     }
-    ets_printf("================================================================\n");
+    ets_printf(separatorLine);
 }
 
 void uart_write_char_d(char c) {

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -76,15 +76,16 @@ index 1bc584f..e4af916 100644
  $(LIB): $(OBJS)
  	$(AR) rcs $@ $^
 diff --git a/include/arch/cc.h b/include/arch/cc.h
-index ff03b30..348ee12 100644
+index ff03b30..5efcf13 100644
 --- a/include/arch/cc.h
 +++ b/include/arch/cc.h
-@@ -38,8 +38,26 @@
+@@ -38,8 +38,27 @@
  #include "c_types.h"
  #include "ets_sys.h"
  #include "osapi.h"
 +#include "mem.h"
 +#include <stdarg.h>
++#include "FakePgmSpace.h"
 +
  #define EFAULT 14
  
@@ -106,7 +107,7 @@ index ff03b30..348ee12 100644
  //#define LWIP_PROVIDE_ERRNO
  
  #if (1)
-@@ -56,6 +74,7 @@ typedef signed     short   s16_t;
+@@ -56,6 +75,7 @@ typedef signed     short   s16_t;
  typedef unsigned   long    u32_t;
  typedef signed     long    s32_t;
  typedef unsigned long   mem_ptr_t;
@@ -114,7 +115,7 @@ index ff03b30..348ee12 100644
  
  #define S16_F "d"
  #define U16_F "d"
-@@ -73,11 +92,12 @@ typedef unsigned long   mem_ptr_t;
+@@ -73,11 +93,12 @@ typedef unsigned long   mem_ptr_t;
  #define PACK_STRUCT_BEGIN
  #define PACK_STRUCT_END
  
@@ -221,10 +222,26 @@ index 1e46ee5..cfc10f8 100644
                        ipaddr != NULL ? ip4_addr2_16(ipaddr) : 0,       \
                        ipaddr != NULL ? ip4_addr3_16(ipaddr) : 0,       \
 diff --git a/lwip/app/dhcpserver.c b/lwip/app/dhcpserver.c
-index ddb5984..fb677c6 100644
+index ddb5984..fdaedea 100644
 --- a/lwip/app/dhcpserver.c
 +++ b/lwip/app/dhcpserver.c
-@@ -133,21 +133,16 @@ static uint8_t* ICACHE_FLASH_ATTR add_offer_options(uint8_t *optptr)
+@@ -1,5 +1,5 @@
+ #include "lwip/inet.h"
+-#include "lwip/err.h"
++#include "lwip/err.h"
+ #include "lwip/pbuf.h"
+ #include "lwip/udp.h"
+ #include "lwip/mem.h"
+@@ -13,6 +13,8 @@
+ 
+ #include "user_interface.h"
+ 
++extern bool wifi_softap_set_station_info(uint8_t*,struct ip_addr*);
++
+ #ifdef MEMLEAK_DEBUG
+ static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
+ #endif
+@@ -133,21 +135,16 @@ static uint8_t* ICACHE_FLASH_ATTR add_offer_options(uint8_t *optptr)
  
          ipadd.addr = *( (uint32_t *) &server_address);
  
@@ -255,7 +272,7 @@ index ddb5984..fb677c6 100644
  
          *optptr++ = DHCP_OPTION_LEASE_TIME;
          *optptr++ = 4;  
-@@ -164,10 +159,6 @@ static uint8_t* ICACHE_FLASH_ATTR add_offer_options(uint8_t *optptr)
+@@ -164,10 +161,6 @@ static uint8_t* ICACHE_FLASH_ATTR add_offer_options(uint8_t *optptr)
          *optptr++ = ip4_addr4( &ipadd);
  
          if (dhcps_router_enabled(offer)){
@@ -266,19 +283,33 @@ index ddb5984..fb677c6 100644
  			*optptr++ = DHCP_OPTION_ROUTER;
  			*optptr++ = 4;
  			*optptr++ = ip4_addr1( &if_ip.gw);
-diff --git a/include/lwip/tcp_impl.h b/include/lwip/tcp_impl.h
-index 24ca8bb..0c20b6a 100644
---- a/include/lwip/tcp_impl.h
-+++ b/include/lwip/tcp_impl.h
-@@ -130,7 +130,7 @@ u32_t            tcp_update_rcv_ann_wnd(struct tcp_pcb *pcb)ICACHE_FLASH_ATTR;
- #define TCP_OOSEQ_TIMEOUT        6U /* x RTO */
+@@ -573,7 +566,7 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
+ ///////////////////////////////////////////////////////////////////////////////////
+ ///////////////////////////////////////////////////////////////////////////////////
+ static sint16_t ICACHE_FLASH_ATTR parse_msg(struct dhcps_msg *m, u16_t len)
+-{
++{
+ 		if(os_memcmp((char *)m->options,
+               &magic_cookie,
+               sizeof(magic_cookie)) == 0){
+@@ -678,7 +671,7 @@ static sint16_t ICACHE_FLASH_ATTR parse_msg(struct dhcps_msg *m, u16_t len)
  
- #ifndef TCP_MSL
--#define TCP_MSL 60000UL /* The maximum segment lifetime in milliseconds */
-+#define TCP_MSL 2000UL /* The maximum segment lifetime in milliseconds */
- #endif
+ 						POOL_CHECK:
+ 						if ((client_address.addr > dhcps_lease.end_ip.addr) || (ip_addr_isany(&client_address))){
+-                            os_printf("client_address_plus.addr %x %d\n", client_address_plus.addr, system_get_free_heap_size());
++                            os_printf(_F("client_address_plus.addr %x %d\n"), client_address_plus.addr, system_get_free_heap_size());
+ 						    if(pnode != NULL) {
+ 						        node_remove_from_list(&plist,pnode);
+ 						        os_free(pnode);
+@@ -890,7 +883,7 @@ void ICACHE_FLASH_ATTR dhcps_start(struct ip_info *info)
  
- /* Keepalive values, compliant with RFC 1122. Don't change this unless you know what you're doing */
+ 	pcb_dhcps = udp_new();
+ 	if (pcb_dhcps == NULL || info ==NULL) {
+-		os_printf("dhcps_start(): could not obtain pcb\n");
++		os_printf(_F("dhcps_start(): could not obtain pcb\n"));
+ 	}
+ 
+ 	apnetif->dhcps_pcb = pcb_dhcps;
 diff --git a/include/lwip/igmp.h b/include/lwip/igmp.h
 index c90adcd..f0c9dea 100644
 --- a/include/lwip/igmp.h
@@ -343,3 +374,165 @@ index af6e360..71b2178 100644
  #endif
  #ifndef os_realloc
  #define os_realloc(p, s) mem_realloc((p), (s))
+diff --git a/include/lwip/app/espconn.h b/include/lwip/app/espconn.h
+index ae9ed50..46420df 100644
+--- a/include/lwip/app/espconn.h
++++ b/include/lwip/app/espconn.h
+@@ -660,5 +660,11 @@ extern void espconn_mdns_enable(void);
+  *  Returns     : none
+ *******************************************************************************/
+ extern void espconn_dns_setserver(u8_t numdns, ip_addr_t *dnsserver);
++
++// Missing functions
++extern err_t espconn_tcp_write(void *arg);
++extern sint8 espconn_tcp_delete(struct espconn *pdeletecon);
++extern void espconn_pbuf_delete(espconn_buf **phead, espconn_buf* pdelete);
++
+ #endif
+ 
+diff --git a/include/lwip/mdns.h b/include/lwip/mdns.h
+index 08db68a..b4763ec 100644
+--- a/include/lwip/mdns.h
++++ b/include/lwip/mdns.h
+@@ -96,16 +96,17 @@ struct mdns_info {
+ 	char *txt_data[10];
+ };
+ #endif
+-//void 		   mdns_enable(void);
+-//void           mdns_disable(void);
+-//void           mdns_init(struct mdns_info *info);
+-//void           mdns_close(void);
+-//char* 		   mdns_get_hostname(void);
+-//void           mdns_set_hostname(char *name);
+-//void           mdns_set_servername(const char *name);
+-//char*          mdns_get_servername(void);
+-//void           mdns_server_unregister(void);
+-//void           mdns_server_register(void) ;
++
++void 		   mdns_enable(void);
++void           mdns_disable(void);
++void           mdns_init(struct mdns_info *info);
++void           mdns_close(void);
++char* 		   mdns_get_hostname(void);
++void           mdns_set_hostname(char *name);
++void           mdns_set_servername(const char *name);
++char*          mdns_get_servername(void);
++void           mdns_server_unregister(void);
++void           mdns_server_register(void) ;
+ //void           mdns_tmr(void);
+ //void           Delay(unsigned long ulSeconds);
+ 
+diff --git a/lwip/app/espconn_tcp.c b/lwip/app/espconn_tcp.c
+index 52cd0b0..4e59429 100644
+--- a/lwip/app/espconn_tcp.c
++++ b/lwip/app/espconn_tcp.c
+@@ -557,7 +557,7 @@ espconn_recv_hold(struct espconn *pespconn)
+     value = espconn_find_connection(pespconn, &pnode);
+ 	if(value != true)
+ 	{
+-		os_printf("RecvHold, By pespconn,find conn_msg fail\n");
++		os_printf(_F("RecvHold, By pespconn,find conn_msg fail\n"));
+ 		return ESPCONN_ARG;
+ 	}
+ 
+@@ -582,7 +582,7 @@ espconn_recv_unhold(struct espconn *pespconn)
+     value = espconn_find_connection(pespconn, &pnode);
+ 	if(value != true)
+ 	{
+-		os_printf("RecvHold, By pespconn,find conn_msg fail\n");
++		os_printf(_F("RecvHold, By pespconn,find conn_msg fail\n"));
+ 		return ESPCONN_ARG;
+ 	}
+ 
+@@ -862,7 +862,7 @@ espconn_client_connect(void *arg, struct tcp_pcb *tpcb, err_t err)
+ 			espconn_keepalive_enable(tpcb);
+ 
+     } else{
+-    	os_printf("err in host connected (%s)\n",lwip_strerr(err));
++    	os_printf(_F("err in host connected (%s)\n"),lwip_strerr(err));
+     }
+     return err;
+ }
+@@ -1354,7 +1354,7 @@ sint8 ICACHE_FLASH_ATTR espconn_tcp_delete(struct espconn *pdeletecon)
+ 				/*remove the node from the client's active connection list*/
+ 				espconn_list_delete(&pserver_list, pdelete_msg);
+ 				pcb = pdelete_msg->preverse;
+-				os_printf("espconn_tcp_delete %d, %d\n",pcb->state, pcb->local_port);
++				os_printf(_F("espconn_tcp_delete %d, %d\n"),pcb->state, pcb->local_port);
+ 				espconn_kill_pcb(pcb->local_port);
+ 				err = tcp_close(pcb);
+ 				os_free(pdelete_msg);
+
+diff --git a/lwip/app/espconn_udp.c b/lwip/app/espconn_udp.c
+index 77ef471..7d6705e 100644
+--- a/lwip/app/espconn_udp.c
++++ b/lwip/app/espconn_udp.c
+@@ -19,9 +19,18 @@
+ #include "lwip/mem.h"
+ #include "lwip/tcp_impl.h"
+ #include "lwip/udp.h"
++#include "lwip/igmp.h"
+ 
+ #include "lwip/app/espconn_udp.h"
+ 
++
++/*
++ * wifi_get_ip_info()
++ * wifi_get_opmode()
++ */
++#include "user_interface.h"
++
++
+ #ifdef MEMLEAK_DEBUG
+ static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
+ #endif
+diff --git a/lwip/core/dhcp.c b/lwip/core/dhcp.c
+index 342543e..9717574 100644
+--- a/lwip/core/dhcp.c
++++ b/lwip/core/dhcp.c
+@@ -137,6 +137,9 @@ u8_t  dhcp_rx_options_given[DHCP_OPTION_IDX_MAX];
+ #define dhcp_get_option_value(dhcp, idx)      (dhcp_rx_options_val[idx])
+ #define dhcp_set_option_value(dhcp, idx, val) (dhcp_rx_options_val[idx] = (val))
+ 
++// Missing prototype
++extern void system_station_got_ip_set(ip_addr_t* ip_addr, ip_addr_t* sn_mask, ip_addr_t* gw_addr);
++
+ 
+ /* DHCP client state machine functions */
+ static err_t dhcp_discover(struct netif *netif);
+@@ -384,7 +387,7 @@ dhcp_fine_tmr()
+       /*add DHCP retries processing by LiuHan*/
+       if (DHCP_MAXRTX != 0) {
+     	  if (netif->dhcp->tries >= DHCP_MAXRTX){
+-			  os_printf("DHCP timeout\n");
++			  os_printf(_F("DHCP timeout\n"));
+ 			  if (netif->dhcp_event != NULL)
+ 				  netif->dhcp_event();
+ 			  break;
+diff --git a/lwip/core/ipv4/ip_addr.c b/lwip/core/ipv4/ip_addr.c
+index 81db807..dd6964e 100644
+--- a/lwip/core/ipv4/ip_addr.c
++++ b/lwip/core/ipv4/ip_addr.c
+@@ -113,7 +113,7 @@ ip4_addr_netmask_valid(u32_t netmask)
+ #ifndef isprint
+ #define in_range(c, lo, up)  ((u8_t)c >= lo && (u8_t)c <= up)
+ #define isprint(c)           in_range(c, 0x20, 0x7f)
+-//#define isdigit(c)           in_range(c, '0', '9')
++#define isdigit(c)           in_range(c, '0', '9')
+ #define isxdigit(c)          (isdigit(c) || in_range(c, 'a', 'f') || in_range(c, 'A', 'F'))
+ #define islower(c)           in_range(c, 'a', 'z')
+ #define isspace(c)           (c == ' ' || c == '\f' || c == '\n' || c == '\r' || c == '\t' || c == '\v')
+diff --git a/lwip/core/tcp.c b/lwip/core/tcp.c
+index ee50ceb..75563e9 100644
+--- a/lwip/core/tcp.c
++++ b/lwip/core/tcp.c
+@@ -55,6 +55,9 @@
+ 
+ #include <string.h>
+ 
++// Missing prototype
++extern uint8_t system_get_data_of_array_8(const uint8_t* array /* ICACHE_RODATA_ATTR */, unsigned offset);
++
+ #ifdef MEMLEAK_DEBUG
+ static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
+ #endif

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -222,16 +222,9 @@ index 1e46ee5..cfc10f8 100644
                        ipaddr != NULL ? ip4_addr2_16(ipaddr) : 0,       \
                        ipaddr != NULL ? ip4_addr3_16(ipaddr) : 0,       \
 diff --git a/lwip/app/dhcpserver.c b/lwip/app/dhcpserver.c
-index ddb5984..fdaedea 100644
+index ddb5984..546a072 100644
 --- a/lwip/app/dhcpserver.c
 +++ b/lwip/app/dhcpserver.c
-@@ -1,5 +1,5 @@
- #include "lwip/inet.h"
--#include "lwip/err.h"
-+#include "lwip/err.h"
- #include "lwip/pbuf.h"
- #include "lwip/udp.h"
- #include "lwip/mem.h"
 @@ -13,6 +13,8 @@
  
  #include "user_interface.h"
@@ -283,33 +276,6 @@ index ddb5984..fdaedea 100644
  			*optptr++ = DHCP_OPTION_ROUTER;
  			*optptr++ = 4;
  			*optptr++ = ip4_addr1( &if_ip.gw);
-@@ -573,7 +566,7 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
- ///////////////////////////////////////////////////////////////////////////////////
- ///////////////////////////////////////////////////////////////////////////////////
- static sint16_t ICACHE_FLASH_ATTR parse_msg(struct dhcps_msg *m, u16_t len)
--{
-+{
- 		if(os_memcmp((char *)m->options,
-               &magic_cookie,
-               sizeof(magic_cookie)) == 0){
-@@ -678,7 +671,7 @@ static sint16_t ICACHE_FLASH_ATTR parse_msg(struct dhcps_msg *m, u16_t len)
- 
- 						POOL_CHECK:
- 						if ((client_address.addr > dhcps_lease.end_ip.addr) || (ip_addr_isany(&client_address))){
--                            os_printf("client_address_plus.addr %x %d\n", client_address_plus.addr, system_get_free_heap_size());
-+                            os_printf(_F("client_address_plus.addr %x %d\n"), client_address_plus.addr, system_get_free_heap_size());
- 						    if(pnode != NULL) {
- 						        node_remove_from_list(&plist,pnode);
- 						        os_free(pnode);
-@@ -890,7 +883,7 @@ void ICACHE_FLASH_ATTR dhcps_start(struct ip_info *info)
- 
- 	pcb_dhcps = udp_new();
- 	if (pcb_dhcps == NULL || info ==NULL) {
--		os_printf("dhcps_start(): could not obtain pcb\n");
-+		os_printf(_F("dhcps_start(): could not obtain pcb\n"));
- 	}
- 
- 	apnetif->dhcps_pcb = pcb_dhcps;
 --- a/include/lwip/tcp_impl.h
 +++ b/include/lwip/tcp_impl.h
 @@ -130,7 +130,7 @@ u32_t            tcp_update_rcv_ann_wnd(struct tcp_pcb *pcb)ICACHE_FLASH_ATTR;
@@ -433,47 +399,6 @@ index 08db68a..b4763ec 100644
  //void           mdns_tmr(void);
  //void           Delay(unsigned long ulSeconds);
  
-diff --git a/lwip/app/espconn_tcp.c b/lwip/app/espconn_tcp.c
-index 52cd0b0..4e59429 100644
---- a/lwip/app/espconn_tcp.c
-+++ b/lwip/app/espconn_tcp.c
-@@ -557,7 +557,7 @@ espconn_recv_hold(struct espconn *pespconn)
-     value = espconn_find_connection(pespconn, &pnode);
- 	if(value != true)
- 	{
--		os_printf("RecvHold, By pespconn,find conn_msg fail\n");
-+		os_printf(_F("RecvHold, By pespconn,find conn_msg fail\n"));
- 		return ESPCONN_ARG;
- 	}
- 
-@@ -582,7 +582,7 @@ espconn_recv_unhold(struct espconn *pespconn)
-     value = espconn_find_connection(pespconn, &pnode);
- 	if(value != true)
- 	{
--		os_printf("RecvHold, By pespconn,find conn_msg fail\n");
-+		os_printf(_F("RecvHold, By pespconn,find conn_msg fail\n"));
- 		return ESPCONN_ARG;
- 	}
- 
-@@ -862,7 +862,7 @@ espconn_client_connect(void *arg, struct tcp_pcb *tpcb, err_t err)
- 			espconn_keepalive_enable(tpcb);
- 
-     } else{
--    	os_printf("err in host connected (%s)\n",lwip_strerr(err));
-+    	os_printf(_F("err in host connected (%s)\n"),lwip_strerr(err));
-     }
-     return err;
- }
-@@ -1354,7 +1354,7 @@ sint8 ICACHE_FLASH_ATTR espconn_tcp_delete(struct espconn *pdeletecon)
- 				/*remove the node from the client's active connection list*/
- 				espconn_list_delete(&pserver_list, pdelete_msg);
- 				pcb = pdelete_msg->preverse;
--				os_printf("espconn_tcp_delete %d, %d\n",pcb->state, pcb->local_port);
-+				os_printf(_F("espconn_tcp_delete %d, %d\n"),pcb->state, pcb->local_port);
- 				espconn_kill_pcb(pcb->local_port);
- 				err = tcp_close(pcb);
- 				os_free(pdelete_msg);
-
 diff --git a/lwip/app/espconn_udp.c b/lwip/app/espconn_udp.c
 index 77ef471..0e4936a 100644
 --- a/lwip/app/espconn_udp.c
@@ -492,7 +417,7 @@ index 77ef471..0e4936a 100644
  static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
  #endif
 diff --git a/lwip/core/dhcp.c b/lwip/core/dhcp.c
-index 342543e..9717574 100644
+index 342543e..92ad15b 100644
 --- a/lwip/core/dhcp.c
 +++ b/lwip/core/dhcp.c
 @@ -137,6 +137,9 @@ u8_t  dhcp_rx_options_given[DHCP_OPTION_IDX_MAX];
@@ -505,15 +430,6 @@ index 342543e..9717574 100644
  
  /* DHCP client state machine functions */
  static err_t dhcp_discover(struct netif *netif);
-@@ -384,7 +387,7 @@ dhcp_fine_tmr()
-       /*add DHCP retries processing by LiuHan*/
-       if (DHCP_MAXRTX != 0) {
-     	  if (netif->dhcp->tries >= DHCP_MAXRTX){
--			  os_printf("DHCP timeout\n");
-+			  os_printf(_F("DHCP timeout\n"));
- 			  if (netif->dhcp_event != NULL)
- 				  netif->dhcp_event();
- 			  break;
 diff --git a/lwip/core/ipv4/ip_addr.c b/lwip/core/ipv4/ip_addr.c
 index 81db807..dd6964e 100644
 --- a/lwip/core/ipv4/ip_addr.c

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -310,6 +310,17 @@ index ddb5984..fdaedea 100644
  	}
  
  	apnetif->dhcps_pcb = pcb_dhcps;
+--- a/include/lwip/tcp_impl.h
++++ b/include/lwip/tcp_impl.h
+@@ -130,7 +130,7 @@ u32_t            tcp_update_rcv_ann_wnd(struct tcp_pcb *pcb)ICACHE_FLASH_ATTR;
+ #define TCP_OOSEQ_TIMEOUT        6U /* x RTO */
+ 
+ #ifndef TCP_MSL
+-#define TCP_MSL 60000UL /* The maximum segment lifetime in milliseconds */
++#define TCP_MSL 2000UL /* The maximum segment lifetime in milliseconds */
+ #endif
+ 
+ /* Keepalive values, compliant with RFC 1122. Don't change this unless you know what you're doing */
 diff --git a/include/lwip/igmp.h b/include/lwip/igmp.h
 index c90adcd..f0c9dea 100644
 --- a/include/lwip/igmp.h

--- a/Sming/third-party/.patches/esp-open-lwip.patch
+++ b/Sming/third-party/.patches/esp-open-lwip.patch
@@ -475,10 +475,10 @@ index 52cd0b0..4e59429 100644
  				os_free(pdelete_msg);
 
 diff --git a/lwip/app/espconn_udp.c b/lwip/app/espconn_udp.c
-index 77ef471..7d6705e 100644
+index 77ef471..0e4936a 100644
 --- a/lwip/app/espconn_udp.c
 +++ b/lwip/app/espconn_udp.c
-@@ -19,9 +19,18 @@
+@@ -19,9 +19,12 @@
  #include "lwip/mem.h"
  #include "lwip/tcp_impl.h"
  #include "lwip/udp.h"
@@ -486,13 +486,7 @@ index 77ef471..7d6705e 100644
  
  #include "lwip/app/espconn_udp.h"
  
-+
-+/*
-+ * wifi_get_ip_info()
-+ * wifi_get_opmode()
-+ */
 +#include "user_interface.h"
-+
 +
  #ifdef MEMLEAK_DEBUG
  static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ build_script:
   - make tools V=1
 # Followed by the library and test sample apps
   - cd %SMING_HOME%
-  - make
+  - make STRICT=1
   - cd %SMING_HOME%\..\samples\Basic_Blink
   - make V=1 
   - cd %SMING_HOME%\..\samples\Basic_Ssl


### PR DESCRIPTION
Modify Makefile to enable ALL compiler warnings, then selectively disable so we can see exactly which warnings are being suppressed.

Note: This PR disables warnings-as-errors because it won't (quite) build at the moment.

Core plus ArduinoJson build with only these warnings disabled:

```
	comment
	strict-aliasing
	unused-function
	unused-variable
```

Libraries require these ones disabled also

```
	reorder
	parentheses
	unused-but-set-variable
	maybe-uninitialized *
	return-type *
	sign-compare +
	array-bounds *
```

   \* masks serious issues
   \+ frail code, likely to break

Bugfixes:
* WebsocketFrame.cpp line 152 - error in expression logic (<< used instead of <<=)
* CommandExecutor::executorReceive() - missing return statement

Changes:
* Change Vector::contains() method to use indexOf() - duplicate code
* Change AtClient retries parameter to unsigned
* Use flash strings in gdbstub.c
* Remove SimpleQueue class from AtClient, replace with basic FIFO<>
* Modify esp-open-lwip patch to include additional missing function prototypes, also use _F() on flash strings to conserve RAM