### PR TITLE
Revise IPAddress class

### DIFF
--- a/Sming/Wiring/IPAddress.cpp
+++ b/Sming/Wiring/IPAddress.cpp
@@ -20,37 +20,6 @@
 #include "IPAddress.h"
 #include "Print.h"
 
-IPAddress::IPAddress()
-{
-}
-
-IPAddress::IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet)
-{
-	IP4_ADDR(&_address, first_octet, second_octet, third_octet, fourth_octet);
-}
-
-IPAddress::IPAddress(uint32_t address)
-{
-	_address.addr = address;
-}
-
-IPAddress::IPAddress(ip_addr address)
-{
-	_address = address;
-}
-
-#if LWIP_VERSION_MAJOR == 2
-IPAddress::IPAddress(ip_addr_t address)
-{
-	_address = address;
-}
-#endif
-
-IPAddress::IPAddress(const uint8_t* address)
-{
-	IP4_ADDR(&_address, address[0], address[1], address[2], address[3]);
-}
-
 void IPAddress::fromString(const String& address)
 {
 	int p = -1;
@@ -67,29 +36,6 @@ void IPAddress::fromString(const String& address)
 
 	String sub = address.substring(p + 1);
 	operator[](3) = sub.toInt();
-}
-
-IPAddress::IPAddress(const String address)
-{
-	fromString(address);
-}
-
-IPAddress& IPAddress::operator=(const uint8_t *address)
-{
-    IP4_ADDR(&_address, address[0], address[1], address[2], address[3]);
-    return *this;
-}
-
-IPAddress& IPAddress::operator=(uint32_t address)
-{
-    _address.addr = address;
-    return *this;
-}
-
-IPAddress& IPAddress::operator=(const String address)
-{
-	fromString(address);
-    return *this;
 }
 
 bool IPAddress::operator==(const uint8_t* addr)

--- a/Sming/Wiring/IPAddress.cpp
+++ b/Sming/Wiring/IPAddress.cpp
@@ -42,7 +42,7 @@ bool IPAddress::operator==(const uint8_t* addr)
 {
     ip_addr_t a;
     IP4_ADDR(&a, addr[0], addr[1], addr[2], addr[3]);
-    return _address.addr == a.addr;
+    return address.addr == a.addr;
 }
 
 size_t IPAddress::printTo(Print& p) const
@@ -59,8 +59,8 @@ size_t IPAddress::printTo(Print& p) const
 String IPAddress::toString() const
 {
 	String res;
-    res.reserve(sizeof(_address) * 4);
-    for (unsigned i = 0; i < sizeof(_address); i++)
+    res.reserve(sizeof(address) * 4);
+    for (unsigned i = 0; i < sizeof(address); i++)
     {
     	if (i)
     	  res += '.';

--- a/Sming/Wiring/IPAddress.cpp
+++ b/Sming/Wiring/IPAddress.cpp
@@ -22,20 +22,13 @@
 
 void IPAddress::fromString(const String& address)
 {
-	int p = -1;
-	for (unsigned i = 0; i < 3; i++) {
-		int prev = p + 1;
-		p = address.indexOf('.', prev);
-		if (p < 0) {
-			debugf("WRONG IP: %s", address.c_str());
-			break;
-		}
-		String sub = address.substring(prev, p);
-		operator[](i) = sub.toInt();
+	this->address.addr = 0;
+	const char* p = address.c_str();
+	for(unsigned i = 0; i < 4; ++i) {
+		operator[](i) = strtol(p, const_cast<char**>(&p), 10);
+		if (*p++ != '.')
+			break;	// Missing '.' or end of input string
 	}
-
-	String sub = address.substring(p + 1);
-	operator[](3) = sub.toInt();
 }
 
 bool IPAddress::operator==(const uint8_t* addr)

--- a/Sming/Wiring/IPAddress.h
+++ b/Sming/Wiring/IPAddress.h
@@ -102,15 +102,15 @@ public:
     }
 
     // Overloaded index operator to allow getting and setting individual octets of the address
-    uint8_t operator[](unsigned index) const
+    uint8_t operator[](int index) const
     {
-        assert(index < sizeof(address));
-        return (index < sizeof(address)) ? reinterpret_cast<const uint8_t*>(&address)[index] : 0;
+        assert(unsigned(index) < sizeof(address));
+        return (unsigned(index) < sizeof(address)) ? reinterpret_cast<const uint8_t*>(&address)[index] : 0;
     }
 
-    uint8_t& operator[](unsigned index)
+    uint8_t& operator[](int index)
     {
-        assert(index < sizeof(address));
+        assert(unsigned(index) < sizeof(address));
         return reinterpret_cast<uint8_t*>(&address)[index];
     }
 

--- a/Sming/Wiring/IPAddress.h
+++ b/Sming/Wiring/IPAddress.h
@@ -37,7 +37,7 @@ typedef struct ip_addr ip_addr_t;
 class IPAddress : public Printable
 {
 private:
-    ip_addr_t _address = {0}; ///< IPv4 address
+    ip_addr_t address = {0}; ///< IPv4 address
 
 	void fromString(const String& address);
 
@@ -49,29 +49,29 @@ public:
 
     IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet)
 	{
-		IP4_ADDR(&_address, first_octet, second_octet, third_octet, fourth_octet);
+		IP4_ADDR(&address, first_octet, second_octet, third_octet, fourth_octet);
 	}
 
     IPAddress(uint32_t address)
 	{
-		_address.addr = address;
+		this->address.addr = address;
 	}
 
     IPAddress(ip_addr address)
 	{
-		_address = address;
+		this->address = address;
 	}
 
 #if LWIP_VERSION_MAJOR == 2
     IPAddress(ip_addr_t address);
 	{
-		_address = address;
+		this->address = address;
 	}
 #endif
 
     IPAddress(const uint8_t *address)
 	{
-		IP4_ADDR(&_address, address[0], address[1], address[2], address[3]);
+		IP4_ADDR(&this->address, address[0], address[1], address[2], address[3]);
 	}
 
     IPAddress(const String address)
@@ -81,49 +81,49 @@ public:
 
     // Overloaded cast operator to allow IPAddress objects to be used where a pointer
     // to a four-byte uint8_t array is expected
-    operator uint32_t() const { return _address.addr; }
-    operator ip_addr() const { return _address; }
-    operator ip_addr*() { return &_address; }
+    operator uint32_t() const { return address.addr; }
+    operator ip_addr() const { return address; }
+    operator ip_addr*() { return &address; }
 
     operator char*() { return toString().begin(); }
 #if LWIP_VERSION_MAJOR == 2
-    operator ip_addr_t*() { return &_address; }
+    operator ip_addr_t*() { return &address; }
 #endif
 
-    bool operator==(const IPAddress& addr) { return _address.addr == addr._address.addr; }
+    bool operator==(const IPAddress& addr) { return address.addr == addr.address.addr; }
     bool operator==(const uint8_t* addr);
 
-    bool isNull() const { return _address.addr == 0; }
+    bool isNull() const { return address.addr == 0; }
     String toString() const;
 
     bool compare(const IPAddress& addr, const IPAddress& mask) const
     {
-        return ip_addr_netcmp(&_address, &addr._address, &mask._address);
+        return ip_addr_netcmp(&address, &addr.address, &mask.address);
     }
 
     // Overloaded index operator to allow getting and setting individual octets of the address
     uint8_t operator[](unsigned index) const
     {
-        assert(index < sizeof(_address));
-        return (index < sizeof(_address)) ? reinterpret_cast<const uint8_t*>(&_address)[index] : 0;
+        assert(index < sizeof(address));
+        return (index < sizeof(address)) ? reinterpret_cast<const uint8_t*>(&address)[index] : 0;
     }
 
     uint8_t& operator[](unsigned index)
     {
-        assert(index < sizeof(_address));
-        return reinterpret_cast<uint8_t*>(&_address)[index];
+        assert(index < sizeof(address));
+        return reinterpret_cast<uint8_t*>(&address)[index];
     }
 
     // Overloaded copy operators to allow initialisation of IPAddress objects from other types
     IPAddress& operator=(const uint8_t *address)
     {
-        IP4_ADDR(&_address, address[0], address[1], address[2], address[3]);
+        IP4_ADDR(&this->address, address[0], address[1], address[2], address[3]);
         return *this;
     }
 
     IPAddress& operator=(uint32_t address)
     {
-        _address.addr = address;
+        this->address.addr = address;
         return *this;
     }
 
@@ -135,7 +135,6 @@ public:
 
     virtual size_t printTo(Print& p) const;
 };
-
 
 // Making this extern saves 100's of bytes; each usage otherwise incurs 4 bytes of BSS
 #define INADDR_NONE IPAddress()

--- a/Sming/Wiring/IPAddress.h
+++ b/Sming/Wiring/IPAddress.h
@@ -43,15 +43,41 @@ private:
 
 public:
     // Constructors
-    IPAddress();
-    IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet);
-    IPAddress(uint32_t address);
-    IPAddress(ip_addr address);
+    IPAddress()
+	{
+	}
+
+    IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet)
+	{
+		IP4_ADDR(&_address, first_octet, second_octet, third_octet, fourth_octet);
+	}
+
+    IPAddress(uint32_t address)
+	{
+		_address.addr = address;
+	}
+
+    IPAddress(ip_addr address)
+	{
+		_address = address;
+	}
+
 #if LWIP_VERSION_MAJOR == 2
     IPAddress(ip_addr_t address);
+	{
+		_address = address;
+	}
 #endif
-    IPAddress(const uint8_t *address);
-    IPAddress(const String address);
+
+    IPAddress(const uint8_t *address)
+	{
+		IP4_ADDR(&_address, address[0], address[1], address[2], address[3]);
+	}
+
+    IPAddress(const String address)
+    {
+    	fromString(address);
+    }
 
     // Overloaded cast operator to allow IPAddress objects to be used where a pointer
     // to a four-byte uint8_t array is expected
@@ -89,14 +115,29 @@ public:
     }
 
     // Overloaded copy operators to allow initialisation of IPAddress objects from other types
-    IPAddress& operator=(const uint8_t *address);
-    IPAddress& operator=(uint32_t address);
-    IPAddress& operator=(const String address);
+    IPAddress& operator=(const uint8_t *address)
+    {
+        IP4_ADDR(&_address, address[0], address[1], address[2], address[3]);
+        return *this;
+    }
+
+    IPAddress& operator=(uint32_t address)
+    {
+        _address.addr = address;
+        return *this;
+    }
+
+    IPAddress& operator=(const String address)
+    {
+    	fromString(address);
+        return *this;
+    }
 
     virtual size_t printTo(Print& p) const;
 };
 
 
+// Making this extern saves 100's of bytes; each usage otherwise incurs 4 bytes of BSS
 #define INADDR_NONE IPAddress()
 
 #endif


### PR DESCRIPTION
* Replace `address` member variable with ip_addr_t instead of byte array
* Remove un-necessary casting, replace C-style with appropriate C++ cast operator
* Re-define INADDR_NONE as macro instead of const definition. Saves RAM, 4 bytes of BSS for every reference.
* Move trivial methods into header
* Remove underscore from `_address`
* Rewrite fromString() method to avoid heap allocations