### PR TITLE
Changes to FileStream class

### DIFF
--- a/Sming/SmingCore/Data/Stream/FileStream.cpp
+++ b/Sming/SmingCore/Data/Stream/FileStream.cpp
@@ -9,100 +9,105 @@
 
 /* FileStream */
 
-FileStream::FileStream()
+void FileStream::attach(file_t file, size_t size)
 {
-	handle = -1;
-	size = -1;
-	pos = 0;
-}
-
-FileStream::FileStream(const String& filename)
-{
-	attach(filename, eFO_ReadOnly);
-}
-
-bool FileStream::attach(const String& fileName, FileOpenFlags openFlags)
-{
-	handle = fileOpen(fileName.c_str(), openFlags);
-	if(handle == -1) {
-		debug_w("File wasn't found: %s", fileName.c_str());
-		size = -1;
+	close();
+	if(file >= 0) {
+		handle = file;
+		this->size = size;
+		fileSeek(handle, 0, eSO_FileStart);
 		pos = 0;
+		debug_d("attached file: '%s' (%u bytes) #0x%08X", fileName().c_str(), size, this);
+	}
+}
+
+bool FileStream::open(const String& fileName, FileOpenFlags openFlags)
+{
+	lastError = SPIFFS_OK;
+
+	file_t file = fileOpen(fileName, openFlags);
+	if(!check(file)) {
+		debug_w("File wasn't found: %s", fileName.c_str());
 		return false;
 	}
 
 	// Get size
-	fileSeek(handle, 0, eSO_FileEnd);
-	size = fileTell(handle);
+	if(check(fileSeek(file, 0, eSO_FileEnd))) {
+		int size = fileTell(file);
+		if(check(size)) {
+			attach(file, size);
+			return true;
+		}
+	}
 
-	fileSeek(handle, 0, eSO_FileStart);
-	pos = 0;
-
-	debug_d("attached file: %s (%d bytes)", fileName.c_str(), size);
-	return true;
+	fileClose(file);
+	return false;
 }
 
-FileStream::~FileStream()
+void FileStream::close()
 {
-	fileClose(handle);
-	handle = 0;
+	if(handle >= 0) {
+		fileClose(handle);
+		handle = -1;
+	}
+	size = 0;
 	pos = 0;
+	lastError = SPIFFS_OK;
 }
 
 uint16_t FileStream::readMemoryBlock(char* data, int bufSize)
 {
-	int len = std::min(bufSize, size - pos);
-	int available = fileRead(handle, data, len);
-	fileSeek(handle, pos, eSO_FileStart); // Don't move cursor now (waiting seek)
-	if(available < 0) {
-		available = 0;
+	if(data == nullptr || bufSize <= 0 || pos >= size) {
+		return 0;
 	}
-	return available;
-}
 
-size_t FileStream::write(uint8_t charToWrite)
-{
-	uint8_t tempbuf[1]{charToWrite};
-	return write(tempbuf, 1);
+	int available = fileRead(handle, data, std::min(size - pos, size_t(bufSize)));
+	check(available);
+
+	// Don't move cursor now (waiting seek)
+	fileSeek(handle, pos, eSO_FileStart);
+
+	return available > 0 ? available : 0;
 }
 
 size_t FileStream::write(const uint8_t* buffer, size_t size)
 {
-	if(!fileExist())
+	if(!fileExist()) {
 		return 0;
+	}
 
-	fileSeek(handle, 0, eSO_FileEnd);
-	return fileWrite(handle, buffer, size);
+	int pos = fileSeek(handle, 0, eSO_FileEnd);
+	if(!check(pos)) {
+		return 0;
+	}
+
+	this->pos = size_t(pos);
+
+	int written = fileWrite(handle, buffer, size);
+	if(check(written)) {
+		this->pos += size_t(written);
+	}
+
+	return written;
 }
 
 bool FileStream::seek(int len)
 {
-	if(len < 0)
+	int newpos = fileSeek(handle, len, eSO_CurrentPos);
+	if(!check(newpos)) {
 		return false;
+	}
 
-	bool result = fileSeek(handle, len, eSO_CurrentPos) >= 0;
-	if(result)
-		pos += len;
-	return result;
-}
+	pos = newpos;
 
-bool FileStream::isFinished()
-{
-	return fileIsEOF(handle);
+	return true;
 }
 
 String FileStream::fileName() const
 {
 	spiffs_stat stat;
-	if(fileStats(handle, &stat) < 0)
-		return nullptr;
-	else
-		return String((char*)stat.name);
-}
-
-bool FileStream::fileExist() const
-{
-	return size != -1;
+	fileStats(handle, &stat);
+	return String(reinterpret_cast<const char*>(stat.name));
 }
 
 String FileStream::id() const
@@ -112,7 +117,8 @@ String FileStream::id() const
 
 #define ETAG_SIZE 16
 	char buf[ETAG_SIZE];
-	m_snprintf(buf, ETAG_SIZE, _F("00f-%x-%x0-%x"), stat.obj_id, stat.size, strlen((char*)stat.name));
+	m_snprintf(buf, ETAG_SIZE, _F("00f-%x-%x0-%x"), stat.obj_id, stat.size,
+			   strlen(reinterpret_cast<const char*>(stat.name)));
 
 	return String(buf);
 }


### PR DESCRIPTION
* Add close() method
* Change size, pos to size_t
* Handle value < 0 if invalid
* bugfix: available() returned wrong value
* Remove write(uint8_t) method, implemented in ReadWriteStream
* Add getLastError() method and track file error code internally
* Additional file API error checks
* Don't prevent negative offsets in seek() method, perfectly legitimate
* Track file position in write() method