### PR TITLE
Fix Basic_WebSkeletonApp

### DIFF
--- a/samples/Basic_WebSkeletonApp/app/webserver.cpp
+++ b/samples/Basic_WebSkeletonApp/app/webserver.cpp
@@ -98,6 +98,7 @@ void startWebServer()
 	server.addPath("/config.json", onConfiguration_json);
 	server.addPath("/state", onAJAXGetState);
 	server.setDefaultHandler(onFile);
+	server.setBodyParser("application/json", bodyToStringParser);
 	serverStarted = true;
 
 	if(WifiStation.isEnabled())


### PR DESCRIPTION
Setting network parameters was broken. After sending the configuration
the body of the response always appeared to be empty, since no
BodyParser was set. After setting bodyToStringParser as parser for
application/json, the request is parsed correctly.