### PR TITLE
Add toHTTPDate to DateTime class with supporting changes to CStringArray

### DIFF
--- a/Sming/Services/DateTime/DateTime.cpp
+++ b/Sming/Services/DateTime/DateTime.cpp
@@ -155,7 +155,7 @@ String DateTime::toISO8601()
 
 String DateTime::toHTTPDate()
 {
-    char buf[30];
+	char buf[30];
 	m_snprintf(buf, sizeof(buf), _F("%s, %02d %s %04d %02d:%02d:%02d GMT"), CStringArray(flashDayNames)[DayofWeek], Day, CStringArray(flashMonthNames)[Month], Year, Hour, Minute, Second);
 	return String(buf);
 }

--- a/Sming/Services/DateTime/DateTime.cpp
+++ b/Sming/Services/DateTime/DateTime.cpp
@@ -4,7 +4,7 @@
 
   This library is distributed in the hope that it will be useful,
   but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. 
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
 */
 
 #include "DateTime.h"
@@ -17,6 +17,7 @@
  * Used to parse HTTP date strings - see parseHttpDate()
  */
 static DEFINE_FSTR(flashMonthNames, "Jan\0Feb\0Mar\0Apr\0May\0Jun\0Jul\0Aug\0Sep\0Oct\0Nov\0Dec");
+static DEFINE_FSTR(flashDayNames, "Sun\0Mon\0Tue\0Wed\0Thu\0Fri\0Sat");
 
 /** @brief Get the number of days in a month, taking leap years into account
  *  @param month 0=jan
@@ -148,7 +149,14 @@ String DateTime::toFullDateTimeString()
 String DateTime::toISO8601()
 {
 	char buf[32];
-	m_snprintf(buf, sizeof(buf), _F("%02d-%02d-%02dT%02d:%02d:%02dZ"), Year, Month + 1, Day, Hour, Minute, Second);
+	m_snprintf(buf, sizeof(buf), _F("%04d-%02d-%02dT%02d:%02d:%02dZ"), Year, Month + 1, Day, Hour, Minute, Second);
+	return String(buf);
+}
+
+String DateTime::toHTTPDate()
+{
+    char buf[30];
+	m_snprintf(buf, sizeof(buf), _F("%s, %02d %s %04d %02d:%02d:%02d GMT"), CStringArray(flashDayNames)[DayofWeek], Day, CStringArray(flashMonthNames)[Month], Year, Hour, Minute, Second);
 	return String(buf);
 }
 

--- a/Sming/Services/DateTime/DateTime.h
+++ b/Sming/Services/DateTime/DateTime.h
@@ -76,20 +76,20 @@ typedef enum {
 class DateTime
 {
 public:
-    /** @brief  Instantiate an uninitialised date and time object
-     */
+	/** @brief  Instantiate an uninitialised date and time object
+	 */
 	DateTime()
 	{
 	}
 
-    /** @brief  Instantiate a date and time object
-     *  @param  time Unix time to assign to object
-     */
+	/** @brief  Instantiate a date and time object
+	 *  @param  time Unix time to assign to object
+	 */
 	DateTime(time_t time);
 
-    /** @brief  Get current Unix time
-     *  @retval time_t Quantity of seconds since 00:00:00 1970-01-01
-    */
+	/** @brief  Get current Unix time
+	 *  @retval time_t Quantity of seconds since 00:00:00 1970-01-01
+	 */
 	operator time_t() { return toUnixTime(); }
 
     /** @brief  Set time using Unix time
@@ -106,12 +106,12 @@ public:
 	 */
 	void setTime(int8_t sec, int8_t min, int8_t hour, int8_t day, int8_t month, int16_t year);
 
-    /** @brief  Parse a HTTP full date and set time and date
-     *  @param  httpDate HTTP full date in RFC 1123 format, e.g. Sun, 06 Nov 1994 08:49:37 GMT
-     *  @retval bool True on success
-     *  @note   Also supports obsolete RFC 850 date format, e.g. Sunday, 06-Nov-94 08:49:37 GMT where 2 digit year represents range 1970-2069
-     *  @note   GMT suffix is optional and is always assumed / ignored
-     */
+	/** @brief  Parse a HTTP full date and set time and date
+	 *  @param  httpDate HTTP full date in RFC 1123 format, e.g. Sun, 06 Nov 1994 08:49:37 GMT
+	 *  @retval bool True on success
+	 *  @note   Also supports obsolete RFC 850 date format, e.g. Sunday, 06-Nov-94 08:49:37 GMT where 2 digit year represents range 1970-2069
+	 *  @note   GMT suffix is optional and is always assumed / ignored
+	 */
 	bool parseHttpDate(const String& httpDate);
 
 	/** @brief  Check if time date object is initialised
@@ -120,14 +120,14 @@ public:
 	bool isNull();
 
     /** @brief  Get Unix time
-     *  @retval time_t Unix time, quantity of seconds since 00:00:00 1970-01-01
+	 *  @retval time_t Unix time, quantity of seconds since 00:00:00 1970-01-01
 	 *  @note   Unix time does not account for leap seconds. To convert Unix time to UTC requires reference to a leap second table.
-     */
+	 */
 	time_t toUnixTime();
 
-    /** @brief  Get human readable date
-     *  @retval String Date in requested format, e.g. DD.MM.YYYY
-     */
+	/** @brief  Get human readable date
+	 *  @retval String Date in requested format, e.g. DD.MM.YYYY
+	 */
 	String toShortDateString();
 
 	/** @brief  Get human readable time
@@ -136,24 +136,24 @@ public:
 	 */
 	String toShortTimeString(bool includeSeconds = false);
 
-    /** @brief  Get human readable date and time
-     *  @retval String Date and time in format DD.MM.YYYY hh:mm:ss
-     */
+	/** @brief  Get human readable date and time
+	 *  @retval String Date and time in format DD.MM.YYYY hh:mm:ss
+	 */
 	String toFullDateTimeString();
 
-   /** @brief  Get human readable date and time
-     *  @retval String Date and time in format YYYY-MM-DDThh:mm:ssZ
-     */
+	/** @brief  Get human readable date and time
+	 *  @retval String Date and time in format YYYY-MM-DDThh:mm:ssZ
+	 */
 	String toISO8601();
 
-   /** @brief  Get human readable date and time
-     *  @retval String Date and time in format DDD, DD MMM YYYY hh:mm:ss GMT
-     */
+	/** @brief  Get human readable date and time
+	 *  @retval String Date and time in format DDD, DD MMM YYYY hh:mm:ss GMT
+	 */
 	String toHTTPDate();
 
-    /** @brief  Add time to date time object
-     *  @param  add Quantity of milliseconds to add to object
-     */
+	/** @brief  Add time to date time object
+	 *  @param  add Quantity of milliseconds to add to object
+	 */
 	void addMilliseconds(long add);
 
 	// functions to convert to and from time components (hrs, secs, days, years etc) to time_t

--- a/Sming/Services/DateTime/DateTime.h
+++ b/Sming/Services/DateTime/DateTime.h
@@ -126,7 +126,7 @@ public:
 	time_t toUnixTime();
 
     /** @brief  Get human readable date
-     *  @retval String Date in requested format, e.g. dd.mm.yyyy
+     *  @retval String Date in requested format, e.g. DD.MM.YYYY
      */
 	String toShortDateString();
 
@@ -137,10 +137,19 @@ public:
 	String toShortTimeString(bool includeSeconds = false);
 
     /** @brief  Get human readable date and time
-     *  @retval String Date and time in format dd.mm.yyyy hh:mm:ss
+     *  @retval String Date and time in format DD.MM.YYYY hh:mm:ss
      */
 	String toFullDateTimeString();
+
+   /** @brief  Get human readable date and time
+     *  @retval String Date and time in format YYYY-MM-DDThh:mm:ssZ
+     */
 	String toISO8601();
+
+   /** @brief  Get human readable date and time
+     *  @retval String Date and time in format DDD, DD MMM YYYY hh:mm:ss GMT
+     */
+	String toHTTPDate();
 
     /** @brief  Add time to date time object
      *  @param  add Quantity of milliseconds to add to object

--- a/Sming/SmingCore/Data/CStringArray.cpp
+++ b/Sming/SmingCore/Data/CStringArray.cpp
@@ -58,7 +58,7 @@ unsigned CStringArray::count() const
 {
 	if(stringCount == 0 && length() > 0) {
 		//If array is created by assignment (e.g. CStringsArray csa = "Hello\0World";) then stringCount is not set so set it here
-		for(unsigned offset = 0; offset < length() + 1; offset++) {
+		for(unsigned offset = 0; offset <= length(); offset++) {
 			if(buffer[offset] == '\0')
 				++stringCount;
 		}

--- a/Sming/SmingCore/Data/CStringArray.cpp
+++ b/Sming/SmingCore/Data/CStringArray.cpp
@@ -42,8 +42,10 @@ int CStringArray::indexOf(const char* str) const
 
 const char* CStringArray::getValue(unsigned index) const
 {
-	if(index < stringCount) {
-		for(unsigned offset = 0; offset < length(); --index) {
+	if(index < count())
+    {
+		for(unsigned offset = 0; offset < length(); --index)
+		{
 			const char* s = buffer + offset;
 			if(index == 0)
 				return s;
@@ -52,4 +54,18 @@ const char* CStringArray::getValue(unsigned index) const
 	}
 
 	return nullptr;
+}
+
+unsigned CStringArray::count() const
+{
+    if(stringCount == 0 && length() > 0)
+    {
+        //If array is created by assignment (e.g. CStringsArray csa = "Hello\0World";) then stringCount is not set so set it here
+        for(unsigned offset = 0; offset < length() + 1; offset++)
+        {
+            if(buffer[offset] == '\0')
+                ++stringCount;
+        }
+    }
+    return stringCount;
 }

--- a/Sming/SmingCore/Data/CStringArray.h
+++ b/Sming/SmingCore/Data/CStringArray.h
@@ -69,34 +69,34 @@ public:
 	}
 
 	/** @brief  Check if array contains a string
-	*   @param  str String to search for
-	*   @retval bool True if string exists in array
-	*   @note   Search is not case-sensitive
-	*/
+	 *  @param  str String to search for
+	 *  @retval bool True if string exists in array
+	 *  @note   Search is not case-sensitive
+	 */
 	bool contains(const char* str) const
 	{
 		return indexOf(str) >= 0;
 	}
 
 	/** @brief  Check if array contains a string
-	*   @param  str String to search for
-	*   @retval bool True if string exists in array
-	*   @note   Search is not case-sensitive
-	*/
+	 *  @param  str String to search for
+	 *  @retval bool True if string exists in array
+	 *  @note   Search is not case-sensitive
+	 */
 	bool contains(const String& str) const
 	{
 		return indexOf(str) >= 0;
 	}
 
 	/** @brief Get string at the given position
-	 * 	@param index 0-based index of string to obtain
-	 * 	@retval const char* nullptr if index is not valid
+	 *  @param index 0-based index of string to obtain
+	 *  @retval const char* nullptr if index is not valid
 	 */
 	const char* getValue(unsigned index) const;
 
 	/** @brief Get string at the given position
-	 * 	@param index 0-based index of string to obtain
-	 * 	@retval const char* nullptr if index is not valid
+	 *  @param index 0-based index of string to obtain
+	 *  @retval const char* nullptr if index is not valid
 	 */
 	const char* operator[](unsigned index) const
 	{

--- a/Sming/SmingCore/Data/CStringArray.h
+++ b/Sming/SmingCore/Data/CStringArray.h
@@ -34,12 +34,18 @@ public:
 	// Inherit all constructors
 	using String::String;
 
-	/** @brief append a new string to the end of the array
+
+	/** @brief Append a new string to the end of the array
 	 *  @param str
+	 *  @param length Length of new string in array (default is length of str)
 	 *  @retval bool false on memory allocation error
 	 */
 	bool add(const char* str, unsigned length = 0);
 
+	/** @brief Append a new string to the end of the array
+	 *  @param str
+	 *  @retval bool false on memory allocation error
+	 */
 	bool add(const String& str)
 	{
 		return add(str.c_str(), str.length());
@@ -48,20 +54,35 @@ public:
 	/** @brief Find the given string and return its index
 	 * 	@param str String to find
 	 * 	@retval int index of given string, -1 if not found
-	 * 	@note comparison is not case-sensitive
+	 * 	@note Comparison is not case-sensitive
 	 */
 	int indexOf(const char* str) const;
 
+	/** @brief Find the given string and return its index
+	 * 	@param str String to find
+	 * 	@retval int index of given string, -1 if not found
+	 * 	@note Comparison is not case-sensitive
+	 */
 	int indexOf(const String& str) const
 	{
 		return indexOf(str.c_str());
 	}
 
+	/** @brief  Check if array contains a string
+	*   @param  str String to search for
+	*   @retval bool True if string exists in array
+	*   @note   Search is not case-sensitive
+	*/
 	bool contains(const char* str) const
 	{
 		return indexOf(str) >= 0;
 	}
 
+	/** @brief  Check if array contains a string
+	*   @param  str String to search for
+	*   @retval bool True if string exists in array
+	*   @note   Search is not case-sensitive
+	*/
 	bool contains(const String& str) const
 	{
 		return indexOf(str) >= 0;
@@ -73,6 +94,10 @@ public:
 	 */
 	const char* getValue(unsigned index) const;
 
+	/** @brief Get string at the given position
+	 * 	@param index 0-based index of string to obtain
+	 * 	@retval const char* nullptr if index is not valid
+	 */
 	const char* operator[](unsigned index) const
 	{
 		return getValue(index);
@@ -86,13 +111,13 @@ public:
 		stringCount = 0;
 	}
 
-	unsigned count() const
-	{
-		return stringCount;
-	}
+	/** @brief  Get quantity of strings in array
+	*   @retval unsigned Quantity of strings
+	*/
+	unsigned count() const;
 
 private:
-	unsigned stringCount = 0;
+	mutable unsigned stringCount = 0;
 };
 
 #endif // _SMING_CORE_DATA_STRING_ARRAY_H_


### PR DESCRIPTION
Corrects ISO8601 year to use 4 characters.
Add toHTTPDate function to DateTime class.
Calculate stringCount for CStringArray if not set, e.g. if object instantiated using assignment. Note: stringCount now mutable.
Add missing documentation for CStringArray class.
Use uppercase Y,M,D for date formats in documentation.