### PR TITLE
Add the possibility to use strict compilation also for applications.

### DIFF
--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -238,8 +238,12 @@ EXTRA_INCDIR += $(SMING_HOME)/include $(SMING_HOME)/ $(LWIP_INCDIR) $(SMING_HOME
 USER_LIBDIR  = $(SMING_HOME)/compiler/lib/
 
 # compiler flags using during compilation of source files
-CFLAGS   = -Wpointer-arith -Wundef -Werror -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
+CFLAGS   = -Wall -Wundef -Wpointer-arith -Wno-comment -Wl,-EL -nostdlib -mlongcalls -mtext-section-literals -finline-functions -fdata-sections -ffunction-sections \
            -D__ets__ -DICACHE_FLASH -DARDUINO=106 -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL) $(USER_CFLAGS) -DENABLE_CMD_EXECUTOR=$(ENABLE_CMD_EXECUTOR) -DSMING_INCLUDED=1 
+ifneq ($(STRICT),1)
+CFLAGS += -Werror -Wno-sign-compare -Wno-parentheses -Wno-unused-variable -Wno-unused-but-set-variable -Wno-strict-aliasing -Wno-return-type -Wno-maybe-uninitialized
+endif
+
 # => SDK
 ifneq (,$(findstring third-party/ESP8266_NONOS_SDK, $(SDK_BASE)))
 	CFLAGS += -DSDK_INTERNAL

--- a/Sming/SmingCore/Network/rBootHttpUpdate.cpp
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.cpp
@@ -89,7 +89,7 @@ void rBootHttpUpdate::setBaseRequest(HttpRequest* request)
 
 void rBootHttpUpdate::start()
 {
-	for(int i = 0; i < items.count(); i++) {
+	for(unsigned i = 0; i < items.count(); i++) {
 		rBootHttpUpdateItem& it = items[i];
 		debug_d("Download file:\r\n    (%d) %s -> %X", currentItem, it.url.c_str(), it.targetOffset);
 

--- a/samples/TcpClient_NarodMon/app/application.cpp
+++ b/samples/TcpClient_NarodMon/app/application.cpp
@@ -78,8 +78,10 @@ void connectOk(String ssid, uint8_t ssid_len, uint8_t bssid[6], uint8_t channel)
 	// в верхний регистр
 	mac.toUpperCase();
 	// преобразуем из XXXXXXXXXXXX в XX-XX-XX-XX-XX-XX
-	for(int i = 2; i < mac.length(); i += 2)
-		mac = mac.substring(0, i) + "-" + mac.substring(i++);
+	for(int i = 2; i < mac.length(); i += 2) {
+		mac = mac.substring(0, i) + "-" + mac.substring(i);
+		i++;
+	}
 
 	debugf("mac: %s", mac.c_str());
 }


### PR DESCRIPTION
Warning: Since non-rBoot projects are deprecated this change is applied only here and not in the Makefile-project.mk file.