### PR TITLE
Create separate libraries with name suffix to indicate build option, …

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -29,9 +29,6 @@
 # MacOS / Linux:
 # COM_PORT = /dev/tty.usbserial
 
-# Com port speed
-COM_SPEED = 115200
-
 # Git command
 GIT ?= git
 
@@ -159,16 +156,21 @@ USER_LIBDIR = compiler/lib
 
 LIBSMING = libsming
 ifeq ($(ENABLE_SSL),1)
-	LIBSMING= libsmingssl
+	LIBSMING := $(LIBSMING)ssl
+	BUILD_BASE := $(BUILD_BASE)ssl
 endif
 
+ifeq ($(ENABLE_GDB),1)
+	LIBSMING := $(LIBSMING)d
+	BUILD_BASE := $(BUILD_BASE)d
+endif
 
 # name for the target project
 TARGET		= app
 
 CUSTOM_TARGETS ?=
 
-ARDUINO_LIBRARIES = $(shell git submodule status Libraries | cut -c2- | cut -f2 -d ' ' | sed -r 's/Libraries\/([^/]*)/Libraries\/\1\/library.properties/g' )
+ARDUINO_LIBRARIES =
 
 # which modules (subdirectories) of the project to include in compiling
 MODULES     = system system/helpers Wiring appinit \

--- a/Sming/Makefile-project.mk
+++ b/Sming/Makefile-project.mk
@@ -200,8 +200,12 @@ THIRD_PARTY_DIR = $(SMING_HOME)/third-party
 SMING_FEATURES = none
 LIBSMING = sming
 ifeq ($(ENABLE_SSL),1)
-	LIBSMING = smingssl
+	LIBSMING := $(LIBSMING)ssl
 	SMING_FEATURES = SSL
+endif
+
+ifeq ($(ENABLE_GDB),1)
+	LIBSMING := $(LIBSMING)d
 endif
 
 # which modules (subdirectories) of the project to include in compiling

--- a/Sming/Makefile-rboot.mk
+++ b/Sming/Makefile-rboot.mk
@@ -210,8 +210,12 @@ THIRD_PARTY_DIR = $(SMING_HOME)/third-party
 LIBSMING = sming
 SMING_FEATURES = none
 ifeq ($(ENABLE_SSL),1)
-	LIBSMING = smingssl
+	LIBSMING := $(LIBSMING)ssl
 	SMING_FEATURES = SSL
+endif
+
+ifeq ($(ENABLE_GDB),1)
+	LIBSMING := $(LIBSMING)d
 endif
 
 # which modules (subdirectories) of the project to include in compiling

--- a/Sming/compiler/ld/common.ld
+++ b/Sming/compiler/ld/common.ld
@@ -113,8 +113,7 @@ SECTIONS
      *(.rodata._ZTV*) /* C++ vtables */
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.debug.*)
     out/build/app_app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
-  *libsming.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
-  *libsmingssl.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
+  *libsming*.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
   *libmqttc.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
 
     _irom0_text_end = ABSOLUTE(.);


### PR DESCRIPTION
…e.g. libsmingssld.a for debug library with SSL support.

Use different build locations to avoid need to clean and rebuild everything every time.

Allow creation of libsming, libsmingssl, libsmingd and libsmingssld. Suffix 'd' indicates ENABLE_GDB=1. Suffix 'ssl' indicates ENABLE_SSL=1. This allows simultaneous existence of normal and debug version of SSL and non-SSL versions of the library. Note: common.ld needed to be adjusted to ensure the correct map. SSL and non-SSL (and gdb) builds use the same value so use of wildcard '*' allowed all to be handled by single line. All relevant makefiles use the new naming convention.

An advantage of this PR is to allow debug libraries to be available without time consuming recompiling or awkward file renaming.