### PR TITLE
Add HttpHeaders::setMultiple() method

### DIFF
--- a/Sming/SmingCore/Network/Http/HttpHeaders.h
+++ b/Sming/SmingCore/Network/Http/HttpHeaders.h
@@ -169,6 +169,15 @@ public:
 		remove(fromString(name));
 	}
 
+	void setMultiple(const HttpHeaders& headers)
+	{
+		for(unsigned i = 0; i < headers.count(); i++) {
+			HttpHeaderFieldName fieldName = headers.keyAt(i);
+			auto fieldNameString = headers.toString(fieldName);
+			operator[](fieldNameString) = headers.valueAt(i);
+		}
+	}
+
 	HttpHeaders& operator=(const HttpHeaders& headers)
 	{
 		clear();

--- a/Sming/SmingCore/Network/Http/HttpHeaders.h
+++ b/Sming/SmingCore/Network/Http/HttpHeaders.h
@@ -90,7 +90,7 @@ enum HttpHeaderFieldName {
  *
  *  @todo add name and/or value escaping
  */
-class HttpHeaders : public HashMap<HttpHeaderFieldName, String>
+class HttpHeaders : private HashMap<HttpHeaderFieldName, String>
 {
 public:
 	String toString(HttpHeaderFieldName name) const;
@@ -190,6 +190,8 @@ public:
 		customFieldNames.clear();
 		HashMap::clear();
 	}
+
+	using HashMap::count;
 
 private:
 	/** @brief Try to match a string against the list of custom field names


### PR DESCRIPTION
Using inherited HashMap version doesn't work. Fixes #1562