### PR TITLE
Fixes Basic_APA102 sample missing comment for COM_PORT

### DIFF
--- a/samples/Basic_APA102/Makefile-user.mk
+++ b/samples/Basic_APA102/Makefile-user.mk
@@ -25,7 +25,7 @@
 # COM_PORT = COM3
 
 ## MacOS / Linux:
-COM_PORT = /dev/ttyUSB0
+# COM_PORT = /dev/ttyUSB0
 
 ## Com port speed
 #COM_SPEED	= 230400


### PR DESCRIPTION
The Basic_APA102 sample has one of its Makefile lines uncommented. This PR corrects that inconsistency.