### PR TITLE
General improvements to UdpConnection class

### DIFF
--- a/Sming/SmingCore/Network/UdpConnection.cpp
+++ b/Sming/SmingCore/Network/UdpConnection.cpp
@@ -6,44 +6,31 @@
  ****/
 
 #include "UdpConnection.h"
-#include "../../Wiring/WString.h"
+#include "WString.h"
 
-UdpConnection::UdpConnection() : onDataCallback(NULL)
+void UdpConnection::initialize(udp_pcb* pcb)
 {
-	initialize();
-}
-
-UdpConnection::UdpConnection(UdpConnectionDataDelegate dataHandler) : onDataCallback(dataHandler)
-{
-	initialize();
-}
-
-UdpConnection::~UdpConnection()
-{
-	close();
-}
-
-void UdpConnection::initialize(udp_pcb* pcb /* = NULL*/)
-{
-	if(pcb == NULL)
+	if(pcb == nullptr) {
 		pcb = udp_new();
+	}
 	udp = pcb;
 	udp_recv(udp, staticOnReceive, (void*)this);
 }
 
 void UdpConnection::close()
 {
-	udp_recv(udp, NULL, NULL);
+	udp_recv(udp, nullptr, nullptr);
 	udp_remove(udp);
-	udp = NULL;
+	udp = nullptr;
 }
 
 bool UdpConnection::listen(int port)
 {
-	if(udp != NULL && udp->local_port != 0)
+	if(udp != nullptr && udp->local_port != 0) {
 		return false;
-	else if(udp == NULL)
+	} else if(udp == nullptr) {
 		initialize();
+	}
 
 	debug_d("UDP listen port %d", port);
 	err_t res = udp_bind(udp, IP_ADDR_ANY, port);
@@ -52,8 +39,9 @@ bool UdpConnection::listen(int port)
 
 bool UdpConnection::connect(IPAddress ip, uint16_t port)
 {
-	if(udp == NULL)
+	if(udp == nullptr) {
 		initialize();
+	}
 
 	if(udp->local_port == 0) {
 		udp_bind(udp, IP_ADDR_ANY, 0);
@@ -68,37 +56,21 @@ bool UdpConnection::connect(IPAddress ip, uint16_t port)
 void UdpConnection::send(const char* data, int length)
 {
 	pbuf* p = pbuf_alloc(PBUF_TRANSPORT, length, PBUF_RAM);
-	memcpy(p->payload, data, length);
-	udp_send(udp, p);
-	pbuf_free(p);
-}
-
-void UdpConnection::sendString(const char* data)
-{
-	send(data, strlen(data));
-}
-
-void UdpConnection::sendString(const String& data)
-{
-	sendString(data.c_str());
+	if(p != nullptr) {
+		memcpy(p->payload, data, length);
+		udp_send(udp, p);
+		pbuf_free(p);
+	}
 }
 
 void UdpConnection::sendTo(IPAddress remoteIP, uint16_t remotePort, const char* data, int length)
 {
 	pbuf* p = pbuf_alloc(PBUF_TRANSPORT, length, PBUF_RAM);
-	memcpy(p->payload, data, length);
-	udp_sendto(udp, p, remoteIP, remotePort);
-	pbuf_free(p);
-}
-
-void UdpConnection::sendStringTo(IPAddress remoteIP, uint16_t remotePort, const char* data)
-{
-	sendTo(remoteIP, remotePort, data, strlen(data));
-}
-
-void UdpConnection::sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String& data)
-{
-	sendStringTo(remoteIP, remotePort, data.c_str());
+	if(p != nullptr) {
+		memcpy(p->payload, data, length);
+		udp_sendto(udp, p, remoteIP, remotePort);
+		pbuf_free(p);
+	}
 }
 
 void UdpConnection::onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort)
@@ -117,11 +89,10 @@ void UdpConnection::onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort
 
 void UdpConnection::staticOnReceive(void* arg, struct udp_pcb* pcb, struct pbuf* p, LWIP_IP_ADDR_T* addr, u16_t port)
 {
-	UdpConnection* self = (UdpConnection*)arg;
-	if(self == NULL)
-		return;
-
-	IPAddress reip = addr != NULL ? IPAddress(*addr) : IPAddress();
-	self->onReceive(p, reip, port);
+	auto conn = static_cast<UdpConnection*>(arg);
+	if(conn != nullptr) {
+		IPAddress reip = addr != nullptr ? IPAddress(*addr) : IPAddress();
+		conn->onReceive(p, reip, port);
+	}
 	pbuf_free(p);
 }

--- a/Sming/SmingCore/Network/UdpConnection.h
+++ b/Sming/SmingCore/Network/UdpConnection.h
@@ -46,26 +46,26 @@ public:
 	virtual void close();
 
 	// After connect(..)
-	virtual void send(const char* data, int length);
+	virtual bool send(const char* data, int length);
 
-	void sendString(const char* data)
+	bool sendString(const char* data)
 	{
-		send(data, strlen(data));
+		return send(data, strlen(data));
 	}
 
-	void sendString(const String& data)
+	bool sendString(const String& data)
 	{
-		send(data.c_str(), data.length());
+		return send(data.c_str(), data.length());
 	}
 
-	virtual void sendTo(IPAddress remoteIP, uint16_t remotePort, const char* data, int length);
+	virtual bool sendTo(IPAddress remoteIP, uint16_t remotePort, const char* data, int length);
 
-	void sendStringTo(IPAddress remoteIP, uint16_t remotePort, const char* data)
+	bool sendStringTo(IPAddress remoteIP, uint16_t remotePort, const char* data)
 	{
 		sendTo(remoteIP, remotePort, data, strlen(data));
 	}
 
-	void sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String& data)
+	bool sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String& data)
 	{
 		sendTo(remoteIP, remotePort, data.c_str(), data.length());
 	}
@@ -74,7 +74,7 @@ protected:
 	virtual void onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort);
 
 protected:
-	void initialize(udp_pcb* pcb = nullptr);
+	bool initialize(udp_pcb* pcb = nullptr);
 	static void staticOnReceive(void* arg, struct udp_pcb* pcb, struct pbuf* p, LWIP_IP_ADDR_T* addr, u16_t port);
 
 protected:

--- a/Sming/SmingCore/Network/UdpConnection.h
+++ b/Sming/SmingCore/Network/UdpConnection.h
@@ -14,22 +14,32 @@
 #ifndef SMINGCORE_NETWORK_UDPCONNECTION_H_
 #define SMINGCORE_NETWORK_UDPCONNECTION_H_
 
-#include "../Wiring/WiringFrameworkDependencies.h"
-#include "../Delegate.h"
+#include "WiringFrameworkDependencies.h"
+#include "Delegate.h"
 #include "IPAddress.h"
 
 class UdpConnection;
 
-//typedef void (*UdpConnectionDataCallback)(UdpConnection& connection, char *data, int size, IPAddress remoteIP, uint16_t remotePort);
 typedef Delegate<void(UdpConnection& connection, char* data, int size, IPAddress remoteIP, uint16_t remotePort)>
 	UdpConnectionDataDelegate;
 
 class UdpConnection
 {
 public:
-	UdpConnection();
-	UdpConnection(UdpConnectionDataDelegate dataHandler);
-	virtual ~UdpConnection();
+	UdpConnection()
+	{
+		initialize();
+	}
+
+	UdpConnection(UdpConnectionDataDelegate dataHandler) : onDataCallback(dataHandler)
+	{
+		initialize();
+	}
+
+	virtual ~UdpConnection()
+	{
+		close();
+	}
 
 	virtual bool listen(int port);
 	virtual bool connect(IPAddress ip, uint16_t port);
@@ -37,23 +47,39 @@ public:
 
 	// After connect(..)
 	virtual void send(const char* data, int length);
-	void sendString(const char* data);
-	void sendString(const String& data);
+
+	void sendString(const char* data)
+	{
+		send(data, strlen(data));
+	}
+
+	void sendString(const String& data)
+	{
+		send(data.c_str(), data.length());
+	}
 
 	virtual void sendTo(IPAddress remoteIP, uint16_t remotePort, const char* data, int length);
-	void sendStringTo(IPAddress remoteIP, uint16_t remotePort, const char* data);
-	void sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String& data);
+
+	void sendStringTo(IPAddress remoteIP, uint16_t remotePort, const char* data)
+	{
+		sendTo(remoteIP, remotePort, data, strlen(data));
+	}
+
+	void sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String& data)
+	{
+		sendTo(remoteIP, remotePort, data.c_str(), data.length());
+	}
 
 protected:
 	virtual void onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort);
 
 protected:
-	void initialize(udp_pcb* pcb = NULL);
+	void initialize(udp_pcb* pcb = nullptr);
 	static void staticOnReceive(void* arg, struct udp_pcb* pcb, struct pbuf* p, LWIP_IP_ADDR_T* addr, u16_t port);
 
 protected:
-	udp_pcb* udp;
-	UdpConnectionDataDelegate onDataCallback;
+	udp_pcb* udp = nullptr;
+	UdpConnectionDataDelegate onDataCallback = nullptr;
 };
 
 /** @} */


### PR DESCRIPTION
bugfix: Potential memory leak in UdpConnection::staticOnReceive
Simplify #includes
Remove redundant code
Move trivial method implementations into header
Provide initialisers for all member variables
Replace NULL with nullptr
Consistent use of braces