### PR TITLE
Dns server improvements

### DIFF
--- a/Sming/SmingCore/Network/DNSServer.cpp
+++ b/Sming/SmingCore/Network/DNSServer.cpp
@@ -18,7 +18,7 @@
 
 DNSServer::DNSServer()
 {
-	ttl = htonl(60);
+	ttl = 60;
 	errorReplyCode = DNSReplyCode::NonExistentDomain;
 }
 
@@ -53,7 +53,7 @@ void DNSServer::setErrorReplyCode(const DNSReplyCode& replyCode)
 
 void DNSServer::setTTL(const uint32_t& ttl)
 {
-	this->ttl = htonl(ttl);
+	this->ttl = ttl;
 }
 
 void DNSServer::downcaseAndRemoveWwwPrefix(String& domainName)
@@ -100,10 +100,11 @@ void DNSServer::onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort)
 		response[idx + 5] = 0x01;
 
 		//TTL
-		response[idx + 6] = ttl >> 24;
-		response[idx + 7] = ttl >> 16;
-		response[idx + 8] = ttl >> 8;
-		response[idx + 9] = ttl;
+		ttln = htonl(ttl);
+		response[idx + 6] = ttln >> 24;
+		response[idx + 7] = ttln >> 16;
+		response[idx + 8] = ttln >> 8;
+		response[idx + 9] = ttln;
 
 		//RDATA length
 		response[idx + 10] = 0x00;

--- a/Sming/SmingCore/Network/DNSServer.cpp
+++ b/Sming/SmingCore/Network/DNSServer.cpp
@@ -29,7 +29,7 @@ bool DNSServer::start(uint16_t port, const String& domainName, const IPAddress& 
 void DNSServer::stop()
 {
 	close();
-	free(buffer);
+	delete[] buffer;
 	buffer = nullptr;
 }
 

--- a/Sming/SmingCore/Network/DNSServer.h
+++ b/Sming/SmingCore/Network/DNSServer.h
@@ -69,13 +69,13 @@ public:
 	void stop();
 
 private:
-	uint16_t _port = 0;
-	String _domainName;
-	char _resolvedIP[4];
-	char* _buffer = NULL;
-	DNSHeader* _dnsHeader = NULL;
-	uint32_t _ttl;
-	DNSReplyCode _errorReplyCode;
+	uint16_t port = 0;
+	String domainName;
+	char resolvedIP[4];
+	char* buffer = NULL;
+	DNSHeader* dnsHeader = NULL;
+	uint32_t ttl;
+	DNSReplyCode errorReplyCode;
 
 	virtual void onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort);
 	void downcaseAndRemoveWwwPrefix(String& domainName);

--- a/Sming/SmingCore/Network/DNSServer.h
+++ b/Sming/SmingCore/Network/DNSServer.h
@@ -20,7 +20,7 @@
 #define DNSServer_h
 
 #include "UdpConnection.h"
-#include "../Wiring/WString.h"
+#include "WString.h"
 
 #define DNS_QR_QUERY 0
 #define DNS_QR_RESPONSE 1
@@ -57,10 +57,23 @@ struct DNSHeader {
 class DNSServer : public UdpConnection
 {
 public:
-	DNSServer();
-	virtual ~DNSServer();
-	void setErrorReplyCode(const DNSReplyCode& replyCode);
-	void setTTL(const uint32_t& ttl);
+	DNSServer()
+	{
+	}
+
+	virtual ~DNSServer()
+	{
+	}
+
+	void setErrorReplyCode(DNSReplyCode replyCode)
+	{
+		errorReplyCode = replyCode;
+	}
+
+	void setTTL(uint32_t ttl)
+	{
+		this->ttl = ttl;
+	}
 
 	// Returns true if successful, false if there are no sockets available
 	bool start(const uint16_t& port, const String& domainName, const IPAddress& resolvedIP);
@@ -72,10 +85,10 @@ private:
 	uint16_t port = 0;
 	String domainName;
 	char resolvedIP[4];
-	char* buffer = NULL;
-	DNSHeader* dnsHeader = NULL;
-	uint32_t ttl;
-	DNSReplyCode errorReplyCode;
+	char* buffer = nullptr;
+	DNSHeader* dnsHeader = nullptr;
+	uint32_t ttl = 60;
+	DNSReplyCode errorReplyCode = DNSReplyCode::NonExistentDomain;
 
 	virtual void onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort);
 	void downcaseAndRemoveWwwPrefix(String& domainName);

--- a/Sming/SmingCore/Network/DNSServer.h
+++ b/Sming/SmingCore/Network/DNSServer.h
@@ -76,7 +76,7 @@ public:
 	}
 
 	// Returns true if successful, false if there are no sockets available
-	bool start(const uint16_t& port, const String& domainName, const IPAddress& resolvedIP);
+	bool start(uint16_t port, const String& domainName, const IPAddress& resolvedIP);
 
 	// stops the DNS server
 	void stop();
@@ -84,14 +84,14 @@ public:
 private:
 	uint16_t port = 0;
 	String domainName;
-	char resolvedIP[4];
+	ip_addr resolvedIP;
 	char* buffer = nullptr;
 	DNSHeader* dnsHeader = nullptr;
 	uint32_t ttl = 60;
 	DNSReplyCode errorReplyCode = DNSReplyCode::NonExistentDomain;
 
 	virtual void onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort);
-	void downcaseAndRemoveWwwPrefix(String& domainName);
+	static void downcaseAndRemoveWwwPrefix(String& domainName);
 	String getDomainNameWithoutWwwPrefix();
 	bool requestIncludesOnlyOneQuestion();
 };


### PR DESCRIPTION
Remove leading underscores from member variable names
Provide initialisers for all member variables
Store `ttl` member variable in host order, not network 
Use ip_addr for resolvedIP
Tidy #includes
Move trivial code into header
downcaseAndRemoveWwwPrefix is a static method
Use new/delete instead of malloc/free