### PR TITLE
UdpConnection::sendStringTo() missing return value

### DIFF
--- a/Sming/SmingCore/Network/UdpConnection.h
+++ b/Sming/SmingCore/Network/UdpConnection.h
@@ -62,12 +62,12 @@ public:
 
 	bool sendStringTo(IPAddress remoteIP, uint16_t remotePort, const char* data)
 	{
-		sendTo(remoteIP, remotePort, data, strlen(data));
+		return sendTo(remoteIP, remotePort, data, strlen(data));
 	}
 
 	bool sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String& data)
 	{
-		sendTo(remoteIP, remotePort, data.c_str(), data.length());
+		return sendTo(remoteIP, remotePort, data.c_str(), data.length());
 	}
 
 protected:


### PR DESCRIPTION
Added `bool` return value to methods in #1571 but missed return statements in `sendStringTo()` methods.