### PR TITLE
Revert to default MAC string format for `getMAC` method...

### DIFF
--- a/Sming/SmingCore/Platform/AccessPoint.cpp
+++ b/Sming/SmingCore/Platform/AccessPoint.cpp
@@ -138,11 +138,11 @@ bool AccessPointClass::setIP(IPAddress address)
 	return true;
 }
 
-String AccessPointClass::getMAC()
+String AccessPointClass::getMAC(char sep)
 {
 	uint8 hwaddr[6];
 	if(wifi_get_macaddr(SOFTAP_IF, hwaddr))
-		return makeHexString(hwaddr, sizeof(hwaddr), ':');
+		return makeHexString(hwaddr, sizeof(hwaddr), sep);
 	else
 		return nullptr;
 }

--- a/Sming/SmingCore/Platform/AccessPoint.h
+++ b/Sming/SmingCore/Platform/AccessPoint.h
@@ -70,9 +70,10 @@ public:
 	bool setIP(IPAddress address);
 
 	/** @brief  Get WiFi AP MAC address
+	 *  @param optional separator between bytes (e.g. ':')
      *  @retval String WiFi AP MAC address
      */
-	String getMAC();
+	String getMAC(char sep = '\0');
 
 	/** @brief  Get WiFi AP network mask
      *  @retval IPAddress WiFi AP network mask

--- a/Sming/SmingCore/Platform/Station.cpp
+++ b/Sming/SmingCore/Platform/Station.cpp
@@ -157,11 +157,11 @@ IPAddress StationClass::getIP()
 	return info.ip;
 }
 
-String StationClass::getMAC()
+String StationClass::getMAC(char sep)
 {
 	uint8 hwaddr[6];
 	if(wifi_get_macaddr(STATION_IF, hwaddr))
-		return makeHexString(hwaddr, sizeof(hwaddr), ':');
+		return makeHexString(hwaddr, sizeof(hwaddr), sep);
 	else
 		return nullptr;
 }

--- a/Sming/SmingCore/Platform/Station.h
+++ b/Sming/SmingCore/Platform/Station.h
@@ -157,9 +157,10 @@ public:
 	IPAddress getIP();
 
 	/**	@brief	Get WiFi station MAC address
+	 *  @param optional separator between bytes (e.g. ':')
 	 *	@retval	String WiFi station MAC address
 	 */
-	String getMAC();
+	String getMAC(char sep = '\0');
 
 	/**	@brief	Get WiFi station network mask
 	 *	@retval	IPAddress WiFi station network mask


### PR DESCRIPTION
...in `AccessPointClass` and `StationClass`

Fixes #1583, so by default reverts to previous behaviour, but supports alternative formats.