### PR TITLE
Change use of `ReadWriteStream*` to `IDataSourceStream*` where appropriate

### DIFF
--- a/Sming/Libraries/ArduCAM/ArduCAMStream.h
+++ b/Sming/Libraries/ArduCAM/ArduCAMStream.h
@@ -13,7 +13,7 @@
 #include "../../Services/HexDump/HexDump.h"
 
 
-class ArduCAMStream: public ReadWriteStream {
+class ArduCAMStream: public IDataSourceStream {
 public:
 	ArduCAMStream(ArduCAM *cam);
 	virtual ~ArduCAMStream();
@@ -23,21 +23,6 @@ public:
 	virtual uint16_t readMemoryBlock(char* data, int bufSize);
 	virtual bool seek(int len);
 	virtual bool isFinished();
-
-	virtual size_t write(uint8_t charToWrite)
-	{
-		return 0;
-	}
-
-	/** @brief  Write chars to stream
-	*  @param  buffer Pointer to buffer to write to the stream
-	*  @param  size Quantity of chars to writen
-	*  @retval size_t Quantity of chars written to stream
-	*/
-	virtual size_t write(const uint8_t *buffer, size_t size)
-	{
-		return 0;
-	}
 
 	bool dataReady();
 	int available();

--- a/Sming/SmingCore/Data/MailMessage.cpp
+++ b/Sming/SmingCore/Data/MailMessage.cpp
@@ -45,7 +45,7 @@ MailMessage& MailMessage::setBody(const String& body, MimeType mime /* = MIME_TE
 	return setBody(memory, mime);
 }
 
-MailMessage& MailMessage::setBody(ReadWriteStream* stream, MimeType mime /* = MIME_TEXT */)
+MailMessage& MailMessage::setBody(IDataSourceStream* stream, MimeType mime /* = MIME_TEXT */)
 {
 	if(this->stream != nullptr) {
 		debug_e("MailMessage::setBody: Discarding already set stream!");
@@ -71,12 +71,13 @@ MailMessage& MailMessage::addAttachment(FileStream* stream)
 	return addAttachment(stream, mime, filename);
 }
 
-MailMessage& MailMessage::addAttachment(ReadWriteStream* stream, MimeType mime, const String& filename /* = "" */)
+MailMessage& MailMessage::addAttachment(IDataSourceStream* stream, MimeType mime, const String& filename /* = "" */)
 {
 	return addAttachment(stream, ContentType::toString(mime), filename);
 }
 
-MailMessage& MailMessage::addAttachment(ReadWriteStream* stream, const String& mime, const String& filename /* = "" */)
+MailMessage& MailMessage::addAttachment(IDataSourceStream* stream, const String& mime,
+										const String& filename /* = "" */)
 {
 	HttpPartResult attachment;
 	attachment.stream = stream;

--- a/Sming/SmingCore/Data/MailMessage.cpp
+++ b/Sming/SmingCore/Data/MailMessage.cpp
@@ -37,7 +37,7 @@ HttpHeaders& MailMessage::getHeaders()
 MailMessage& MailMessage::setBody(const String& body, MimeType mime /* = MIME_TEXT */)
 {
 	MemoryDataStream* memory = new MemoryDataStream();
-	int written = memory->write((uint8_t*)body.c_str(), body.length());
+	auto written = memory->write((uint8_t*)body.c_str(), body.length());
 	if(written < body.length()) {
 		debug_e("MailMessage::setBody: Unable to store the complete body");
 	}

--- a/Sming/SmingCore/Data/MailMessage.h
+++ b/Sming/SmingCore/Data/MailMessage.h
@@ -54,7 +54,7 @@ public:
 	 * @param Stream& stream
 	 * @param MimeType mime
 	 */
-	MailMessage& setBody(ReadWriteStream* stream, MimeType mime = MIME_TEXT);
+	MailMessage& setBody(IDataSourceStream* stream, MimeType mime = MIME_TEXT);
 
 	/**
 	 * @brief Adds attachment to the email
@@ -64,20 +64,15 @@ public:
 	/**
 	 * @brief Adds attachment to the email
 	 */
-	MailMessage& addAttachment(ReadWriteStream* stream, MimeType mime, const String& filename = "");
+	MailMessage& addAttachment(IDataSourceStream* stream, MimeType mime, const String& filename = "");
 
 	/**
 	 * @brief Adds attachment to the email
 	 */
-	MailMessage& addAttachment(ReadWriteStream* stream, const String& mime, const String& filename = "");
-
-	/**
-	 * @brief Get the generated data stream
-	 */
-	ReadWriteStream* getData();
+	MailMessage& addAttachment(IDataSourceStream* stream, const String& mime, const String& filename = "");
 
 private:
-	ReadWriteStream* stream = nullptr;
+	IDataSourceStream* stream = nullptr;
 	HttpHeaders headers;
 	Vector<HttpPartResult> attachments;
 };

--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
@@ -13,7 +13,7 @@
 // Produce line breaks in output encodings
 const unsigned CHARS_PER_LINE = 72;
 
-Base64OutputStream::Base64OutputStream(ReadWriteStream* stream, size_t resultSize /* = 512 */)
+Base64OutputStream::Base64OutputStream(IDataSourceStream* stream, size_t resultSize /* = 512 */)
 	: StreamTransformer(stream, nullptr, resultSize, (resultSize / 4))
 
 {

--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.h
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.h
@@ -26,18 +26,17 @@ class Base64OutputStream : public StreamTransformer
 public:
 	/**
 	 * @brief Stream that transforms bytes of data into base64 data stream
-	 * @param ReadWriteStream *stream - source stream
-	 * @param size_t resultSize - the size of the intermediate buffer.
-	 * 							- it will be created once per object, reused multiple times and kept until the end of the object
+	 * @param stream - source stream
+	 * @param resultSize The size of the intermediate buffer, created once per object and reused multiple times
 	 */
-	Base64OutputStream(ReadWriteStream* stream, size_t resultSize = 500);
+	Base64OutputStream(IDataSourceStream* stream, size_t resultSize = 500);
 
 	/**
 	 * Encodes a chunk of data into base64. Keeps a state of the progress.
-	 * @param uint8_t* source - the incoming data
-	 * @param size_t sourceLength -length of the incoming data
-	 * @param uint8_t* target - the result data. The pointer must point to an already allocated memory
-	 * @param int* targetLength - the length of the result data
+	 * @param source The incoming data
+	 * @param sourceLength Length of the incoming data
+	 * @param target The result data. The pointer must point to an already allocated memory
+	 * @param targetLength The length of the result data
 	 *
 	 * @return the length of the encoded target.
 	 */

--- a/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
+++ b/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
@@ -10,7 +10,7 @@
 
 #include "ChunkedStream.h"
 
-ChunkedStream::ChunkedStream(ReadWriteStream* stream, size_t resultSize /* = 512 */)
+ChunkedStream::ChunkedStream(IDataSourceStream* stream, size_t resultSize /* = 512 */)
 	: StreamTransformer(stream, nullptr, resultSize, resultSize - 12)
 {
 	transformCallback = std::bind(&ChunkedStream::encode, this, std::placeholders::_1, std::placeholders::_2,

--- a/Sming/SmingCore/Data/Stream/ChunkedStream.h
+++ b/Sming/SmingCore/Data/Stream/ChunkedStream.h
@@ -23,7 +23,7 @@
 class ChunkedStream : public StreamTransformer
 {
 public:
-	ChunkedStream(ReadWriteStream* stream, size_t resultSize = 512);
+	ChunkedStream(IDataSourceStream* stream, size_t resultSize = 512);
 
 	/**
 	 * Encodes a chunk of data

--- a/Sming/SmingCore/Data/Stream/MultiStream.cpp
+++ b/Sming/SmingCore/Data/Stream/MultiStream.cpp
@@ -18,18 +18,6 @@ MultiStream::~MultiStream()
 	nextStream = nullptr;
 }
 
-size_t MultiStream::write(uint8_t charToWrite)
-{
-	// those methods should not be used...
-	return 0;
-}
-
-size_t MultiStream::write(const uint8_t* buffer, size_t size)
-{
-	// those methods should not be used...
-	return 0;
-}
-
 //Use base class documentation
 uint16_t MultiStream::readMemoryBlock(char* data, int bufSize)
 {

--- a/Sming/SmingCore/Data/Stream/MultiStream.h
+++ b/Sming/SmingCore/Data/Stream/MultiStream.h
@@ -8,9 +8,9 @@
 #ifndef SMINGCORE_DATA_STREAM_MULTISTREAM_H_
 #define SMINGCORE_DATA_STREAM_MULTISTREAM_H_
 
-#include "ReadWriteStream.h"
+#include "DataSourceStream.h"
 
-class MultiStream : public ReadWriteStream
+class MultiStream : public IDataSourceStream
 {
 public:
 	virtual ~MultiStream();
@@ -29,19 +29,6 @@ public:
 		return -1;
 	}
 
-	/** @brief  Write a single char to stream
-	 *  @param  charToWrite Char to write to the stream
-	 *  @retval size_t Quantity of chars written to stream (always 1)
-	 */
-	virtual size_t write(uint8_t charToWrite);
-
-	/** @brief  Write chars to stream
-	 *  @param  buffer Pointer to buffer to write to the stream
-	 *  @param  size Quantity of chars to written
-	 *  @retval size_t Quantity of chars written to stream
-	 */
-	virtual size_t write(const uint8_t* buffer, size_t size);
-
 	//Use base class documentation
 	virtual uint16_t readMemoryBlock(char* data, int bufSize);
 
@@ -52,7 +39,7 @@ public:
 	virtual bool isFinished();
 
 protected:
-	virtual ReadWriteStream* getNextStream() = 0;
+	virtual IDataSourceStream* getNextStream() = 0;
 
 	virtual bool onCompleted()
 	{
@@ -66,8 +53,8 @@ protected:
 	}
 
 protected:
-	ReadWriteStream* stream = nullptr;
-	ReadWriteStream* nextStream = nullptr;
+	IDataSourceStream* stream = nullptr;
+	IDataSourceStream* nextStream = nullptr;
 
 	bool finished = false;
 };

--- a/Sming/SmingCore/Data/Stream/MultipartStream.cpp
+++ b/Sming/SmingCore/Data/Stream/MultipartStream.cpp
@@ -21,9 +21,10 @@ MultipartStream::~MultipartStream()
 
 bool MultipartStream::onCompleted()
 {
-	stream = new MemoryDataStream();
+	auto mem = new MemoryDataStream();
 	String line = F("\r\n--") + getBoundary() + F("--\r\n");
-	stream->print(line);
+	mem->print(line);
+	stream = mem;
 
 	return true;
 }

--- a/Sming/SmingCore/Data/Stream/MultipartStream.h
+++ b/Sming/SmingCore/Data/Stream/MultipartStream.h
@@ -24,7 +24,7 @@
 
 typedef struct {
 	HttpHeaders* headers = nullptr;
-	ReadWriteStream* stream = nullptr;
+	IDataSourceStream* stream = nullptr;
 } HttpPartResult;
 
 typedef Delegate<HttpPartResult()> HttpPartProducerDelegate;
@@ -44,7 +44,7 @@ public:
 	const char* getBoundary();
 
 protected:
-	virtual ReadWriteStream* getNextStream()
+	virtual IDataSourceStream* getNextStream()
 	{
 		result = producer();
 		return result.stream;

--- a/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
@@ -37,7 +37,7 @@ static int quotedPrintableTransformer(uint8_t* source, size_t sourceLength, uint
 	return count;
 }
 
-QuotedPrintableOutputStream::QuotedPrintableOutputStream(ReadWriteStream* stream, size_t resultSize /* = 512 */)
+QuotedPrintableOutputStream::QuotedPrintableOutputStream(IDataSourceStream* stream, size_t resultSize /* = 512 */)
 	: StreamTransformer(stream, nullptr, resultSize, resultSize / 2)
 
 {

--- a/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
@@ -22,7 +22,7 @@ static int quotedPrintableTransformer(uint8_t* source, size_t sourceLength, uint
 	const char hex[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
 	int count = 0;
-	for(int i = 0; i < sourceLength; i++) {
+	for(unsigned i = 0; i < sourceLength; i++) {
 		char byte = source[i];
 
 		if((byte == ' ') || ((byte >= 33) && (byte <= 126) && (byte != '='))) {

--- a/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.h
+++ b/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.h
@@ -25,11 +25,10 @@ class QuotedPrintableOutputStream : public StreamTransformer
 public:
 	/**
 	 * @brief Stream that transforms bytes of data into quoted printable data stream
-	 * @param ReadWriteStream *stream - source stream
-	 * @param size_t resultSize - the size of the intermediate buffer.
-	 * 							- it will be created once per object, reused multiple times and kept until the end of the object
+	 * @param stream source stream
+	 * @param resultSize The size of the intermediate buffer, created once per object and reused multiple times
 	 */
-	QuotedPrintableOutputStream(ReadWriteStream* stream, size_t resultSize = 512);
+	QuotedPrintableOutputStream(IDataSourceStream* stream, size_t resultSize = 512);
 };
 
 /** @} */

--- a/Sming/SmingCore/Data/Stream/StreamChain.h
+++ b/Sming/SmingCore/Data/Stream/StreamChain.h
@@ -18,7 +18,7 @@
 #define MAX_STREAM_CHAIN_SIZE 10
 #endif
 
-typedef ObjectQueue<ReadWriteStream, MAX_STREAM_CHAIN_SIZE> StreamChainQueue;
+typedef ObjectQueue<IDataSourceStream, MAX_STREAM_CHAIN_SIZE> StreamChainQueue;
 
 class StreamChain : public MultiStream
 {
@@ -27,13 +27,13 @@ public:
 	{
 	}
 
-	bool attachStream(ReadWriteStream* stream)
+	bool attachStream(IDataSourceStream* stream)
 	{
 		return queue.enqueue(stream);
 	}
 
 protected:
-	virtual ReadWriteStream* getNextStream()
+	virtual IDataSourceStream* getNextStream()
 	{
 		return queue.dequeue();
 	}

--- a/Sming/SmingCore/Data/Stream/TemplateStream.h
+++ b/Sming/SmingCore/Data/Stream/TemplateStream.h
@@ -37,7 +37,7 @@ enum TemplateExpandState {
  *  @{
  */
 
-class TemplateStream : public ReadWriteStream
+class TemplateStream : public IDataSourceStream
 {
 public:
 	/** @brief Create a template stream

--- a/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.h
+++ b/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.h
@@ -21,12 +21,12 @@
  *  @{
  */
 
-class UrlencodedOutputStream : public ReadWriteStream
+class UrlencodedOutputStream : public IDataSourceStream
 {
 public:
 	/**
 	 * @brief Represents key-value pairs as urlencoded string
-	 * @param const HttpParams& params - the key-value parameters
+	 * @param params The key-value parameters
 	 */
 	UrlencodedOutputStream(const HttpParams& params);
 
@@ -47,25 +47,6 @@ public:
 	int available()
 	{
 		return stream.available();
-	}
-
-	/** @brief  Write a single char to stream
-	 *  @param  charToWrite Char to write to the stream
-	 *  @retval size_t Quantity of chars written to stream (always 1)
-	 */
-	virtual size_t write(uint8_t charToWrite)
-	{
-		return 0;
-	}
-
-	/** @brief  Write chars to stream
-	 *  @param  buffer Pointer to buffer to write to the stream
-	 *  @param  size Quantity of chars to written
-	 *  @retval size_t Quantity of chars written to stream
-	 */
-	virtual size_t write(const uint8_t* buffer, size_t size)
-	{
-		return 0;
 	}
 
 	//Use base class documentation

--- a/Sming/SmingCore/Data/StreamTransformer.cpp
+++ b/Sming/SmingCore/Data/StreamTransformer.cpp
@@ -58,7 +58,7 @@ uint16_t StreamTransformer::readMemoryBlock(char* data, int bufSize)
 			}
 
 			saveState();
-			int outLength = transformCallback((uint8_t*)data, len, result, resultSize);
+			size_t outLength = transformCallback((uint8_t*)data, len, result, resultSize);
 			if(outLength > tempStream->room()) {
 				restoreState();
 				break;

--- a/Sming/SmingCore/Data/StreamTransformer.cpp
+++ b/Sming/SmingCore/Data/StreamTransformer.cpp
@@ -12,7 +12,7 @@
 
 #define NETWORK_SEND_BUFFER_SIZE 1024
 
-StreamTransformer::StreamTransformer(ReadWriteStream* stream, const StreamTransformerCallback& callback,
+StreamTransformer::StreamTransformer(IDataSourceStream* stream, const StreamTransformerCallback& callback,
 									 size_t resultSize /* = 256 */, size_t blockSize /* = 64 */
 									 )
 	: transformCallback(callback)
@@ -28,24 +28,14 @@ StreamTransformer::~StreamTransformer()
 	delete[] result;
 	delete tempStream;
 	delete sourceStream;
-	result = NULL;
-	tempStream = NULL;
-	sourceStream = NULL;
-}
-
-size_t StreamTransformer::write(uint8_t charToWrite)
-{
-	return sourceStream->write(charToWrite);
-}
-
-size_t StreamTransformer::write(const uint8_t* buffer, size_t size)
-{
-	return sourceStream->write(buffer, size);
+	result = nullptr;
+	tempStream = nullptr;
+	sourceStream = nullptr;
 }
 
 uint16_t StreamTransformer::readMemoryBlock(char* data, int bufSize)
 {
-	if(tempStream == NULL) {
+	if(tempStream == nullptr) {
 		tempStream = new CircularBuffer(NETWORK_SEND_BUFFER_SIZE + 10);
 	}
 
@@ -84,7 +74,7 @@ uint16_t StreamTransformer::readMemoryBlock(char* data, int bufSize)
 		} while(--i);
 
 		if(sourceStream->isFinished()) {
-			int outLength = transformCallback(NULL, 0, result, resultSize);
+			int outLength = transformCallback(nullptr, 0, result, resultSize);
 			tempStream->write(result, outLength);
 		}
 

--- a/Sming/SmingCore/Data/StreamTransformer.h
+++ b/Sming/SmingCore/Data/StreamTransformer.h
@@ -36,10 +36,10 @@
  */
 typedef std::function<int(uint8_t* in, size_t inLength, uint8_t* out, size_t outLength)> StreamTransformerCallback;
 
-class StreamTransformer : public ReadWriteStream
+class StreamTransformer : public IDataSourceStream
 {
 public:
-	StreamTransformer(ReadWriteStream* stream, const StreamTransformerCallback& callback, size_t resultSize = 256,
+	StreamTransformer(IDataSourceStream* stream, const StreamTransformerCallback& callback, size_t resultSize = 256,
 					  size_t blockSize = 64);
 	virtual ~StreamTransformer();
 
@@ -57,19 +57,6 @@ public:
 	{
 		return -1;
 	}
-
-	/** @brief  Write a single char to stream
-	 *  @param  charToWrite Char to write to the stream
-	 *  @retval size_t Quantity of chars written to stream (always 1)
-	 */
-	virtual size_t write(uint8_t charToWrite);
-
-	/** @brief  Write chars to stream
-	 *  @param  buffer Pointer to buffer to write to the stream
-	 *  @param  size Quantity of chars to written
-	 *  @retval size_t Quantity of chars written to stream
-	 */
-	virtual size_t write(const uint8_t* buffer, size_t size);
 
 	//Use base class documentation
 	virtual uint16_t readMemoryBlock(char* data, int bufSize);
@@ -95,8 +82,8 @@ protected:
 	StreamTransformerCallback transformCallback = nullptr;
 
 private:
-	ReadWriteStream* sourceStream = NULL;
-	CircularBuffer* tempStream = NULL;
+	IDataSourceStream* sourceStream = nullptr;
+	CircularBuffer* tempStream = nullptr;
 	uint8_t* result = nullptr;
 	size_t resultSize;
 	size_t blockSize;

--- a/Sming/SmingCore/Network/Http/HttpConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpConnection.cpp
@@ -243,10 +243,10 @@ int HttpConnection::onHeadersComplete(const HttpHeaders& headers)
 	if(!error) {
 		// set the response stream
 		if(incomingRequest->responseStream != nullptr) {
-			response.stream = incomingRequest->responseStream;
+			response.setBuffer(incomingRequest->responseStream);
 			incomingRequest->responseStream = nullptr; // the response object will release that stream
 		} else {
-			response.stream = new LimitedMemoryStream(NETWORK_SEND_BUFFER_SIZE);
+			response.setBuffer(new LimitedMemoryStream(NETWORK_SEND_BUFFER_SIZE));
 		}
 	}
 
@@ -264,12 +264,11 @@ int HttpConnection::onBody(const char* at, size_t length)
 		return incomingRequest->requestBodyDelegate(*this, at, length);
 	}
 
-	if(response.stream != nullptr) {
-		int res = response.stream->write((const uint8_t*)at, length);
+	if(response.buffer != nullptr) {
+		int res = response.buffer->write((const uint8_t*)at, length);
 		if(res != length) {
 			// unable to write the requested bytes - stop here...
-			delete response.stream;
-			response.stream = nullptr;
+			response.freeStreams();
 			return 1;
 		}
 	}

--- a/Sming/SmingCore/Network/Http/HttpConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpConnection.cpp
@@ -265,7 +265,7 @@ int HttpConnection::onBody(const char* at, size_t length)
 	}
 
 	if(response.buffer != nullptr) {
-		int res = response.buffer->write((const uint8_t*)at, length);
+		auto res = response.buffer->write((const uint8_t*)at, length);
 		if(res != length) {
 			// unable to write the requested bytes - stop here...
 			response.freeStreams();

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -96,7 +96,7 @@ String HttpRequest::getBody()
 	return ret;
 }
 
-ReadWriteStream* HttpRequest::getBodyStream()
+IDataSourceStream* HttpRequest::getBodyStream()
 {
 	return bodyStream;
 }
@@ -124,7 +124,7 @@ HttpRequest* HttpRequest::setBody(uint8_t* rawData, size_t length)
 	return setBody(memory);
 }
 
-HttpRequest* HttpRequest::setBody(ReadWriteStream* stream)
+HttpRequest* HttpRequest::setBody(IDataSourceStream* stream)
 {
 	if(bodyStream != nullptr) {
 		debug_e("HttpRequest::setBody: Discarding already set stream!");

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -20,7 +20,7 @@
 #include "../TcpConnection.h"
 #include "Data/Stream/DataSourceStream.h"
 #include "Data/Stream/MultipartStream.h"
-#include "Network/Http/HttpHeaders.h"
+#include "HttpHeaders.h"
 #include "HttpParams.h"
 
 class HttpClient;
@@ -106,11 +106,11 @@ public:
 	/**
 	 * @brief Sets a file to be sent
 	 * @param const String& formElementName the name of the element in the form
-	 * @param ReadWriteStream* stream - pointer to the stream (doesn't have to be a FileStream)
+	 * @param IDataSourceStream* stream - pointer to the stream (doesn't have to be a FileStream)
 	 *
 	 * @return HttpRequest*
 	 */
-	HttpRequest* setFile(const String& formElementName, ReadWriteStream* stream)
+	HttpRequest* setFile(const String& formElementName, IDataSourceStream* stream)
 	{
 		if(stream) {
 			files[formElementName] = stream;
@@ -160,10 +160,10 @@ public:
 
 	/**
 	 * @brief Return the current body stream and pass ownership to the caller
-	 * @retval ReadWriteStream*
+	 * @retval IDataSourceStream*
 	 * @note may return null
 	 */
-	ReadWriteStream* getBodyStream();
+	IDataSourceStream* getBodyStream();
 
 	HttpRequest* setBody(const String& body)
 	{
@@ -171,14 +171,13 @@ public:
 		return this;
 	}
 
-	HttpRequest* setBody(ReadWriteStream* stream);
+	HttpRequest* setBody(IDataSourceStream* stream);
 
 	HttpRequest* setBody(uint8_t* rawData, size_t length);
 
 	/**
 	 * @brief Instead of storing the response body we can set a stream that will take care to process it
-	 * @param ReadWriteStream *stream
-	 *
+	 * @param stream
 	 * @retval HttpRequest*
 	 *
 	 * @note The response to this request will be stored in the user-provided stream.
@@ -186,7 +185,7 @@ public:
 	HttpRequest* setResponseStream(ReadWriteStream* stream);
 
 	/**
-	 * @brief Get access to the currently set response stream.
+	 * @brief Get the response stream (if any)
 	 */
 	ReadWriteStream* getResponseStream()
 	{
@@ -276,8 +275,8 @@ protected:
 	RequestBodyDelegate requestBodyDelegate;
 	RequestCompletedDelegate requestCompletedDelegate;
 
-	ReadWriteStream* bodyStream = nullptr;
-	ReadWriteStream* responseStream = nullptr;
+	IDataSourceStream* bodyStream = nullptr;
+	ReadWriteStream* responseStream = nullptr; ///< User-requested stream to store response
 
 #ifdef ENABLE_HTTP_REQUEST_AUTH
 	AuthAdapter* auth = nullptr;
@@ -290,7 +289,7 @@ protected:
 #endif
 
 private:
-	HashMap<String, ReadWriteStream*> files;
+	HashMap<String, IDataSourceStream*> files;
 
 	HttpParams* queryParams = nullptr; // << deprecated
 };

--- a/Sming/SmingCore/Network/Http/HttpResponse.h
+++ b/Sming/SmingCore/Network/Http/HttpResponse.h
@@ -100,14 +100,13 @@ public:
 
 	/*
 	 * Called by connection to specify where incoming response data is written.
-	 * If this is null or not called then a circular buffer is used. See bodyReceived().
 	 */
-	void setBuffer(ReadWriteStream* stream);
+	void setBuffer(ReadWriteStream* buffer);
 
 	void freeStreams();
 
 private:
-	void setBodyStream(IDataSourceStream* stream);
+	void setStream(IDataSourceStream* stream);
 
 public:
 	unsigned code = HTTP_STATUS_OK; ///< The HTTP status response code

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
@@ -41,12 +41,7 @@ void HttpServerConnection::setBodyParsers(BodyParsers* bodyParsers)
 int HttpServerConnection::onMessageBegin(http_parser* parser)
 {
 	// Reset Response ...
-	response.code = 200;
-	response.headers.clear();
-	if(response.stream != nullptr) {
-		delete response.stream;
-		response.stream = nullptr;
-	}
+	response.reset();
 
 	// ... and Request
 	request.setMethod((const HttpMethod)parser->method);

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -258,7 +258,7 @@ bool MqttClient::publish(const String& topic, const String& content, uint8_t fla
 	return requestQueue.enqueue(message);
 }
 
-bool MqttClient::publish(const String& topic, ReadWriteStream* stream, uint8_t flags)
+bool MqttClient::publish(const String& topic, IDataSourceStream* stream, uint8_t flags)
 {
 	if(!stream || stream->available() < 1) {
 		debug_e("Sending empty stream or stream with unknown size is not supported");
@@ -328,10 +328,10 @@ void MqttClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 			outgoingMessage->common.type = MQTT_TYPE_PINGREQ;
 		}
 
-		ReadWriteStream* payloadStream = nullptr;
+		IDataSourceStream* payloadStream = nullptr;
 		if(outgoingMessage->common.type == MQTT_TYPE_PUBLISH &&
 		   outgoingMessage->publish.content.length == MQTT_PUBLISH_STREAM) {
-			payloadStream = reinterpret_cast<ReadWriteStream*>(outgoingMessage->publish.content.data);
+			payloadStream = reinterpret_cast<IDataSourceStream*>(outgoingMessage->publish.content.data);
 			if(payloadStream) {
 				outgoingMessage->publish.content.length = payloadStream->available();
 			}

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -90,7 +90,7 @@ public:
 	bool connect(const URL& url, const String& uniqueClientName, uint32_t sslOptions = 0);
 
 	bool publish(const String& topic, const String& message, uint8_t flags = 0);
-	bool publish(const String& topic, ReadWriteStream* stream, uint8_t flags = 0);
+	bool publish(const String& topic, IDataSourceStream* stream, uint8_t flags = 0);
 
 	bool subscribe(const String& topic);
 	bool unsubscribe(const String& topic);

--- a/Sming/SmingCore/Network/SmtpClient.cpp
+++ b/Sming/SmingCore/Network/SmtpClient.cpp
@@ -75,18 +75,12 @@ SmtpClient::SmtpClient(bool autoDestroy /* =false */) : TcpClient(autoDestroy), 
 
 SmtpClient::~SmtpClient()
 {
-	// TODO: clear all pointers...
-	delete stream;
 	delete outgoingMail;
-	stream = nullptr;
 	outgoingMail = nullptr;
-	do {
-		MailMessage* mail = mailQ.dequeue();
-		if(mail == nullptr) {
-			break;
-		}
-		delete mail;
-	} while(1);
+
+	while(mailQ.count() != 0) {
+		delete mailQ.dequeue();
+	}
 }
 
 bool SmtpClient::connect(const URL& url)

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -60,7 +60,6 @@ public:
 	 */
 	void setCompleteDelegate(TcpClientCompleteDelegate completeCb = nullptr);
 
-	bool send(IDataSourceStream* stream, bool forceCloseAfterSent = false);
 	bool send(const char* data, uint16_t len, bool forceCloseAfterSent = false);
 	bool sendString(const String& data, bool forceCloseAfterSent = false);
 	__forceinline bool isProcessing()
@@ -138,6 +137,8 @@ protected:
 	void freeStreams();
 
 protected:
+	void setBuffer(ReadWriteStream* stream);
+
 	ReadWriteStream* buffer = nullptr;   ///< Used internally to buffer arbitrary data via send() methods
 	IDataSourceStream* stream = nullptr; ///< The currently active stream being sent
 


### PR DESCRIPTION
Changes to parameter types, member variables
`MultiStream`and `StreamTransformer` classes now inherit from `IDataSourceStream` instead of `ReadWriteStream`; this affects all inherited classes

With `TcpClient`, a stream is used for outgoing data so should be inherited from IDataSourceStream, not ReadWriteStream. An additional internal 'buffer' ReadWriteStream is used where necessary.
This is also done for the `HttpResponse`class.