### PR TITLE
StreamTransformer improvements

### DIFF
--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
@@ -13,19 +13,15 @@
 // Produce line breaks in output encodings
 const unsigned CHARS_PER_LINE = 72;
 
-Base64OutputStream::Base64OutputStream(IDataSourceStream* stream, size_t resultSize /* = 512 */)
+Base64OutputStream::Base64OutputStream(IDataSourceStream* stream, size_t resultSize)
 	: StreamTransformer(stream, nullptr, resultSize, (resultSize / 4))
-
 {
 	base64_init_encodestate(&state, CHARS_PER_LINE);
-
-	transformCallback = std::bind(&Base64OutputStream::encode, this, std::placeholders::_1, std::placeholders::_2,
-								  std::placeholders::_3, std::placeholders::_4);
 }
 
-int Base64OutputStream::encode(uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength)
+size_t Base64OutputStream::transform(const uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength)
 {
-	int count = 0;
+	size_t count = 0;
 	if(sourceLength == 0) {
 		count = base64_encode_blockend((char*)target, &state);
 	} else {

--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
@@ -14,7 +14,7 @@
 const unsigned CHARS_PER_LINE = 72;
 
 Base64OutputStream::Base64OutputStream(IDataSourceStream* stream, size_t resultSize)
-	: StreamTransformer(stream, nullptr, resultSize, (resultSize / 4))
+	: StreamTransformer(stream, resultSize, (resultSize / 4))
 {
 	base64_init_encodestate(&state, CHARS_PER_LINE);
 }

--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.h
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.h
@@ -31,16 +31,7 @@ public:
 	 */
 	Base64OutputStream(IDataSourceStream* stream, size_t resultSize = 500);
 
-	/**
-	 * Encodes a chunk of data into base64. Keeps a state of the progress.
-	 * @param source The incoming data
-	 * @param sourceLength Length of the incoming data
-	 * @param target The result data. The pointer must point to an already allocated memory
-	 * @param targetLength The length of the result data
-	 *
-	 * @return the length of the encoded target.
-	 */
-	int encode(uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength);
+	virtual size_t transform(const uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength);
 
 	/**
 	 * @brief A method that backs up the current state

--- a/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
+++ b/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
@@ -11,7 +11,7 @@
 #include "ChunkedStream.h"
 
 ChunkedStream::ChunkedStream(IDataSourceStream* stream, size_t resultSize)
-	: StreamTransformer(stream, nullptr, resultSize, resultSize - 12)
+	: StreamTransformer(stream, resultSize, resultSize - 12)
 {
 }
 

--- a/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
+++ b/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
@@ -10,14 +10,12 @@
 
 #include "ChunkedStream.h"
 
-ChunkedStream::ChunkedStream(IDataSourceStream* stream, size_t resultSize /* = 512 */)
+ChunkedStream::ChunkedStream(IDataSourceStream* stream, size_t resultSize)
 	: StreamTransformer(stream, nullptr, resultSize, resultSize - 12)
 {
-	transformCallback = std::bind(&ChunkedStream::encode, this, std::placeholders::_1, std::placeholders::_2,
-								  std::placeholders::_3, std::placeholders::_4);
 }
 
-int ChunkedStream::encode(uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength)
+size_t ChunkedStream::transform(const uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength)
 {
 	if(sourceLength == 0) {
 		const char* end = "0\r\n\r\n";

--- a/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
+++ b/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
@@ -18,26 +18,18 @@ ChunkedStream::ChunkedStream(IDataSourceStream* stream, size_t resultSize)
 size_t ChunkedStream::transform(const uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength)
 {
 	if(sourceLength == 0) {
-		const char* end = "0\r\n\r\n";
-		memcpy(target, end, strlen(end));
-		return strlen(end);
+		memcpy(target, _F("0\r\n\r\n"), 5);
+		return 5;
 	}
 
-	int offset = 0;
-	char chunkSize[5] = {0};
-	ets_sprintf(chunkSize, "%X", sourceLength);
+	// Header
+	unsigned offset = m_snprintf(reinterpret_cast<char*>(target), targetLength, "%X\r\n", sourceLength);
 
-	memcpy(target, chunkSize, strlen(chunkSize));
-	offset += strlen(chunkSize);
-
-	// \r\n
-	memcpy(target + offset, "\r\n", 2);
-	offset += 2;
-
+	// Content
 	memcpy(target + offset, source, sourceLength);
 	offset += sourceLength;
 
-	// \r\n
+	// Footer
 	memcpy(target + offset, "\r\n", 2);
 	offset += 2;
 

--- a/Sming/SmingCore/Data/Stream/ChunkedStream.h
+++ b/Sming/SmingCore/Data/Stream/ChunkedStream.h
@@ -25,16 +25,8 @@ class ChunkedStream : public StreamTransformer
 public:
 	ChunkedStream(IDataSourceStream* stream, size_t resultSize = 512);
 
-	/**
-	 * Encodes a chunk of data
-	 * @param uint8_t* source - the incoming data
-	 * @param size_t sourceLength -length of the incoming data
-	 * @param uint8_t* target - the result data. The pointer must point to an already allocated memory
-	 * @param int* targetLength - the length of the result data
-	 *
-	 * @return the length of the encoded target.
-	 */
-	int encode(uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength);
+protected:
+	virtual size_t transform(const uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength);
 };
 
 /** @} */

--- a/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
@@ -17,7 +17,8 @@
  * @param uint8_t* target - the result data. The pointer must point to an already allocated memory
  * @param int* targetLength - the length of the allocated result data
  */
-static int quotedPrintableTransformer(uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength)
+size_t QuotedPrintableOutputStream::transform(const uint8_t* source, size_t sourceLength, uint8_t* target,
+											  size_t targetLength)
 {
 	const char hex[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
@@ -35,11 +36,4 @@ static int quotedPrintableTransformer(uint8_t* source, size_t sourceLength, uint
 	}
 
 	return count;
-}
-
-QuotedPrintableOutputStream::QuotedPrintableOutputStream(IDataSourceStream* stream, size_t resultSize /* = 512 */)
-	: StreamTransformer(stream, nullptr, resultSize, resultSize / 2)
-
-{
-	transformCallback = quotedPrintableTransformer;
 }

--- a/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
@@ -20,9 +20,7 @@
 size_t QuotedPrintableOutputStream::transform(const uint8_t* source, size_t sourceLength, uint8_t* target,
 											  size_t targetLength)
 {
-	const char hex[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
-
-	int count = 0;
+	unsigned count = 0;
 	for(unsigned i = 0; i < sourceLength; i++) {
 		char byte = source[i];
 
@@ -30,8 +28,8 @@ size_t QuotedPrintableOutputStream::transform(const uint8_t* source, size_t sour
 			target[count++] = byte;
 		} else {
 			target[count++] = '=';
-			target[count++] = hex[((byte >> 4) & 0x0F)];
-			target[count++] = hex[(byte & 0x0F)];
+			target[count++] = hexchar(byte >> 4);
+			target[count++] = hexchar(byte & 0x0F);
 		}
 	}
 

--- a/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.h
+++ b/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.h
@@ -29,7 +29,7 @@ public:
 	 * @param resultSize The size of the intermediate buffer, created once per object and reused multiple times
 	 */
 	QuotedPrintableOutputStream(IDataSourceStream* stream, size_t resultSize = 512)
-		: StreamTransformer(stream, nullptr, resultSize, resultSize / 2)
+		: StreamTransformer(stream, resultSize, resultSize / 2)
 
 	{
 	}

--- a/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.h
+++ b/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.h
@@ -28,7 +28,14 @@ public:
 	 * @param stream source stream
 	 * @param resultSize The size of the intermediate buffer, created once per object and reused multiple times
 	 */
-	QuotedPrintableOutputStream(IDataSourceStream* stream, size_t resultSize = 512);
+	QuotedPrintableOutputStream(IDataSourceStream* stream, size_t resultSize = 512)
+		: StreamTransformer(stream, nullptr, resultSize, resultSize / 2)
+
+	{
+	}
+
+protected:
+	virtual size_t transform(const uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength);
 };
 
 /** @} */

--- a/Sming/SmingCore/Data/StreamTransformer.cpp
+++ b/Sming/SmingCore/Data/StreamTransformer.cpp
@@ -13,8 +13,7 @@
 #define NETWORK_SEND_BUFFER_SIZE 1024
 
 StreamTransformer::StreamTransformer(IDataSourceStream* stream, const StreamTransformerCallback& callback,
-									 size_t resultSize /* = 256 */, size_t blockSize /* = 64 */
-									 )
+									 size_t resultSize, size_t blockSize)
 	: transformCallback(callback)
 {
 	sourceStream = stream;
@@ -58,7 +57,7 @@ uint16_t StreamTransformer::readMemoryBlock(char* data, int bufSize)
 			}
 
 			saveState();
-			size_t outLength = transformCallback((uint8_t*)data, len, result, resultSize);
+			size_t outLength = transform(reinterpret_cast<const uint8_t*>(data), len, result, resultSize);
 			if(outLength > tempStream->room()) {
 				restoreState();
 				break;
@@ -74,7 +73,7 @@ uint16_t StreamTransformer::readMemoryBlock(char* data, int bufSize)
 		} while(--i);
 
 		if(sourceStream->isFinished()) {
-			int outLength = transformCallback(nullptr, 0, result, resultSize);
+			int outLength = transform(nullptr, 0, result, resultSize);
 			tempStream->write(result, outLength);
 		}
 

--- a/Sming/SmingCore/Data/StreamTransformer.cpp
+++ b/Sming/SmingCore/Data/StreamTransformer.cpp
@@ -12,26 +12,6 @@
 
 #define NETWORK_SEND_BUFFER_SIZE 1024
 
-StreamTransformer::StreamTransformer(IDataSourceStream* stream, const StreamTransformerCallback& callback,
-									 size_t resultSize, size_t blockSize)
-	: transformCallback(callback)
-{
-	sourceStream = stream;
-	this->resultSize = resultSize;
-	result = new uint8_t[this->resultSize];
-	this->blockSize = blockSize;
-}
-
-StreamTransformer::~StreamTransformer()
-{
-	delete[] result;
-	delete tempStream;
-	delete sourceStream;
-	result = nullptr;
-	tempStream = nullptr;
-	sourceStream = nullptr;
-}
-
 uint16_t StreamTransformer::readMemoryBlock(char* data, int bufSize)
 {
 	if(tempStream == nullptr) {

--- a/Sming/SmingCore/Data/StreamTransformer.h
+++ b/Sming/SmingCore/Data/StreamTransformer.h
@@ -30,9 +30,27 @@ typedef std::function<size_t(const uint8_t* in, size_t inLength, uint8_t* out, s
 class StreamTransformer : public IDataSourceStream
 {
 public:
+	StreamTransformer(IDataSourceStream* stream, size_t resultSize = 256, size_t blockSize = 64)
+		: sourceStream(stream), resultSize(resultSize), result(new uint8_t[resultSize]), blockSize(blockSize)
+	{
+	}
+
+	/** @brief Constructor with external callback function
+	 *  @deprecated
+	 */
 	StreamTransformer(IDataSourceStream* stream, const StreamTransformerCallback& callback, size_t resultSize = 256,
-					  size_t blockSize = 64);
-	virtual ~StreamTransformer();
+					  size_t blockSize = 64) __attribute__((deprecated))
+	: transformCallback(callback), sourceStream(stream), resultSize(resultSize), result(new uint8_t[resultSize]),
+	  blockSize(blockSize)
+	{
+	}
+
+	virtual ~StreamTransformer()
+	{
+		delete[] result;
+		delete tempStream;
+		delete sourceStream;
+	}
 
 	//Use base class documentation
 	virtual StreamType getStreamType() const
@@ -84,6 +102,9 @@ protected:
 		return (transformCallback == nullptr) ? 0 : transformCallback(in, inLength, out, outLength);
 	}
 
+	/** @brief Callback function to perform transformation
+	 *  @deprecated The virtual transform() method should be used instead in an inherited class
+	 */
 	StreamTransformerCallback transformCallback = nullptr;
 
 private:

--- a/Sming/SmingCore/Data/StreamTransformer.h
+++ b/Sming/SmingCore/Data/StreamTransformer.h
@@ -13,10 +13,6 @@
 
 #include "CircularBuffer.h"
 
-#undef max
-#undef min
-#include <functional>
-
 /**
  * @brief      Class that can be used to transform streams of data on the fly
  * @ingroup    stream data
@@ -26,15 +22,10 @@
 
 /**
  * @brief Callback specification for the stream transformers
- *
- * @param uint8_t* in incoming stream
- * @param int inLength incoming stream length
- * @param uint8_t* out output stream
- * @param int outLength max bytes in the output stream
- *
- * @return int number of output bytes
+ * @note See StreamTransformer::transform() method for details
  */
-typedef std::function<int(uint8_t* in, size_t inLength, uint8_t* out, size_t outLength)> StreamTransformerCallback;
+typedef std::function<size_t(const uint8_t* in, size_t inLength, uint8_t* out, size_t outLength)>
+	StreamTransformerCallback;
 
 class StreamTransformer : public IDataSourceStream
 {
@@ -79,6 +70,20 @@ public:
 	virtual void restoreState(){};
 
 protected:
+	/**
+	 * @brief Inherited class implements this method to transform a block of data
+	 * @param const uint8_t* in source data
+	 * @param size_t inLength source data length
+	 * @param uint8_t* out output buffer
+	 * @param size_t outLength size of output buffer
+	 * @retval size_t number of output bytes written
+	 * @note Called with `in = nullptr` and `inLength = 0' at end of input stream
+	 */
+	virtual size_t transform(const uint8_t* in, size_t inLength, uint8_t* out, size_t outLength)
+	{
+		return (transformCallback == nullptr) ? 0 : transformCallback(in, inLength, out, outLength);
+	}
+
 	StreamTransformerCallback transformCallback = nullptr;
 
 private:


### PR DESCRIPTION
Add virtual `transform` method to `StreamTransformer` class, optimise `QuotedPrintableOutputStream` and `ChunkedStream`.

transformCallback retained, but no longer required by framework; could deprecate and make `transform` a pure virtual method?