### PR TITLE
TCP improvements

### DIFF
--- a/Sming/SmingCore/Network/FTPServer.cpp
+++ b/Sming/SmingCore/Network/FTPServer.cpp
@@ -11,7 +11,7 @@
 #include "HttpResponse.h"
 #include "FTPServerConnection.h"
 #include "TcpClient.h"
-#include "../Wiring/WString.h"
+#include "WString.h"
 
 FTPServer::FTPServer()
 {
@@ -28,13 +28,13 @@ TcpConnection* FTPServer::createClient(tcp_pcb* clientTcp)
 	return con;
 }
 
-void FTPServer::addUser(String login, String pass)
+void FTPServer::addUser(const String& login, const String& pass)
 {
 	debug_d("addUser: %s %s", login.c_str(), pass.c_str());
 	users[login] = pass;
 }
 
-bool FTPServer::checkUser(String login, const String& pass)
+bool FTPServer::checkUser(const String& login, const String& pass)
 {
 	debug_d("checkUser: %s %s", login.c_str(), pass.c_str());
 	if(!users.contains(login))
@@ -47,7 +47,7 @@ bool FTPServer::onCommand(String cmd, String data, FTPServerConnection& connecti
 {
 	if(cmd == "FSFORMAT") {
 		spiffs_format();
-		connection.response(200, "File system successfully formated");
+		connection.response(200, F("File system successfully formatted"));
 		return true;
 	}
 	return false;

--- a/Sming/SmingCore/Network/FTPServer.h
+++ b/Sming/SmingCore/Network/FTPServer.h
@@ -15,9 +15,9 @@
 #define _SMING_CORE_FTPSERVER_H_
 
 #include "TcpServer.h"
-#include "../../Wiring/WHashMap.h"
-#include "../../Wiring/WVector.h"
-#include "../../Wiring/WString.h"
+#include "WHashMap.h"
+#include "WVector.h"
+#include "WString.h"
 
 class FTPServerConnection;
 
@@ -29,8 +29,8 @@ public:
 	FTPServer();
 	virtual ~FTPServer();
 
-	void addUser(String login, String pass);
-	bool checkUser(String login, const String& pass);
+	void addUser(const String& login, const String& pass);
+	bool checkUser(const String& login, const String& pass);
 
 protected:
 	virtual TcpConnection* createClient(tcp_pcb* clientTcp);

--- a/Sming/SmingCore/Network/FTPServerConnection.cpp
+++ b/Sming/SmingCore/Network/FTPServerConnection.cpp
@@ -2,7 +2,7 @@
 #include "FTPServer.h"
 #include "NetUtils.h"
 #include "TcpConnection.h"
-#include "../FileSystem.h"
+#include "FileSystem.h"
 
 class FTPDataStream : public TcpConnection
 {

--- a/Sming/SmingCore/Network/FTPServerConnection.cpp
+++ b/Sming/SmingCore/Network/FTPServerConnection.cpp
@@ -7,55 +7,64 @@
 class FTPDataStream : public TcpConnection
 {
 public:
-	FTPDataStream(FTPServerConnection* connection)
-		: TcpConnection(true), parent(connection), completed(false), sent(0), written(0)
+	FTPDataStream(FTPServerConnection* connection) : TcpConnection(true), parent(connection)
 	{
 	}
+
 	virtual err_t onConnected(err_t err)
 	{
 		//response(125, "Connected");
 		setTimeOut(300); // Update timeout
 		return TcpConnection::onConnected(err);
 	}
+
 	virtual err_t onSent(uint16_t len)
 	{
 		sent += len;
-		if(written < sent || !completed)
+		if(written < sent || !completed) {
 			return TcpConnection::onSent(len);
+		}
 		finishTransfer();
 		return TcpConnection::onSent(len);
 	}
+
 	void finishTransfer()
 	{
 		close();
 		parent->dataTransferFinished(this);
 	}
-	void response(int code, String text = "")
+
+	void response(int code, String text = nullptr)
 	{
 		parent->response(code, text);
 	}
+
 	int write(const char* data, int len, uint8_t apiflags = 0)
 	{
 		written += len;
 		return TcpConnection::write(data, len, apiflags);
 	}
+
 	virtual void onReadyToSendData(TcpConnectionEvent sourceEvent)
 	{
-		if(!parent->isCanTransfer())
+		if(!parent->isCanTransfer()) {
 			return;
-		if(completed && written == 0)
+		}
+		if(completed && written == 0) {
 			finishTransfer();
+		}
 		transferData(sourceEvent);
 	}
+
 	virtual void transferData(TcpConnectionEvent sourceEvent)
 	{
 	}
 
 protected:
-	FTPServerConnection* parent;
-	bool completed;
-	int written;
-	int sent;
+	FTPServerConnection* parent = nullptr;
+	bool completed = false;
+	unsigned written = 0;
+	unsigned sent = 0;
 };
 
 class FTPDataFileList : public FTPDataStream
@@ -64,14 +73,17 @@ public:
 	FTPDataFileList(FTPServerConnection* connection) : FTPDataStream(connection)
 	{
 	}
+
 	virtual void transferData(TcpConnectionEvent sourceEvent)
 	{
-		if(completed)
+		if(completed) {
 			return;
+		}
 		Vector<String> list = fileList();
 		debug_d("send file list: %d", list.count());
-		for(int i = 0; i < list.count(); i++)
+		for(unsigned i = 0; i < list.count(); i++) {
 			writeString("01-01-15  01:00AM               " + String(fileGetSize(list[i])) + " " + list[i] + "\r\n");
+		}
 		completed = true;
 		finishTransfer();
 	}
@@ -84,14 +96,17 @@ public:
 	{
 		file = fileOpen(fileName, eFO_ReadOnly);
 	}
+
 	~FTPDataRetrieve()
 	{
 		fileClose(file);
 	}
+
 	virtual void transferData(TcpConnectionEvent sourceEvent)
 	{
-		if(completed)
+		if(completed) {
 			return;
+		}
 		char buf[1024];
 		int len = fileRead(file, buf, 1024);
 		write(buf, len, TCP_WRITE_FLAG_COPY);
@@ -112,23 +127,26 @@ public:
 	{
 		file = fileOpen(fileName, eFO_WriteOnly | eFO_CreateNewAlways);
 	}
+
 	~FTPDataStore()
 	{
 		fileClose(file);
 	}
+
 	virtual err_t onReceive(pbuf* buf)
 	{
-		if(completed)
+		if(completed) {
 			return TcpConnection::onReceive(buf);
+		}
 
-		if(buf == NULL) {
+		if(buf == nullptr) {
 			completed = true;
 			response(226, "Transfer completed");
 			return TcpConnection::onReceive(buf);
 		}
 
 		pbuf* cur = buf;
-		while(cur != NULL && cur->len > 0) {
+		while(cur != nullptr && cur->len > 0) {
 			fileWrite(file, (uint8_t*)cur->payload, cur->len);
 			cur = cur->next;
 		}
@@ -142,47 +160,38 @@ private:
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-FTPServerConnection::FTPServerConnection(FTPServer* parentServer, tcp_pcb* clientTcp)
-	: TcpConnection(clientTcp, true), server(parentServer), state(eFCS_Ready)
-{
-	dataConnection = NULL;
-	port = 0;
-	canTransfer = true;
-}
-
-FTPServerConnection::~FTPServerConnection()
-{
-}
-
 err_t FTPServerConnection::onReceive(pbuf* buf)
 {
-	if(buf == NULL)
+	if(buf == nullptr)
 		return ERR_OK;
 	int p = 0, prev = 0;
 
 	while(true) {
 		p = NetUtils::pbufFindStr(buf, "\r\n", prev);
-		if(p == -1 || p - prev > MAX_FTP_CMD)
+		if(p < 0 || p - prev > MAX_FTP_CMD) {
 			break;
+		}
 		int split = NetUtils::pbufFindChar(buf, ' ', prev);
 		String cmd, data;
-		if(split != -1 && split < p) {
+		if(split >= 0 && split < p) {
 			cmd = NetUtils::pbufStrCopy(buf, prev, split - prev);
 			split++;
 			data = NetUtils::pbufStrCopy(buf, split, p - split);
-		} else
+		} else {
 			cmd = NetUtils::pbufStrCopy(buf, prev, p - prev);
+		}
 		debug_d("%s: '%s'", cmd.c_str(), data.c_str());
 		onCommand(cmd, data);
 		prev = p + 1;
-	};
+	}
+
 	return ERR_OK;
 }
 
 void FTPServerConnection::cmdPort(const String& data)
 {
 	int last = getSplitterPos(data, ',', 4);
-	if(last == -1) {
+	if(last < 0) {
 		response(550); // Invalid arguments
 					   //return;
 	}
@@ -297,13 +306,15 @@ err_t FTPServerConnection::onSent(uint16_t len)
 
 String FTPServerConnection::makeFileName(String name, bool shortIt)
 {
-	if(name.startsWith("/"))
+	if(name.startsWith("/")) {
 		name = name.substring(1);
+	}
 
 	if(shortIt && name.length() > 20) {
 		String ext = "";
-		if(name.lastIndexOf('.') != -1)
+		if(name.lastIndexOf('.') != -1) {
 			ext = name.substring(name.lastIndexOf('.'));
+		}
 
 		return name.substring(0, 16) + ext;
 	}
@@ -319,10 +330,11 @@ void FTPServerConnection::createDataConnection(TcpConnection* connection)
 
 void FTPServerConnection::dataTransferFinished(TcpConnection* connection)
 {
-	if(connection != dataConnection)
+	if(connection != dataConnection) {
 		SYSTEM_ERROR("FTP Wrong state: connection != dataConnection");
+	}
 
-	dataConnection = NULL;
+	dataConnection = nullptr;
 	response(226, F("Transfer Complete."));
 }
 
@@ -330,7 +342,7 @@ int FTPServerConnection::getSplitterPos(String data, char splitter, uint8_t numb
 {
 	uint8_t k = 0;
 
-	for(int i = 0; i < data.length(); i++) {
+	for(unsigned i = 0; i < data.length(); i++) {
 		if(data[i] == splitter) {
 			if(k == number) {
 				return i;
@@ -346,16 +358,18 @@ void FTPServerConnection::response(int code, String text /* = "" */)
 {
 	String response = String(code, DEC);
 	if(text.length() == 0) {
-		if(code >= 200 && code <= 399) // Just for simplify
+		if(code >= 200 && code <= 399) { // Just for simplify
 			response += _F(" OK");
-		else
+		} else {
 			response += _F(" FAIL");
-	} else
+		}
+	} else {
 		response += ' ' + text;
+	}
 	response += "\r\n";
 
 	debug_d("> %s", response.c_str());
-	writeString(response.c_str(), TCP_WRITE_FLAG_COPY); // Dynamic memory, should copy
+	writeString(response, TCP_WRITE_FLAG_COPY); // Dynamic memory, should copy
 	canTransfer = false;
 	flush();
 }

--- a/Sming/SmingCore/Network/FTPServerConnection.h
+++ b/Sming/SmingCore/Network/FTPServerConnection.h
@@ -2,8 +2,8 @@
 #define SMINGCORE_NETWORK_FTPSERVERCONNECTION_H_
 
 #include "TcpConnection.h"
-#include "../../Wiring/IPAddress.h"
-#include "../Wiring/WString.h"
+#include "IPAddress.h"
+#include "WString.h"
 
 #define MAX_FTP_CMD 255
 

--- a/Sming/SmingCore/Network/FTPServerConnection.h
+++ b/Sming/SmingCore/Network/FTPServerConnection.h
@@ -17,8 +17,14 @@ class FTPServerConnection : public TcpConnection
 	friend class FTPServer;
 
 public:
-	FTPServerConnection(FTPServer* parentServer, tcp_pcb* clientTcp);
-	virtual ~FTPServerConnection();
+	FTPServerConnection(FTPServer* parentServer, tcp_pcb* clientTcp)
+		: TcpConnection(clientTcp, true), server(parentServer), state(eFCS_Ready)
+	{
+	}
+
+	virtual ~FTPServerConnection()
+	{
+	}
 
 	virtual err_t onReceive(pbuf* buf);
 	virtual err_t onSent(uint16_t len);
@@ -46,9 +52,9 @@ private:
 	String renameFrom;
 
 	IPAddress ip;
-	int port;
-	TcpConnection* dataConnection;
-	bool canTransfer;
+	int port = 0;
+	TcpConnection* dataConnection = nullptr;
+	bool canTransfer = true;
 };
 
 #endif /* SMINGCORE_NETWORK_FTPSERVERCONNECTION_H_ */

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -9,15 +9,15 @@
 #define _SMING_CORE_NETWORK_MqttClient_H_
 
 #include "TcpClient.h"
-#include "../Network/URL.h"
-#include "../../Wiring/WString.h"
-#include "../../Wiring/WHashMap.h"
+#include "URL.h"
+#include "WString.h"
+#include "WHashMap.h"
 #include "Data/ObjectQueue.h"
 #include "Mqtt/MqttPayloadParser.h"
 #include "../mqtt-codec/src/message.h"
 #include "../mqtt-codec/src/serialiser.h"
 #include "../mqtt-codec/src/parser.h"
-#include <functional>
+//#include <functional>
 
 /** @defgroup   mqttclient MQTT client
  *  @brief      Provides MQTT client
@@ -67,13 +67,16 @@ public:
 	 * Sets keep-alive time. That information is sent during connection to the server
 	 * @param uint16_t seconds
 	 */
-	void setKeepAlive(uint16_t seconds); //send to broker
+	void setKeepAlive(uint16_t seconds) //send to broker
+	{
+		keepAlive = seconds;
+	}
 
 	/**
 	 * Sets the interval in which to ping the remote server if there was no activity
-	 * @param int seconds
+	 * @param unsigned int seconds
 	 */
-	void setPingRepeatTime(int seconds);
+	void setPingRepeatTime(unsigned seconds);
 
 	/**
 	 * Sets last will and testament
@@ -95,7 +98,10 @@ public:
 	bool subscribe(const String& topic);
 	bool unsubscribe(const String& topic);
 
-	void setEventHandler(mqtt_type_t type, MqttDelegate handler);
+	void setEventHandler(mqtt_type_t type, MqttDelegate handler)
+	{
+		eventHandler[type] = handler;
+	}
 
 	/**
 	 * Sets or clears a payload parser (for PUBLISH messages from the server to us)
@@ -259,7 +265,7 @@ private:
 	/* @deprecated This method is only for compatibility with the previous release and will be removed soon. */
 	static int onPublish(MqttClient& client, mqtt_message_t* message)
 	{
-		if(!message) {
+		if(message == nullptr) {
 			return -1;
 		}
 
@@ -293,7 +299,7 @@ private:
 
 	// keep-alives and pings
 	uint16_t keepAlive = 60;
-	int pingRepeatTime = 20;
+	unsigned pingRepeatTime = 20;
 	unsigned long lastMessage = 0;
 
 	// messages
@@ -316,9 +322,9 @@ private:
 
 #ifndef MQTT_NO_COMPAT
 	// @deprecated
-	MqttMessageDeliveredCallback onDelivery = 0;
+	MqttMessageDeliveredCallback onDelivery = nullptr;
 	// @deprecated
-	MqttStringSubscriptionCallback subscriptionCallback = 0;
+	MqttStringSubscriptionCallback subscriptionCallback = nullptr;
 #endif
 };
 

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -17,7 +17,6 @@
 #include "../mqtt-codec/src/message.h"
 #include "../mqtt-codec/src/serialiser.h"
 #include "../mqtt-codec/src/parser.h"
-//#include <functional>
 
 /** @defgroup   mqttclient MQTT client
  *  @brief      Provides MQTT client

--- a/Sming/SmingCore/Network/NetUtils.h
+++ b/Sming/SmingCore/Network/NetUtils.h
@@ -14,12 +14,6 @@
 
 struct pbuf;
 class String;
-class TcpConnection;
-
-struct DnsLookup {
-	TcpConnection* con;
-	int port;
-};
 
 class NetUtils
 {

--- a/Sming/SmingCore/Network/SmtpClient.cpp
+++ b/Sming/SmingCore/Network/SmtpClient.cpp
@@ -402,7 +402,7 @@ int SmtpClient::smtpParse(char* buffer, size_t len)
 
 			if(!useSsl && (options & SMTP_OPT_STARTTLS)) {
 				useSsl = true;
-				TcpConnection::tcpOnConnected(ERR_OK);
+				TcpConnection::internalOnConnected(ERR_OK);
 			}
 
 			sendString(F("EHLO ") + url.Host + "\r\n");
@@ -424,9 +424,6 @@ int SmtpClient::smtpParse(char* buffer, size_t len)
 				// Process authentication methods
 				// Ex: 250-AUTH CRAM-MD5 PLAIN LOGIN
 				// See: https://tools.ietf.org/html/rfc4954
-				int offset = 0;
-				int pos = -1;
-
 				String text(line + 5, lineLength - 5);
 				splitString(text, ' ', authMethods);
 			}

--- a/Sming/SmingCore/Network/SmtpClient.cpp
+++ b/Sming/SmingCore/Network/SmtpClient.cpp
@@ -402,7 +402,7 @@ int SmtpClient::smtpParse(char* buffer, size_t len)
 
 			if(!useSsl && (options & SMTP_OPT_STARTTLS)) {
 				useSsl = true;
-				TcpConnection::staticOnConnected((void*)this, tcp, ERR_OK);
+				TcpConnection::tcpOnConnected(ERR_OK);
 			}
 
 			sendString(F("EHLO ") + url.Host + "\r\n");

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -103,7 +103,7 @@ err_t TcpConnection::onSent(uint16_t len)
 	debug_d("TCP sent: %d", len);
 
 	//debug_d("%d %d", tcp->state, tcp->flags); // WRONG!
-	if(len >= 0 && tcp != nullptr && getAvailableWriteSize() > 0) {
+	if(tcp != nullptr && getAvailableWriteSize() > 0) {
 		onReadyToSendData(eTCE_Sent);
 	}
 

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -257,7 +257,8 @@ public:
 
 protected:
 	void initialize(tcp_pcb* pcb);
-	bool internalTcpConnect(IPAddress addr, uint16_t port);
+	bool internalConnect(IPAddress addr, uint16_t port);
+
 	virtual err_t onConnected(err_t err);
 	virtual err_t onReceive(pbuf* buf);
 	virtual err_t onSent(uint16_t len);
@@ -268,13 +269,13 @@ protected:
 	virtual err_t onSslConnected(SSL* ssl);
 #endif
 
-	// These do most of the work - called from static methods
-	err_t tcpOnConnected(err_t err);
-	err_t tcpOnReceive(pbuf* p, err_t err);
-	err_t tcpOnSent(uint16_t len);
-	err_t tcpOnPoll();
-	void tcpOnError(err_t err);
-	void tcpOnDnsResponse(const char* name, LWIP_IP_ADDR_T* ipaddr, int port);
+	// These methods are called via LWIP handlers
+	err_t internalOnConnected(err_t err);
+	err_t internalOnReceive(pbuf* p, err_t err);
+	err_t internalOnSent(uint16_t len);
+	err_t internalOnPoll();
+	void internalOnError(err_t err);
+	void internalOnDnsResponse(const char* name, LWIP_IP_ADDR_T* ipaddr, int port);
 
 private:
 	// Methods called directly from TCP stack
@@ -287,7 +288,6 @@ private:
 
 	static void closeTcpConnection(tcp_pcb* tpcb);
 
-private:
 	inline void checkSelfFree()
 	{
 		if(tcp == nullptr && autoSelfDestruct) {

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -256,6 +256,7 @@ public:
 #endif
 
 protected:
+	void initialize(tcp_pcb* pcb);
 	bool internalTcpConnect(IPAddress addr, uint16_t port);
 	virtual err_t onConnected(err_t err);
 	virtual err_t onReceive(pbuf* buf);
@@ -267,6 +268,16 @@ protected:
 	virtual err_t onSslConnected(SSL* ssl);
 #endif
 
+	// These do most of the work - called from static methods
+	err_t tcpOnConnected(err_t err);
+	err_t tcpOnReceive(pbuf* p, err_t err);
+	err_t tcpOnSent(uint16_t len);
+	err_t tcpOnPoll();
+	void tcpOnError(err_t err);
+	void tcpOnDnsResponse(const char* name, LWIP_IP_ADDR_T* ipaddr, int port);
+
+private:
+	// Methods called directly from TCP stack
 	static err_t staticOnConnected(void* arg, tcp_pcb* tcp, err_t err);
 	static err_t staticOnReceive(void* arg, tcp_pcb* tcp, pbuf* p, err_t err);
 	static err_t staticOnSent(void* arg, tcp_pcb* tcp, uint16_t len);
@@ -275,7 +286,6 @@ protected:
 	static void staticDnsResponse(const char* name, LWIP_IP_ADDR_T* ipaddr, void* arg);
 
 	static void closeTcpConnection(tcp_pcb* tpcb);
-	void initialize(tcp_pcb* pcb);
 
 private:
 	inline void checkSelfFree()

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -278,14 +278,7 @@ protected:
 	void internalOnDnsResponse(const char* name, LWIP_IP_ADDR_T* ipaddr, int port);
 
 private:
-	// Methods called directly from TCP stack
-	static err_t staticOnConnected(void* arg, tcp_pcb* tcp, err_t err);
-	static err_t staticOnReceive(void* arg, tcp_pcb* tcp, pbuf* p, err_t err);
-	static err_t staticOnSent(void* arg, tcp_pcb* tcp, uint16_t len);
 	static err_t staticOnPoll(void* arg, tcp_pcb* tcp);
-	static void staticOnError(void* arg, err_t err);
-	static void staticDnsResponse(const char* name, LWIP_IP_ADDR_T* ipaddr, void* arg);
-
 	static void closeTcpConnection(tcp_pcb* tpcb);
 
 	inline void checkSelfFree()

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -69,15 +69,12 @@ struct pbuf;
 class String;
 class IDataSourceStream;
 class IPAddress;
-class TcpServer;
 class TcpConnection;
 
 typedef Delegate<void(TcpConnection&)> TcpConnectionDestroyedDelegate;
 
 class TcpConnection
 {
-	friend class TcpServer;
-
 public:
 	TcpConnection(bool autoDestruct) : autoSelfDestruct(autoDestruct)
 	{
@@ -243,6 +240,13 @@ public:
 	 * @brief Frees the memory used for the key and certificate pair
 	 */
 	void freeSslKeyCert();
+
+	// Called by TcpServer
+	void setSsl(SSL* ssl)
+	{
+		this->ssl = ssl;
+		useSsl = true;
+	}
 
 	SSL* getSsl()
 	{

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -290,8 +290,9 @@ private:
 private:
 	inline void checkSelfFree()
 	{
-		if(tcp == nullptr && autoSelfDestruct)
+		if(tcp == nullptr && autoSelfDestruct) {
 			delete this;
+		}
 	}
 
 protected:

--- a/Sming/SmingCore/Network/TcpServer.cpp
+++ b/Sming/SmingCore/Network/TcpServer.cpp
@@ -6,55 +6,16 @@
  ****/
 
 #include "TcpServer.h"
-#include "TcpClient.h"
 
-#include "../../SmingCore/Digital.h"
-#include "../../SmingCore/Timer.h"
-
-int16_t TcpServer::totalConnections = 0;
-
-TcpServer::TcpServer() : TcpConnection(false)
-{
-	timeOut = TCP_SERVER_TIMEOUT;
-}
-
-TcpServer::TcpServer(TcpClientConnectDelegate onClientHandler, TcpClientDataDelegate clientReceiveDataHandler,
-					 TcpClientCompleteDelegate clientCompleteHandler)
-	: TcpConnection(false), clientConnectDelegate(onClientHandler), clientReceiveDelegate(clientReceiveDataHandler),
-	  clientCompleteDelegate(clientCompleteHandler)
-{
-	timeOut = TCP_SERVER_TIMEOUT;
-}
-
-TcpServer::TcpServer(TcpClientDataDelegate clientReceiveDataHandler, TcpClientCompleteDelegate clientCompleteHandler)
-	: TcpConnection(false), clientReceiveDelegate(clientReceiveDataHandler),
-	  clientCompleteDelegate(clientCompleteHandler)
-{
-	timeOut = TCP_SERVER_TIMEOUT;
-}
-
-TcpServer::TcpServer(TcpClientDataDelegate clientReceiveDataHandler)
-	: TcpConnection(false), clientReceiveDelegate(clientReceiveDataHandler)
-{
-	timeOut = TCP_SERVER_TIMEOUT;
-}
-
-TcpServer::~TcpServer()
-{
-	debug_i("Server is destroyed.");
-}
+uint16_t TcpServer::totalConnections = 0;
 
 TcpConnection* TcpServer::createClient(tcp_pcb* clientTcp)
 {
-	if(clientTcp == NULL) {
-		debug_d("TCP Server createClient NULL\r\n");
-	} else {
-		debug_d("TCP Server createClient not NULL");
-	}
+	debug_d("TCP Server createClient %sNULL\r\n", clientTcp ? "not" : "");
 
 	if(!active) {
 		debug_w("Refusing new connections. The server is shutting down");
-		return NULL;
+		return nullptr;
 	}
 
 	TcpConnection* con = new TcpClient(clientTcp, TcpClientDataDelegate(&TcpServer::onClientReceive, this),
@@ -66,23 +27,25 @@ TcpConnection* TcpServer::createClient(tcp_pcb* clientTcp)
 //Timer stateTimer;
 void list_mem()
 {
-	debug_d("Free heap size=%d, K=%d", system_get_free_heap_size(), TcpServer::totalConnections);
+	debug_d("Free heap size=%u, K=%u", system_get_free_heap_size(), TcpServer::totalConnections);
 }
 
 void TcpServer::setKeepAlive(uint16_t seconds)
 {
-	debug_d("Server keep-alive updating: %d -> %d", keepAlive, seconds);
+	debug_d("Server keep-alive updating: %u -> %u", keepAlive, seconds);
 	keepAlive = seconds;
 }
 
-bool TcpServer::listen(int port, bool useSsl /*= false */)
+bool TcpServer::listen(int port, bool useSsl)
 {
-	if(tcp == NULL)
+	if(tcp == nullptr) {
 		initialize(tcp_new());
+	}
 
 	err_t res = tcp_bind(tcp, IP_ADDR_ANY, port);
-	if(res != ERR_OK)
+	if(res != ERR_OK) {
 		return res;
+	}
 
 #ifdef ENABLE_SSL
 	this->useSsl = useSsl;
@@ -106,7 +69,7 @@ bool TcpServer::listen(int port, bool useSsl /*= false */)
 		}
 
 		if(ssl_obj_memory_load(sslContext, SSL_OBJ_X509_CERT, sslKeyCert.certificate, sslKeyCert.certificateLength,
-							   NULL) != SSL_OK) {
+							   nullptr) != SSL_OK) {
 			debug_e("SSL: Unable to load server certificate");
 			return false;
 		}
@@ -137,13 +100,14 @@ err_t TcpServer::onAccept(tcp_pcb* clientTcp, err_t err)
 #endif
 
 	if(err != ERR_OK) {
-		//closeTcpConnection(clientTcp, NULL);
+		//closeTcpConnection(clientTcp, nullptr);
 		return err;
 	}
 
 	TcpConnection* client = createClient(clientTcp);
-	if(client == NULL)
+	if(client == nullptr) {
 		return ERR_MEM;
+	}
 	client->setTimeOut(keepAlive);
 
 #ifdef ENABLE_SSL
@@ -180,12 +144,12 @@ void TcpServer::onClient(TcpClient* client)
 	}
 }
 
-void TcpServer::onClientComplete(TcpClient& client, bool succesfull)
+void TcpServer::onClientComplete(TcpClient& client, bool successful)
 {
 	activeClients--;
 	debug_d("TcpSever onComplete: %s\r\n", client.getRemoteIp().toString().c_str());
 	if(clientCompleteDelegate) {
-		clientCompleteDelegate(client, succesfull);
+		clientCompleteDelegate(client, successful);
 	}
 }
 
@@ -201,15 +165,16 @@ bool TcpServer::onClientReceive(TcpClient& client, char* data, int size)
 
 err_t TcpServer::staticAccept(void* arg, tcp_pcb* new_tcp, err_t err)
 {
-	TcpServer* con = (TcpServer*)arg;
+	auto con = static_cast<TcpServer*>(arg);
 
-	if(con == NULL) {
+	if(con == nullptr) {
 		debug_e("NO CONNECTION ON TCP");
 		//closeTcpConnection(new_tcp);
 		tcp_abort(new_tcp);
 		return ERR_ABRT;
-	} else
+	} else {
 		con->sleep = 0;
+	}
 
 	err_t res = con->onAccept(new_tcp, err);
 	return res;
@@ -222,21 +187,21 @@ void TcpServer::shutdown()
 	debug_i("Shutting down the server ...");
 
 	if(tcp) {
-		tcp_arg(tcp, NULL);
-		tcp_accept(tcp, NULL);
+		tcp_arg(tcp, nullptr);
+		tcp_accept(tcp, nullptr);
 		tcp_close(tcp);
 
-		tcp = NULL;
+		tcp = nullptr;
 	}
 
-	if(!connections.count()) {
+	if(connections.count() == 0) {
 		delete this;
 		return;
 	}
 
-	for(int i = 0; i < connections.count(); i++) {
+	for(unsigned i = 0; i < connections.count(); i++) {
 		TcpConnection* connection = connections[i];
-		if(connection == NULL) {
+		if(connection == nullptr) {
 			continue;
 		}
 

--- a/Sming/SmingCore/Network/TcpServer.cpp
+++ b/Sming/SmingCore/Network/TcpServer.cpp
@@ -120,8 +120,7 @@ err_t TcpServer::onAccept(tcp_pcb* clientTcp, err_t err)
 		}
 
 		debug_d("SSL: handshake start (%d ms)", millis());
-		client->ssl = ssl_server_new(sslContext, clientfd);
-		client->useSsl = true;
+		client->setSsl(ssl_server_new(sslContext, clientfd));
 	}
 #endif
 

--- a/Sming/SmingCore/Network/TcpServer.h
+++ b/Sming/SmingCore/Network/TcpServer.h
@@ -26,12 +26,36 @@ typedef Delegate<void(TcpClient* client)> TcpClientConnectDelegate;
 class TcpServer : public TcpConnection
 {
 public:
-	TcpServer();
+	TcpServer() : TcpConnection(false)
+	{
+		TcpConnection::timeOut = TCP_SERVER_TIMEOUT;
+	}
+
 	TcpServer(TcpClientConnectDelegate onClientHandler, TcpClientDataDelegate clientReceiveDataHandler,
-			  TcpClientCompleteDelegate clientCompleteHandler);
-	TcpServer(TcpClientDataDelegate clientReceiveDataHandler, TcpClientCompleteDelegate clientCompleteHandler);
-	TcpServer(TcpClientDataDelegate clientReceiveDataHandler);
-	virtual ~TcpServer();
+			  TcpClientCompleteDelegate clientCompleteHandler)
+		: TcpConnection(false), clientConnectDelegate(onClientHandler), clientReceiveDelegate(clientReceiveDataHandler),
+		  clientCompleteDelegate(clientCompleteHandler)
+	{
+		TcpConnection::timeOut = TCP_SERVER_TIMEOUT;
+	}
+
+	TcpServer(TcpClientDataDelegate clientReceiveDataHandler, TcpClientCompleteDelegate clientCompleteHandler)
+		: TcpConnection(false), clientReceiveDelegate(clientReceiveDataHandler),
+		  clientCompleteDelegate(clientCompleteHandler)
+	{
+		TcpConnection::timeOut = TCP_SERVER_TIMEOUT;
+	}
+
+	TcpServer(TcpClientDataDelegate clientReceiveDataHandler)
+		: TcpConnection(false), clientReceiveDelegate(clientReceiveDataHandler)
+	{
+		TcpConnection::timeOut = TCP_SERVER_TIMEOUT;
+	}
+
+	virtual ~TcpServer()
+	{
+		debug_i("TcpServer destroyed");
+	}
 
 public:
 	virtual bool listen(int port, bool useSsl = false);
@@ -62,17 +86,17 @@ protected:
 	virtual err_t onAccept(tcp_pcb* clientTcp, err_t err);
 	virtual void onClient(TcpClient* client);
 	virtual bool onClientReceive(TcpClient& client, char* data, int size);
-	virtual void onClientComplete(TcpClient& client, bool succesfull);
+	virtual void onClientComplete(TcpClient& client, bool successful);
 	virtual void onClientDestroy(TcpConnection& connection);
 
 	static err_t staticAccept(void* arg, tcp_pcb* new_tcp, err_t err);
 
 public:
-	static int16_t totalConnections;
+	static uint16_t totalConnections; ///< @deprecated not updated by framework
 	uint16_t activeClients = 0;
 
 protected:
-	int minHeapSize = 3000;
+	size_t minHeapSize = 3000;
 
 #ifdef ENABLE_SSL
 	int sslSessionCacheSize = 50;
@@ -84,9 +108,9 @@ protected:
 private:
 	uint16_t keepAlive = 70; // << The time to wait after the connection is established. If there is no data
 							 //  coming or going to the client within that period the client connection will be closed
-	TcpClientDataDelegate clientReceiveDelegate = NULL;
-	TcpClientCompleteDelegate clientCompleteDelegate = NULL;
-	TcpClientConnectDelegate clientConnectDelegate = NULL;
+	TcpClientConnectDelegate clientConnectDelegate = nullptr;
+	TcpClientDataDelegate clientReceiveDelegate = nullptr;
+	TcpClientCompleteDelegate clientCompleteDelegate = nullptr;
 };
 
 /** @} */

--- a/Sming/SmingCore/Network/TelnetServer.h
+++ b/Sming/SmingCore/Network/TelnetServer.h
@@ -15,14 +15,11 @@
 #define APP_TELNETSERVER_H_
 
 #include <user_config.h>
-#include "../Delegate.h"
-#include "../Debug.h"
+#include "Delegate.h"
 #include "TcpClient.h"
 #include "TcpServer.h"
 #include "SystemClock.h"
 #include "../Services/CommandProcessing/CommandExecutor.h"
-
-#include <stdio.h>
 
 #define TELNETSERVER_MAX_COMMANDSIZE 64
 
@@ -31,8 +28,14 @@ typedef Delegate<void(TcpClient* client, char* data, int size)> TelnetServerComm
 class TelnetServer : public TcpServer
 {
 public:
-	TelnetServer();
-	virtual ~TelnetServer();
+	TelnetServer()
+	{
+	}
+
+	virtual ~TelnetServer()
+	{
+	}
+
 	//	void setCommandDelegate(TelnetServerCommandDelegate reqDelegate);
 	void enableDebug(bool reqStatus);
 	void enableCommand(bool reqStatus);
@@ -40,7 +43,7 @@ public:
 private:
 	void onClient(TcpClient* client);
 	bool onClientReceive(TcpClient& client, char* data, int size);
-	void onClientComplete(TcpClient& client, bool succesfull);
+	void onClientComplete(TcpClient& client, bool successful);
 	void wrchar(char c);
 	TcpClient* curClient = nullptr;
 	CommandExecutor* commandExecutor = nullptr;

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -2,7 +2,7 @@
 #include <SmingCore/SmingCore.h>
 //#include <SmingCore/Network/WebConstants.h>
 #include <SmingCore/Network/TelnetServer.h>
-//#include <SmingCore/Debug.h>
+#include <SmingCore/Debug.h>
 //#include <Libraries/ArduCAM/ArduCAM.h>
 //#include <Libraries/ArduCAM/ov2640_regs.h>
 


### PR DESCRIPTION
Consistent use of braces
Tidy #includes
NULL -> nullptr
Move trivial code into header
Some methods are const
Ensure ALL member variables have initializers; remove corresponding redundant assignments from constructors
Used unsigned types where appropriate

Remove `TcpServer` as friend of `TcpConnection`, use accessor methods instead

`TcpConnection`: Move callback handler code out of static methods 