### PR TITLE
Fix/file stream size tracking

### DIFF
--- a/Sming/SmingCore/Data/Stream/FileStream.cpp
+++ b/Sming/SmingCore/Data/Stream/FileStream.cpp
@@ -76,16 +76,19 @@ size_t FileStream::write(const uint8_t* buffer, size_t size)
 		return 0;
 	}
 
-	int pos = fileSeek(handle, 0, eSO_FileEnd);
-	if(!check(pos)) {
+	int writePos = fileSeek(handle, 0, eSO_FileEnd);
+	if(!check(writePos)) {
 		return 0;
 	}
 
-	this->pos = size_t(pos);
+	pos = size_t(writePos);
 
 	int written = fileWrite(handle, buffer, size);
 	if(check(written)) {
-		this->pos += size_t(written);
+		pos += size_t(written);
+		if(pos > this->size) {
+			this->size = pos;
+		}
 	}
 
 	return written;
@@ -98,7 +101,10 @@ bool FileStream::seek(int len)
 		return false;
 	}
 
-	pos = newpos;
+	pos = size_t(newpos);
+	if(pos > size) {
+		size = pos;
+	}
 
 	return true;
 }

--- a/Sming/SmingCore/Data/Stream/FileStream.h
+++ b/Sming/SmingCore/Data/Stream/FileStream.h
@@ -45,7 +45,7 @@ public:
 	void attach(file_t file, size_t size);
 
 	/* @deprecated: use open() method */
-	bool attach(const String& fileName, FileOpenFlags openFlags = eFO_ReadOnly)
+	bool attach(const String& fileName, FileOpenFlags openFlags = eFO_ReadOnly) __attribute__((deprecated))
 	{
 		return open(fileName, openFlags);
 	}

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -85,7 +85,7 @@ bool HttpClient::downloadFile(const String& url, const String& saveFileName,
 		file = saveFileName;
 
 	FileStream* fileStream = new FileStream();
-	fileStream->attach(file, eFO_CreateNewAlways | eFO_WriteOnly);
+	fileStream->open(file, eFO_CreateNewAlways | eFO_WriteOnly);
 
 	return send(request(url)->setResponseStream(fileStream)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
 }

--- a/samples/Basic_Serial/app/application.cpp
+++ b/samples/Basic_Serial/app/application.cpp
@@ -201,7 +201,7 @@ void handleCommand(const String& command)
 	if(command.equalsIgnoreCase(_F("cat"))) {
 		String filename = F("Readme.md");
 		FileStream* fileStream = new FileStream;
-		if(fileStream && fileStream->attach(filename, eFO_ReadOnly)) {
+		if(fileStream && fileStream->open(filename, eFO_ReadOnly)) {
 			Serial.printf(_F("Sending \"%s\" (%u bytes)\r\n"), filename.c_str(), fileStream->available());
 			auto demo = new SerialStreamTransmitDemo;
 			demo->begin(Serial1);

--- a/samples/HttpClient/app/application.cpp
+++ b/samples/HttpClient/app/application.cpp
@@ -181,7 +181,7 @@ void connectOk(IPAddress ip, IPAddress mask, IPAddress gateway)
 
 	// Or if you want to directly save the response body to a file then the following can be done
 	//	FileStream* responseBodyFile = new FileStream();
-	//	responseBodyFile->attach("file.name", eFO_CreateNewAlways | eFO_WriteOnly);
+	//	responseBodyFile->open("file.name", eFO_CreateNewAlways | eFO_WriteOnly);
 	//	putRequest->setResponseStream(responseBodyFile); // << the complete body will be stored on your file system
 	// see the implementation of `bool HttpClient::downloadFile(const String& url, const String& saveFileName, ...` for details.
 


### PR DESCRIPTION
Check current position against `size` in `FileStream::write()` and `FileStream::seek()`
Fixes problem where `available()` reports negative value

Also remove deprecated `FileStream::attach(const String&)` usage from samples.