### PR TITLE
Fix: `HardwareSerial` interrupt callback code not in IRAM

### DIFF
--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -156,6 +156,14 @@ void HardwareSerial::callbackHandler(uint32_t status)
 	}
 }
 
+void HardwareSerial::staticCallbackHandler(uart_t* uart, uint32_t status)
+{
+	auto serial = reinterpret_cast<HardwareSerial*>(uart_get_callback_param(uart));
+	if(serial) {
+		serial->callbackHandler(status);
+	}
+}
+
 bool HardwareSerial::updateUartCallback()
 {
 	if(uart == nullptr) {
@@ -167,14 +175,7 @@ bool HardwareSerial::updateUartCallback()
 #else
 	if(HWSDelegate || transmitComplete) {
 #endif
-		setUartCallback(
-			[](uart_t* uart, uint32_t status) {
-				auto serial = reinterpret_cast<HardwareSerial*>(uart_get_callback_param(uart));
-				if(serial) {
-					serial->callbackHandler(status);
-				}
-			},
-			this);
+		setUartCallback(staticCallbackHandler, this);
 		return true;
 	} else {
 		setUartCallback(nullptr, nullptr);

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -419,10 +419,11 @@ private:
 	size_t rxSize = DEFAULT_RX_BUFFER_SIZE;
 
 	/**
-	 * @brief  Interrupt handler for UART0 receive events
+	 * @brief Serial interrupt handler, called by serial driver
 	 * @param uart_t* pointer to UART object
 	 * @param status UART status flags indicating cause(s) of interrupt
 	 */
+	static void IRAM_ATTR staticCallbackHandler(uart_t* uart, uint32_t status);
 	void IRAM_ATTR callbackHandler(uint32_t status);
 
 	/**


### PR DESCRIPTION
Supersedes #1604, fixes #1520 and possibly #1602

Lambda inherits code segment of enclosing statement, i.e. flash. Adding IRAM_ATTR doesn't work, even if it's separated out into a different statement. However, placing the entire `updateUartCallback` method into IRAM_ATTR _does_ work, but is wasteful of RAM. Therefore reverted to regular static callback handler.