### PR TITLE
Add optional `deferMillis` parameter to `System::restart()`

### DIFF
--- a/Sming/SmingCore/Platform/System.cpp
+++ b/Sming/SmingCore/Platform/System.cpp
@@ -6,6 +6,7 @@
  ****/
 
 #include "System.h"
+#include "SimpleTimer.h"
 
 SystemClass System;
 
@@ -80,6 +81,22 @@ void SystemClass::onReady(ISystemReadyHandler* readyHandler)
 				handler->onSystemReady();
 			},
 			reinterpret_cast<uint32_t>(readyHandler));
+	}
+}
+
+void SystemClass::restart(unsigned deferMillis)
+{
+	if(deferMillis == 0) {
+		queueCallback([](uint32_t) { system_restart(); });
+	} else {
+		auto timer = new SimpleTimer;
+		timer->setCallback(
+			[](void* timer) {
+				delete static_cast<SimpleTimer*>(timer);
+				system_restart();
+			},
+			timer);
+		timer->startMs(deferMillis);
 	}
 }
 

--- a/Sming/SmingCore/Platform/System.h
+++ b/Sming/SmingCore/Platform/System.h
@@ -107,12 +107,13 @@ public:
 		return state == eSS_Ready;
 	}
 
-	/** @brief  Restart system
+	/** @brief Request a restart of the system
+	 *  @param deferMillis defer restart request by a number of milliseconds
+	 *  @note A delay is often required to allow network callback code to complete correctly.
+	 *  The restart is always deferred, either using the task queue (if deferMillis == 0)
+	 *  or using a timer. This method always returns immediately.
      */
-	void restart()
-	{
-		system_restart();
-	}
+	void restart(unsigned deferMillis = 0);
 
 	/** @brief  Set the CPU frequency
      *  @param  freq Frequency to set CPU


### PR DESCRIPTION
A system restart may be requested from within a deeply-nested callback routine, such as on network transfer completion. This happens in the `Basic_rBoot` sample application, which I have found occasionally crashes at the end of an update cycle; this is probably more likely in debug mode where there is more going on.

In such scenarios it is best to defer the actual restart request so that the callback can unwind and complete fully. Therefore, this modification will _always_ defer a restart request, using either the task queue (if deferMillis == 0) or a system timer if a longer delay is required by the application.