### PR TITLE
Fix/mqtt fifo memleak

### DIFF
--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -238,6 +238,10 @@ bool MqttClient::connect(const URL& url, const String& clientName, uint32_t sslO
 
 bool MqttClient::publish(const String& topic, const String& content, uint8_t flags)
 {
+	if (requestQueue.full()) {
+		return false;
+	}
+
 	mqtt_message_t* message = (mqtt_message_t*)malloc(sizeof(mqtt_message_t));
 	mqtt_message_init(message);
 	message->common.type = MQTT_TYPE_PUBLISH;
@@ -256,6 +260,10 @@ bool MqttClient::publish(const String& topic, IDataSourceStream* stream, uint8_t
 {
 	if(!stream || stream->available() < 1) {
 		debug_e("Sending empty stream or stream with unknown size is not supported");
+		return false;
+	}
+
+	if (requestQueue.full()) {
 		return false;
 	}
 
@@ -278,6 +286,10 @@ bool MqttClient::subscribe(const String& topic)
 {
 	debug_d("subscription '%s' registered", topic.c_str());
 
+	if (requestQueue.full()) {
+		return false;
+	}
+
 	mqtt_message_t* message = (mqtt_message_t*)malloc(sizeof(mqtt_message_t));
 	mqtt_message_init(message);
 	message->common.type = MQTT_TYPE_SUBSCRIBE;
@@ -292,6 +304,10 @@ bool MqttClient::subscribe(const String& topic)
 bool MqttClient::unsubscribe(const String& topic)
 {
 	debug_d("unsubscribing from '%s'", topic.c_str());
+
+	if (requestQueue.full()) {
+		return false;
+	}
 
 	mqtt_message_t* message = (mqtt_message_t*)malloc(sizeof(mqtt_message_t));
 	mqtt_message_init(message);

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -238,7 +238,7 @@ bool MqttClient::connect(const URL& url, const String& clientName, uint32_t sslO
 
 bool MqttClient::publish(const String& topic, const String& content, uint8_t flags)
 {
-	if (requestQueue.full()) {
+	if(requestQueue.full()) {
 		return false;
 	}
 
@@ -263,7 +263,7 @@ bool MqttClient::publish(const String& topic, IDataSourceStream* stream, uint8_t
 		return false;
 	}
 
-	if (requestQueue.full()) {
+	if(requestQueue.full()) {
 		return false;
 	}
 
@@ -286,7 +286,7 @@ bool MqttClient::subscribe(const String& topic)
 {
 	debug_d("subscription '%s' registered", topic.c_str());
 
-	if (requestQueue.full()) {
+	if(requestQueue.full()) {
 		return false;
 	}
 
@@ -305,7 +305,7 @@ bool MqttClient::unsubscribe(const String& topic)
 {
 	debug_d("unsubscribing from '%s'", topic.c_str());
 
-	if (requestQueue.full()) {
+	if(requestQueue.full()) {
 		return false;
 	}
 

--- a/Sming/Wiring/FIFO.h
+++ b/Sming/Wiring/FIFO.h
@@ -41,6 +41,11 @@ class FIFO : public Countable<T>
       return numberOfElements;
     }
 
+    bool full() const
+    {
+      return (count() >= rawSize);
+    }
+
     const T &operator[](unsigned int index) const
     {
       return raw[index]; /* unsafe */
@@ -67,7 +72,7 @@ FIFO<T, rawSize>::FIFO() : size(rawSize)
 template<typename T, int rawSize>
 bool FIFO<T, rawSize>::enqueue(T element)
 {
-  if (count() >= rawSize)
+  if (full())
   {
     return false;
   }


### PR DESCRIPTION
When adding too many messages to the MQTT requestqueue they get dropped when the queue is full. In this case, the allocated memory is not released. This fix first checks if there is room in  the queue.

May also fix #1576