### PR TITLE
Add HttpClientConnection class

### DIFF
--- a/Sming/SmingCore/Network/Http/HttpClientConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpClientConnection.cpp
@@ -1,0 +1,49 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HttpClientConnection.cpp
+ *
+ ****/
+
+#include "HttpClientConnection.h"
+#include "Data/Stream/FileStream.h"
+
+HttpClientConnection::~HttpClientConnection()
+{
+	// ObjectQueue doesn't own its objects
+	while(requestQueue.count() != 0) {
+		delete requestQueue.dequeue();
+	}
+#ifdef ENABLE_SSL
+	delete sslSessionId;
+#endif
+}
+
+bool HttpClientConnection::send(HttpRequest* request)
+{
+	if(!requestQueue.enqueue(request)) {
+		// the queue is full and we cannot add more requests at the time.
+		debug_e("The request queue is full at the moment");
+		delete request;
+		return false;
+	}
+
+	bool useSsl = (request->uri.Protocol == HTTPS_URL_PROTOCOL);
+
+#ifdef ENABLE_SSL
+	// Based on the URL decide if we should reuse the SSL and TCP pool
+	if(useSsl) {
+		if(sslSessionId == nullptr) {
+			sslSessionId = new SslSessionId;
+		}
+		addSslOptions(request->getSslOptions());
+		pinCertificate(request->sslFingerprints);
+		setSslKeyCert(request->sslKeyCertPair);
+	}
+#endif
+
+	return connect(request->uri.Host, request->uri.Port, useSsl);
+}

--- a/Sming/SmingCore/Network/Http/HttpClientConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpClientConnection.cpp
@@ -9,7 +9,6 @@
  ****/
 
 #include "HttpClientConnection.h"
-#include "Data/Stream/FileStream.h"
 
 HttpClientConnection::~HttpClientConnection()
 {

--- a/Sming/SmingCore/Network/Http/HttpClientConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpClientConnection.h
@@ -1,0 +1,43 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HttpClientConnection.h
+ *
+ ****/
+
+/** @defgroup   HTTP client connection
+ *  @brief      Provides HTTP/S client connection
+ *  @ingroup    http
+ *  @{
+ */
+
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_CLIENT_CONNECTION_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_CLIENT_CONNECTION_H_
+
+#include "HttpConnection.h"
+
+class HttpClientConnection : public HttpConnection
+{
+public:
+	HttpClientConnection() : HttpConnection(&requestQueue)
+	{
+	}
+
+	virtual ~HttpClientConnection();
+
+	/** @brief Queue a request
+	 *  @param request
+	 *  @retval bool true on success
+	 *  @note we take ownership of the request. On error, it is destroyed before returning.
+	 */
+	bool send(HttpRequest* request);
+
+private:
+	RequestQueue requestQueue;
+};
+
+/** @} */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_CLIENT_CONNECTION_H_ */

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -36,8 +36,8 @@ typedef Delegate<int(HttpConnection& client, bool successful)> RequestCompletedD
  */
 class HttpRequest
 {
-	friend class HttpClient;
 	friend class HttpConnection;
+	friend class HttpClientConnection;
 	friend class HttpServerConnection;
 
 public:

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -72,7 +72,8 @@ bool HttpClient::downloadFile(const String& url, const String& saveFileName, Req
 		return false;
 	}
 
-	return send(request(url)->setResponseStream(fileStream)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
+	return send(
+		createRequest(url)->setResponseStream(fileStream)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
 }
 
 // end convenience methods

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -31,25 +31,25 @@ public:
 
 	bool sendRequest(const String& url, RequestCompletedDelegate requestComplete)
 	{
-		return send(request(url)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
+		return send(createRequest(url)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
 	}
 
 	bool sendRequest(const HttpMethod method, const String& url, const HttpHeaders& headers,
 					 RequestCompletedDelegate requestComplete)
 	{
-		return send(request(url)->setMethod(method)->setHeaders(headers)->onRequestComplete(requestComplete));
+		return send(createRequest(url)->setMethod(method)->setHeaders(headers)->onRequestComplete(requestComplete));
 	}
 
 	bool sendRequest(const HttpMethod method, const String& url, const HttpHeaders& headers, const String& body,
 					 RequestCompletedDelegate requestComplete)
 	{
-		return send(
-			request(url)->setMethod(method)->setHeaders(headers)->setBody(body)->onRequestComplete(requestComplete));
+		return send(createRequest(url)->setMethod(method)->setHeaders(headers)->setBody(body)->onRequestComplete(
+			requestComplete));
 	}
 
 	bool downloadString(const String& url, RequestCompletedDelegate requestComplete)
 	{
-		return send(request(url)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
+		return send(createRequest(url)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
 	}
 
 	bool downloadFile(const String& url, RequestCompletedDelegate requestComplete = nullptr)
@@ -72,7 +72,12 @@ public:
 	 */
 	bool send(HttpRequest* request);
 
-	HttpRequest* request(const String& url)
+	HttpRequest* request(const String& url) __attribute__((deprecated))
+	{
+		return createRequest(url);
+	}
+
+	HttpRequest* createRequest(const String& url)
 	{
 		return new HttpRequest(URL(url));
 	}

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -72,11 +72,16 @@ public:
 	 */
 	bool send(HttpRequest* request);
 
+	/** @deprecated Please use createRequest instead */
 	HttpRequest* request(const String& url) __attribute__((deprecated))
 	{
 		return createRequest(url);
 	}
 
+	/** @brief Helper function to create a new request on a URL
+	 *  @param url
+	 *  @retval HttpRequest*
+	 */
 	HttpRequest* createRequest(const String& url)
 	{
 		return new HttpRequest(URL(url));

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -22,7 +22,7 @@
 #include "TcpClient.h"
 #include "Http/HttpCommon.h"
 #include "Http/HttpRequest.h"
-#include "Http/HttpConnection.h"
+#include "Http/HttpClientConnection.h"
 
 class HttpClient
 {
@@ -77,12 +77,6 @@ public:
 		return new HttpRequest(URL(url));
 	}
 
-#ifdef ENABLE_SSL
-	static void freeSslSessionPool();
-#endif
-	static void freeHttpConnectionPool();
-	static void freeRequestQueue();
-
 	/**
 	 * Use this method to clean all request queues and object pools
 	 */
@@ -94,12 +88,7 @@ protected:
 	String getCacheKey(URL url);
 
 protected:
-	static HashMap<String, HttpConnection*> httpConnectionPool;
-	static HashMap<String, RequestQueue*> queue;
-
-#ifdef ENABLE_SSL
-	static HashMap<String, SslSessionId*> sslSessionIdPool;
-#endif
+	static HashMap<String, HttpClientConnection*> httpConnectionPool;
 };
 
 /** @} */

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -27,34 +27,38 @@
 class HttpClient
 {
 public:
-	/* High-Level Method */
+	/* High-Level Methods */
 
-	__forceinline bool sendRequest(const String& url, RequestCompletedDelegate requestComplete)
+	bool sendRequest(const String& url, RequestCompletedDelegate requestComplete)
 	{
 		return send(request(url)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
 	}
 
-	__forceinline bool sendRequest(const HttpMethod method, const String& url, const HttpHeaders& headers,
-								   RequestCompletedDelegate requestComplete)
+	bool sendRequest(const HttpMethod method, const String& url, const HttpHeaders& headers,
+					 RequestCompletedDelegate requestComplete)
 	{
 		return send(request(url)->setMethod(method)->setHeaders(headers)->onRequestComplete(requestComplete));
 	}
 
-	__forceinline bool sendRequest(const HttpMethod method, const String& url, const HttpHeaders& headers,
-								   const String& body, RequestCompletedDelegate requestComplete)
+	bool sendRequest(const HttpMethod method, const String& url, const HttpHeaders& headers, const String& body,
+					 RequestCompletedDelegate requestComplete)
 	{
 		return send(
 			request(url)->setMethod(method)->setHeaders(headers)->setBody(body)->onRequestComplete(requestComplete));
 	}
 
-	bool downloadString(const String& url, RequestCompletedDelegate requestComplete);
-
-	__forceinline bool downloadFile(const String& url, RequestCompletedDelegate requestComplete = NULL)
+	bool downloadString(const String& url, RequestCompletedDelegate requestComplete)
 	{
-		return downloadFile(url, "", requestComplete);
+		return send(request(url)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
 	}
 
-	bool downloadFile(const String& url, const String& saveFileName, RequestCompletedDelegate requestComplete = NULL);
+	bool downloadFile(const String& url, RequestCompletedDelegate requestComplete = nullptr)
+	{
+		return downloadFile(url, nullptr, requestComplete);
+	}
+
+	bool downloadFile(const String& url, const String& saveFileName,
+					  RequestCompletedDelegate requestComplete = nullptr);
 
 	/* Low Level Methods */
 
@@ -68,7 +72,10 @@ public:
 	 */
 	bool send(HttpRequest* request);
 
-	HttpRequest* request(const String& url);
+	HttpRequest* request(const String& url)
+	{
+		return new HttpRequest(URL(url));
+	}
 
 #ifdef ENABLE_SSL
 	static void freeSslSessionPool();


### PR DESCRIPTION
New class simplifies HttpClient and manages request queue and ssl information.
Rename `HttpRequest::request()` to `createRequest()`, deprecate old version.