### PR TITLE
Do not try to apply non-existent patches (#1626)

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -522,8 +522,10 @@ docs: wiki api
 third-party/%:
 	$(vecho) "Fetching $(dir $@) ..."
 	$(Q) $(GIT) submodule update --init --recursive $(dir $@)
-	$(Q) touch $(patsubst third-party/%/,third-party/.patches/%.patch, $(dir $@))
-	$(Q) -cd $(dir $@); $(GIT) apply -v $(patsubst third-party/%/,$(SMING_HOME)/third-party/.patches/%.patch, $(dir $@)) --ignore-whitespace --whitespace=nowarn
+	$(Q) if [ -f $(patsubst third-party/%/,third-party/.patches/%.patch, $(dir $@)) ]; then \
+		touch $(patsubst third-party/%/,third-party/.patches/%.patch, $(dir $@)); \
+		cd $(dir $@); $(GIT) apply -v $(patsubst third-party/%/,$(SMING_HOME)/third-party/.patches/%.patch, $(dir $@)) --ignore-whitespace --whitespace=nowarn; \
+	fi
 # if the new submodule brings source code files that need to be compiled inside Sming
 # then we need somehow to be able to "see" these new files.
 # For now we solve this by "reloading" the makefile after fetching a module.
@@ -532,8 +534,10 @@ third-party/%:
 Libraries/%:
 	$(vecho) "Fetching Arduino Library $(dir $@) ..."
 	$(Q) $(GIT) submodule update --init --recursive $(dir $@)
-	$(Q) touch $(patsubst Libraries/%/,Libraries/.patches/%.patch, $(dir $@))
-	$(Q) -cd $(dir $@); $(GIT) apply -v $(patsubst Libraries/%/,$(SMING_HOME)/Libraries/.patches/%.patch, $(dir $@)) --ignore-whitespace --whitespace=nowarn
+	$(Q) if [ -f $(patsubst Libraries/%/,Libraries/.patches/%.patch, $(dir $@)) ]; then \
+		touch $(patsubst Libraries/%/,Libraries/.patches/%.patch, $(dir $@)); \
+		cd $(dir $@); $(GIT) apply -v $(patsubst Libraries/%/,$(SMING_HOME)/Libraries/.patches/%.patch, $(dir $@)) --ignore-whitespace --whitespace=nowarn; \
+	fi
 # if the new submodule brings source code files that need to be compiled inside Sming
 # then we need somehow to be able to "see" these new files.
 # For now we solve this by "reloading" the makefile after fetching a module.


### PR DESCRIPTION
Current build system assumes that all Arduino libraries
have relevant patches and tries to apply those without
checking if patches really exist. Fix this by checking
if patch file exists before applying it.

Signed-off-by: Oleksandr Andrushchenko <andr2000@gmail.com>