### PR TITLE
Ensure all core code has standard header and consistent guard naming

### DIFF
--- a/Sming/SmingCore/ArduinoCompat.cpp
+++ b/Sming/SmingCore/ArduinoCompat.cpp
@@ -4,7 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * Arduino Compatibility Layer
+ * ArduinoCompact.cpp - Arduino Compatibility Layer
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *

--- a/Sming/SmingCore/ArduinoCompat.h
+++ b/Sming/SmingCore/ArduinoCompat.h
@@ -4,14 +4,14 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * Arduino Compatibility Layer
+ * ArduinoCompat.h - Arduino Compatibility Layer
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
  ****/
 
-#ifndef SMINGCORE_ARDUINOCOMPAT_H_
-#define SMINGCORE_ARDUINOCOMPAT_H_
+#ifndef _SMING_CORE_ARDUINO_COMPAT_H_
+#define _SMING_CORE_ARDUINO_COMPAT_H_
 
 #include "SmingCore.h"
 #include <stdio.h> ///< sprintf()
@@ -29,4 +29,4 @@ void yield();
 }
 #endif
 
-#endif /* SMINGCORE_ARDUINOCOMPAT_H_ */
+#endif /* _SMING_CORE_ARDUINO_COMPAT_H_ */

--- a/Sming/SmingCore/AtClient.cpp
+++ b/Sming/SmingCore/AtClient.cpp
@@ -1,9 +1,15 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * AtClient.cpp
  *
  *  Created on: Feb 23, 2017
  *      Author: slavey
- */
+ *
+ ****/
 
 #include "AtClient.h"
 #include "Clock.h"

--- a/Sming/SmingCore/AtClient.h
+++ b/Sming/SmingCore/AtClient.h
@@ -3,6 +3,9 @@
  * Created 2017 by Slavey Karadzhov
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * AtClient.h
+ *
  ****/
 
 /**	@defgroup serial AtCommand serial

--- a/Sming/SmingCore/Clock.cpp
+++ b/Sming/SmingCore/Clock.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Clock.cpp
+ *
  ****/
 
 #include "Clock.h"

--- a/Sming/SmingCore/Clock.h
+++ b/Sming/SmingCore/Clock.h
@@ -3,7 +3,11 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Clock.h
+ *
  ****/
+
 /** @defgroup   timedelay Time and Delay
  *  @brief      Provides time and delay functions
  *  @ingroup    datetime

--- a/Sming/SmingCore/Data/CStringArray.cpp
+++ b/Sming/SmingCore/Data/CStringArray.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * CStringArray.cpp
+ *
  * @author: 2018 - Mikee47 <mike@sillyhouse.net>
  *
  ****/

--- a/Sming/SmingCore/Data/CStringArray.h
+++ b/Sming/SmingCore/Data/CStringArray.h
@@ -4,12 +4,14 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * CStringArray.h
+ *
  * @author: 2018 - Mikee47 <mike@sillyhouse.net>
  *
  ****/
 
-#ifndef _SMING_CORE_DATA_STRING_ARRAY_H_
-#define _SMING_CORE_DATA_STRING_ARRAY_H_
+#ifndef _SMING_CORE_DATA_C_STRING_ARRAY_H_
+#define _SMING_CORE_DATA_C_STRING_ARRAY_H_
 
 #include "WString.h"
 
@@ -119,4 +121,4 @@ private:
 	mutable unsigned stringCount = 0;
 };
 
-#endif // _SMING_CORE_DATA_STRING_ARRAY_H_
+#endif // _SMING_CORE_DATA_C_STRING_ARRAY_H_

--- a/Sming/SmingCore/Data/CircularBuffer.cpp
+++ b/Sming/SmingCore/Data/CircularBuffer.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * CircularBuffer.cpp
+ *
  * Initial code done by Ivan Grokhotkov as part of the esp8266 core for Arduino environment.
  * https://github.com/esp8266/Arduino/blob/master/cores/esp8266/cbuf.h
  *

--- a/Sming/SmingCore/Data/CircularBuffer.h
+++ b/Sming/SmingCore/Data/CircularBuffer.h
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * CircularBuffer.h
+ *
  * Initial code done by Ivan Grokhotkov as part of the esp8266 core for Arduino environment.
  * https://github.com/esp8266/Arduino/blob/master/cores/esp8266/cbuf.h
  *

--- a/Sming/SmingCore/Data/HexString.cpp
+++ b/Sming/SmingCore/Data/HexString.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * HexString.cpp
+ *
  */
 
 #include "HexString.h"

--- a/Sming/SmingCore/Data/HexString.h
+++ b/Sming/SmingCore/Data/HexString.h
@@ -4,13 +4,14 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * HexString.h - Utility functions to deal with hex-encoded strings
+ *
  * @author: 2018 - Mikee47 <mike@sillyhouse.net>
  *
- * Utility functions to deal with hex-encoded strings
  */
 
-#ifndef _HEX_STRING_H_
-#define _HEX_STRING_H_
+#ifndef _SMING_CORE_DATA_HEX_STRING_H_
+#define _SMING_CORE_DATA_HEX_STRING_H_
 
 #include "WString.h"
 
@@ -22,4 +23,4 @@
  */
 String makeHexString(const uint8_t* data, unsigned length, char separator = '\0');
 
-#endif // _HEX_STRING_H_
+#endif /* _SMING_CORE_DATA_HEX_STRING_H_ */

--- a/Sming/SmingCore/Data/MailMessage.cpp
+++ b/Sming/SmingCore/Data/MailMessage.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * MailMessage.cpp
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Data/MailMessage.h
+++ b/Sming/SmingCore/Data/MailMessage.h
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * MailMessage.h
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/
@@ -14,13 +16,12 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_DATA_MESSAGE_H_
-#define _SMING_CORE_DATA_MESSAGE_H_
+#ifndef _SMING_CORE_DATA_MAIL_MESSAGE_H_
+#define _SMING_CORE_DATA_MAIL_MESSAGE_H_
 
-#include "../../Wiring/WString.h"
-#include "../../Wiring/WVector.h"
-#include "../Network/WebConstants.h"
-
+#include "WString.h"
+#include "WVector.h"
+#include "Network/WebConstants.h"
 #include "Network/Http/HttpHeaders.h"
 #include "Stream/MultipartStream.h"
 #include "Stream/DataSourceStream.h"
@@ -78,4 +79,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_MESSAGE_H_ */
+#endif /* _SMING_CORE_DATA_MAIL_MESSAGE_H_ */

--- a/Sming/SmingCore/Data/ObjectQueue.h
+++ b/Sming/SmingCore/Data/ObjectQueue.h
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * ObjectQueue.h
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  * @author: 12 Aug 2018 - Mikee47 <mike@sillyhouse.net>

--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * Base64OutputStream.cpp
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Data/Stream/Base64OutputStream.h
+++ b/Sming/SmingCore/Data/Stream/Base64OutputStream.h
@@ -4,12 +4,14 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * Base64OutputStream.h
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/
 
-#ifndef _SMING_CORE_DATA_BASE64_OUTPUT_STREAM_H_
-#define _SMING_CORE_DATA_BASE64_OUTPUT_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_BASE64_OUTPUT_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_BASE64_OUTPUT_STREAM_H_
 
 #include "../StreamTransformer.h"
 #include "../Services/libb64/cencode.h"
@@ -49,4 +51,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_BASE64_OUTPUT_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_BASE64_OUTPUT_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
+++ b/Sming/SmingCore/Data/Stream/ChunkedStream.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * ChunkedStream.cpp
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Data/Stream/ChunkedStream.h
+++ b/Sming/SmingCore/Data/Stream/ChunkedStream.h
@@ -4,12 +4,14 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * ChunkedStream.h
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/
 
-#ifndef _SMING_CORE_DATA_CHUNKED_STREAM_H_
-#define _SMING_CORE_DATA_CHUNKED_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_CHUNKED_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_CHUNKED_STREAM_H_
 
 #include "../StreamTransformer.h"
 
@@ -30,4 +32,4 @@ protected:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_CHUNKED_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_CHUNKED_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/DataSourceStream.cpp
+++ b/Sming/SmingCore/Data/Stream/DataSourceStream.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * DataSourceStream.cpp
+ *
  ****/
 
 #include "DataSourceStream.h"

--- a/Sming/SmingCore/Data/Stream/DataSourceStream.h
+++ b/Sming/SmingCore/Data/Stream/DataSourceStream.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * DataSourceStream.h
+ *
  ****/
 
-#ifndef _SMING_CORE_DATA_DATA_SOURCE_STREAM_H_
-#define _SMING_CORE_DATA_DATA_SOURCE_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_DATA_SOURCE_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_DATA_SOURCE_STREAM_H_
 
 #include <user_config.h>
 #include "Stream.h"
@@ -141,4 +144,4 @@ public:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_DATA_SOURCE_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_DATA_SOURCE_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/EndlessMemoryStream.cpp
+++ b/Sming/SmingCore/Data/Stream/EndlessMemoryStream.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * EndlessMemoryStream.cpp
+ *
  ****/
 
 #include "EndlessMemoryStream.h"

--- a/Sming/SmingCore/Data/Stream/EndlessMemoryStream.h
+++ b/Sming/SmingCore/Data/Stream/EndlessMemoryStream.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * EndlessMemoryStream.h
+ *
  ****/
 
-#ifndef _SMING_CORE_ENDLESS_MEMORY_STREAM_H_
-#define _SMING_CORE_ENDLESS_MEMORY_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_ENDLESS_MEMORY_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_ENDLESS_MEMORY_STREAM_H_
 
 #include "MemoryDataStream.h"
 
@@ -59,4 +62,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_ENDLESS_MEMORY_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_ENDLESS_MEMORY_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/FileStream.cpp
+++ b/Sming/SmingCore/Data/Stream/FileStream.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * FileStream.cpp
+ *
  ****/
 
 #include "FileStream.h"

--- a/Sming/SmingCore/Data/Stream/FileStream.h
+++ b/Sming/SmingCore/Data/Stream/FileStream.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * FileStream.h
+ *
  ****/
 
 #ifndef _SMING_CORE_DATA_FILE_STREAM_H_

--- a/Sming/SmingCore/Data/Stream/FlashMemoryStream.cpp
+++ b/Sming/SmingCore/Data/Stream/FlashMemoryStream.cpp
@@ -4,6 +4,8 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * FlashMemoryStream.cpp
+ *
  * @author: 23 Oct 2018 - mikee47 <mike@sillyhouse.net>
  *
  ****/

--- a/Sming/SmingCore/Data/Stream/FlashMemoryStream.h
+++ b/Sming/SmingCore/Data/Stream/FlashMemoryStream.h
@@ -4,12 +4,14 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * FlashMemoryStream.h
+ *
  * @author: 23 Oct 2018 - mikee47 <mike@sillyhouse.net>
  *
  ****/
 
-#ifndef _SMING_CORE_DATA_FLASH_MEMORY_STREAM_H_
-#define _SMING_CORE_DATA_FLASH_MEMORY_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_FLASH_MEMORY_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_FLASH_MEMORY_STREAM_H_
 
 #include "DataSourceStream.h"
 
@@ -59,4 +61,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_FLASH_MEMORY_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_FLASH_MEMORY_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/JsonObjectStream.cpp
+++ b/Sming/SmingCore/Data/Stream/JsonObjectStream.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * JsonObjectStream.cpp
+ *
  ****/
 
 #include "JsonObjectStream.h"

--- a/Sming/SmingCore/Data/Stream/JsonObjectStream.h
+++ b/Sming/SmingCore/Data/Stream/JsonObjectStream.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * JsonObjectStream.h
+ *
  ****/
 
-#ifndef _SMING_CORE_DATA_JSON_OBJECT_STREAM_H_
-#define _SMING_CORE_DATA_JSON_OBJECT_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_JSON_OBJECT_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_JSON_OBJECT_STREAM_H_
 
 #include "MemoryDataStream.h"
 #include "../Libraries/ArduinoJson/include/ArduinoJson.h"
@@ -59,4 +62,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_JSON_OBJECT_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_JSON_OBJECT_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/LimitedMemoryStream.cpp
+++ b/Sming/SmingCore/Data/Stream/LimitedMemoryStream.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * LimitedMemoryStream.cpp
+ *
  ****/
 
 #include "LimitedMemoryStream.h"

--- a/Sming/SmingCore/Data/Stream/LimitedMemoryStream.h
+++ b/Sming/SmingCore/Data/Stream/LimitedMemoryStream.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * LimitedMemoryStream.h
+ *
  ****/
 
-#ifndef _SMING_CORE_DATA_LIMITED_MEMORY_STREAM_H_
-#define _SMING_CORE_DATA_LIMITED_MEMORY_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_LIMITED_MEMORY_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_LIMITED_MEMORY_STREAM_H_
 
 #include "ReadWriteStream.h"
 
@@ -70,4 +73,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_LIMITED_MEMORY_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_LIMITED_MEMORY_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/MemoryDataStream.cpp
+++ b/Sming/SmingCore/Data/Stream/MemoryDataStream.cpp
@@ -3,11 +3,12 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * MemoryDataStream.cpp
+ *
  ****/
 
 #include "MemoryDataStream.h"
-
-/* MemoryDataStream */
 
 size_t MemoryDataStream::write(const uint8_t* data, size_t len)
 {

--- a/Sming/SmingCore/Data/Stream/MemoryDataStream.h
+++ b/Sming/SmingCore/Data/Stream/MemoryDataStream.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * MemoryDataStream.h
+ *
  ****/
 
-#ifndef _SMING_CORE_DATA_MEMORY_DATA_STREAM_H_
-#define _SMING_CORE_DATA_MEMORY_DATA_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_MEMORY_DATA_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_MEMORY_DATA_STREAM_H_
 
 #include "ReadWriteStream.h"
 
@@ -83,4 +86,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_MEMORY_DATA_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_MEMORY_DATA_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/MultiStream.cpp
+++ b/Sming/SmingCore/Data/Stream/MultiStream.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * MultiStream.cpp
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Data/Stream/MultiStream.h
+++ b/Sming/SmingCore/Data/Stream/MultiStream.h
@@ -1,12 +1,18 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * MultiStream.h
  *
  *  Created on: Nov 7, 2018
  *      Author: slavey
- */
+ *
+ ****/
 
-#ifndef SMINGCORE_DATA_STREAM_MULTISTREAM_H_
-#define SMINGCORE_DATA_STREAM_MULTISTREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_MULTISTREAM_H_
+#define _SMING_CORE_DATA_STREAM_MULTISTREAM_H_
 
 #include "DataSourceStream.h"
 
@@ -63,4 +69,4 @@ protected:
 	bool finished = false;
 };
 
-#endif /* SMINGCORE_DATA_STREAM_MULTISTREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_MULTISTREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/MultipartStream.cpp
+++ b/Sming/SmingCore/Data/Stream/MultipartStream.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * MultipartStream.cpp
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Data/Stream/MultipartStream.h
+++ b/Sming/SmingCore/Data/Stream/MultipartStream.h
@@ -4,12 +4,14 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * MultipartStream.h
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/
 
-#ifndef _SMING_CORE_DATA_MULTIPART_STREAM_H_
-#define _SMING_CORE_DATA_MULTIPART_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_MULTIPART_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_MULTIPART_STREAM_H_
 
 #include "MultiStream.h"
 #include "Delegate.h"
@@ -61,4 +63,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_MULTIPART_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_MULTIPART_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * QuotedPrintableOutputStream.cpp
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.h
+++ b/Sming/SmingCore/Data/Stream/QuotedPrintableOutputStream.h
@@ -4,12 +4,14 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * QuotedPrintableOutputStream.h
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/
 
-#ifndef _SMING_CORE_DATA_QUOTED_PRINTABLE_OUTPUT_STREAM_H_
-#define _SMING_CORE_DATA_QUOTED_PRINTABLE_OUTPUT_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_QUOTED_PRINTABLE_OUTPUT_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_QUOTED_PRINTABLE_OUTPUT_STREAM_H_
 
 #include "../StreamTransformer.h"
 
@@ -39,4 +41,4 @@ protected:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_QUOTED_PRINTABLE_OUTPUT_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_QUOTED_PRINTABLE_OUTPUT_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/ReadWriteStream.h
+++ b/Sming/SmingCore/Data/Stream/ReadWriteStream.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * ReadWriteStream.h
+ *
  ****/
 
-#ifndef _SMING_CORE_DATA_READ_WRITE_STREAM_H_
-#define _SMING_CORE_DATA_READ_WRITE_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_READ_WRITE_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_READ_WRITE_STREAM_H_
 
 #include "DataSourceStream.h"
 
@@ -44,4 +47,4 @@ public:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_READ_WRITE_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_READ_WRITE_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/StreamChain.h
+++ b/Sming/SmingCore/Data/Stream/StreamChain.h
@@ -2,14 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * StreamChain.h
  *
  * @author: 2018 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_CORE_DATA_READ_STREAM_CHAIN_H_
-#define _SMING_CORE_DATA_READ_STREAM_CHAIN_H_
+#ifndef _SMING_CORE_DATA_STREAM_STREAM_CHAIN_H_
+#define _SMING_CORE_DATA_STREAM_STREAM_CHAIN_H_
 
 #include "MultiStream.h"
 #include "../ObjectQueue.h"
@@ -46,4 +48,4 @@ private:
 	StreamChainQueue queue;
 };
 
-#endif /* _SMING_CORE_DATA_READ_STREAM_CHAIN_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_STREAM_CHAIN_H_ */

--- a/Sming/SmingCore/Data/Stream/TemplateFileStream.h
+++ b/Sming/SmingCore/Data/Stream/TemplateFileStream.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TemplateFileStream.h
+ *
  ****/
 
-#ifndef _SMING_CORE_DATA_TEMPLATE_FILE_STREAM_H_
-#define _SMING_CORE_DATA_TEMPLATE_FILE_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_TEMPLATE_FILE_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_TEMPLATE_FILE_STREAM_H_
 
 #include "FileStream.h"
 #include "TemplateStream.h"
@@ -31,4 +34,4 @@ public:
 
 /** @} */
 
-#endif /* _SMING_CORE_DATA_TEMPLATE_FILE_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_TEMPLATE_FILE_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/TemplateFlashMemoryStream.h
+++ b/Sming/SmingCore/Data/Stream/TemplateFlashMemoryStream.h
@@ -4,12 +4,14 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * TemplateFlashMemoryStream.h
+ *
  * @author: 23 Oct 2018 - mikee47 <mike@sillyhouse.net>
  *
  ****/
 
-#ifndef _SMING_CORE_DATA_TEMPLATE_FLASH_MEMORY_STREAM_H_
-#define _SMING_CORE_DATA_TEMPLATE_FLASH_MEMORY_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_TEMPLATE_FLASH_MEMORY_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_TEMPLATE_FLASH_MEMORY_STREAM_H_
 
 #include "FlashMemoryStream.h"
 #include "TemplateStream.h"
@@ -34,4 +36,4 @@ public:
 
 /** @} */
 
-#endif /* _SMING_CORE_DATA_TEMPLATE_FLASH_MEMORY_STREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_TEMPLATE_FLASH_MEMORY_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/TemplateStream.cpp
+++ b/Sming/SmingCore/Data/Stream/TemplateStream.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TemplateStream.cpp
+ *
  ****/
 
 #include "TemplateStream.h"

--- a/Sming/SmingCore/Data/Stream/TemplateStream.h
+++ b/Sming/SmingCore/Data/Stream/TemplateStream.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TemplateStream.h
+ *
  ****/
 
-#ifndef _SMING_CORE_DATA_TEMPLATE_STREAM_H_
-#define _SMING_CORE_DATA_TEMPLATE_STREAM_H_
+#ifndef _SMING_CORE_DATA_STREAM_TEMPLATE_STREAM_H_
+#define _SMING_CORE_DATA_STREAM_TEMPLATE_STREAM_H_
 
 #include "DataSourceStream.h"
 #include "WHashMap.h"
@@ -123,4 +126,4 @@ private:
 
 /** @} */
 
-#endif /* _SMING_CORE_DATA_TEMPLATESTREAM_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_TEMPLATE_STREAM_H_ */

--- a/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * UrlencodedOutputStream.cpp
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.h
+++ b/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.h
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * UrlencodedOutputStream.h
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Data/StreamTransformer.cpp
+++ b/Sming/SmingCore/Data/StreamTransformer.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * StreamTransformer.cpp
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Data/StreamTransformer.h
+++ b/Sming/SmingCore/Data/StreamTransformer.h
@@ -4,12 +4,14 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * StreamTransformer.h
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/
 
-#ifndef _SMING_CORE_DATA_STREAMTRANSFORMER_H_
-#define _SMING_CORE_DATA_STREAMTRANSFORMER_H_
+#ifndef _SMING_CORE_DATA_STREAM_TRANSFORMER_H_
+#define _SMING_CORE_DATA_STREAM_TRANSFORMER_H_
 
 #include "CircularBuffer.h"
 
@@ -118,4 +120,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_DATA_STREAMTRANSFORMER_H_ */
+#endif /* _SMING_CORE_DATA_STREAM_TRANSFORMER_H_ */

--- a/Sming/SmingCore/Debug.cpp
+++ b/Sming/SmingCore/Debug.cpp
@@ -1,7 +1,12 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * Debug.cpp
  *
- */
+ ****/
 
 #include "Debug.h"
 

--- a/Sming/SmingCore/Debug.h
+++ b/Sming/SmingCore/Debug.h
@@ -1,10 +1,15 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * Debug.h
  *
- */
+ ****/
 
-#ifndef SMINGCORE_DEBUG_H_
-#define SMINGCORE_DEBUG_H_
+#ifndef _SMING_CORE_DEBUG_H_
+#define _SMING_CORE_DEBUG_H_
 
 #include "HardwareSerial.h"
 #include "Clock.h"
@@ -105,4 +110,4 @@ private:
 extern DebugClass Debug;
 
 /** @} */
-#endif /* SMINGCORE_DEBUG_H_ */
+#endif /* _SMING_CORE_DEBUG_H_ */

--- a/Sming/SmingCore/Delegate.h
+++ b/Sming/SmingCore/Delegate.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Delegate.h
+ *
  ****/
 
 /** @defgroup   delegate Delegate
@@ -10,8 +13,8 @@
  *              Several handlers may be triggered for each event
  *  @{
  */
-#ifndef SMINGCORE_DELEGATE_H_
-#define SMINGCORE_DELEGATE_H_
+#ifndef _SMING_CORE_DELEGATE_H_
+#define _SMING_CORE_DELEGATE_H_
 
 #include <user_config.h>
 
@@ -239,4 +242,4 @@ private:
 };
 
 /** @} */
-#endif /* SMINGCORE_DELEGATE_H_ */
+#endif /* _SMING_CORE_DELEGATE_H_ */

--- a/Sming/SmingCore/Digital.cpp
+++ b/Sming/SmingCore/Digital.cpp
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Digital.cpp
+ *
  ****/
 
-#include "../SmingCore/Digital.h"
-#include "../Wiring/WiringFrameworkIncludes.h"
+#include "Digital.h"
+#include "WiringFrameworkIncludes.h"
 #include "espinc/peri.h"
 
 const unsigned int A0 = 17; // Single ESP8266EX analog input pin (TOUT) 10 bit, 0..1v

--- a/Sming/SmingCore/Digital.h
+++ b/Sming/SmingCore/Digital.h
@@ -3,15 +3,19 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Digital.h
+ *
  ****/
+
 /** @defgroup   gpio GPIO functions
  *  @brief      Provides general purpose input and output (GPIO) functions
  *  @see        pwm
  *  @{
 */
 
-#ifndef _NWDigital_H_
-#define _NWDigital_H_
+#ifndef _SMING_CORE_DIGITAL_H_
+#define _SMING_CORE_DIGITAL_H_
 
 #include "../SmingCore/ESP8266EX.h"
 #include "../Wiring/WiringFrameworkDependencies.h"
@@ -71,4 +75,4 @@ inline uint16_t analogRead(uint16_t pin)
 
 /** @} */
 
-#endif
+#endif /* _SMING_CORE_DIGITAL_H_ */

--- a/Sming/SmingCore/ESP8266EX.cpp
+++ b/Sming/SmingCore/ESP8266EX.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * ESP8266EX.cpp
+ *
  ****/
 
 #include "Digital.h"

--- a/Sming/SmingCore/ESP8266EX.h
+++ b/Sming/SmingCore/ESP8266EX.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * ESP8266EX.h
+ *
  ****/
 
 #ifndef _SMING_CORE_ESP8266EX_H_

--- a/Sming/SmingCore/FileSystem.cpp
+++ b/Sming/SmingCore/FileSystem.cpp
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * FileSystem.cpp
+ *
  ****/
 
 #include "FileSystem.h"
-#include "../Wiring/WString.h"
+#include "WString.h"
 
 file_t fileOpen(const String& name, FileOpenFlags flags)
 {

--- a/Sming/SmingCore/FileSystem.h
+++ b/Sming/SmingCore/FileSystem.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * FileSystem.h
+ *
  ****/
 
 /**	@defgroup filesystem File system
@@ -10,11 +13,11 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_FILESYSTEM_H_
-#define _SMING_CORE_FILESYSTEM_H_
+#ifndef _SMING_CORE_FILE_SYSTEM_H_
+#define _SMING_CORE_FILE_SYSTEM_H_
 
 #include "../Services/SpifFS/spiffs_sming.h"
-#include "../Wiring/WVector.h"
+#include "WVector.h"
 
 class String;
 
@@ -197,4 +200,4 @@ void fileDelete(file_t file);
 bool fileExist(const String& name);
 
 /** @} */
-#endif /* _SMING_CORE_FILESYSTEM_H_ */
+#endif /* _SMING_CORE_FILE_SYSTEM_H_ */

--- a/Sming/SmingCore/HardwarePWM.cpp
+++ b/Sming/SmingCore/HardwarePWM.cpp
@@ -1,5 +1,11 @@
-/*
- * File: HardwarePWM.cpp
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HardwarePWM.cpp
+ *
  * Original Author: https://github.com/hrsavla
  *
  * This HardwarePWM library enables Sming framework user to use ESP SDK PWM API
@@ -14,6 +20,7 @@
  *
  * See also ESP8266 Technical Reference, Chapter 12:
  * http://espressif.com/sites/default/files/documentation/esp8266-technical_reference_en.pdf
+ *
  */
 
 #include "Clock.h"

--- a/Sming/SmingCore/HardwarePWM.h
+++ b/Sming/SmingCore/HardwarePWM.h
@@ -1,5 +1,11 @@
-/*
- * File: HardwarePWM.h
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HardwarePWM.h
+ *
  * Original Author: https://github.com/hrsavla
  *
  * This HW_PWM library enables Sming framework user to use ESP SDK PWM API
@@ -11,14 +17,16 @@
  *
  * PWM can be generated on upto 8 pins (ie All pins except pin 16)
  * Created on August 17, 2015, 2:27 PM
- */
+ *
+ ****/
+
 /** @defgroup   hw_pwm Hardware PWM functions
  *  @brief      Provides hardware pulse width modulation functions
  *  @{
 */
 
-#ifndef HARDWAREPWM_H
-#define HARDWAREPWM_H
+#ifndef _SMING_CORE_HARDWARE_PWM_H_
+#define _SMING_CORE_HARDWARE_PWM_H_
 
 #include "ESP8266EX.h"
 #include "WiringFrameworkDependencies.h"
@@ -130,4 +138,4 @@ private:
 };
 
 /** @} */
-#endif /* HARDWAREPWM_H */
+#endif /* _SMING_CORE_HARDWARE_PWM_H_ */

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -3,9 +3,12 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HardwareSerial.cpp
+ *
+ * HardwareSerial based on Espressif Systems' code
+ *
  ****/
-
-// HardwareSerial based on Espressif Systems code
 
 #include "HardwareSerial.h"
 #include <cstdarg>

--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HardwareSerial.h
+ *
  ****/
 
 /**	@defgroup serial Hardware serial
@@ -10,8 +13,8 @@
  *  @{
  */
 
-#ifndef _HARDWARESERIAL_H_
-#define _HARDWARESERIAL_H_
+#ifndef _SMING_CORE_HARDWARE_SERIAL_H_
+#define _SMING_CORE_HARDWARE_SERIAL_H_
 
 #include "WiringFrameworkDependencies.h"
 #include "Data/Stream/ReadWriteStream.h"
@@ -446,4 +449,4 @@ private:
 extern HardwareSerial Serial;
 
 /** @} */
-#endif /* _HARDWARESERIAL_H_ */
+#endif /* _SMING_CORE_HARDWARE_SERIAL_H_ */

--- a/Sming/SmingCore/HardwareTimer.cpp
+++ b/Sming/SmingCore/HardwareTimer.cpp
@@ -1,10 +1,13 @@
-/*
- * HWTimer.cpp
- *
+/****
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
- * Created 23.11.2015 by johndoe
+ * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HWTimer.cpp
+ *
+ * Created 23.11.2015 by johndoe
+ *
  ****/
 
 #include "HardwareTimer.h"

--- a/Sming/SmingCore/HardwareTimer.h
+++ b/Sming/SmingCore/HardwareTimer.h
@@ -1,10 +1,13 @@
-/*
- * HWTimer.h
- *
+/****
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
- * Created 23.11.2015 by johndoe
+ * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HardwareTimer.h
+ *
+ * Created 23.11.2015 by johndoe
+ *
  ****/
 
 /**	@defgroup hwtimer Hardware timer

--- a/Sming/SmingCore/Interrupts.cpp
+++ b/Sming/SmingCore/Interrupts.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Interrupts.cpp
+ *
  ****/
 
 #include "Interrupts.h"

--- a/Sming/SmingCore/Interrupts.h
+++ b/Sming/SmingCore/Interrupts.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Interrupts.h
+ *
  ****/
 
 /** @defgroup   interrupts Interrupt functions

--- a/Sming/SmingCore/Network/DNSServer.cpp
+++ b/Sming/SmingCore/Network/DNSServer.cpp
@@ -3,6 +3,8 @@
  * http://github.com/anakod/Sming
  * This file is provided under the LGPL v3 license.
  *
+ * DnsServer.cpp
+ *
  * File Author: https://github.com/patrickjahns
  *
  * The code is a port of the following projects
@@ -10,7 +12,9 @@
  * https://github.com/esp8266/Arduino/tree/master/libraries/DNSServer
  *
  * Created on March 4, 2016
- */
+ *
+ ****/
+
 #include "DNSServer.h"
 #include "UdpConnection.h"
 #include "WString.h"

--- a/Sming/SmingCore/Network/DNSServer.h
+++ b/Sming/SmingCore/Network/DNSServer.h
@@ -1,7 +1,10 @@
-/* This file is part of Sming Framework Project
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
- * This file is provided under the LGPL v3 license.
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * DnsServer.h
  *
  * File Author: https://github.com/patrickjahns
  *
@@ -9,15 +12,16 @@
  * https://github.com/israellot/esp-ginx/tree/master/app/dns
  * https://github.com/esp8266/Arduino/tree/master/libraries/DNSServer
  * Created on March 4, 2016
- */
+ *
+ ****/
 
 /** @defgroup   dnsserver DNS server
  *  @brief      Provides DNS server
  *  @ingroup    udp
  *  @{
  */
-#ifndef DNSServer_h
-#define DNSServer_h
+#ifndef _SMING_CORE_NETWORK_DNS_SERVER_H_
+#define _SMING_CORE_NETWORK_DNS_SERVER_H_
 
 #include "UdpConnection.h"
 #include "WString.h"
@@ -95,4 +99,4 @@ private:
 };
 
 /** @} */
-#endif //DNSServer_h
+#endif /* _SMING_CORE_NETWORK_DNS_SERVER_H_ */

--- a/Sming/SmingCore/Network/FTPServer.cpp
+++ b/Sming/SmingCore/Network/FTPServer.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * FtpServer.cpp
+ *
  ****/
 
 #include "FTPServer.h"

--- a/Sming/SmingCore/Network/FTPServer.h
+++ b/Sming/SmingCore/Network/FTPServer.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * FtpServer.h
+ *
  ****/
 
 /** @defgroup   ftpserver FTP server
@@ -11,8 +14,8 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_FTPSERVER_H_
-#define _SMING_CORE_FTPSERVER_H_
+#ifndef _SMING_CORE_NETWORK_FTP_SERVER_H_
+#define _SMING_CORE_NETWORK_FTP_SERVER_H_
 
 #include "TcpServer.h"
 #include "WHashMap.h"
@@ -42,4 +45,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_FTPServer_H_ */
+#endif /* _SMING_CORE_NETWORK_FTP_SERVER_H_ */

--- a/Sming/SmingCore/Network/FTPServerConnection.cpp
+++ b/Sming/SmingCore/Network/FTPServerConnection.cpp
@@ -1,3 +1,13 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * FtpServerConnection.cpp
+ *
+ ****/
+
 #include "FTPServerConnection.h"
 #include "FTPServer.h"
 #include "NetUtils.h"

--- a/Sming/SmingCore/Network/FTPServerConnection.h
+++ b/Sming/SmingCore/Network/FTPServerConnection.h
@@ -1,5 +1,15 @@
-#ifndef SMINGCORE_NETWORK_FTPSERVERCONNECTION_H_
-#define SMINGCORE_NETWORK_FTPSERVERCONNECTION_H_
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * FtpServerConnection.h
+ *
+ ****/
+
+#ifndef _SMING_CORE_NETWORK_FTP_SERVER_CONNECTION_H_
+#define _SMING_CORE_NETWORK_FTP_SERVER_CONNECTION_H_
 
 #include "TcpConnection.h"
 #include "IPAddress.h"
@@ -55,4 +65,4 @@ private:
 	bool canTransfer = true;
 };
 
-#endif /* SMINGCORE_NETWORK_FTPSERVERCONNECTION_H_ */
+#endif /* _SMING_CORE_NETWORK_FTP_SERVER_CONNECTION_H_ */

--- a/Sming/SmingCore/Network/Http/HttpBodyParser.cpp
+++ b/Sming/SmingCore/Network/Http/HttpBodyParser.cpp
@@ -4,7 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpBodyParser
+ * HttpBodyParser.cpp
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *

--- a/Sming/SmingCore/Network/Http/HttpBodyParser.h
+++ b/Sming/SmingCore/Network/Http/HttpBodyParser.h
@@ -4,14 +4,14 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpBodyParser
+ * HttpBodyParser.h
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
  ****/
 
-#ifndef _SMING_CORE_HTTP_BODY_PARSER_H_
-#define _SMING_CORE_HTTP_BODY_PARSER_H_
+#ifndef _SMING_CORE_HTTP_HTTP_BODY_PARSER_H_
+#define _SMING_CORE_HTTP_HTTP_BODY_PARSER_H_
 
 #include "HttpCommon.h"
 #include "HttpRequest.h"
@@ -49,4 +49,4 @@ void formUrlParser(HttpRequest& request, const char* at, int length);
  */
 void bodyToStringParser(HttpRequest& request, const char* at, int length);
 
-#endif /* _SMING_CORE_HTTP_BODY_PARSER_H_ */
+#endif /* _SMING_CORE_HTTP_HTTP_BODY_PARSER_H_ */

--- a/Sming/SmingCore/Network/Http/HttpCommon.cpp
+++ b/Sming/SmingCore/Network/Http/HttpCommon.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * HttpCommon.cpp
+ *
  * @author: 2018 - Mikee47 <mike@sillyhouse.net>
  *
  * 	httpGetErrorName(), httpGetErrorDescription() and httpGetStatusText() functions added

--- a/Sming/SmingCore/Network/Http/HttpCommon.h
+++ b/Sming/SmingCore/Network/Http/HttpCommon.h
@@ -2,16 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpServerResource
+ * HttpCommon.h
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_CORE_HTTP_COMMON_H_
-#define _SMING_CORE_HTTP_COMMON_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_COMMON_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_COMMON_H_
 
 #define ENABLE_HTTP_REQUEST_AUTH 1
 
@@ -73,4 +73,4 @@ static inline String httpGetStatusText(unsigned code)
 	return httpGetStatusText((enum http_status)code);
 }
 
-#endif /* _SMING_CORE_HTTP_COMMON_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_COMMON_H_ */

--- a/Sming/SmingCore/Network/Http/HttpConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpConnection.cpp
@@ -2,12 +2,12 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpConnection
+ * HttpConnection.cpp
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
 #include "HttpConnection.h"

--- a/Sming/SmingCore/Network/Http/HttpConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpConnection.h
@@ -2,16 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpConnection
+ * HttpConnection.h
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_CORE_NETWORK_HTTP_CONNECTION_H_
-#define _SMING_CORE_NETWORK_HTTP_CONNECTION_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_CONNECTION_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_CONNECTION_H_
 
 #include "HttpConnectionBase.h"
 #include "DateTime.h"
@@ -166,4 +166,4 @@ protected:
 };
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_HTTP_CONNECTION_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_CONNECTION_H_ */

--- a/Sming/SmingCore/Network/Http/HttpConnectionBase.cpp
+++ b/Sming/SmingCore/Network/Http/HttpConnectionBase.cpp
@@ -2,12 +2,12 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpConnectionBase
+ * HttpConnectionBase.cpp
  *
  * @author: 2018 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
 #include "HttpConnectionBase.h"

--- a/Sming/SmingCore/Network/Http/HttpConnectionBase.h
+++ b/Sming/SmingCore/Network/Http/HttpConnectionBase.h
@@ -2,16 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpConnectionBase
+ * HttpConnectionBase.h
  *
  * @author: 2018 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_CORE_NETWORK_HTTP_HTTPCONNECTIONBASE_H_
-#define _SMING_CORE_NETWORK_HTTP_HTTPCONNECTIONBASE_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_CONNECTION_BASE_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_CONNECTION_BASE_H_
 
 #include "../TcpClient.h"
 #include "WString.h"
@@ -197,4 +197,4 @@ protected:
 };
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_HTTP_HTTPCONNECTIONBASE_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_CONNECTION_BASE_H_ */

--- a/Sming/SmingCore/Network/Http/HttpHeaders.cpp
+++ b/Sming/SmingCore/Network/Http/HttpHeaders.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * HttpHeaders.cpp
+ *
  * @author: 2018 - Mikee47 <mike@sillyhouse.net>
  *
  ****/

--- a/Sming/SmingCore/Network/Http/HttpHeaders.h
+++ b/Sming/SmingCore/Network/Http/HttpHeaders.h
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * HttpHeaders.h
+ *
  * @author: 2018 - Mikee47 <mike@sillyhouse.net>
  *
  *  Encapsulate encoding and decoding of HTTP header fields
@@ -15,8 +17,8 @@
  *
  ****/
 
-#ifndef _SMING_CORE_NETWORK_HTTP_HEADERS_H_
-#define _SMING_CORE_NETWORK_HTTP_HEADERS_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_HEADERS_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_HEADERS_H_
 
 #include "Data/CStringArray.h"
 #include "WString.h"
@@ -203,4 +205,4 @@ private:
 	CStringArray customFieldNames;
 };
 
-#endif /* _SMING_CORE_NETWORK_HTTP_HEADERS_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_HEADERS_H_ */

--- a/Sming/SmingCore/Network/Http/HttpParams.cpp
+++ b/Sming/SmingCore/Network/Http/HttpParams.cpp
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * HttpParams.cpp
+ *
  * @author: 2018 - Mikee47 <mike@sillyhouse.net>
  *
  ****/

--- a/Sming/SmingCore/Network/Http/HttpParams.h
+++ b/Sming/SmingCore/Network/Http/HttpParams.h
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * HttpParams.h
+ *
  * @author: 2018 - Mikee47 <mike@sillyhouse.net>
  *
  * 	Class to manage HTTP URI query parameters
@@ -14,8 +16,8 @@
  *
  ****/
 
-#ifndef _SMINGCORE_HTTP_HTTP_PARAMS_H_
-#define _SMINGCORE_HTTP_HTTP_PARAMS_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_PARAMS_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_PARAMS_H_
 
 #include "WString.h"
 #include "WHashMap.h"
@@ -34,4 +36,4 @@ public:
 	size_t printTo(Print& p) const override;
 };
 
-#endif // _SMINGCORE_HTTP_HTTP_PARAMS_H_
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_PARAMS_H_ */

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -2,12 +2,12 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpRequest
+ * HttpRequest.cpp
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
 #include "HttpRequest.h"

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -2,16 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpRequest
+ * HttpRequest.h
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_CORE_HTTP_REQUEST_H_
-#define _SMING_CORE_HTTP_REQUEST_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_REQUEST_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_REQUEST_H_
 
 #include "HttpCommon.h"
 #ifdef ENABLE_HTTP_REQUEST_AUTH
@@ -293,4 +293,4 @@ private:
 	HttpParams* queryParams = nullptr; // << @todo deprecate
 };
 
-#endif /* _SMING_CORE_HTTP_REQUEST_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_REQUEST_H_ */

--- a/Sming/SmingCore/Network/Http/HttpRequestAuth.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequestAuth.cpp
@@ -2,12 +2,12 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpRequestAuth
+ * HttpRequestAuth.cpp
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
 #include "HttpRequestAuth.h"

--- a/Sming/SmingCore/Network/Http/HttpRequestAuth.h
+++ b/Sming/SmingCore/Network/Http/HttpRequestAuth.h
@@ -2,16 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpRequestAuth
+ * HttpRequestAuth.h
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_CORE_HTTP_REQUEST_AUTH_H_
-#define _SMING_CORE_HTTP_REQUEST_AUTH_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_REQUEST_AUTH_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_REQUEST_AUTH_H_
 
 #include "HttpResponse.h"
 
@@ -65,4 +65,4 @@ private:
 	HttpRequest* request = nullptr;
 };
 
-#endif /* _SMING_CORE_HTTP_REQUEST_AUTH_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_REQUEST_AUTH_H_ */

--- a/Sming/SmingCore/Network/Http/HttpResource.h
+++ b/Sming/SmingCore/Network/Http/HttpResource.h
@@ -2,16 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpResource
+ * HttpResource.h
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_CORE_HTTP_RESOURCE_H_
-#define _SMING_CORE_HTTP_RESOURCE_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_H_
 
 #include "WString.h"
 #include "WHashMap.h"
@@ -71,4 +71,4 @@ private:
 
 typedef HashMap<String, HttpResource*> ResourceTree;
 
-#endif /* _SMING_CORE_HTTP_RESOURCE_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_H_ */

--- a/Sming/SmingCore/Network/Http/HttpResponse.cpp
+++ b/Sming/SmingCore/Network/Http/HttpResponse.cpp
@@ -2,12 +2,12 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpResponse
+ * HttpResponse.cpp
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
 #include "HttpResponse.h"

--- a/Sming/SmingCore/Network/Http/HttpResponse.h
+++ b/Sming/SmingCore/Network/Http/HttpResponse.h
@@ -2,16 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpResponse
+ * HttpResponse.h
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_CORE_HTTP_RESPONSE_H_
-#define _SMING_CORE_HTTP_RESPONSE_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_RESPONSE_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_RESPONSE_H_
 
 #include "HttpCommon.h"
 #include "Data/Stream/ReadWriteStream.h"
@@ -145,4 +145,4 @@ public:
 	IDataSourceStream* stream = nullptr; ///< The body stream
 };
 
-#endif /* _SMING_CORE_HTTP_RESPONSE_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_RESPONSE_H_ */

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
@@ -4,7 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpServerConnection
+ * HttpServerConnection.cpp
  *
  * Modified: 2017 - Slavey Karadzhov <slav@attachix.com>
  *

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.h
@@ -4,14 +4,14 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpServerConnection
+ * HttpServerConnection.h
  *
  * Modified: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
  ****/
 
-#ifndef _SMING_CORE_NETWORK_HTTP_HTTPSERVERCONNECTION_H_
-#define _SMING_CORE_NETWORK_HTTP_HTTPSERVERCONNECTION_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_SERVER_CONNECTION_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_SERVER_CONNECTION_H_
 
 #include "HttpConnectionBase.h"
 #include "HttpResource.h"
@@ -153,4 +153,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_HTTP_HTTPSERVERCONNECTION_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_SERVER_CONNECTION_H_ */

--- a/Sming/SmingCore/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/SmingCore/Network/Http/Websocket/WebsocketConnection.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * WebsocketConnection.cpp
+ *
  ****/
 
 #include "WebsocketConnection.h"

--- a/Sming/SmingCore/Network/Http/Websocket/WebsocketConnection.h
+++ b/Sming/SmingCore/Network/Http/Websocket/WebsocketConnection.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * WebsocketConnection.h
+ *
  ****/
 
-#ifndef SMINGCORE_NETWORK_WEBSOCKETCONNECTION_H_
-#define SMINGCORE_NETWORK_WEBSOCKETCONNECTION_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_WEBSOCKET_WEBSOCKET_CONNECTION_H_
+#define _SMING_CORE_NETWORK_HTTP_WEBSOCKET_WEBSOCKET_CONNECTION_H_
 
 #include "Network/TcpServer.h"
 #include "../HttpConnectionBase.h"
@@ -231,4 +234,4 @@ private:
 };
 
 /** @} */
-#endif /* SMINGCORE_NETWORK_WEBSOCKETCONNECTION_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_WEBSOCKET_WEBSOCKET_CONNECTION_H_ */

--- a/Sming/SmingCore/Network/Http/Websocket/WebsocketResource.cpp
+++ b/Sming/SmingCore/Network/Http/Websocket/WebsocketResource.cpp
@@ -2,10 +2,12 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * WebsocketResource.cpp
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
 #include "WebsocketResource.h"

--- a/Sming/SmingCore/Network/Http/Websocket/WebsocketResource.h
+++ b/Sming/SmingCore/Network/Http/Websocket/WebsocketResource.h
@@ -2,14 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * WebsocketResource.h
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_SMINGCORE_NETWORK_WEBSOCKET_RESOURCE_H_
-#define _SMING_SMINGCORE_NETWORK_WEBSOCKET_RESOURCE_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_WEBSOCKET_WEBSOCKET_RESOURCE_H_
+#define _SMING_CORE_NETWORK_HTTP_WEBSOCKET_WEBSOCKET_RESOURCE_H_
 
 #include "../HttpServerConnection.h"
 #include "../HttpResource.h"
@@ -58,4 +60,4 @@ protected:
 	WebsocketDelegate wsDisconnect = nullptr;
 };
 
-#endif /* _SMING_SMINGCORE_NETWORK_WEBSOCKET_RESOURCE_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_WEBSOCKET_WEBSOCKET_RESOURCE_H_ */

--- a/Sming/SmingCore/Network/Http/Websocket/WsCommandHandlerResource.h
+++ b/Sming/SmingCore/Network/Http/Websocket/WsCommandHandlerResource.h
@@ -2,14 +2,16 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * WsCommandHandlerResource.h
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
-#ifndef _SMING_SMINGCORE_NETWORK_WEBSOCKET_RESOURCE_H_
-#define _SMING_SMINGCORE_NETWORK_WEBSOCKET_RESOURCE_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_WEBSOCKET_WS_COMMAND_HANDLER_RESOURCE_H_
+#define _SMING_CORE_NETWORK_HTTP_WEBSOCKET_WS_COMMAND_HANDLER_RESOURCE_H_
 
 #include "../HttpResource.h"
 #include "WebsocketConnection.h"
@@ -49,4 +51,4 @@ private:
 	CommandExecutor commandExecutor;
 };
 
-#endif /* _SMING_SMINGCORE_NETWORK_WEBSOCKET_RESOURCE_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_WEBSOCKET_WS_COMMAND_HANDLER_RESOURCE_H_ */

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -4,7 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpClient
+ * HttpClient.cpp
  *
  * Modified: 2017 - Slavey Karadzhov <slav@attachix.com>
  *

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -4,7 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpClient
+ * HttpClient.h
  *
  * Modified: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
@@ -16,8 +16,8 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_NETWORK_HTTPCLIENT_H_
-#define _SMING_CORE_NETWORK_HTTPCLIENT_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_CLIENT_H_
+#define _SMING_CORE_NETWORK_HTTP_CLIENT_H_
 
 #include "TcpClient.h"
 #include "Http/HttpCommon.h"
@@ -111,4 +111,4 @@ protected:
 };
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_HTTPCLIENT_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_CLIENT_H_ */

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -4,7 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpServer
+ * HttpServer.cpp
  *
  * Modified: 2017 - Slavey Karadzhov <slav@attachix.com>
  *

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -4,7 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * HttpServer
+ * HttpServer.h
  *
  * Modified: 2017 - Slavey Karadzhov <slav@attachix.com>
  *
@@ -16,8 +16,8 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_HTTPSERVER_H_
-#define _SMING_CORE_HTTPSERVER_H_
+#ifndef _SMING_CORE_NETWORK_HTTP_SERVER_H_
+#define _SMING_CORE_NETWORK_HTTP_SERVER_H_
 
 #include "TcpServer.h"
 #include "WString.h"
@@ -101,4 +101,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_HTTPSERVER_H_ */
+#endif /* _SMING_CORE_NETWORK_HTTP_SERVER_H_ */

--- a/Sming/SmingCore/Network/Mqtt/MqttPayloadParser.cpp
+++ b/Sming/SmingCore/Network/Mqtt/MqttPayloadParser.cpp
@@ -4,6 +4,8 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * MqttPayloadParser.cpp
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Network/Mqtt/MqttPayloadParser.h
+++ b/Sming/SmingCore/Network/Mqtt/MqttPayloadParser.h
@@ -4,12 +4,14 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * MqttPayloadParser.h
+ *
  * @author Slavey Karadzhov <slaff@attachix.com>
  *
  ****/
 
-#ifndef _SMING_CORE_NETWORK_MQTT_PAYLOADPARSER_H_
-#define _SMING_CORE_NETWORK_MQTT_PAYLOADPARSER_H_
+#ifndef _SMING_CORE_NETWORK_MQTT_PAYLOAD_PARSER_H_
+#define _SMING_CORE_NETWORK_MQTT_PAYLOAD_PARSER_H_
 
 #include "Delegate.h"
 #include "../mqtt-codec/src/message.h"
@@ -39,4 +41,4 @@ typedef Delegate<int(MqttPayloadParserState& state, mqtt_message_t* message, con
 int defaultPayloadParser(MqttPayloadParserState& state, mqtt_message_t* message, const char* buffer, int length);
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_MQTT_PAYLOADPARSER_H_ */
+#endif /* _SMING_CORE_NETWORK_MQTT_PAYLOAD_PARSER_H_ */

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * MqttClient.cpp
+ *
  ****/
 
 #include "MqttClient.h"

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * MqttClient.h
+ *
  ****/
 
-#ifndef _SMING_CORE_NETWORK_MqttClient_H_
-#define _SMING_CORE_NETWORK_MqttClient_H_
+#ifndef _SMING_CORE_NETWORK_MQTT_CLIENT_H_
+#define _SMING_CORE_NETWORK_MQTT_CLIENT_H_
 
 #include "TcpClient.h"
 #include "URL.h"
@@ -322,4 +325,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_MqttClient_H_ */
+#endif /* _SMING_CORE_NETWORK_MQTT_CLIENT_H_ */

--- a/Sming/SmingCore/Network/NetUtils.cpp
+++ b/Sming/SmingCore/Network/NetUtils.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * NetUtils.cpp
+ *
  ****/
 
 #include "NetUtils.h"

--- a/Sming/SmingCore/Network/NetUtils.h
+++ b/Sming/SmingCore/Network/NetUtils.h
@@ -3,14 +3,17 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * NetUtils.h
+ *
  ****/
 
 /** @defgroup   networking Networking
  *  @{
  */
 
-#ifndef _SMING_CORE_NETWORK_NETUTILS_H_
-#define _SMING_CORE_NETWORK_NETUTILS_H_
+#ifndef _SMING_CORE_NETWORK_NET_UTILS_H_
+#define _SMING_CORE_NETWORK_NET_UTILS_H_
 
 struct pbuf;
 class String;
@@ -44,4 +47,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_NETUTILS_H_ */
+#endif /* _SMING_CORE_NETWORK_NET_UTILS_H_ */

--- a/Sming/SmingCore/Network/NtpClient.cpp
+++ b/Sming/SmingCore/Network/NtpClient.cpp
@@ -4,6 +4,8 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * NtpClient.cpp
+ *
  ****/
 
 #include "NtpClient.h"

--- a/Sming/SmingCore/Network/NtpClient.h
+++ b/Sming/SmingCore/Network/NtpClient.h
@@ -4,6 +4,8 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * NtpClient.h
+ *
  ****/
 
 /** @defgroup   ntp Network Time Protocol client
@@ -12,8 +14,8 @@
  *  @ingroup    udp
  *  @{
  */
-#ifndef _SMING_CORE_NETWORK_NTPCLIENT_H_
-#define _SMING_CORE_NETWORK_NTPCLIENT_H_
+#ifndef _SMING_CORE_NETWORK_NTP_CLIENT_H_
+#define _SMING_CORE_NETWORK_NTP_CLIENT_H_
 
 #include "UdpConnection.h"
 #include "Platform/System.h"
@@ -134,4 +136,4 @@ protected:
 };
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_NTPCLIENT_H_ */
+#endif /* _SMING_CORE_NETWORK_NTP_CLIENT_H_ */

--- a/Sming/SmingCore/Network/SmtpClient.cpp
+++ b/Sming/SmingCore/Network/SmtpClient.cpp
@@ -4,7 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * SmtpClient
+ * SmtpClient.cpp
  *
  * Author: 2018 - Slavey Karadzhov <slav@attachix.com>
  *

--- a/Sming/SmingCore/Network/SmtpClient.h
+++ b/Sming/SmingCore/Network/SmtpClient.h
@@ -4,7 +4,8 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * SmtpClient - asynchronous SmtpClient that supports the following features:
+ * SmtpClient.h - Asynchronous SmtpClient that supports the following features:
+ *
  * - extended HELO command set
  * - support for PIPELINING
  * - support for STARTTLS (if the directive ENABLE_SSL=1 is set)
@@ -17,13 +18,14 @@
  *
  ****/
 
+#ifndef _SMING_CORE_NETWORK_SMTPCLIENT_H_
+#define _SMING_CORE_NETWORK_SMTPCLIENT_H_
+
 /** @defgroup   smtpclient SMTP client
  *  @brief      Provides SMTP/S client
  *  @ingroup    tcpclient
  *  @{
  */
-
-#pragma once
 
 #include "TcpClient.h"
 #include "Data/MailMessage.h"
@@ -215,3 +217,5 @@ private:
 	 */
 	HttpPartResult multipartProducer();
 };
+
+#endif /* _SMING_CORE_NETWORK_SMTPCLIENT_H_ */

--- a/Sming/SmingCore/Network/Ssl/SslFingerprints.cpp
+++ b/Sming/SmingCore/Network/Ssl/SslFingerprints.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SslFingerprints.cpp
+ *
  ****/
 
 #ifdef ENABLE_SSL

--- a/Sming/SmingCore/Network/Ssl/SslFingerprints.h
+++ b/Sming/SmingCore/Network/Ssl/SslFingerprints.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SslFingerprints.h
+ *
  ****/
 
-#ifndef SMINGCORE_NETWORK_SSLFINGERPRINTS_H_
-#define SMINGCORE_NETWORK_SSLFINGERPRINTS_H_
+#ifndef _SMING_CORE_NETWORK_SSL_SSL_FINGERPRINTS_H_
+#define _SMING_CORE_NETWORK_SSL_SSL_FINGERPRINTS_H_
 
 #include "ssl/ssl.h"
 
@@ -99,4 +102,4 @@ private:
 	bool setValue(const uint8_t*& value, unsigned requiredLength, const uint8_t* newValue, unsigned newLength);
 };
 
-#endif // SMINGCORE_NETWORK_SSLFINGERPRINTS_H_
+#endif // _SMING_CORE_NETWORK_SSL_SSL_FINGERPRINTS_H_

--- a/Sming/SmingCore/Network/Ssl/SslKeyCertPair.h
+++ b/Sming/SmingCore/Network/Ssl/SslKeyCertPair.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SslKeyCertPair.h
+ *
  ****/
 
-#ifndef SMINGCORE_NETWORK_SSLKEYCERTPAIR_H_
-#define SMINGCORE_NETWORK_SSLKEYCERTPAIR_H_
+#ifndef _SMING_CORE_NETWORK_SSL_KEY_CERT_PAIR_H_
+#define _SMING_CORE_NETWORK_SSL_KEY_CERT_PAIR_H_
 
 #include "ssl/ssl.h"
 #include "WString.h"
@@ -109,4 +112,4 @@ private:
 	String certificate;
 };
 
-#endif /* SMINGCORE_NETWORK_SSLKEYCERTPAIR_H_ */
+#endif /* _SMING_CORE_NETWORK_SSL_KEY_CERT_PAIR_H_ */

--- a/Sming/SmingCore/Network/Ssl/SslSessionId.h
+++ b/Sming/SmingCore/Network/Ssl/SslSessionId.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SslSessionId.h
+ *
  ****/
 
-#ifndef SMINGCORE_NETWORK_SSLSESSIONID_H_
-#define SMINGCORE_NETWORK_SSLSESSIONID_H_
+#ifndef _SMING_CORE_NETWORK_SSL_SSL_SESSION_ID_H_
+#define _SMING_CORE_NETWORK_SSL_SSL_SESSION_ID_H_
 
 #include "ssl/ssl.h"
 #include "WString.h"
@@ -46,4 +49,4 @@ private:
 	String value;
 };
 
-#endif /* SMINGCORE_NETWORK_SSLSESSIONID_H_ */
+#endif /* _SMING_CORE_NETWORK_SSL_SSL_SESSION_ID_H_ */

--- a/Sming/SmingCore/Network/Ssl/SslStructs.h
+++ b/Sming/SmingCore/Network/Ssl/SslStructs.h
@@ -3,10 +3,13 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SslStructs.h
+ *
  ****/
 
-#ifndef SMINGCORE_NETWORK_SSL_SSLSTRUCTS_H_
-#define SMINGCORE_NETWORK_SSL_SSLSTRUCTS_H_
+#ifndef _SMING_CORE_NETWORK_SSL_SSL_STRUCTS_H_
+#define _SMING_CORE_NETWORK_SSL_SSL_STRUCTS_H_
 
 #include "SslFingerprints.h"
 #include "SslKeyCertPair.h"
@@ -20,4 +23,4 @@ typedef SslSessionId SSLSessionId SMING_DEPRECATED;				///< @deprecated Use SslS
 typedef SslFingerprints SSLFingerprints SMING_DEPRECATED;		///< @deprecated Use SslFingerprints instead
 typedef SslFingerprintType SSLFingerprintType SMING_DEPRECATED; ///< @deprecated Use SslFingerprintType instead
 
-#endif /* SMINGCORE_NETWORK_SSL_SSLSTRUCTS_H_ */
+#endif /* _SMING_CORE_NETWORK_SSL_SSL_STRUCTS_H_ */

--- a/Sming/SmingCore/Network/Ssl/SslValidator.cpp
+++ b/Sming/SmingCore/Network/Ssl/SslValidator.cpp
@@ -4,6 +4,8 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * SslValidator.cpp
+ *
  * @author: 2018 - Slavey Karadzhov <slav@attachix.com>
  *
  ****/

--- a/Sming/SmingCore/Network/Ssl/SslValidator.h
+++ b/Sming/SmingCore/Network/Ssl/SslValidator.h
@@ -4,6 +4,8 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * SslValidator.h
+ *
  * @author: 2018 - Slavey Karadzhov <slav@attachix.com>
  *
  ****/
@@ -13,8 +15,8 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_SSLVALIDATOR_H_
-#define _SMING_CORE_SSLVALIDATOR_H_
+#ifndef _SMING_CORE_SSL_VALIDATOR_H_
+#define _SMING_CORE_SSL_VALIDATOR_H_
 
 #include "ssl/ssl.h"
 #include "ssl/tls1.h"
@@ -76,4 +78,4 @@ public:
 };
 
 /** @} */
-#endif /* _SMING_CORE_SSLVALIDATOR_H_ */
+#endif /* _SMING_CORE_SSL_VALIDATOR_H_ */

--- a/Sming/SmingCore/Network/TcpClient.cpp
+++ b/Sming/SmingCore/Network/TcpClient.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TcpClient.cpp
+ *
  ****/
 
 #include "TcpClient.h"

--- a/Sming/SmingCore/Network/TcpClient.h
+++ b/Sming/SmingCore/Network/TcpClient.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TcpClient.h
+ *
  ****/
 
 /** @defgroup   tcpclient Clients
@@ -11,8 +14,8 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_TCPCLIENT_H_
-#define _SMING_CORE_TCPCLIENT_H_
+#ifndef _SMING_CORE_NETWORK_TCP_CLIENT_H_
+#define _SMING_CORE_NETWORK_TCP_CLIENT_H_
 
 #include "TcpConnection.h"
 #include "Delegate.h"
@@ -200,4 +203,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_TCPCLIENT_H_ */
+#endif /* _SMING_CORE_NETWORK_TCP_CLIENT_H_ */

--- a/Sming/SmingCore/Network/TcpConnection.cpp
+++ b/Sming/SmingCore/Network/TcpConnection.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TcpConnection.cpp
+ *
  ****/
 
 #include "TcpConnection.h"

--- a/Sming/SmingCore/Network/TcpConnection.h
+++ b/Sming/SmingCore/Network/TcpConnection.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TcpConnection.h
+ *
  ****/
 
 /** @defgroup tcp TCP
@@ -10,8 +13,8 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_TCPCONNECTION_H_
-#define _SMING_CORE_TCPCONNECTION_H_
+#ifndef _SMING_CORE_NETWORK_TCP_CONNECTION_H_
+#define _SMING_CORE_NETWORK_TCP_CONNECTION_H_
 
 #ifdef ENABLE_SSL
 #include "../axtls-8266/compat/lwipr_compat.h"
@@ -296,4 +299,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_TCPCONNECTION_H_ */
+#endif /* _SMING_CORE_NETWORK_TCP_CONNECTION_H_ */

--- a/Sming/SmingCore/Network/TcpServer.cpp
+++ b/Sming/SmingCore/Network/TcpServer.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TcpServer.cpp
+ *
  ****/
 
 #include "TcpServer.h"

--- a/Sming/SmingCore/Network/TcpServer.h
+++ b/Sming/SmingCore/Network/TcpServer.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TcpServer.h
+ *
  ****/
 
 /** @defgroup tcpserver Servers
@@ -12,8 +15,8 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_TCPSERVER_H_
-#define _SMING_CORE_TCPSERVER_H_
+#ifndef _SMING_CORE_NETWORK_TCP_SERVER_H_
+#define _SMING_CORE_NETWORK_TCP_SERVER_H_
 
 #include "TcpConnection.h"
 #include "TcpClient.h"
@@ -116,4 +119,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_TCPSERVER_H_ */
+#endif /* _SMING_CORE_NETWORK_TCP_SERVER_H_ */

--- a/Sming/SmingCore/Network/TelnetServer.cpp
+++ b/Sming/SmingCore/Network/TelnetServer.cpp
@@ -1,9 +1,15 @@
-/*
- * telnetServer.cpp
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TelnetServer.cpp
  *
  *  Created on: 18 apr. 2015
  *      Author: Herman
- */
+ *
+ ****/
 
 #include "TelnetServer.h"
 #include "Debug.h"

--- a/Sming/SmingCore/Network/TelnetServer.h
+++ b/Sming/SmingCore/Network/TelnetServer.h
@@ -1,9 +1,15 @@
-/*
- * telnetServer.h
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * TelnetServer.h
  *
  *  Created on: 18 apr. 2015
  *      Author: Herman
- */
+ *
+ ****/
 
 /** @defgroup   telnetserver Telnet server
  *  @brief      Provides Telnet server
@@ -11,8 +17,8 @@
  *  @{
  */
 
-#ifndef APP_TELNETSERVER_H_
-#define APP_TELNETSERVER_H_
+#ifndef _SMING_CORE_NETWORK_TELNET_SERVER_H_
+#define _SMING_CORE_NETWORK_TELNET_SERVER_H_
 
 #include <user_config.h>
 #include "Delegate.h"
@@ -51,4 +57,4 @@ private:
 };
 
 /** @} */
-#endif /* APP_TELNETSERVER_H_ */
+#endif /* _SMING_CORE_NETWORK_TELNET_SERVER_H_ */

--- a/Sming/SmingCore/Network/URL.cpp
+++ b/Sming/SmingCore/Network/URL.cpp
@@ -3,9 +3,12 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * URL.cpp
+ *
+ * Code based on http://stackoverflow.com/questions/2616011/easy-way-to-parse-a-url-in-c-cross-platform
+ *
  ****/
-
-// Code based on http://stackoverflow.com/questions/2616011/easy-way-to-parse-a-url-in-c-cross-platform
 
 #include "URL.h"
 

--- a/Sming/SmingCore/Network/URL.h
+++ b/Sming/SmingCore/Network/URL.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * URL.h
+ *
  ****/
 
 /** @defgroup   url URL
@@ -15,7 +18,7 @@
 #ifndef _SMING_CORE_NETWORK_URL_H_
 #define _SMING_CORE_NETWORK_URL_H_
 
-#include "../../Wiring/WString.h"
+#include "WString.h"
 
 #define DEFAULT_URL_PROTOCOL _F("http")
 #define HTTPS_URL_PROTOCOL _F("https")

--- a/Sming/SmingCore/Network/UdpConnection.cpp
+++ b/Sming/SmingCore/Network/UdpConnection.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * UdpConnection.cpp
+ *
  ****/
 
 #include "UdpConnection.h"

--- a/Sming/SmingCore/Network/UdpConnection.h
+++ b/Sming/SmingCore/Network/UdpConnection.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * UdpConnection.h
+ *
  ****/
 
 /** @defgroup   udp UDP
@@ -11,8 +14,8 @@
  *  @{
  */
 
-#ifndef SMINGCORE_NETWORK_UDPCONNECTION_H_
-#define SMINGCORE_NETWORK_UDPCONNECTION_H_
+#ifndef _SMING_CORE_NETWORK_UDP_CONNECTION_H_
+#define _SMING_CORE_NETWORK_UDP_CONNECTION_H_
 
 #include "WiringFrameworkDependencies.h"
 #include "Delegate.h"
@@ -83,4 +86,4 @@ protected:
 };
 
 /** @} */
-#endif /* SMINGCORE_NETWORK_UDPCONNECTION_H_ */
+#endif /* _SMING_CORE_NETWORK_UDP_CONNECTION_H_ */

--- a/Sming/SmingCore/Network/WebConstants.cpp
+++ b/Sming/SmingCore/Network/WebConstants.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * WebConstants.cpp
+ *
  ****/
 
 #include "WebConstants.h"

--- a/Sming/SmingCore/Network/WebConstants.h
+++ b/Sming/SmingCore/Network/WebConstants.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * WebConstants.h
+ *
  ****/
 
 /** @defgroup   httpconsts HTTP constants to be used with HTTP client or HTTP server
@@ -12,8 +15,8 @@
  *  @{
  */
 
-#ifndef _SMING_CORE_NETWORK_WEBCONSTANTS_H_
-#define _SMING_CORE_NETWORK_WEBCONSTANTS_H_
+#ifndef _SMING_CORE_NETWORK_WEB_CONSTANTS_H_
+#define _SMING_CORE_NETWORK_WEB_CONSTANTS_H_
 
 #include "WString.h"
 
@@ -95,4 +98,4 @@ static inline String fromFullFileName(const String& fileName)
 }; // namespace ContentType
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_WEBCONSTANTS_H_ */
+#endif /* _SMING_CORE_NETWORK_WEB_CONSTANTS_H_ */

--- a/Sming/SmingCore/Network/WebsocketClient.cpp
+++ b/Sming/SmingCore/Network/WebsocketClient.cpp
@@ -2,15 +2,15 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * WebsocketClient
+ * WebsocketClient.cpp
  *
  * @authors:
  * 		 Originally - hrsavla <https://github.com/hrsavla>
  * 		 Refactored - Alexander V, Ribchansky <https://github.com/avr39-ripe>
  * 		 Refactored(2018) - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
 #include "WebsocketClient.h"

--- a/Sming/SmingCore/Network/WebsocketClient.h
+++ b/Sming/SmingCore/Network/WebsocketClient.h
@@ -2,21 +2,21 @@
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * WebsocketClient
+ * WebsocketClient.h
  *
  * @authors:
  * 		 Originally - hrsavla <https://github.com/hrsavla>
  * 		 Refactored - Alexander V, Ribchansky <https://github.com/avr39-ripe>
  * 		 Refactored - Slavey Karadzhov <slav@attachix.com>
  *
- * All files of the Sming Core are provided under the LGPL v3 license.
  ****/
 
 //TODO: Add stream support for sending big chunks of data via websockets.
 
-#ifndef _SMING_CORE_NETWORK_WEBSOCKETCLIENT_H
-#define _SMING_CORE_NETWORK_WEBSOCKETCLIENT_H
+#ifndef _SMING_CORE_NETWORK_WEBSOCKET_CLIENT_H_
+#define _SMING_CORE_NETWORK_WEBSOCKET_CLIENT_H_
 
 #include "Http/HttpConnection.h"
 #include "Http/Websocket/WebsocketConnection.h"
@@ -100,4 +100,4 @@ private:
 };
 
 /** @} */
-#endif /* _SMING_CORE_NETWORK_WEBSOCKETCLIENT_H */
+#endif /* _SMING_CORE_NETWORK_WEBSOCKET_CLIENT_H_ */

--- a/Sming/SmingCore/Network/rBootHttpUpdate.cpp
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.cpp
@@ -1,10 +1,16 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * rBootHttpUpdate.cpp
  *
  *  Created on: 2015/09/03.
  *      Author: Richard A Burton & Anakod
  *
  *  Modified: 2017 - Slavey Karadzhov <slav@attachix.com>
+ *
  */
 
 #include "rBootHttpUpdate.h"

--- a/Sming/SmingCore/Network/rBootHttpUpdate.h
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.h
@@ -1,14 +1,20 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * rBootHttpUpdate.h
  *
  *  Created on: 2015/09/03.
  *      Author: Richard A Burton & Anakod
  *
  *  Modified: 2017 - Slavey Karadzhov <slav@attachix.com>
- */
+ *
+ ****/
 
-#ifndef SMINGCORE_NETWORK_RBOOTHTTPUPDATE_H_
-#define SMINGCORE_NETWORK_RBOOTHTTPUPDATE_H_
+#ifndef _SMING_CORE_NETWORK_RBOOT_HTTP_UPDATE_H_
+#define _SMING_CORE_NETWORK_RBOOT_HTTP_UPDATE_H_
 
 #include "Data/Stream/DataSourceStream.h"
 #include "HttpClient.h"
@@ -105,4 +111,4 @@ protected:
 	HttpRequest* baseRequest = nullptr;
 };
 
-#endif /* SMINGCORE_NETWORK_RBOOTHTTPUPDATE_H_ */
+#endif /* _SMING_CORE_NETWORK_RBOOT_HTTP_UPDATE_H_ */

--- a/Sming/SmingCore/Platform/AccessPoint.cpp
+++ b/Sming/SmingCore/Platform/AccessPoint.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * AccessPoint.cpp
+ *
  ****/
 
 #include "AccessPoint.h"

--- a/Sming/SmingCore/Platform/AccessPoint.h
+++ b/Sming/SmingCore/Platform/AccessPoint.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * AccessPoint.h
+ *
  ****/
 
 /**	@defgroup wifi_ap WiFi Access Point
@@ -14,8 +17,8 @@
  *  @todo   How is wifi access point dhcp controlled?
 */
 
-#ifndef SMINGCORE_PLATFORM_ACCESSPOINT_H_
-#define SMINGCORE_PLATFORM_ACCESSPOINT_H_
+#ifndef _SMING_CORE_PLATFORM_ACCESS_POINT_H_
+#define _SMING_CORE_PLATFORM_ACCESS_POINT_H_
 
 #include "System.h"
 #include "WString.h"
@@ -116,4 +119,4 @@ private:
  */
 extern AccessPointClass WifiAccessPoint;
 
-#endif /* SMINGCORE_PLATFORM_ACCESSPOINT_H_ */
+#endif /* _SMING_CORE_PLATFORM_ACCESS_POINT_H_ */

--- a/Sming/SmingCore/Platform/RTC.cpp
+++ b/Sming/SmingCore/Platform/RTC.cpp
@@ -1,4 +1,14 @@
-#include "../SmingCore/Platform/RTC.h"
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * RTC.cpp
+ *
+ ****/
+
+#include "RTC.h"
 
 RtcClass::RtcClass()
 {

--- a/Sming/SmingCore/Platform/RTC.h
+++ b/Sming/SmingCore/Platform/RTC.h
@@ -1,10 +1,20 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * RTC.h
+ *
+ ****/
+
 /**	@defgroup rtc Real Time Clock
  *	@brief	Access to the real time clock
  *	@note   Provides ability to set and read the ESP8266 RTC.
  *  @ingroup datetime
 */
-#ifndef SMINGCORE_RTC_H_
-#define SMINGCORE_RTC_H_
+#ifndef _SMING_CORE_PLATFORM_RTC_H_
+#define _SMING_CORE_PLATFORM_RTC_H_
 
 #include "../Wiring/WiringFrameworkDependencies.h"
 
@@ -73,4 +83,4 @@ private:
  *  @ingroup rtc
  */
 extern RtcClass RTC;
-#endif /* SMINGCORE_RTC_H_ */
+#endif /* _SMING_CORE_PLATFORM_RTC_H_ */

--- a/Sming/SmingCore/Platform/Station.cpp
+++ b/Sming/SmingCore/Platform/Station.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Station.cpp
+ *
  ****/
 
 #include "Station.h"

--- a/Sming/SmingCore/Platform/Station.h
+++ b/Sming/SmingCore/Platform/Station.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Station.h
+ *
  ****/
 
 /**	@defgroup wifi_sta WiFi Station Interface
@@ -13,8 +16,8 @@
  *  @see    \ref wifi_ap
 */
 
-#ifndef SMINGCORE_PLATFORM_STATION_H_
-#define SMINGCORE_PLATFORM_STATION_H_
+#ifndef _SMING_CORE_PLATFORM_STATION_H_
+#define _SMING_CORE_PLATFORM_STATION_H_
 
 #include "System.h"
 #include "Delegate.h"
@@ -299,4 +302,4 @@ public:
 extern StationClass WifiStation;
 
 /** @} */
-#endif /* SMINGCORE_PLATFORM_STATION_H_ */
+#endif /* _SMING_CORE_PLATFORM_STATION_H_ */

--- a/Sming/SmingCore/Platform/System.cpp
+++ b/Sming/SmingCore/Platform/System.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * System.cpp
+ *
  ****/
 
 #include "System.h"

--- a/Sming/SmingCore/Platform/System.h
+++ b/Sming/SmingCore/Platform/System.h
@@ -4,6 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * System.h
  *
  * @author: 14/8/2018 - mikee47 <mike@sillyhouse.net>
  *
@@ -13,14 +14,15 @@
  * 	simplify application code, the callback is invoked immediately in this situation.
  *
  * 	Global task queue added to class, initialised at system startup.
+ *
  */
 
 /**	@defgroup system System
  *	@brief	Access to the ESP8266 system
  *	@note   Provides system control and monitoring of the ESP8266.
 */
-#ifndef SMINGCORE_PLATFORM_SYSTEM_H_
-#define SMINGCORE_PLATFORM_SYSTEM_H_
+#ifndef _SMING_CORE_PLATFORM_SYSTEM_H_
+#define _SMING_CORE_PLATFORM_SYSTEM_H_
 
 #include "Delegate.h"
 
@@ -195,4 +197,4 @@ private:
 extern SystemClass System;
 
 /** @} */
-#endif /* SMINGCORE_PLATFORM_SYSTEM_H_ */
+#endif /* _SMING_CORE_PLATFORM_SYSTEM_H_ */

--- a/Sming/SmingCore/Platform/WDT.cpp
+++ b/Sming/SmingCore/Platform/WDT.cpp
@@ -1,8 +1,14 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * WDT.cpp
  *
  *  Created on: 06 àïð. 2015 ã.
  *      Author: Anakod
+ *
  */
 
 #include "WDT.h"

--- a/Sming/SmingCore/Platform/WDT.h
+++ b/Sming/SmingCore/Platform/WDT.h
@@ -1,9 +1,16 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * WDT.h
  *
  *  Created on: 06 ���. 2015 �.
  *      Author: Anakod
- */
+ *
+ ****/
+
 /**	@defgroup wdt Watchdog Timer
  *	@brief	Access to the ESP8266 watchdog timer
  *	@note   Provides control of the ESP8266 watchdog timer.
@@ -11,8 +18,8 @@
  *          To use WDT, enable the WDT then poke it regularly with WDT.alive();
 */
 
-#ifndef SMINGCORE_PLATFORM_WDT_H_
-#define SMINGCORE_PLATFORM_WDT_H_
+#ifndef _SMING_CORE_PLATFORM_WDT_H_
+#define _SMING_CORE_PLATFORM_WDT_H_
 
 #include <user_config.h>
 #include "System.h"
@@ -53,4 +60,4 @@ private:
  */
 extern WDTClass WDT;
 
-#endif /* SMINGCORE_PLATFORM_WDT_H_ */
+#endif /* _SMING_CORE_PLATFORM_WDT_H_ */

--- a/Sming/SmingCore/Platform/WifiEvents.cpp
+++ b/Sming/SmingCore/Platform/WifiEvents.cpp
@@ -1,4 +1,9 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * WifiEvents.cpp
  *
  *  Created on: 19 февр. 2016 г.

--- a/Sming/SmingCore/Platform/WifiEvents.h
+++ b/Sming/SmingCore/Platform/WifiEvents.h
@@ -1,12 +1,18 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * WifiEvents.h
  *
  *  Created on: 19 февр. 2016 г.
  *      Author: shurik
- */
+ *
+ ****/
 
-#ifndef SMINGCORE_PLATFORM_WIFIEVENTS_H_
-#define SMINGCORE_PLATFORM_WIFIEVENTS_H_
+#ifndef _SMING_CORE_PLATFORM_WIFI_EVENTS_H_
+#define _SMING_CORE_PLATFORM_WIFI_EVENTS_H_
 
 #include "../SmingCore/Delegate.h"
 #include "../../Wiring/WString.h"
@@ -48,4 +54,4 @@ private:
 };
 
 extern WifiEventsClass WifiEvents;
-#endif /* SMINGCORE_PLATFORM_WIFIEVENTS_H_ */
+#endif /* _SMING_CORE_PLATFORM_WIFI_EVENTS_H_ */

--- a/Sming/SmingCore/SPI.cpp
+++ b/Sming/SmingCore/SPI.cpp
@@ -1,4 +1,4 @@
-/*
+/****
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
@@ -12,7 +12,7 @@
  *  Some code is derived from:
  *  	David Ogilvy (MetalPhreak)
  *
- */
+ ****/
 
 #include "SPI.h"
 

--- a/Sming/SmingCore/SPI.h
+++ b/Sming/SmingCore/SPI.h
@@ -1,4 +1,4 @@
-/*
+/****
  * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
@@ -8,7 +8,9 @@
  *
  *  Created on: Mar 2, 2016
  *      Author: harry-boe
+ *
  */
+
 /** @defgroup hw_spi SPI Hardware support
  *  @brief    Provides hardware SPI support
  */

--- a/Sming/SmingCore/SPIBase.h
+++ b/Sming/SmingCore/SPIBase.h
@@ -10,12 +10,13 @@
  *      Author: harry-boe
  *
  */
+
 /** @defgroup base_spi SPI support classes
  *  @brief    Provides SPI support
  */
 
-#ifndef SMINGCORE_SPIBASE_H_
-#define SMINGCORE_SPIBASE_H_
+#ifndef _SMING_CORE_SPI_BASE_H_
+#define _SMING_CORE_SPI_BASE_H_
 
 #include "SPISettings.h"
 
@@ -69,4 +70,4 @@ public:
 	SPISettings SPIDefaultSettings;
 };
 
-#endif /* SMINGCORE_SPIBASE_H_ */
+#endif /* _SMING_CORE_SPI_BASE_H_ */

--- a/Sming/SmingCore/SPISettings.h
+++ b/Sming/SmingCore/SPISettings.h
@@ -1,9 +1,16 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * SPISettings.h
  *
  *  Created on: Mar 2, 2016
  *      Author: harry
- */
+ *
+ ****/
+
 /** @defgroup base_spi SPI support classes
  *  @brief    Provides SPI support
  */

--- a/Sming/SmingCore/SPISoft.h
+++ b/Sming/SmingCore/SPISoft.h
@@ -5,8 +5,9 @@ License: MIT
 Date: 15.07.2015
 Descr: Implement software SPI for HW configs other than hardware SPI pins(GPIO 12,13,14)
 */
-#ifndef _SPI_SOFT_
-#define _SPI_SOFT_
+
+#ifndef _SMING_CORE_SPI_SOFT_H_
+#define _SMING_CORE_SPI_SOFT_H_
 
 #include "SPIBase.h"
 #include "SPISettings.h"
@@ -82,4 +83,4 @@ private:
 	uint8_t m_delay;
 };
 
-#endif /*_SPI_SOFT_*/
+#endif /* _SMING_CORE_SPI_SOFT_H_ */

--- a/Sming/SmingCore/SimpleTimer.h
+++ b/Sming/SmingCore/SimpleTimer.h
@@ -4,6 +4,7 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * SimpleTimer.h
  *
  * @author: 13 August 2018 - mikee47 <mike@sillyhouse.net>
  *
@@ -20,8 +21,8 @@
  *  @brief      Provides basic OS timer functions
 */
 
-#ifndef _SMING_CORE_SIMPLETIMER_H_
-#define _SMING_CORE_SIMPLETIMER_H_
+#ifndef _SMING_CORE_SIMPLE_TIMER_H_
+#define _SMING_CORE_SIMPLE_TIMER_H_
 
 extern "C" {
 #include "esp_systemapi.h"
@@ -98,4 +99,4 @@ private:
 	os_timer_t osTimer;
 };
 
-#endif /* _SMING_CORE_SIMPLETIMER_H_ */
+#endif /* _SMING_CORE_SIMPLE_TIMER_H_ */

--- a/Sming/SmingCore/SmingCore.h
+++ b/Sming/SmingCore/SmingCore.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SmingCore.h
+ *
  ****/
 
 #ifndef _SMING_CORE_H_
@@ -12,7 +15,7 @@
 
 #include <functional>
 
-#include "../Wiring/WiringFrameworkIncludes.h"
+#include "WiringFrameworkIncludes.h"
 
 #include "Delegate.h"
 #include "Clock.h"

--- a/Sming/SmingCore/SmingLocale.h
+++ b/Sming/SmingCore/SmingLocale.h
@@ -1,13 +1,22 @@
-/**	Localization is defined within SmingLocale.h
-*	Each locale has a unique ID (usually its international dial code, e.g. GB=44
-*	The default locale is GB and the default values are those used by GB.
-*	To add a new locale:
-*		#define LOCALE_xx_yy zz (where xx_yy is the locale identifier and zz is the IDC)
-*		Override any variation from GB settings within a "#elifdef LOCALE_xx_yy zz" block
-*	Default settings are at end of file
-*/
-#ifndef LOCALE_H_INCLUDED
-#define LOCALE_H_INCLUDED
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SmingLocale.h
+ *
+ * Localization is defined within SmingLocale.h
+ *	Each locale has a unique ID (usually its international dial code, e.g. GB=44
+ *	The default locale is GB and the default values are those used by GB.
+ *	To add a new locale:
+ *		#define LOCALE_xx_yy zz (where xx_yy is the locale identifier and zz is the IDC)
+ *		Override any variation from GB settings within a "#elifdef LOCALE_xx_yy zz" block
+ *	Default settings are at end of file
+ */
+
+#ifndef _SMING_CORE_SMING_LOCALE_H_
+#define _SMING_CORE_SMING_LOCALE_H_
 
 // Define unique values for each locale (try to use ISD codes if appropriate)
 #define LOCALE_EN_US 1
@@ -71,4 +80,4 @@
 #define LOCALE_DATE_TIME "%a %d %b %Y %X"
 #endif // LOCALE_DATE_TIME
 
-#endif // LOCALE_H_INCLUDED
+#endif /* _SMING_CORE_SMING_LOCALE_H_ */

--- a/Sming/SmingCore/SystemClock.cpp
+++ b/Sming/SmingCore/SystemClock.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SystemClock.cpp
+ *
  ****/
 
 #include "SystemClock.h"

--- a/Sming/SmingCore/SystemClock.h
+++ b/Sming/SmingCore/SystemClock.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SystemClock.h
+ *
  ****/
 
 /** @defgroup   systemclock System clock functions
@@ -10,8 +13,8 @@
  *  @brief      Provides system clock functions
 */
 
-#ifndef SMINGCORE_SYSTEMCLOCK_H_
-#define SMINGCORE_SYSTEMCLOCK_H_
+#ifndef _SMING_CORE_SYSTEM_CLOCK_H_
+#define _SMING_CORE_SYSTEM_CLOCK_H_
 
 #include "DateTime.h"
 #include "WString.h"
@@ -91,4 +94,4 @@ private:
 extern SystemClockClass SystemClock;
 
 /** @} */
-#endif /* SMINGCORE_SYSTEMCLOCK_H_ */
+#endif /* _SMING_CORE_SYSTEM_CLOCK_H_ */

--- a/Sming/SmingCore/Timer.cpp
+++ b/Sming/SmingCore/Timer.cpp
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Timer.cpp
+ *
  ****/
 
 #include "Timer.h"

--- a/Sming/SmingCore/Timer.h
+++ b/Sming/SmingCore/Timer.h
@@ -3,6 +3,9 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * Timer.h
+ *
  ****/
 
 /** @defgroup   timer Timer functions

--- a/Sming/SmingCore/Wire.h
+++ b/Sming/SmingCore/Wire.h
@@ -21,8 +21,8 @@
   Modified April 2015 by Hrsto Gochkov (ficeto@ficeto.com) - alternative esp8266 support
 */
 
-#ifndef TwoWire_h
-#define TwoWire_h
+#ifndef _SMING_CORE_WIRE_H_
+#define _SMING_CORE_WIRE_H_
 
 #include <inttypes.h>
 #include "Stream.h"
@@ -101,4 +101,4 @@ public:
 extern TwoWire Wire;
 #endif
 
-#endif
+#endif /* _SMING_CORE_WIRE_H_ */

--- a/Sming/SmingCore/pgmspace.h
+++ b/Sming/SmingCore/pgmspace.h
@@ -1,2 +1,12 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * pgmspace.h
+ *
+ ****/
+
 #include "SmingCore.h"
-#include "../Wiring/FakePgmSpace.h"
+#include "FakePgmSpace.h"

--- a/Sming/SmingCore/pins_arduino.h
+++ b/Sming/SmingCore/pins_arduino.h
@@ -3,12 +3,15 @@
  * Created 2015 by Skurydin Alexey
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * pins_arduino.h
+ *
  ****/
 
 // File name selected for compatibility
 
-#ifndef WIRING_PINS_ARDUINO_H_
-#define WIRING_PINS_ARDUINO_H_
+#ifndef _SMING_CORE_PINS_ARDUINO_H_
+#define _SMING_CORE_PINS_ARDUINO_H_
 
 #include "espinc/peri.h"
 
@@ -33,4 +36,4 @@ extern const unsigned int A0; // Single ESP8266EX analog input pin (TOUT) 10 bit
 #define portInputRegister(port) ((volatile uint32_t*)&GPI)
 #define portModeRegister(port) ((volatile uint32_t*)&GPE)
 
-#endif /* WIRING_PINS_ARDUINO_H_ */
+#endif /* _SMING_CORE_PINS_ARDUINO_H_ */

--- a/Sming/SmingCore/twi.h
+++ b/Sming/SmingCore/twi.h
@@ -18,9 +18,11 @@
   License along with this library; if not, write to the Free Software
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-#ifndef SI2C_h
-#define SI2C_h
-#include "../Wiring/WiringFrameworkDependencies.h"
+
+#ifndef _SMING_CORE_TWI_H_
+#define _SMING_CORE_TWI_H_
+
+#include "WiringFrameworkDependencies.h"
 #include "espinc/peri.h"
 
 #ifdef __cplusplus
@@ -45,4 +47,4 @@ uint8_t twi_status();
 }
 #endif
 
-#endif
+#endif /* _SMING_CORE_TWI_H_ */

--- a/Sming/system/flashmem.c
+++ b/Sming/system/flashmem.c
@@ -4,6 +4,8 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * flashmem.c
+ *
  * Based on NodeMCU platform_flash
  * https://github.com/nodemcu/nodemcu-firmware
  *

--- a/Sming/system/include/SerialBuffer.h
+++ b/Sming/system/include/SerialBuffer.h
@@ -4,12 +4,14 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
+ * SerialBuffer.h
+ *
  * @author 22 Aug 2018 - mikee47 <mike@sillyhouse.net>
  *
  ****/
 
-#ifndef _SERIAL_BUFFER_H_
-#define _SERIAL_BUFFER_H_
+#ifndef _SYSTEM_INCLUDE_SERIAL_BUFFER_H_
+#define _SYSTEM_INCLUDE_SERIAL_BUFFER_H_
 
 /** @brief FIFO buffer used for both receive and transmit data
  *  @note For receive operations, data is written via ISR and read via task
@@ -170,4 +172,4 @@ private:
 	uint8_t* buffer = nullptr;
 };
 
-#endif //  _SERIAL_BUFFER_H_
+#endif //  _SYSTEM_INCLUDE_SERIAL_BUFFER_H_

--- a/Sming/system/include/debug_progmem.h
+++ b/Sming/system/include/debug_progmem.h
@@ -1,4 +1,9 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * debug_progmem.h
  *
  *  Contains debug functions that facilitate using strings stored in flash(irom). 
@@ -6,9 +11,11 @@
  *
  *  Created on: 27.01.2017
  *  Author: (github.com/)ADiea
- */
-#ifndef DEBUG_PROGMEM_H
-#define DEBUG_PROGMEM_H
+ *
+ ****/
+
+#ifndef _SYSTEM_INCLUDE_DEBUG_PROGMEM_H
+#define _SYSTEM_INCLUDE_DEBUG_PROGMEM_H
 
 #include <stdarg.h>
 #include "FakePgmSpace.h"
@@ -125,4 +132,4 @@ extern "C" {
 }
 #endif
 
-#endif /*#ifndef DEBUG_PROGMEM_H*/
+#endif /* _SYSTEM_INCLUDE_DEBUG_PROGMEM_H */

--- a/Sming/system/include/esp_cplusplus.h
+++ b/Sming/system/include/esp_cplusplus.h
@@ -1,5 +1,15 @@
-#ifndef __C_PLUS_PLUS_H__
-#define __C_PLUS_PLUS_H__
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * esp_cplusplus.h
+ *
+ ****/
+
+#ifndef _SYSTEM_INCLUDE_ESP_CPLUSPLUS_H_
+#define _SYSTEM_INCLUDE_ESP_CPLUSPLUS_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,4 +24,4 @@ extern void (*__init_array_end)(void);
 
 void cpp_core_initialize();
 
-#endif
+#endif /* _SYSTEM_INCLUDE_ESP_CPLUSPLUS_H_ */

--- a/Sming/system/include/esp_systemapi.h
+++ b/Sming/system/include/esp_systemapi.h
@@ -1,7 +1,17 @@
-// Based on mziwisky espmissingincludes.h && ESP8266_IoT_SDK_Programming Guide_v0.9.1.pdf && ESP SDK defines
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * esp_systemapi.h
+ *
+ * Based on mziwisky espmissingincludes.h && ESP8266_IoT_SDK_Programming Guide_v0.9.1.pdf && ESP SDK defines
+ *
+ ****/
 
-#ifndef __ESP_SYSTEM_API_H__
-#define __ESP_SYSTEM_API_H__
+#ifndef _SYSTEM_INCLUDE_ESP_SYSTEMAPI_H_
+#define _SYSTEM_INCLUDE_ESP_SYSTEMAPI_H_
 
 #include <ets_sys.h>
 #include <osapi.h>
@@ -127,4 +137,4 @@ extern void ets_isr_unmask(unsigned intr);
 
 typedef signed short file_t;
 
-#endif
+#endif /* _SYSTEM_INCLUDE_ESP_SYSTEMAPI_H_ */

--- a/Sming/system/include/espinc/c_types_compatible.h
+++ b/Sming/system/include/espinc/c_types_compatible.h
@@ -6,8 +6,8 @@
  // Updated, compatible version of c_types.h
  // Just removed types declared in <stdint.h>
  
-#ifndef _ESP_C_TYPES_COMPATIBLE_H
-#define _ESP_C_TYPES_COMPATIBLE_H
+#ifndef _SYSTEM_INCLUDE_ESPINC_C_TYPES_COMPATIBLE_H_
+#define _SYSTEM_INCLUDE_ESPINC_C_TYPES_COMPATIBLE_H_
 
 /*typedef unsigned char       uint8_t;
 typedef signed char         sint8_t;
@@ -101,4 +101,4 @@ typedef unsigned char   bool;
 
 #endif /* !__cplusplus */
 
-#endif /* _C_TYPES_H_ */
+#endif /* _SYSTEM_INCLUDE_ESPINC_C_TYPES_COMPATIBLE_H_ */

--- a/Sming/system/include/espinc/lwip_includes.h
+++ b/Sming/system/include/espinc/lwip_includes.h
@@ -1,12 +1,12 @@
 /*
  * lwip_includes.h
  *
- *  Created on: 23 февр. 2015 г.
+ *  Created on: 23 пїЅпїЅпїЅпїЅ. 2015 пїЅ.
  *      Author: Anakonda
  */
 
-#ifndef SYSTEM_INCLUDE_ESPINC_LWIP_INCLUDES_H_
-#define SYSTEM_INCLUDE_ESPINC_LWIP_INCLUDES_H_
+#ifndef _SYSTEM_INCLUDE_ESPINC_LWIP_INCLUDES_H_
+#define _SYSTEM_INCLUDE_ESPINC_LWIP_INCLUDES_H_
 
 #include <lwipopts.h>
 #include <lwip/init.h>
@@ -16,4 +16,4 @@
 #include <lwip/udp.h>
 #include <lwip/dns.h>
 
-#endif /* SYSTEM_INCLUDE_ESPINC_LWIP_INCLUDES_H_ */
+#endif /* _SYSTEM_INCLUDE_ESPINC_LWIP_INCLUDES_H_ */

--- a/Sming/system/include/espinc/peri.h
+++ b/Sming/system/include/espinc/peri.h
@@ -19,8 +19,8 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef SYSTEM_INCLUDE_ESPINC_PERI_H_
-#define SYSTEM_INCLUDE_ESPINC_PERI_H_
+#ifndef _SYSTEM_INCLUDE_ESPINC_PERI_H_
+#define _SYSTEM_INCLUDE_ESPINC_PERI_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -851,4 +851,4 @@ extern const uint8_t esp8266_gpioToFn[16];
 }
 #endif
 
-#endif /* SYSTEM_INCLUDE_ESPINC_PERI_H_ */
+#endif /* _SYSTEM_INCLUDE_ESPINC_PERI_H_ */

--- a/Sming/system/include/espinc/spi_register.h
+++ b/Sming/system/include/espinc/spi_register.h
@@ -8,8 +8,8 @@
  *  names of these defines are likely to change.
  */
 
-#ifndef SPI_REGISTER_H_INCLUDED
-#define SPI_REGISTER_H_INCLUDED
+#ifndef _SYSTEM_INCLUDE_ESPINC_SPI_REGISTER_H_
+#define _SYSTEM_INCLUDE_ESPINC_SPI_REGISTER_H_
 
 #define REG_SPI_BASE(i)  (0x60000200-i*0x100)
 
@@ -275,4 +275,5 @@
 #define SPI_EXT3(i)                           (REG_SPI_BASE(i)  + 0xFC)
 #define SPI_INT_HOLD_ENA 0x00000003
 #define SPI_INT_HOLD_ENA_S 0
-#endif // SPI_REGISTER_H_INCLUDED
+
+#endif /* _SYSTEM_INCLUDE_ESPINC_SPI_REGISTER_H_ */

--- a/Sming/system/include/espinc/uart_register.h
+++ b/Sming/system/include/espinc/uart_register.h
@@ -4,8 +4,9 @@
  *
  */
 
-#ifndef UART_REGISTER_H_INCLUDED
-#define UART_REGISTER_H_INCLUDED
+#ifndef _SYSTEM_INCLUDE_ESPINC_UART_REGISTER_H_
+#define _SYSTEM_INCLUDE_ESPINC_UART_REGISTER_H_
+
 #define REG_UART_BASE( i )  (0x60000000+(i)*0xf00)
 //version value:32'h062000
 
@@ -129,4 +130,5 @@
 
 #define UART_DATE( i )                          (REG_UART_BASE( i ) + 0x78)
 #define UART_ID( i )                            (REG_UART_BASE( i ) + 0x7C)
-#endif // UART_REGISTER_H_INCLUDED
+
+#endif /* _SYSTEM_INCLUDE_ESPINC_UART_REGISTER_H_ */

--- a/Sming/system/include/flashmem.h
+++ b/Sming/system/include/flashmem.h
@@ -9,8 +9,8 @@
  *
  ****/
 
-#ifndef SYSTEM_FLASHMEM_H_
-#define SYSTEM_FLASHMEM_H_
+#ifndef _SYSTEM_INCLUDE_FLASHMEM_H_
+#define _SYSTEM_INCLUDE_FLASHMEM_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -161,4 +161,4 @@ uint32_t flashmem_get_first_free_block_address();
 }
 #endif
 
-#endif /* SYSTEM_FLASHMEM_H_ */
+#endif /* _SYSTEM_INCLUDE_FLASHMEM_H_ */

--- a/Sming/system/include/mem_manager.h
+++ b/Sming/system/include/mem_manager.h
@@ -1,10 +1,20 @@
-#ifndef __MEM_MANAGER_H__
-#define __MEM_MANAGER_H__
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * mem_manager.h
+ *
+ ****/
+
+#ifndef _SYSTEM_INCLUDE_MEM_MANAGER_H_
+#define _SYSTEM_INCLUDE_MEM_MANAGER_H_
 
 //#include "c_types.h"
 #include <mem.h>
 
-/*------------------------±äÁ¿¶¨Òå------------------------*/
+/*------------------------ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½------------------------*/
 
 #define MPU_WRAPPERS_INCLUDED_FROM_API_FILE
 #ifndef IOT_SIP_MODE
@@ -62,7 +72,7 @@ static xBlockLink xStart, *pxEnd = NULL;
 //static size_t xFreeBytesRemaining = ( ( size_t ) configADJUSTED_HEAP_SIZE ) & ( ( size_t ) ~portBYTE_ALIGNMENT_MASK );
 
 
-/*------------------------º¯ÊýÉùÃ÷-----------------------------------*/
+/*------------------------ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½-----------------------------------*/
 
 static void prvInsertBlockIntoFreeList( xBlockLink *pxBlockToInsert ) ;//ICACHE_FLASH_ATTR;
 
@@ -75,4 +85,4 @@ size_t xPortGetFreeHeapSize( void ) ;//ICACHE_FLASH_ATTR;
 void vPortInitialiseBlocks( void ) ;//ICACHE_FLASH_ATTR;
 /*-----------------------------------------------------------*/
 
-#endif
+#endif /* _SYSTEM_INCLUDE_MEM_MANAGER_H_ */

--- a/Sming/system/include/rboot-integration.h
+++ b/Sming/system/include/rboot-integration.h
@@ -1,5 +1,15 @@
-#ifndef __RBOOT_INTEGRATION_H__
-#define __RBOOT_INTEGRATION_H__
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * rboot-integration.h
+ *
+ ****/
+
+#ifndef _SYSTEM_INCLUDE_RBOOT_INTEGRATION_H_
+#define _SYSTEM_INCLUDE_RBOOT_INTEGRATION_H_
 
 // prevent sming user_config.h being included
 #define __USER_CONFIG_H__
@@ -10,4 +20,4 @@
 // missing prototypes for sdk functions
 #include <esp_systemapi.h>
 
-#endif /* __RBOOT_INTEGRATION_H__ */
+#endif /* _SYSTEM_INCLUDE_RBOOT_INTEGRATION_H_ */

--- a/Sming/system/include/stringconversion.h
+++ b/Sming/system/include/stringconversion.h
@@ -1,12 +1,18 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * StringConversion.h
  *
- *  Created on: 28 ÿíâ. 2015 ã.
+ *  Created on: 28 ï¿½ï¿½ï¿½. 2015 ï¿½.
  *      Author: Anakonda
- */
+ *
+ ****/
 
-#ifndef INCLUDE_STRINGCONVERSION_H_
-#define INCLUDE_STRINGCONVERSION_H_
+#ifndef _SYSTEM_INCLUDE_STRINGCONVERSION_H_
+#define _SYSTEM_INCLUDE_STRINGCONVERSION_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -34,4 +40,4 @@ double os_atof(const char* s);
 }
 #endif
 
-#endif /* INCLUDE_STRINGCONVERSION_H_ */
+#endif /* _SYSTEM_INCLUDE_STRINGCONVERSION_H_ */

--- a/Sming/system/include/stringutil.h
+++ b/Sming/system/include/stringutil.h
@@ -1,14 +1,20 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * StringUtil.h
  *
  *  Contains utility functions for working with char strings.
  *
  *  Created on: 26.01.2017
  *  Author: (github.com/)ADiea
- */
+ *
+ ****/
 
-#ifndef INCLUDE_STRINGUTIL_H_
-#define INCLUDE_STRINGUTIL_H_
+#ifndef _SYSTEM_INCLUDE_STRINGUTIL_H_
+#define _SYSTEM_INCLUDE_STRINGUTIL_H_
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,4 +70,4 @@ static inline signed char unhex(char c)
 }
 #endif
 
-#endif //INCLUDE_STRINGUTIL_H_
+#endif /* _SYSTEM_INCLUDE_STRINGUTIL_H_ */

--- a/Sming/system/stringconversion.cpp
+++ b/Sming/system/stringconversion.cpp
@@ -1,3 +1,13 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * StringConversion.cpp
+ *
+ ****/
+
 #include <user_config.h>
 #include <math.h>
 #include <stdlib.h>

--- a/Sming/system/stringutil.cpp
+++ b/Sming/system/stringutil.cpp
@@ -1,10 +1,16 @@
-/*
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
  * StringUtil.cpp
  *
  *  Contains utility functions for working with char strings.
  *
  *  Created on: 26.01.2017
  *  Author: (github.com/)ADiea
+ *
  */
 
 #include "stringutil.h"

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -18,6 +18,10 @@
  License along with this library; if not, write to the Free Software
  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
+ @author 2018 mikee47 <mike@sillyhouse.net>
+
+ Additional features to support flexible transmit buffering and callbacks
+
  */
 
 


### PR DESCRIPTION
Comment headers in the following files have been left due to potential license conflict:

SmingCore/Wire.h
SmingCore/twi.h
SmingCore/core_esp82666_si2c.cpp
SmingCore/Wire.cpp
SmingCore/DateTime.cpp
SmingCore/DateTime.h
SmingCore/SPISoft.cpp
SmingCore/SPISoft.h

system/esp-lwip/lwip/*
system/include/espinc/*
system/irq_checks.s
system/xt_interrupts.cpp
system/include/m_printf.h
system/include/m_printf.cpp
system/crash_handler.c
system/esp_cplusplus.cpp
system/uart.cpp