### PR TITLE
Fix `map()` bug in `WMath.cpp`

### DIFF
--- a/Sming/Wiring/WMath.cpp
+++ b/Sming/Wiring/WMath.cpp
@@ -80,11 +80,11 @@ long random(long howsmall, long howbig)
 
 
 long map(long x, long in_min, long in_max, long out_min, long out_max) {
-    long divisor = (in_max - in_min) + out_min;
+    long divisor = in_max - in_min;
     if(divisor == 0){
         return -1; //AVR returns -1, SAM returns 0
     }
-    return (x - in_min) * (out_max - out_min) / divisor;
+    return ( (x - in_min) * (out_max - out_min) / divisor ) + out_min;
 }
 
 


### PR DESCRIPTION
Closes #1634

Known bug in Arduino core, fixed 18/8/2016 https://github.com/esp8266/Arduino/pull/2408