### PR TITLE
Introduce ObjectMap

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -215,9 +215,9 @@ For a complete example take a look at the [Basic_rBoot](samples/Basic_rBoot/app/
 ### Embedded HTTP Web Server
 ```c++
 server.listen(80);
-server.addPath("/", onIndex);
-server.addPath("/hello", onHello);
-server.setDefaultHandler(onFile);
+server.paths.set("/", onIndex);
+server.paths.set("/hello", onHello);
+server.paths.setDefault(onFile);
 
 Serial.println("=== WEB SERVER STARTED ===");
 Serial.println(WifiStation.getIP());

--- a/Sming/SmingCore/Data/ObjectMap.h
+++ b/Sming/SmingCore/Data/ObjectMap.h
@@ -103,6 +103,16 @@ public:
 			return map.remove(key);
 		}
 
+		/**
+		 * @brief Get the value for a given key and remove it from the map, without destroying it
+		 * @retval V*
+		 * @note The returned object must be freed by the caller when no longer required
+		 */
+		V* extract()
+		{
+			return map.extract(key);
+		}
+
 	private:
 		ObjectMap<K, V>& map;
 		K key;
@@ -267,6 +277,24 @@ public:
 			removeAt(index);
 			return true;
 		}
+	}
+
+	/**
+	 * @brief Get the value for a given key and remove it from the map, without destroying it
+	 * @param key
+	 * @retval V*
+	 * @note The returned object must be freed by the caller when no longer required
+	 */
+	V* extract(const K& key)
+	{
+		V* value = nullptr;
+		int i = indexOf(key);
+		if(i >= 0) {
+			value = entries[i].value;
+			entries[i].value = nullptr;
+			entries.remove(i);
+		}
+		return value;
 	}
 
 	/**

--- a/Sming/SmingCore/Data/ObjectMap.h
+++ b/Sming/SmingCore/Data/ObjectMap.h
@@ -1,0 +1,249 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * ObjectMap.h
+ *
+ * @author: 31 Jul 2018 - Mikee47 <mike@sillyhouse.net>
+ *
+ * Implementation of a HashMap for owned objects, i.e. anything created with new().
+ * Once added to the map the object is destroyed when no longer required.
+ *
+ */
+
+#ifndef _SMING_CORE_DATA_OBJECT_MAP_H_
+#define _SMING_CORE_DATA_OBJECT_MAP_H_
+
+#include "WVector.h"
+
+template <typename K, typename V> class ObjectMap
+{
+public:
+	ObjectMap()
+	{
+	}
+
+	~ObjectMap()
+	{
+		clear();
+	}
+
+	/**
+	 * @brief Get the number of entries in this map
+	 * @retval int Entry count
+	 */
+	unsigned count() const
+	{
+		return entries.count();
+	}
+
+	/*
+	 * @brief Get a key at a specified index, non-modifiable
+	 * @param idx the index to get the key at
+	 * @return The key at index idx
+	 */
+	const K& keyAt(unsigned idx) const
+	{
+		return entries[idx].key;
+	}
+
+	/*
+	 * @brief Get a key at a specified index
+	 * @param idx the index to get the key at
+	 * @return Reference to the key at index idx
+	 */
+	K& keyAt(unsigned idx)
+	{
+		return entries[idx].key;
+	}
+
+	/*
+	 * @brief Get a value at a specified index, non-modifiable
+	 * @param idx the index to get the value at
+	 * @retval The value at index idx
+	 * @note The caller must not use `delete` on the returned value
+	 */
+	const V* valueAt(unsigned idx) const
+	{
+		return entries[idx].value;
+	}
+
+	/*
+	 * @brief Get a value at a specified index
+	 * @param idx the index to get the value at
+	 * @retval The value at index idx
+	 * @note Because a reference is returned any existing value must be `delete`d first
+	 * @see `operator[]`
+	 * @see `set()`
+	 */
+	V*& valueAt(unsigned idx)
+	{
+		return entries[idx].value;
+	}
+
+	/**
+	 * @brief Get value for given key, if it exists
+	 * @param key
+	 * @retval const V* Will be null if not found in the map
+	 */
+	const V* operator[](const K& key) const
+	{
+		return find(key);
+	}
+
+	/** @brief Access map entry by reference
+	 *  @param key
+	 *  @retval V*& Reference to mapped value corresponding to given key
+	 *  @note If the given key does not exist in the map then it will be created
+	 *  and a null value entry returned.
+	 *  Be careful to check for existing value before assigning to avoid memory leaks.
+	 *  In most cases `set()` should be used to avoid this complication.
+	 *
+	 *  Example:
+	 *
+	 *  ```
+	 *	void test()
+	 *	{
+	 *		ObjectMap<String, MyType> map;
+	 *		MyType* object1 = new MyType();
+	 *		MyType* object2 = new MyType();
+	 *		map["key1"] = object1;
+	 *		auto& value = map["key1"]; // value now refers to object1
+	 *		delete value;
+	 *		value = object2;
+	 *		// As soon as `map` goes out of scope, object2 is released
+	 *	}
+	 * 	```
+	 *
+	 * 	@see `set()`
+	 * 	@see `valueAt()`
+	 *
+	 */
+	V*& operator[](const K& key)
+	{
+		int i = indexOf(key);
+		if(i >= 0) {
+			return entries[i].value;
+		}
+
+		auto entry = new Entry(key, nullptr);
+		entries.addElement(entry);
+		return entry->value;
+	}
+
+	/**
+	 * @brief Set a key value, ensuring any existing value is released
+	 *  @param key
+	 *  @param value
+	 *  @note Example:
+	 *  Example:
+	 *
+	 *		void test()
+	 *		{
+	 *			ObjectMap<String, MyType> map;
+	 *			MyType* object1 = new MyType();
+	 *			MyType* object2 = new MyType();
+	 *			map.set("key1", object1);
+	 *			map.set("key1", object2); // object1 is freed automatically
+	 *			// As soon as `map` goes out of scope, object2 is released
+	 *		}
+	 *
+	 */
+	void set(const K& key, V* value)
+	{
+		auto& cur = operator[](key);
+		delete cur;
+		cur = value;
+	}
+
+	/**
+	 * @brief Find the value for a given key, if it exists
+	 * @param key
+	 * @retval V* Points to the object if it exists, otherwise nullptr
+	 * @note If you need to modify the existing map entry, use `operator[]` or `valueAt()`
+	 */
+	V* find(const K& key) const
+	{
+		int index = indexOf(key);
+		return (index < 0) ? nullptr : entries[index].value;
+	}
+
+	/**
+	 * @brief Get the index of a key
+	 * @param key
+	 * @retval int The index of the key, or -1 if key does not exist
+	 */
+	int indexOf(const K& key) const
+	{
+		for(unsigned i = 0; i < entries.count(); i++) {
+			if(entries[i].key == key) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	/**
+	 * @brief Check if a key is contained within this map
+	 * @param key the key to check
+	 * @retval bool true if key exists
+	 */
+	bool contains(const K& key) const
+	{
+		return indexOf(key) >= 0;
+	}
+
+	/**
+	 * @brief Remove entry at given index
+	 * @param index location to remove from this map
+	 */
+	void removeAt(unsigned index)
+	{
+		entries.remove(index);
+	}
+
+	/**
+	 * @brief Remove a key from this map
+	 * @param key The key identifying the entry to remove
+	 */
+	void remove(const K& key)
+	{
+		int index = indexOf(key);
+		if(index >= 0) {
+			removeAt(index);
+		}
+	}
+
+	/**
+	 * @brief Clear the map of all entries
+	 */
+	void clear()
+	{
+		entries.clear();
+	}
+
+protected:
+	struct Entry {
+		K key;
+		V* value = nullptr;
+
+		Entry(const K& key, V* value) : key(key), value(value)
+		{
+		}
+
+		~Entry()
+		{
+			delete value;
+		}
+	};
+
+	Vector<Entry> entries;
+
+private:
+	// Copy constructor unsafe, so prevent access
+	ObjectMap(const ObjectMap<K, V>& that);
+};
+
+#endif // _SMING_CORE_DATA_OBJECT_MAP_H_

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -148,11 +148,6 @@ void HttpRequest::reset()
 	responseStream = nullptr;
 
 	postParams.clear();
-	for(unsigned i = 0; i < files.count(); i++) {
-		String key = files.keyAt(i);
-		delete files[key];
-		files[key] = nullptr;
-	}
 	files.clear();
 }
 

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -113,7 +113,7 @@ public:
 	HttpRequest* setFile(const String& formElementName, IDataSourceStream* stream)
 	{
 		if(stream != nullptr) {
-			files.set(formElementName, stream);
+			files[formElementName] = stream;
 		}
 		return this;
 	}

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -22,6 +22,7 @@
 #include "Data/Stream/MultipartStream.h"
 #include "HttpHeaders.h"
 #include "HttpParams.h"
+#include "Data/ObjectMap.h"
 
 class HttpClient;
 class HttpServerConnection;
@@ -111,8 +112,8 @@ public:
 	 */
 	HttpRequest* setFile(const String& formElementName, IDataSourceStream* stream)
 	{
-		if(stream) {
-			files[formElementName] = stream;
+		if(stream != nullptr) {
+			files.set(formElementName, stream);
 		}
 		return this;
 	}
@@ -288,7 +289,7 @@ protected:
 #endif
 
 private:
-	HashMap<String, IDataSourceStream*> files;
+	ObjectMap<String, IDataSourceStream> files;
 
 	HttpParams* queryParams = nullptr; // << @todo deprecate
 };

--- a/Sming/SmingCore/Network/Http/HttpResource.h
+++ b/Sming/SmingCore/Network/Http/HttpResource.h
@@ -69,6 +69,4 @@ private:
 	HttpPathDelegate callback;
 };
 
-typedef ObjectMap<String, HttpResource> ResourceTree;
-
 #endif /* _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_H_ */

--- a/Sming/SmingCore/Network/Http/HttpResource.h
+++ b/Sming/SmingCore/Network/Http/HttpResource.h
@@ -14,7 +14,7 @@
 #define _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_H_
 
 #include "WString.h"
-#include "WHashMap.h"
+#include "Data/ObjectMap.h"
 #include "Delegate.h"
 
 #include "HttpResponse.h"
@@ -69,6 +69,6 @@ private:
 	HttpPathDelegate callback;
 };
 
-typedef HashMap<String, HttpResource*> ResourceTree;
+typedef ObjectMap<String, HttpResource> ResourceTree;
 
 #endif /* _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_H_ */

--- a/Sming/SmingCore/Network/Http/HttpResource.h
+++ b/Sming/SmingCore/Network/Http/HttpResource.h
@@ -26,8 +26,8 @@ typedef Delegate<int(HttpServerConnection& connection, HttpRequest&, const char*
 	HttpServerConnectionBodyDelegate;
 typedef Delegate<int(HttpServerConnection& connection, HttpRequest&, char* at, int length)>
 	HttpServerConnectionUpgradeDelegate;
-typedef Delegate<int(HttpServerConnection&, HttpRequest&, HttpResponse&)> HttpResourceDelegate;
-typedef Delegate<void(HttpRequest&, HttpResponse&)> HttpPathDelegate;
+typedef Delegate<int(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)>
+	HttpResourceDelegate;
 
 class HttpResource
 {
@@ -48,25 +48,6 @@ public:
 	HttpResourceDelegate onHeadersComplete = nullptr;		 ///< headers are ready
 	HttpResourceDelegate onRequestComplete = nullptr;		 ///< request is complete OR upgraded
 	HttpServerConnectionUpgradeDelegate onUpgrade = nullptr; ///< request is upgraded and raw data is passed to it
-};
-
-class HttpCompatResource : public HttpResource
-{
-public:
-	HttpCompatResource(const HttpPathDelegate& callback) : callback(callback)
-	{
-		onRequestComplete = HttpResourceDelegate(&HttpCompatResource::requestComplete, this);
-	}
-
-private:
-	int requestComplete(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
-	{
-		callback(request, response);
-		return 0;
-	}
-
-private:
-	HttpPathDelegate callback;
 };
 
 #endif /* _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_H_ */

--- a/Sming/SmingCore/Network/Http/HttpResourceTree.cpp
+++ b/Sming/SmingCore/Network/Http/HttpResourceTree.cpp
@@ -1,0 +1,44 @@
+/****`
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HttpResourceTree.cpp
+ *
+ * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
+ *
+ ****/
+
+#include "HttpResourceTree.h"
+
+class HttpCompatResource : public HttpResource
+{
+public:
+	HttpCompatResource(const HttpPathDelegate& callback) : callback(callback)
+	{
+		onRequestComplete = HttpResourceDelegate(&HttpCompatResource::requestComplete, this);
+	}
+
+private:
+	int requestComplete(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
+	{
+		callback(request, response);
+		return 0;
+	}
+
+private:
+	HttpPathDelegate callback;
+};
+
+/* HttpResourceTree */
+
+void HttpResourceTree::set(String path, const HttpPathDelegate& callback)
+{
+	if(path.length() > 1 && path.endsWith("/")) {
+		path.remove(path.length() - 1);
+	}
+	debug_i("'%s' registered", path.c_str());
+
+	set(path, new HttpCompatResource(callback));
+}

--- a/Sming/SmingCore/Network/Http/HttpResourceTree.cpp
+++ b/Sming/SmingCore/Network/Http/HttpResourceTree.cpp
@@ -15,7 +15,7 @@
 class HttpCompatResource : public HttpResource
 {
 public:
-	HttpCompatResource(const HttpPathDelegate& callback) : callback(callback)
+	explicit HttpCompatResource(const HttpPathDelegate& callback) : callback(callback)
 	{
 		onRequestComplete = HttpResourceDelegate(&HttpCompatResource::requestComplete, this);
 	}

--- a/Sming/SmingCore/Network/Http/HttpResourceTree.h
+++ b/Sming/SmingCore/Network/Http/HttpResourceTree.h
@@ -1,0 +1,40 @@
+/****`
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/anakod/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HttpResourceTree.h
+ *
+ * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
+ *
+ ****/
+
+#ifndef _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_TREE_H_
+#define _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_TREE_H_
+
+#include "HttpResource.h"
+
+/** @brief Class to map URL paths to classes which handle them
+ *  @note Use `set()` method to safely set a value
+ */
+class ResourceTree : public ObjectMap<String, HttpResource>
+{
+public:
+	/** @brief The default resource handler, identified by "*" wildcard */
+	void setDefault(HttpResource* resource)
+	{
+		set(String('*'), resource);
+	}
+
+	HttpResource* getDefault()
+	{
+		return find(String('*'));
+	}
+
+private:
+	/* Potentially dangerous as `tree[path] = newValue` would overwrite existing value without freeing it */
+	HttpResource*& operator[](const String& key);
+};
+
+#endif /* _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_TREE_H_ */

--- a/Sming/SmingCore/Network/Http/HttpResourceTree.h
+++ b/Sming/SmingCore/Network/Http/HttpResourceTree.h
@@ -16,7 +16,6 @@
 #include "HttpResource.h"
 
 /** @brief Class to map URL paths to classes which handle them
- *  @note Use `set()` method to safely set a value
  */
 class ResourceTree : public ObjectMap<String, HttpResource>
 {
@@ -24,17 +23,13 @@ public:
 	/** @brief The default resource handler, identified by "*" wildcard */
 	void setDefault(HttpResource* resource)
 	{
-		set(String('*'), resource);
+		operator[](String('*')) = resource;
 	}
 
 	HttpResource* getDefault()
 	{
 		return find(String('*'));
 	}
-
-private:
-	/* Potentially dangerous as `tree[path] = newValue` would overwrite existing value without freeing it */
-	HttpResource*& operator[](const String& key);
 };
 
 #endif /* _SMING_CORE_NETWORK_HTTP_HTTP_RESOURCE_TREE_H_ */

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.h
@@ -33,6 +33,7 @@
 #define HTTP_SERVER_EXPOSE_DATE 0
 #endif
 
+class ResourceTree;
 class HttpServerConnection;
 
 typedef Delegate<void(HttpServerConnection& connection)> HttpServerConnectionDelegate;
@@ -58,7 +59,7 @@ public:
 		this->resourceTree = resourceTree;
 	}
 
-	void setBodyParsers(BodyParsers* bodyParsers)
+	void setBodyParsers(const BodyParsers* bodyParsers)
 	{
 		this->bodyParsers = bodyParsers;
 	}
@@ -137,10 +138,10 @@ public:
 	void* userData = nullptr; ///< use to pass user data between requests
 
 private:
-	ResourceTree* resourceTree = nullptr;
-	HttpResource* resource = nullptr;
+	ResourceTree* resourceTree = nullptr; ///< A reference to the current resource tree - we don't own it
+	HttpResource* resource = nullptr;	 ///< Resource for currently executing path
 
-	HttpRequest request = HttpRequest(URL());
+	HttpRequest request;
 	HttpResponse response;
 
 	HttpResourceDelegate headersCompleteDelegate = nullptr;
@@ -148,8 +149,8 @@ private:
 	HttpServerConnectionBodyDelegate onBodyDelegate = nullptr;
 	HttpServerProtocolUpgradeCallback upgradeCallback = nullptr;
 
-	BodyParsers* bodyParsers = nullptr;
-	HttpBodyParserDelegate bodyParser = nullptr;
+	const BodyParsers* bodyParsers = nullptr;	///< const reference ensures we cannot modify map, only look stuff up
+	HttpBodyParserDelegate bodyParser = nullptr; ///< Active body parser for this message, if any
 };
 
 /** @} */

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.h
@@ -33,7 +33,7 @@
 #define HTTP_SERVER_EXPOSE_DATE 0
 #endif
 
-class ResourceTree;
+class HttpResourceTree;
 class HttpServerConnection;
 
 typedef Delegate<void(HttpServerConnection& connection)> HttpServerConnectionDelegate;
@@ -54,7 +54,7 @@ public:
 		}
 	}
 
-	void setResourceTree(ResourceTree* resourceTree)
+	void setResourceTree(HttpResourceTree* resourceTree)
 	{
 		this->resourceTree = resourceTree;
 	}
@@ -138,8 +138,8 @@ public:
 	void* userData = nullptr; ///< use to pass user data between requests
 
 private:
-	ResourceTree* resourceTree = nullptr; ///< A reference to the current resource tree - we don't own it
-	HttpResource* resource = nullptr;	 ///< Resource for currently executing path
+	HttpResourceTree* resourceTree = nullptr; ///< A reference to the current resource tree - we don't own it
+	HttpResource* resource = nullptr;		  ///< Resource for currently executing path
 
 	HttpRequest request;
 	HttpResponse response;

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -13,13 +13,13 @@
 #include "HttpClient.h"
 #include "Data/Stream/FileStream.h"
 
-ObjectMap<String, HttpClientConnection> HttpClient::httpConnectionPool;
+HttpClient::HttpConnectionPool HttpClient::httpConnectionPool;
 
 bool HttpClient::send(HttpRequest* request)
 {
 	String cacheKey = getCacheKey(request->uri);
 
-	auto connection = httpConnectionPool[cacheKey];
+	HttpConnectionPool::Value connection = httpConnectionPool[cacheKey];
 
 	if(connection != nullptr) {
 		// Check existing connection

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -19,14 +19,13 @@ bool HttpClient::send(HttpRequest* request)
 {
 	String cacheKey = getCacheKey(request->uri);
 
-	auto& connection = httpConnectionPool[cacheKey];
+	auto connection = httpConnectionPool[cacheKey];
 
 	if(connection != nullptr) {
 		// Check existing connection
 		if(connection->getConnectionState() > eTCS_Connecting && !connection->isActive()) {
 			debug_d("Removing stale connection: State: %d, Active: %d", connection->getConnectionState(),
 					connection->isActive());
-			delete connection;
 			connection = nullptr;
 		}
 	}

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -113,7 +113,8 @@ protected:
 	}
 
 protected:
-	static ObjectMap<String, HttpClientConnection> httpConnectionPool;
+	typedef ObjectMap<String, HttpClientConnection> HttpConnectionPool;
+	static HttpConnectionPool httpConnectionPool;
 };
 
 /** @} */

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -101,13 +101,19 @@ public:
 	/**
 	 * Use this method to clean all request queues and object pools
 	 */
-	static void cleanup();
+	static void cleanup()
+	{
+		httpConnectionPool.clear();
+	}
 
 protected:
-	String getCacheKey(URL url);
+	String getCacheKey(URL url)
+	{
+		return url.Host + ':' + url.Port;
+	}
 
 protected:
-	static HashMap<String, HttpClientConnection*> httpConnectionPool;
+	static ObjectMap<String, HttpClientConnection> httpConnectionPool;
 };
 
 /** @} */

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -11,7 +11,6 @@
  ****/
 
 #include "HttpServer.h"
-
 #include "TcpClient.h"
 #include "WString.h"
 
@@ -32,11 +31,6 @@ void HttpServer::configure(const HttpServerSettings& settings)
 #endif
 }
 
-void HttpServer::setBodyParser(const String& contentType, HttpBodyParserDelegate parser)
-{
-	bodyParsers[contentType] = parser;
-}
-
 TcpConnection* HttpServer::createClient(tcp_pcb* clientTcp)
 {
 	HttpServerConnection* con = new HttpServerConnection(clientTcp);
@@ -49,32 +43,16 @@ TcpConnection* HttpServer::createClient(tcp_pcb* clientTcp)
 void HttpServer::addPath(String path, const HttpPathDelegate& callback)
 {
 	if(path.length() > 1 && path.endsWith("/")) {
-		path = path.substring(0, path.length() - 1);
+		path.remove(path.length() - 1);
 	}
 	debug_i("'%s' registered", path.c_str());
 
-	HttpCompatResource* resource = new HttpCompatResource(callback);
-	resourceTree[path] = resource;
-}
-
-void HttpServer::setDefaultHandler(const HttpPathDelegate& callback)
-{
-	addPath("*", callback);
+	resourceTree.set(path, new HttpCompatResource(callback));
 }
 
 void HttpServer::addPath(const String& path, const HttpResourceDelegate& onRequestComplete)
 {
 	HttpResource* resource = new HttpResource;
 	resource->onRequestComplete = onRequestComplete;
-	resourceTree[path] = resource;
-}
-
-void HttpServer::addPath(const String& path, HttpResource* resource)
-{
-	resourceTree[path] = resource;
-}
-
-void HttpServer::setDefaultResource(HttpResource* resource)
-{
-	addPath("*", resource);
+	resourceTree.set(path, resource);
 }

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -47,12 +47,12 @@ void HttpServer::addPath(String path, const HttpPathDelegate& callback)
 	}
 	debug_i("'%s' registered", path.c_str());
 
-	resourceTree.set(path, new HttpCompatResource(callback));
+	resourceTree[path] = new HttpCompatResource(callback);
 }
 
 void HttpServer::addPath(const String& path, const HttpResourceDelegate& onRequestComplete)
 {
 	HttpResource* resource = new HttpResource;
 	resource->onRequestComplete = onRequestComplete;
-	resourceTree.set(path, resource);
+	resourceTree[path] = resource;
 }

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -32,13 +32,6 @@ void HttpServer::configure(const HttpServerSettings& settings)
 #endif
 }
 
-HttpServer::~HttpServer()
-{
-	for(unsigned i = 0; i < resourceTree.count(); i++) {
-		delete resourceTree.valueAt(i);
-	}
-}
-
 void HttpServer::setBodyParser(const String& contentType, HttpBodyParserDelegate parser)
 {
 	bodyParsers[contentType] = parser;

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -34,7 +34,7 @@ void HttpServer::configure(const HttpServerSettings& settings)
 TcpConnection* HttpServer::createClient(tcp_pcb* clientTcp)
 {
 	HttpServerConnection* con = new HttpServerConnection(clientTcp);
-	con->setResourceTree(&resourceTree);
+	con->setResourceTree(&paths);
 	con->setBodyParsers(&bodyParsers);
 
 	return con;

--- a/Sming/SmingCore/Network/HttpServer.cpp
+++ b/Sming/SmingCore/Network/HttpServer.cpp
@@ -39,20 +39,3 @@ TcpConnection* HttpServer::createClient(tcp_pcb* clientTcp)
 
 	return con;
 }
-
-void HttpServer::addPath(String path, const HttpPathDelegate& callback)
-{
-	if(path.length() > 1 && path.endsWith("/")) {
-		path.remove(path.length() - 1);
-	}
-	debug_i("'%s' registered", path.c_str());
-
-	resourceTree[path] = new HttpCompatResource(callback);
-}
-
-void HttpServer::addPath(const String& path, const HttpResourceDelegate& onRequestComplete)
-{
-	HttpResource* resource = new HttpResource;
-	resource->onRequestComplete = onRequestComplete;
-	resourceTree[path] = resource;
-}

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -82,7 +82,7 @@ public:
 
 	void addPath(const String& path, HttpResource* resource)
 	{
-		resourceTree.set(path, resource);
+		resourceTree[path] = resource;
 	}
 
 	void setDefaultHandler(const HttpPathDelegate& callback)

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -21,10 +21,7 @@
 
 #include "TcpServer.h"
 #include "WString.h"
-#include "WHashMap.h"
 #include "Delegate.h"
-#include "Http/HttpResponse.h"
-#include "Http/HttpRequest.h"
 #include "Http/HttpResource.h"
 #include "Http/HttpServerConnection.h"
 #include "Http/HttpBodyParser.h"
@@ -42,8 +39,6 @@ typedef struct {
 
 class HttpServer : public TcpServer
 {
-	friend class HttpServerConnection;
-
 public:
 	HttpServer()
 	{
@@ -55,8 +50,6 @@ public:
 	{
 		configure(settings);
 	}
-
-	~HttpServer();
 
 	/**
 	 * @brief Allows changing the server configuration

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -70,39 +70,39 @@ public:
 		bodyParsers[contentType] = parser;
 	}
 
-	/** @deprecated Use `resourceTree.set()` instead */
+	/** @deprecated Use `paths.set()` instead */
 	void addPath(String path, const HttpPathDelegate& callback) SMING_DEPRECATED
 	{
-		resourceTree.set(path, callback);
+		paths.set(path, callback);
 	}
 
-	/** @deprecated Use `resourceTree.set()` instead */
+	/** @deprecated Use `paths.set()` instead */
 	void addPath(const String& path, const HttpResourceDelegate& onRequestComplete) SMING_DEPRECATED
 	{
-		resourceTree.set(path, onRequestComplete);
+		paths.set(path, onRequestComplete);
 	}
 
-	/** @deprecated Use `resourceTree.set()` instead */
+	/** @deprecated Use `paths.set()` instead */
 	void addPath(const String& path, HttpResource* resource) SMING_DEPRECATED
 	{
-		resourceTree.set(path, resource);
+		paths.set(path, resource);
 	}
 
-	/** @deprecated Use `resourceTree.setDefault()` instead */
+	/** @deprecated Use `paths.setDefault()` instead */
 	void setDefault(const HttpPathDelegate& callback) SMING_DEPRECATED
 	{
-		resourceTree.setDefault(callback);
+		paths.setDefault(callback);
 	}
 
-	/** @deprecated Use `resourceTree.setDefault()` instead */
+	/** @deprecated Use `paths.setDefault()` instead */
 	void setDefaultResource(HttpResource* resource) SMING_DEPRECATED
 	{
-		resourceTree.setDefault(resource);
+		paths.setDefault(resource);
 	}
 
 public:
 	/** @brief Maps paths to resources which deal with incoming requests */
-	HttpResourceTree resourceTree;
+	HttpResourceTree paths;
 
 protected:
 	TcpConnection* createClient(tcp_pcb* clientTcp) override;

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -70,34 +70,39 @@ public:
 		bodyParsers[contentType] = parser;
 	}
 
-	/**
-	 * @brief Add a new path resource with a callback
-	 * @param path URL path
-	 * @note Path should start with slash. Trailing slashes will be removed.
-	 * @param callback -The callback that will handle this path
-	 */
-	void addPath(String path, const HttpPathDelegate& callback);
-
-	void addPath(const String& path, const HttpResourceDelegate& onRequestComplete);
-
-	void addPath(const String& path, HttpResource* resource)
+	/** @deprecated Use `resourceTree.set()` instead */
+	void addPath(String path, const HttpPathDelegate& callback) SMING_DEPRECATED
 	{
-		resourceTree[path] = resource;
+		resourceTree.set(path, callback);
 	}
 
-	void setDefaultHandler(const HttpPathDelegate& callback)
+	/** @deprecated Use `resourceTree.set()` instead */
+	void addPath(const String& path, const HttpResourceDelegate& onRequestComplete) SMING_DEPRECATED
 	{
-		addPath(String('*'), callback);
+		resourceTree.set(path, onRequestComplete);
 	}
 
-	void setDefaultResource(HttpResource* resource)
+	/** @deprecated Use `resourceTree.set()` instead */
+	void addPath(const String& path, HttpResource* resource) SMING_DEPRECATED
+	{
+		resourceTree.set(path, resource);
+	}
+
+	/** @deprecated Use `resourceTree.setDefault()` instead */
+	void setDefault(const HttpPathDelegate& callback) SMING_DEPRECATED
+	{
+		resourceTree.setDefault(callback);
+	}
+
+	/** @deprecated Use `resourceTree.setDefault()` instead */
+	void setDefaultResource(HttpResource* resource) SMING_DEPRECATED
 	{
 		resourceTree.setDefault(resource);
 	}
 
 public:
 	/** @brief Maps paths to resources which deal with incoming requests */
-	ResourceTree resourceTree;
+	HttpResourceTree resourceTree;
 
 protected:
 	TcpConnection* createClient(tcp_pcb* clientTcp) override;

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -229,12 +229,12 @@ void onFavicon(HttpRequest& request, HttpResponse& response)
 void StartServers()
 {
 	server.listen(80);
-	server.addPath("/", onIndex);
-	server.addPath("/cam/set", onCamSetup);
-	server.addPath("/cam/capture", onCapture);
-	server.addPath("/stream", onStream);
-	server.addPath("/favicon.ico", onFavicon);
-	server.setDefaultHandler(onFile);
+	server.resourceTree.set("/", onIndex);
+	server.resourceTree.set("/cam/set", onCamSetup);
+	server.resourceTree.set("/cam/capture", onCapture);
+	server.resourceTree.set("/stream", onStream);
+	server.resourceTree.set("/favicon.ico", onFavicon);
+	server.resourceTree.setDefault(onFile);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -229,12 +229,12 @@ void onFavicon(HttpRequest& request, HttpResponse& response)
 void StartServers()
 {
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
-	server.resourceTree.set("/cam/set", onCamSetup);
-	server.resourceTree.set("/cam/capture", onCapture);
-	server.resourceTree.set("/stream", onStream);
-	server.resourceTree.set("/favicon.ico", onFavicon);
-	server.resourceTree.setDefault(onFile);
+	server.paths.set("/", onIndex);
+	server.paths.set("/cam/set", onCamSetup);
+	server.paths.set("/cam/capture", onCapture);
+	server.paths.set("/stream", onStream);
+	server.paths.set("/favicon.ico", onFavicon);
+	server.paths.setDefault(onFile);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());

--- a/samples/Basic_WebSkeletonApp/app/webserver.cpp
+++ b/samples/Basic_WebSkeletonApp/app/webserver.cpp
@@ -93,11 +93,11 @@ void startWebServer()
 		return;
 
 	server.listen(80);
-	server.addPath("/", onIndex);
-	server.addPath("/config", onConfiguration);
-	server.addPath("/config.json", onConfiguration_json);
-	server.addPath("/state", onAJAXGetState);
-	server.setDefaultHandler(onFile);
+	server.resourceTree.set("/", onIndex);
+	server.resourceTree.set("/config", onConfiguration);
+	server.resourceTree.set("/config.json", onConfiguration_json);
+	server.resourceTree.set("/state", onAJAXGetState);
+	server.resourceTree.setDefault(onFile);
 	server.setBodyParser("application/json", bodyToStringParser);
 	serverStarted = true;
 

--- a/samples/Basic_WebSkeletonApp/app/webserver.cpp
+++ b/samples/Basic_WebSkeletonApp/app/webserver.cpp
@@ -93,11 +93,11 @@ void startWebServer()
 		return;
 
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
-	server.resourceTree.set("/config", onConfiguration);
-	server.resourceTree.set("/config.json", onConfiguration_json);
-	server.resourceTree.set("/state", onAJAXGetState);
-	server.resourceTree.setDefault(onFile);
+	server.paths.set("/", onIndex);
+	server.paths.set("/config", onConfiguration);
+	server.paths.set("/config.json", onConfiguration_json);
+	server.paths.set("/state", onAJAXGetState);
+	server.paths.setDefault(onFile);
 	server.setBodyParser("application/json", bodyToStringParser);
 	serverStarted = true;
 

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -73,8 +73,8 @@ void processApplicationCommands(String commandLine, CommandOutput* commandOutput
 void StartServers()
 {
 	server.listen(80);
-	server.addPath("/", onIndex);
-	server.setDefaultHandler(onFile);
+	server.resourceTree.set("/", onIndex);
+	server.resourceTree.setDefault(onFile);
 
 	// Web Sockets configuration
 	WebsocketResource* wsResource = new WebsocketResource();
@@ -83,7 +83,7 @@ void StartServers()
 	wsResource->setBinaryHandler(wsBinaryReceived);
 	wsResource->setDisconnectionHandler(wsDisconnected);
 
-	server.addPath("/ws", wsResource);
+	server.resourceTree.set("/ws", wsResource);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -73,8 +73,8 @@ void processApplicationCommands(String commandLine, CommandOutput* commandOutput
 void StartServers()
 {
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
-	server.resourceTree.setDefault(onFile);
+	server.paths.set("/", onIndex);
+	server.paths.setDefault(onFile);
 
 	// Web Sockets configuration
 	WebsocketResource* wsResource = new WebsocketResource();
@@ -83,7 +83,7 @@ void StartServers()
 	wsResource->setBinaryHandler(wsBinaryReceived);
 	wsResource->setDisconnectionHandler(wsDisconnected);
 
-	server.resourceTree.set("/ws", wsResource);
+	server.paths.set("/ws", wsResource);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());

--- a/samples/DNSCaptivePortal/app/application.cpp
+++ b/samples/DNSCaptivePortal/app/application.cpp
@@ -15,8 +15,8 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.addPath("/", onIndex);
-	server.setDefaultHandler(onIndex);
+	server.resourceTree.set("/", onIndex);
+	server.resourceTree.setDefault(onIndex);
 }
 
 void startServers()

--- a/samples/DNSCaptivePortal/app/application.cpp
+++ b/samples/DNSCaptivePortal/app/application.cpp
@@ -15,8 +15,8 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
-	server.resourceTree.setDefault(onIndex);
+	server.paths.set("/", onIndex);
+	server.paths.setDefault(onIndex);
 }
 
 void startServers()

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -78,10 +78,10 @@ void onAjaxFrequency(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.addPath("/", onIndex);
-	server.addPath("/ajax/input", onAjaxInput);
-	server.addPath("/ajax/frequency", onAjaxFrequency);
-	server.setDefaultHandler(onFile);
+	server.resourceTree.set("/", onIndex);
+	server.resourceTree.set("/ajax/input", onAjaxInput);
+	server.resourceTree.set("/ajax/frequency", onAjaxFrequency);
+	server.resourceTree.setDefault(onFile);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -78,10 +78,10 @@ void onAjaxFrequency(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
-	server.resourceTree.set("/ajax/input", onAjaxInput);
-	server.resourceTree.set("/ajax/frequency", onAjaxFrequency);
-	server.resourceTree.setDefault(onFile);
+	server.paths.set("/", onIndex);
+	server.paths.set("/ajax/input", onAjaxInput);
+	server.paths.set("/ajax/frequency", onAjaxFrequency);
+	server.paths.setDefault(onFile);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -51,9 +51,9 @@ void onFile(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
-	server.resourceTree.set("/hello", onHello);
-	server.resourceTree.setDefault(onFile);
+	server.paths.set("/", onIndex);
+	server.paths.set("/hello", onHello);
+	server.paths.setDefault(onFile);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -51,9 +51,9 @@ void onFile(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.addPath("/", onIndex);
-	server.addPath("/hello", onHello);
-	server.setDefaultHandler(onFile);
+	server.resourceTree.set("/", onIndex);
+	server.resourceTree.set("/hello", onHello);
+	server.resourceTree.setDefault(onFile);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());

--- a/samples/HttpServer_ConfigNetwork/app/application.cpp
+++ b/samples/HttpServer_ConfigNetwork/app/application.cpp
@@ -171,11 +171,11 @@ void onAjaxConnect(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.addPath("/", onIndex);
-	server.addPath("/ipconfig", onIpConfig);
-	server.addPath("/ajax/get-networks", onAjaxNetworkList);
-	server.addPath("/ajax/connect", onAjaxConnect);
-	server.setDefaultHandler(onFile);
+	server.resourceTree.set("/", onIndex);
+	server.resourceTree.set("/ipconfig", onIpConfig);
+	server.resourceTree.set("/ajax/get-networks", onAjaxNetworkList);
+	server.resourceTree.set("/ajax/connect", onAjaxConnect);
+	server.resourceTree.setDefault(onFile);
 }
 
 void startFTP()
@@ -216,6 +216,7 @@ void init()
 		lastModified.trim();
 	}
 
+	Serial.setPort(UART_ID_1);
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 	AppSettings.load();

--- a/samples/HttpServer_ConfigNetwork/app/application.cpp
+++ b/samples/HttpServer_ConfigNetwork/app/application.cpp
@@ -171,11 +171,11 @@ void onAjaxConnect(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
-	server.resourceTree.set("/ipconfig", onIpConfig);
-	server.resourceTree.set("/ajax/get-networks", onAjaxNetworkList);
-	server.resourceTree.set("/ajax/connect", onAjaxConnect);
-	server.resourceTree.setDefault(onFile);
+	server.paths.set("/", onIndex);
+	server.paths.set("/ipconfig", onIpConfig);
+	server.paths.set("/ajax/get-networks", onAjaxNetworkList);
+	server.paths.set("/ajax/connect", onAjaxConnect);
+	server.paths.setDefault(onFile);
 }
 
 void startFTP()

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -102,8 +102,8 @@ void wsDisconnected(WebsocketConnection& socket)
 void startWebServer()
 {
 	server.listen(80);
-	server.addPath("/", onIndex);
-	server.setDefaultHandler(onFile);
+	server.resourceTree.set("/", onIndex);
+	server.resourceTree.setDefault(onFile);
 
 	// Web Sockets configuration
 	auto wsResource = new WebsocketResource();
@@ -112,7 +112,7 @@ void startWebServer()
 	wsResource->setBinaryHandler(wsBinaryReceived);
 	wsResource->setDisconnectionHandler(wsDisconnected);
 
-	server.addPath("/ws", wsResource);
+	server.resourceTree.set("/ws", wsResource);
 
 	Serial.println(F("\r\n=== WEB SERVER STARTED ==="));
 	Serial.println(WifiStation.getIP());

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -102,8 +102,8 @@ void wsDisconnected(WebsocketConnection& socket)
 void startWebServer()
 {
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
-	server.resourceTree.setDefault(onFile);
+	server.paths.set("/", onIndex);
+	server.paths.setDefault(onFile);
 
 	// Web Sockets configuration
 	auto wsResource = new WebsocketResource();
@@ -112,7 +112,7 @@ void startWebServer()
 	wsResource->setBinaryHandler(wsBinaryReceived);
 	wsResource->setDisconnectionHandler(wsDisconnected);
 
-	server.resourceTree.set("/ws", wsResource);
+	server.paths.set("/ws", wsResource);
 
 	Serial.println(F("\r\n=== WEB SERVER STARTED ==="));
 	Serial.println(WifiStation.getIP());

--- a/samples/MeteoControl/app/webserver.cpp
+++ b/samples/MeteoControl/app/webserver.cpp
@@ -114,12 +114,12 @@ void startWebServer()
 		return;
 
 	server.listen(80);
-	server.addPath("/", onIndex);
-	server.addPath("/api", onApiDoc);
-	server.addPath("/api/sensors", onApiSensors);
-	server.addPath("/api/output", onApiOutput);
-	server.addPath("/config", onConfiguration);
-	server.setDefaultHandler(onFile);
+	server.resourceTree.set("/", onIndex);
+	server.resourceTree.set("/api", onApiDoc);
+	server.resourceTree.set("/api/sensors", onApiSensors);
+	server.resourceTree.set("/api/output", onApiOutput);
+	server.resourceTree.set("/config", onConfiguration);
+	server.resourceTree.setDefault(onFile);
 	serverStarted = true;
 
 	if(WifiStation.isEnabled())

--- a/samples/MeteoControl/app/webserver.cpp
+++ b/samples/MeteoControl/app/webserver.cpp
@@ -114,12 +114,12 @@ void startWebServer()
 		return;
 
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
-	server.resourceTree.set("/api", onApiDoc);
-	server.resourceTree.set("/api/sensors", onApiSensors);
-	server.resourceTree.set("/api/output", onApiOutput);
-	server.resourceTree.set("/config", onConfiguration);
-	server.resourceTree.setDefault(onFile);
+	server.paths.set("/", onIndex);
+	server.paths.set("/api", onApiDoc);
+	server.paths.set("/api/sensors", onApiSensors);
+	server.paths.set("/api/output", onApiOutput);
+	server.paths.set("/config", onConfiguration);
+	server.paths.setDefault(onFile);
 	serverStarted = true;
 
 	if(WifiStation.isEnabled())

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -80,7 +80,7 @@ void onFile(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.resourceTree.set("/", onIndex);
+	server.paths.set("/", onIndex);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -80,7 +80,7 @@ void onFile(HttpRequest& request, HttpResponse& response)
 void startWebServer()
 {
 	server.listen(80);
-	server.addPath("/", onIndex);
+	server.resourceTree.set("/", onIndex);
 
 	Serial.println("\r\n=== WEB SERVER STARTED ===");
 	Serial.println(WifiStation.getIP());


### PR DESCRIPTION
Add `ObjectMap` class
Move `ResourceTree` class into separate file, rename as `HttpResourceTree`
Rename `HttpServer::resourceTree` as `paths`, make public
Deprecate `HttpServer::addPath` and `HttpServer::setDefault` methods

Addresses #1637