### PR TITLE
Fix bug introduced in previous PR #1638

### DIFF
--- a/Sming/SmingCore/Data/ObjectMap.h
+++ b/Sming/SmingCore/Data/ObjectMap.h
@@ -287,12 +287,23 @@ public:
 	 */
 	V* extract(const K& key)
 	{
-		V* value = nullptr;
 		int i = indexOf(key);
-		if(i >= 0) {
-			value = entries[i].value;
-			entries[i].value = nullptr;
-			entries.remove(i);
+		return (i < 0) ? nullptr : extractAt(i);
+	}
+
+	/**
+	 * @brief Get the value at a given index and remove it from the map, without destroying it
+	 * @param index
+	 * @retval V*
+	 * @note The returned object must be freed by the caller when no longer required
+	 */
+	V* extractAt(unsigned index)
+	{
+		V* value = nullptr;
+		if(index < entries.count()) {
+			value = entries[index].value;
+			entries[index].value = nullptr;
+			entries.remove(index);
 		}
 		return value;
 	}

--- a/Sming/SmingCore/Network/Http/HttpConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpConnection.cpp
@@ -115,7 +115,7 @@ HttpPartResult HttpConnection::multipartProducer()
 
 	if(outgoingRequest->files.count()) {
 		String name = outgoingRequest->files.keyAt(0);
-		auto file = outgoingRequest->files[name];
+		auto file = outgoingRequest->files.extractAt(0);
 		result.stream = file;
 
 		HttpHeaders* headers = new HttpHeaders();
@@ -124,7 +124,6 @@ HttpPartResult HttpConnection::multipartProducer()
 		(*headers)[HTTP_HEADER_CONTENT_TYPE] = ContentType::fromFullFileName(file->getName());
 		result.headers = headers;
 
-		outgoingRequest->files.remove(name);
 		return result;
 	}
 


### PR DESCRIPTION
In `HttpConnection::multipartProducer()` the `IDataSourceStream*` entry from `files` must be extracted, not removed
Add `extractAt()` method added to `ObjectMap` to support this operation more efficiently