### PR TITLE
Add support for escaped URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -93,3 +93,6 @@
 	path = Sming/third-party/mqtt-codec
 	url = https://github.com/slaff/mqtt-codec.git
 	ignore = dirty
+[submodule "Sming/third-party/libyuarel"]
+	path = Sming/third-party/libyuarel
+	url = https://github.com/jacketizer/libyuarel.git

--- a/Readme.md
+++ b/Readme.md
@@ -251,7 +251,7 @@ For more examples take a look at the [HttpServer_ConfigNetwork](samples/HttpServ
 ```c++
 SmtpClient emailClient;
 
-emailClient.connect(URL("smtp://user:password@domain.com:25"));
+emailClient.connect(Url("smtp://user:password@domain.com"));
 
 MailMessage* mail = new MailMessage();
 mail->from = "developers@sming";

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -202,6 +202,11 @@ THIRD_PARTY_DATA += third-party/mqtt-codec/Makefile
 EXTRA_INCDIR     += third-party/mqtt-codec/src
 CUSTOM_TARGETS   += $(USER_LIBDIR)/libmqttc.a
 
+# => yuarel
+THIRD_PARTY_DATA += third-party/libyuarel/Makefile
+MODULES          += third-party/libyuarel/
+EXTRA_INCDIR     += third-party/libyuarel/
+
 # => LOCALE
 ifdef LOCALE
 	CFLAGS += -DLOCALE=$(LOCALE)

--- a/Sming/SmingCore/Data/Stream/ReadWriteStream.h
+++ b/Sming/SmingCore/Data/Stream/ReadWriteStream.h
@@ -41,9 +41,6 @@ public:
      *  to implement it
      */
 	virtual size_t write(const uint8_t* buffer, size_t size) = 0;
-
-	//Use base class documentation
-	uint16_t readMemoryBlock(char* data, int bufSize) override;
 };
 
 /** @} */

--- a/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.cpp
+++ b/Sming/SmingCore/Data/Stream/UrlencodedOutputStream.cpp
@@ -11,7 +11,6 @@
  ****/
 
 #include "UrlencodedOutputStream.h"
-#include "../Services/WebHelpers/escape.h"
 
 /*
  * @todo Revise this so stream produces encoded output line-by-line, rather than all at once.

--- a/Sming/SmingCore/Network/Ftp/FtpDataStream.h
+++ b/Sming/SmingCore/Network/Ftp/FtpDataStream.h
@@ -49,7 +49,7 @@ public:
 		parent->response(code, text);
 	}
 
-	int write(const char* data, int len, uint8_t apiflags = 0)
+	int write(const char* data, int len, uint8_t apiflags = 0) override
 	{
 		written += len;
 		return TcpConnection::write(data, len, apiflags);

--- a/Sming/SmingCore/Network/Http/HttpBodyParser.cpp
+++ b/Sming/SmingCore/Network/Http/HttpBodyParser.cpp
@@ -7,12 +7,29 @@
  * HttpBodyParser.cpp
  *
  * @author: 2017 - Slavey Karadzhov <slav@attachix.com>
+ * 	Original author
+ *
+ * @author: 2019 - mikee47 <mike@sillyhouse.net>
+ * 	Implemented un-escaping of incoming parameters
  *
  ****/
 
 #include "HttpBodyParser.h"
 #include "../WebHelpers/escape.h"
 
+/*
+ * Content is received in chunks which we need to reassemble into name=value pairs.
+ * This structure stores the temporary values during parsing.
+ */
+typedef struct {
+	char searchChar = '=';
+	String postName;
+	String postValue;
+} FormUrlParserState;
+
+/*
+ * The incoming URL is parsed
+ */
 void formUrlParser(HttpRequest& request, const char* at, int length)
 {
 	auto state = static_cast<FormUrlParserState*>(request.args);
@@ -23,14 +40,15 @@ void formUrlParser(HttpRequest& request, const char* at, int length)
 		return;
 	}
 
+	assert(state != nullptr);
+
 	auto& params = request.postParams;
 
 	if(length == PARSE_DATAEND) {
-		// Unescape post parameters
-		// @todo this should be done within the HttpParams class
-		for(unsigned i = 0; i < params.count(); i++) {
-			uri_unescape_inplace(params.keyAt(i));
-			uri_unescape_inplace(params.valueAt(i));
+		// Store last parameter, if there is one
+		if(state->postName.length() != 0) {
+			uri_unescape_inplace(state->postValue);
+			params[state->postName] = state->postValue;
 		}
 
 		delete state;
@@ -44,31 +62,37 @@ void formUrlParser(HttpRequest& request, const char* at, int length)
 		return;
 	}
 
-	String data = String(at, length);
+	while(length > 0) {
+		// Look for search character ('=' or '&') in received text
+		auto found = static_cast<const char*>(memchr(at, state->searchChar, length));
+		unsigned foundLength = (found == nullptr) ? length : (found - at);
 
-	while(data.length()) {
-		int pos = data.indexOf(state->searchChar);
-		if(pos < 0) {
+		if(foundLength != 0) {
 			if(state->searchChar == '=') {
-				state->postName += data;
+				state->postName.concat(at, foundLength);
 			} else {
-				params[state->postName] += data;
+				state->postValue.concat(at, foundLength);
 			}
-
-			return;
 		}
 
-		String buf = data.substring(0, pos);
+		if(found == nullptr) {
+			break;
+		}
+
 		if(state->searchChar == '=') {
-			state->postName += buf;
+			uri_unescape_inplace(state->postName);
 			state->searchChar = '&';
 		} else {
-			params[state->postName] += buf;
+			uri_unescape_inplace(state->postValue);
+			params[state->postName] = state->postValue;
 			state->searchChar = '=';
-			state->postName = nullptr;
+			// Keep String memory allocated, but clear content
+			state->postName.setLength(0);
+			state->postValue.setLength(0);
 		}
-
-		data.remove(0, pos + 1);
+		++foundLength; // Skip the '=' or '&'
+		at += foundLength;
+		length -= foundLength;
 	}
 }
 
@@ -79,16 +103,16 @@ void bodyToStringParser(HttpRequest& request, const char* at, int length)
 	if(length == PARSE_DATASTART) {
 		delete data;
 		data = new String();
-		request.args = (void*)data;
+		request.args = data;
 		return;
 	}
 
-	if(!data) {
+	if(data == nullptr) {
 		debug_e("Invalid request argument");
 		return;
 	}
 
-	if(length == PARSE_DATAEND) {
+	if(length == PARSE_DATAEND || length < 0) {
 		request.setBody(*data);
 		delete data;
 		request.args = nullptr;

--- a/Sming/SmingCore/Network/Http/HttpBodyParser.h
+++ b/Sming/SmingCore/Network/Http/HttpBodyParser.h
@@ -17,35 +17,34 @@
 #include "HttpRequest.h"
 
 /** @brief special length values passed to parse functions */
-#define PARSE_DATASTART -1
-#define PARSE_DATAEND -2
+const int PARSE_DATASTART = -1; ///< Start of incoming data
+const int PARSE_DATAEND = -2;   ///< End of incoming data
 
-typedef Delegate<void(HttpRequest&, const char* at, int length)> HttpBodyParserDelegate;
+/**
+ * @brief Body parser callback delegate
+ * @param request
+ * @param at
+ * @param length Negative lengths have special meanings
+ * @see `PARSE_DATASTART`
+ * @see `PARSE_DATAEND`
+ */
+typedef Delegate<void(HttpRequest& request, const char* at, int length)> HttpBodyParserDelegate;
+
+/**
+ * @brief Maps body parsers to a specific content type
+ */
 typedef HashMap<String, HttpBodyParserDelegate> BodyParsers;
-
-typedef struct {
-	char searchChar = '=';
-	String postName;
-} FormUrlParserState;
 
 /**
  * @brief Parses application/x-www-form-urlencoded body data
- * @param HttpRequest&
- * @param const *char
- * @param int length Negative lengths are used to specify special cases
- * 				-1 - start of incoming data
- * 				-2 - end of incoming data
+ * @see `HttpBodyParserDelegate`
  */
 void formUrlParser(HttpRequest& request, const char* at, int length);
 
 /**
- * @brief Stores the complete body into memory.
- *        The content later can be retrieved by calling request.getBody()
- * @param HttpRequest&
- * @param const *char
- * @param int length Negative lengths are used to specify special cases
- * 				-1 - start of incoming data
- * 				-2 - end of incoming data
+ * @brief Stores the complete body into memory
+ * @see `HttpBodyParserDelegate`
+ * @note The content later can be retrieved by calling request.getBody()
  */
 void bodyToStringParser(HttpRequest& request, const char* at, int length);
 

--- a/Sming/SmingCore/Network/Http/HttpClientConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpClientConnection.cpp
@@ -62,7 +62,7 @@ bool HttpClientConnection::send(HttpRequest* request)
 	}
 #endif
 
-	return connect(request->uri.Host, request->uri.Port, useSsl);
+	return connect(request->uri.Host, request->uri.getPort(), useSsl);
 }
 
 void HttpClientConnection::reset()
@@ -300,7 +300,7 @@ void HttpClientConnection::sendRequestHeaders(HttpRequest* request)
 	sendString(String(http_method_str(request->method)) + ' ' + request->uri.getPathWithQuery() + _F(" HTTP/1.1\r\n"));
 
 	if(!request->headers.contains(HTTP_HEADER_HOST)) {
-		request->headers[HTTP_HEADER_HOST] = request->uri.Host;
+		request->headers[HTTP_HEADER_HOST] = request->uri.getHostWithPort();
 	}
 
 	request->headers[HTTP_HEADER_CONTENT_LENGTH] = "0";

--- a/Sming/SmingCore/Network/Http/HttpClientConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpClientConnection.cpp
@@ -48,7 +48,7 @@ bool HttpClientConnection::send(HttpRequest* request)
 		return false;
 	}
 
-	bool useSsl = (request->uri.Protocol == HTTPS_URL_PROTOCOL);
+	bool useSsl = (request->uri.Scheme == URI_SCHEME_HTTP_SECURE);
 
 #ifdef ENABLE_SSL
 	// Based on the URL decide if we should reuse the SSL and TCP pool

--- a/Sming/SmingCore/Network/Http/HttpCommon.h
+++ b/Sming/SmingCore/Network/Http/HttpCommon.h
@@ -17,7 +17,7 @@
 
 #include "WString.h"
 #include "../WebConstants.h"
-#include "../URL.h"
+#include "../Url.h"
 
 #ifndef HTTP_MAX_HEADER_SIZE
 #define HTTP_MAX_HEADER_SIZE (8 * 1024)

--- a/Sming/SmingCore/Network/Http/HttpConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpConnection.cpp
@@ -84,7 +84,7 @@ int HttpConnection::staticOnPath(http_parser* parser, const char* at, size_t len
 {
 	GET_CONNECTION()
 
-	return connection->onPath(URL(String(at, length)));
+	return connection->onPath(String(at, length));
 }
 
 #ifndef COMPACT_MODE

--- a/Sming/SmingCore/Network/Http/HttpConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpConnection.h
@@ -151,7 +151,7 @@ protected:
 	 * 	@param uri
 	 * 	@retval int 0 on success, non-0 on error
 	 */
-	virtual int onPath(const URL& uri)
+	virtual int onPath(const Url& uri)
 	{
 		return 0;
 	}

--- a/Sming/SmingCore/Network/Http/HttpHeaders.h
+++ b/Sming/SmingCore/Network/Http/HttpHeaders.h
@@ -96,6 +96,13 @@ enum HttpHeaderFieldName {
 class HttpHeaders : private HashMap<HttpHeaderFieldName, String>
 {
 public:
+	HttpHeaders() = default;
+
+	HttpHeaders(const HttpHeaders& headers)
+	{
+		*this = headers;
+	}
+
 	String toString(HttpHeaderFieldName name) const;
 
 	/** @brief Produce a string for output in the HTTP header, with line ending

--- a/Sming/SmingCore/Network/Http/HttpParams.cpp
+++ b/Sming/SmingCore/Network/Http/HttpParams.cpp
@@ -13,17 +13,123 @@
 #include "HttpParams.h"
 #include "../Services/WebHelpers/escape.h"
 #include "Print.h"
+#include "../third-party/libyuarel/yuarel.h"
+
+// Set a reasonable limit on the number of expected parameters in a query string
+static const unsigned MAX_PARAMS = 16;
+
+void HttpParams::parseQuery(char* query)
+{
+	clear();
+
+	if(query == nullptr) {
+		return;
+	}
+	// Accept query strings with or without '?' prefix
+	if(*query == '?') {
+		++query;
+	}
+
+	struct yuarel_param params[MAX_PARAMS];
+	int paramCount = yuarel_parse_query(query, '&', params, MAX_PARAMS);
+	if(paramCount <= 0) {
+		return;
+	}
+
+	allocate(paramCount);
+	if(keys == nullptr || values == nullptr) {
+		// Allocation failure
+		return;
+	}
+
+	for(int i = 0; i < paramCount; ++i) {
+		String key = uri_unescape_inplace(params[i].key);
+		String value = uri_unescape_inplace(params[i].val);
+		operator[](key) = value;
+	}
+}
+
+String HttpParams::toString() const
+{
+	if(count() == 0) {
+		return nullptr;
+	}
+
+	/*
+
+		The following code is an optimised version of this:
+
+			String result;
+			for (unsigned i = 0; i < count(); ++i) {
+				if (i > 0)
+					result += '&';
+				result += uri_escape(keyAt(i));
+				result += '=';
+				result += uri_escape(valueAt(i));
+			}
+
+	 */
+
+	// Calculate length of result so we can reserve result String memory in one go
+	unsigned resultLength = 0;
+	for(unsigned i = 0; i < count(); ++i) {
+		resultLength += uri_escape_len(keyAt(i)) + 1 + uri_escape_len(valueAt(i)) + 1; // Allow for '?', '=' and '&'
+	}
+
+	String result;
+	if(!result.setLength(resultLength)) {
+		return nullptr;
+	}
+
+	// Write out the string content
+	char* resultPtr = result.begin();
+	*resultPtr++ = '?';
+	for(unsigned i = 0; i < count(); ++i) {
+		if(i > 0) {
+			*resultPtr++ = '&';
+		}
+
+		// result += uri_escape(keyAt(i));
+		const String& key = keyAt(i);
+		uri_escape(resultPtr, 1 + result.end() - resultPtr, key.c_str(), key.length());
+		resultPtr += strlen(resultPtr);
+
+		// result += '=';
+		*resultPtr++ = '=';
+
+		// result += uri_escape(valueAt(i));
+		const String& value = valueAt(i);
+		uri_escape(resultPtr, 1 + result.end() - resultPtr, value.c_str(), value.length());
+		resultPtr += strlen(resultPtr);
+	}
+
+	assert(resultPtr == result.end());
+
+	return result;
+}
 
 size_t HttpParams::printTo(Print& p) const
 {
 	size_t charsPrinted = 0;
 	for(unsigned i = 0; i < count(); i++) {
-		if(i > 0)
+		if(i > 0) {
 			charsPrinted += p.print('&');
+		}
 		charsPrinted += p.print(uri_escape(keyAt(i)));
 		charsPrinted += p.print('=');
 		charsPrinted += p.print(uri_escape(valueAt(i)));
 	}
 
 	return charsPrinted;
+}
+
+void HttpParams::debugPrintTo(Print& p) const
+{
+	for(unsigned i = 0; i < count(); i++) {
+		p.print(' ');
+		p.print(keyAt(i));
+		p.print(_F(" = ["));
+		p.print(valueAt(i));
+		p.println(']');
+	}
 }

--- a/Sming/SmingCore/Network/Http/HttpParams.h
+++ b/Sming/SmingCore/Network/Http/HttpParams.h
@@ -32,6 +32,20 @@
 class HttpParams : public HashMap<String, String>, public Printable
 {
 public:
+	HttpParams() = default;
+
+	HttpParams(const HttpParams& params)
+	{
+		*this = params;
+	}
+
+	HttpParams& operator=(const HttpParams& params)
+	{
+		clear();
+		setMultiple(params);
+		return *this;
+	}
+
 	// Printable
 	size_t printTo(Print& p) const override;
 };

--- a/Sming/SmingCore/Network/Http/HttpParams.h
+++ b/Sming/SmingCore/Network/Http/HttpParams.h
@@ -39,6 +39,26 @@ public:
 		*this = params;
 	}
 
+	HttpParams(String query)
+	{
+		parseQuery(query.begin());
+	}
+
+	/** @brief Called from URL class to process query section of a URI
+	 *  @param query extracted from URI, with or without '?' prefix
+	 *  @retval bool true on success, false if parsing failed
+	 *  @note query string is modified by this call
+	 */
+	void parseQuery(char* query);
+
+	/** @brief Return full escaped content for incorporation into a URI */
+	String toString() const;
+
+	operator String() const
+	{
+		return toString();
+	}
+
 	HttpParams& operator=(const HttpParams& params)
 	{
 		clear();
@@ -48,6 +68,12 @@ public:
 
 	// Printable
 	size_t printTo(Print& p) const override;
+
+	/**
+	 * @brief Printable output for debugging
+	 * @param p
+	 */
+	void debugPrintTo(Print& p) const;
 };
 
 #endif /* _SMING_CORE_NETWORK_HTTP_HTTP_PARAMS_H_ */

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -115,7 +115,7 @@ String HttpRequest::toString()
 #endif
 
 	content += String(http_method_str(method)) + ' ' + uri.getPathWithQuery() + _F(" HTTP/1.1\n");
-	content += headers.toString(HTTP_HEADER_HOST, uri.Host + ':' + uri.Port);
+	content += headers.toString(HTTP_HEADER_HOST, uri.getHostWithPort());
 	for(unsigned i = 0; i < headers.count(); i++) {
 		content += headers[i];
 	}

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -12,8 +12,6 @@
 
 #include "HttpRequest.h"
 #include "Data/Stream/MemoryDataStream.h"
-#include "Data/Stream/ChunkedStream.h"
-#include "Data/Stream/UrlencodedOutputStream.h"
 
 HttpRequest::HttpRequest(const HttpRequest& value)
 	: uri(value.uri), method(value.method), headers(value.headers), postParams(value.postParams),
@@ -24,35 +22,6 @@ HttpRequest::HttpRequest(const HttpRequest& value)
 	  sslOptions(value.sslOptions), sslFingerprints(value.sslFingerprints), sslKeyCertPair(value.sslKeyCertPair)
 #endif
 {
-}
-
-String HttpRequest::getQueryParameter(const String& parameterName, const String& defaultValue)
-{
-	if(queryParams == nullptr) {
-		queryParams = new HttpParams();
-		if(!uri.Query.length()) {
-			return defaultValue;
-		}
-
-		String query = uri.Query.substring(1);
-		Vector<String> parts;
-		splitString(query, '&', parts);
-		for(unsigned i = 0; i < parts.count(); i++) {
-			Vector<String> pair;
-			int count = splitString(parts[i], '=', pair);
-			if(count != 2) {
-				debug_w("getQueryParameter: Missing = in query string: %s", parts[i].c_str());
-				continue;
-			}
-			(*queryParams)[pair.at(0)] = pair.at(1); // TODO: name and value URI decoding...
-		}
-	}
-
-	if(queryParams->contains(parameterName)) {
-		return (*queryParams)[parameterName];
-	}
-
-	return defaultValue;
 }
 
 String HttpRequest::getBody()

--- a/Sming/SmingCore/Network/Http/HttpRequest.cpp
+++ b/Sming/SmingCore/Network/Http/HttpRequest.cpp
@@ -15,34 +15,15 @@
 #include "Data/Stream/ChunkedStream.h"
 #include "Data/Stream/UrlencodedOutputStream.h"
 
-HttpRequest::HttpRequest(const HttpRequest& value) : uri(value.uri)
-{
-	*this = value;
-	method = value.method;
-	headers = value.headers;
-	headersCompletedDelegate = value.headersCompletedDelegate;
-	requestBodyDelegate = value.requestBodyDelegate;
-	requestCompletedDelegate = value.requestCompletedDelegate;
-
-	debug_w("Warning: HttpRequest streams are not copied..");
-
+HttpRequest::HttpRequest(const HttpRequest& value)
+	: uri(value.uri), method(value.method), headers(value.headers), postParams(value.postParams),
+	  headersCompletedDelegate(value.headersCompletedDelegate), requestBodyDelegate(value.requestBodyDelegate),
+	  requestCompletedDelegate(value.requestCompletedDelegate)
 #ifdef ENABLE_SSL
-	sslOptions = value.sslOptions;
-	sslFingerprints = value.sslFingerprints;
-	sslKeyCertPair = value.sslKeyCertPair;
+	  ,
+	  sslOptions(value.sslOptions), sslFingerprints(value.sslFingerprints), sslKeyCertPair(value.sslKeyCertPair)
 #endif
-}
-
-HttpRequest& HttpRequest::operator=(const HttpRequest& rhs)
 {
-	if(this == &rhs)
-		return *this;
-
-	// TODO: FIX this...
-	//	if (rhs.buffer) copy(rhs.buffer, rhs.len);
-	//	else invalidate();
-
-	return *this;
 }
 
 String HttpRequest::getQueryParameter(const String& parameterName, const String& defaultValue)
@@ -106,14 +87,13 @@ HttpRequest* HttpRequest::setResponseStream(ReadWriteStream* stream)
 	if(responseStream != nullptr) {
 		debug_e("HttpRequest::setResponseStream: Discarding already set stream!");
 		delete responseStream;
-		responseStream = nullptr;
 	}
 
 	responseStream = stream;
 	return this;
 }
 
-HttpRequest* HttpRequest::setBody(uint8_t* rawData, size_t length)
+HttpRequest* HttpRequest::setBody(const uint8_t* rawData, size_t length)
 {
 	auto memory = new MemoryDataStream();
 	auto written = memory->write(rawData, length);
@@ -129,7 +109,6 @@ HttpRequest* HttpRequest::setBody(IDataSourceStream* stream)
 	if(bodyStream != nullptr) {
 		debug_e("HttpRequest::setBody: Discarding already set stream!");
 		delete bodyStream;
-		bodyStream = nullptr;
 	}
 
 	bodyStream = stream;

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -154,8 +154,11 @@ public:
 		return uri.Path;
 	}
 
-	/* @todo deprecate: use uri methods */
-	String getQueryParameter(const String& parameterName, const String& defaultValue = nullptr);
+	/* @deprecated Use methods of `uri.Query` instead */
+	String getQueryParameter(const String& parameterName, const String& defaultValue = nullptr) const
+	{
+		return reinterpret_cast<const HttpParams&>(uri.Query)[parameterName] ?: defaultValue;
+	}
 
 	/**
 	 * @brief Returns content from the body stream as string.

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -43,7 +43,7 @@ public:
 	{
 	}
 
-	HttpRequest(const URL& uri) : uri(uri)
+	HttpRequest(const Url& uri) : uri(uri)
 	{
 	}
 
@@ -74,7 +74,7 @@ public:
 		reset();
 	}
 
-	HttpRequest* setURL(const URL& uri)
+	HttpRequest* setURL(const Url& uri)
 	{
 		this->uri = uri;
 		return this;
@@ -271,7 +271,7 @@ public:
 #endif
 
 public:
-	URL uri;
+	Url uri;
 	HttpMethod method = HTTP_GET;
 	HttpHeaders headers;
 	HttpParams postParams;

--- a/Sming/SmingCore/Network/Http/HttpRequest.h
+++ b/Sming/SmingCore/Network/Http/HttpRequest.h
@@ -47,14 +47,27 @@ public:
 	{
 	}
 
+	/**
+	 * @brief Copy constructor
+	 * @note Internal streams are not copied so these must be dealt with afterwards
+	 */
 	HttpRequest(const HttpRequest& value);
 
+	/**
+	 * @brief Clone this request into a new object using the copy constructor
+	 * @retval HttpRequest* The new request object
+	 * @see HttpRequest(const HttpRequest& value)
+	 */
 	HttpRequest* clone() const
 	{
 		return new HttpRequest(*this);
 	}
 
-	HttpRequest& operator=(const HttpRequest& rhs);
+	/** @deprecated Please use `clone()` instead */
+	HttpRequest& operator=(const HttpRequest& rhs) SMING_DEPRECATED
+	{
+		return *this;
+	}
 
 	~HttpRequest()
 	{
@@ -164,13 +177,13 @@ public:
 
 	HttpRequest* setBody(const String& body)
 	{
-		setBody((uint8_t*)body.c_str(), body.length());
+		setBody(reinterpret_cast<const uint8_t*>(body.c_str()), body.length());
 		return this;
 	}
 
 	HttpRequest* setBody(IDataSourceStream* stream);
 
-	HttpRequest* setBody(uint8_t* rawData, size_t length);
+	HttpRequest* setBody(const uint8_t* rawData, size_t length);
 
 	/**
 	 * @brief Instead of storing the response body we can set a stream that will take care to process it

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.cpp
@@ -32,7 +32,7 @@ int HttpServerConnection::onMessageBegin(http_parser* parser)
 	return 0;
 }
 
-int HttpServerConnection::onPath(const URL& uri)
+int HttpServerConnection::onPath(const Url& uri)
 {
 	if(resourceTree == nullptr) {
 		debug_e("ERROR: HttpServerConnection: The resource tree is not set!");

--- a/Sming/SmingCore/Network/Http/HttpServerConnection.h
+++ b/Sming/SmingCore/Network/Http/HttpServerConnection.h
@@ -86,7 +86,7 @@ protected:
 	// HTTP parser methods
 
 	int onMessageBegin(http_parser* parser) override;
-	int onPath(const URL& path) override;
+	int onPath(const Url& path) override;
 	int onHeadersComplete(const HttpHeaders& headers) override;
 	int onBody(const char* at, size_t length) override;
 	int onMessageComplete(http_parser* parser) override;

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -48,13 +48,11 @@ bool HttpClient::send(HttpRequest* request)
 	return connection->send(request);
 }
 
-bool HttpClient::downloadFile(const String& url, const String& saveFileName, RequestCompletedDelegate requestComplete)
+bool HttpClient::downloadFile(const Url& url, const String& saveFileName, RequestCompletedDelegate requestComplete)
 {
-	Url uri(url);
-
 	String file = saveFileName;
 	if(file.length() == 0) {
-		file = uri.getFileName();
+		file = url.getFileName();
 	}
 
 	auto fileStream = new FileStream();

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -50,7 +50,7 @@ bool HttpClient::send(HttpRequest* request)
 
 bool HttpClient::downloadFile(const String& url, const String& saveFileName, RequestCompletedDelegate requestComplete)
 {
-	URL uri(url);
+	Url uri(url);
 
 	String file;
 	if(saveFileName.length() == 0) {

--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -52,20 +52,15 @@ bool HttpClient::downloadFile(const String& url, const String& saveFileName, Req
 {
 	Url uri(url);
 
-	String file;
-	if(saveFileName.length() == 0) {
-		file = uri.Path;
-		int p = file.lastIndexOf('/');
-		if(p >= 0) {
-			file.remove(0, p + 1);
-		}
-	} else {
-		file = saveFileName;
+	String file = saveFileName;
+	if(file.length() == 0) {
+		file = uri.getFileName();
 	}
 
 	auto fileStream = new FileStream();
 	if(!fileStream->open(file, eFO_CreateNewAlways | eFO_WriteOnly)) {
 		debug_e("HttpClient failed to open \"%s\"", file.c_str());
+		delete fileStream;
 		return false;
 	}
 

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -68,6 +68,12 @@ public:
 		return downloadFile(url, nullptr, requestComplete);
 	}
 
+	/**
+	 * @brief Queue request to download a file
+	 * @param url Source of file data
+	 * @param saveFilename Path to save file to. Optional: specify nullptr to use name from url
+	 * @param requestComplete Completion callback
+	 */
 	bool downloadFile(const String& url, const String& saveFileName,
 					  RequestCompletedDelegate requestComplete = nullptr);
 

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -115,7 +115,7 @@ public:
 protected:
 	String getCacheKey(const Url& url)
 	{
-		return url.Host + ':' + url.Port;
+		return url.Host + ':' + url.getPort();
 	}
 
 protected:

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -40,30 +40,30 @@ public:
 
 	/* High-Level Methods */
 
-	bool sendRequest(const String& url, RequestCompletedDelegate requestComplete)
+	bool sendRequest(const Url& url, RequestCompletedDelegate requestComplete)
 	{
 		return send(createRequest(url)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
 	}
 
-	bool sendRequest(const HttpMethod method, const String& url, const HttpHeaders& headers,
+	bool sendRequest(const HttpMethod method, const Url& url, const HttpHeaders& headers,
 					 RequestCompletedDelegate requestComplete)
 	{
 		return send(createRequest(url)->setMethod(method)->setHeaders(headers)->onRequestComplete(requestComplete));
 	}
 
-	bool sendRequest(const HttpMethod method, const String& url, const HttpHeaders& headers, const String& body,
+	bool sendRequest(const HttpMethod method, const Url& url, const HttpHeaders& headers, const String& body,
 					 RequestCompletedDelegate requestComplete)
 	{
 		return send(createRequest(url)->setMethod(method)->setHeaders(headers)->setBody(body)->onRequestComplete(
 			requestComplete));
 	}
 
-	bool downloadString(const String& url, RequestCompletedDelegate requestComplete)
+	bool downloadString(const Url& url, RequestCompletedDelegate requestComplete)
 	{
 		return send(createRequest(url)->setMethod(HTTP_GET)->onRequestComplete(requestComplete));
 	}
 
-	bool downloadFile(const String& url, RequestCompletedDelegate requestComplete = nullptr)
+	bool downloadFile(const Url& url, RequestCompletedDelegate requestComplete = nullptr)
 	{
 		return downloadFile(url, nullptr, requestComplete);
 	}
@@ -74,7 +74,7 @@ public:
 	 * @param saveFilename Path to save file to. Optional: specify nullptr to use name from url
 	 * @param requestComplete Completion callback
 	 */
-	bool downloadFile(const String& url, const String& saveFileName,
+	bool downloadFile(const Url& url, const String& saveFileName,
 					  RequestCompletedDelegate requestComplete = nullptr);
 
 	/* Low Level Methods */
@@ -99,7 +99,7 @@ public:
 	 *  @param url
 	 *  @retval HttpRequest*
 	 */
-	HttpRequest* createRequest(const String& url)
+	HttpRequest* createRequest(const Url& url)
 	{
 		return new HttpRequest(url);
 	}

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -95,7 +95,7 @@ public:
 	 */
 	HttpRequest* createRequest(const String& url)
 	{
-		return new HttpRequest(URL(url));
+		return new HttpRequest(url);
 	}
 
 	/**
@@ -107,7 +107,7 @@ public:
 	}
 
 protected:
-	String getCacheKey(URL url)
+	String getCacheKey(const Url& url)
 	{
 		return url.Host + ':' + url.Port;
 	}

--- a/Sming/SmingCore/Network/HttpClient.h
+++ b/Sming/SmingCore/Network/HttpClient.h
@@ -74,8 +74,7 @@ public:
 	 * @param saveFilename Path to save file to. Optional: specify nullptr to use name from url
 	 * @param requestComplete Completion callback
 	 */
-	bool downloadFile(const Url& url, const String& saveFileName,
-					  RequestCompletedDelegate requestComplete = nullptr);
+	bool downloadFile(const Url& url, const String& saveFileName, RequestCompletedDelegate requestComplete = nullptr);
 
 	/* Low Level Methods */
 

--- a/Sming/SmingCore/Network/HttpServer.h
+++ b/Sming/SmingCore/Network/HttpServer.h
@@ -89,7 +89,7 @@ public:
 	}
 
 	/** @deprecated Use `paths.setDefault()` instead */
-	void setDefault(const HttpPathDelegate& callback) SMING_DEPRECATED
+	void setDefaultHandler(const HttpPathDelegate& callback) SMING_DEPRECATED
 	{
 		paths.setDefault(callback);
 	}

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -197,8 +197,8 @@ bool MqttClient::setWill(const String& topic, const String& message, uint8_t fla
 bool MqttClient::connect(const Url& url, const String& clientName, uint32_t sslOptions)
 {
 	this->url = url;
-	bool useSsl = (url.Protocol == _F("mqtts"));
-	if(!(useSsl || url.Protocol == _F("mqtt"))) {
+	bool useSsl = (url.Scheme == URI_SCHEME_MQTT_SECURE);
+	if(!useSsl && url.Scheme != URI_SCHEME_MQTT) {
 		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
@@ -210,8 +210,7 @@ bool MqttClient::connect(const Url& url, const String& clientName, uint32_t sslO
 
 	debug_d("MQTT start connection");
 
-	String protocolName = F("MQTT");
-	COPY_STRING(connectMessage.connect.protocol_name, protocolName);
+	COPY_STRING(connectMessage.connect.protocol_name, F("MQTT"));
 
 	connectMessage.connect.keep_alive = keepAlive;
 

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -229,7 +229,7 @@ bool MqttClient::connect(const Url& url, const String& clientName, uint32_t sslO
 	memcpy(message, &connectMessage, sizeof(mqtt_message_t));
 	requestQueue.enqueue(message);
 
-	return TcpClient::connect(url.Host, url.Port, useSsl, sslOptions);
+	return TcpClient::connect(url.Host, url.getPort(), useSsl, sslOptions);
 }
 
 bool MqttClient::publish(const String& topic, const String& content, uint8_t flags)

--- a/Sming/SmingCore/Network/MqttClient.cpp
+++ b/Sming/SmingCore/Network/MqttClient.cpp
@@ -194,7 +194,7 @@ bool MqttClient::setWill(const String& topic, const String& message, uint8_t fla
 	return true;
 }
 
-bool MqttClient::connect(const URL& url, const String& clientName, uint32_t sslOptions)
+bool MqttClient::connect(const Url& url, const String& clientName, uint32_t sslOptions)
 {
 	this->url = url;
 	bool useSsl = (url.Protocol == _F("mqtts"));

--- a/Sming/SmingCore/Network/MqttClient.h
+++ b/Sming/SmingCore/Network/MqttClient.h
@@ -12,7 +12,7 @@
 #define _SMING_CORE_NETWORK_MQTT_CLIENT_H_
 
 #include "TcpClient.h"
-#include "URL.h"
+#include "Url.h"
 #include "WString.h"
 #include "WHashMap.h"
 #include "Data/ObjectQueue.h"
@@ -88,7 +88,7 @@ public:
 	*  @param  url, in the form "mqtt://user:password@server:port" or "mqtts://user:password@server:port"
 	*  @param  client name
 	*/
-	bool connect(const URL& url, const String& uniqueClientName, uint32_t sslOptions = 0);
+	bool connect(const Url& url, const String& uniqueClientName, uint32_t sslOptions = 0);
 
 	bool publish(const String& topic, const String& message, uint8_t flags = 0);
 	bool publish(const String& topic, IDataSourceStream* stream, uint8_t flags = 0);
@@ -285,7 +285,7 @@ private:
 #endif
 
 private:
-	URL url;
+	Url url;
 
 	// callbacks
 	HashMap<mqtt_type_t, MqttDelegate> eventHandler;

--- a/Sming/SmingCore/Network/SmtpClient.cpp
+++ b/Sming/SmingCore/Network/SmtpClient.cpp
@@ -90,13 +90,8 @@ bool SmtpClient::connect(const Url& url)
 	}
 
 	bool isSecure = (url.Scheme == URI_SCHEME_SMTP_SECURE);
-
 	this->url = url;
-	if(this->url.Port == 0) {
-		this->url.Port = isSecure ? 465 : 25;
-	}
-
-	return TcpClient::connect(url.Host, url.Port, isSecure);
+	return TcpClient::connect(url.Host, url.getPort(), isSecure);
 }
 
 bool SmtpClient::send(const String& from, const String& to, const String& subject, const String& body)

--- a/Sming/SmingCore/Network/SmtpClient.cpp
+++ b/Sming/SmingCore/Network/SmtpClient.cpp
@@ -83,7 +83,7 @@ SmtpClient::~SmtpClient()
 	}
 }
 
-bool SmtpClient::connect(const URL& url)
+bool SmtpClient::connect(const Url& url)
 {
 	if(getConnectionState() != eTCS_Ready) {
 		close();

--- a/Sming/SmingCore/Network/SmtpClient.cpp
+++ b/Sming/SmingCore/Network/SmtpClient.cpp
@@ -89,15 +89,14 @@ bool SmtpClient::connect(const Url& url)
 		close();
 	}
 
+	bool isSecure = (url.Scheme == URI_SCHEME_SMTP_SECURE);
+
 	this->url = url;
-	if(!this->url.Port) {
-		this->url.Port = 25;
-		if(this->url.Protocol == SMTP_OVER_SSL_PROTOCOL) {
-			this->url.Port = 465;
-		}
+	if(this->url.Port == 0) {
+		this->url.Port = isSecure ? 465 : 25;
 	}
 
-	return TcpClient::connect(url.Host, url.Port, (url.Protocol == SMTP_OVER_SSL_PROTOCOL));
+	return TcpClient::connect(url.Host, url.Port, isSecure);
 }
 
 bool SmtpClient::send(const String& from, const String& to, const String& subject, const String& body)

--- a/Sming/SmingCore/Network/SmtpClient.h
+++ b/Sming/SmingCore/Network/SmtpClient.h
@@ -38,9 +38,6 @@
 
 #include <functional>
 
-#define SMTP_PROTOCOL _F("smtp")
-#define SMTP_OVER_SSL_PROTOCOL _F("smtps")
-
 /* Maximum waiting emails in the mail queue */
 #define SMTP_QUEUE_SIZE 5
 

--- a/Sming/SmingCore/Network/SmtpClient.h
+++ b/Sming/SmingCore/Network/SmtpClient.h
@@ -29,7 +29,7 @@
 
 #include "TcpClient.h"
 #include "Data/MailMessage.h"
-#include "URL.h"
+#include "Url.h"
 #include "WString.h"
 #include "WVector.h"
 #include "Data/Stream/DataSourceStream.h"
@@ -105,7 +105,7 @@ public:
 	 * 					- smtp  - clear text SMTP
 	 * 					- smtps - SMTP over SSL connection
 	 */
-	bool connect(const URL& url);
+	bool connect(const Url& url);
 
 	/**
 	 * @brief Queues a single message before it is sent later to the SMTP server
@@ -189,7 +189,7 @@ protected:
 	bool sendMailBody(MailMessage* mail);
 
 private:
-	URL url;
+	Url url;
 	Vector<String> authMethods;
 	ObjectQueue<MailMessage, SMTP_QUEUE_SIZE> mailQ;
 	char code[4] = {0};

--- a/Sming/SmingCore/Network/Url.cpp
+++ b/Sming/SmingCore/Network/Url.cpp
@@ -37,6 +37,7 @@ Url& Url::operator=(String urlString)
 		Scheme = URI_SCHEME_DEFAULT;
 	} else {
 		Scheme = url.scheme;
+		Scheme.toLowerCase();
 	}
 	User = uri_unescape_inplace(url.username);
 	Password = uri_unescape_inplace(url.password);

--- a/Sming/SmingCore/Network/Url.cpp
+++ b/Sming/SmingCore/Network/Url.cpp
@@ -4,20 +4,20 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * URL.cpp
+ * Url.cpp
  *
  * Code based on http://stackoverflow.com/questions/2616011/easy-way-to-parse-a-url-in-c-cross-platform
  *
  ****/
 
-#include "URL.h"
+#include "Url.h"
 
-URL::URL()
+Url::Url()
 {
 	Port = 80;
 }
 
-URL::URL(const String& urlString)
+Url::Url(const String& urlString)
 {
 	int len = urlString.length();
 	if(len == 0)

--- a/Sming/SmingCore/Network/Url.h
+++ b/Sming/SmingCore/Network/Url.h
@@ -78,6 +78,13 @@ public:
 		*this = urlString;
 	}
 
+	/** @brief Construct a URL object from a regular null-terminated escaped string
+	 *  @urlString Escaped URL
+	 */
+	Url(const char* urlString) : Url(String(urlString))
+	{
+	}
+
 	Url(const String& scheme, const String& user, const String& password, const String& host, int port = 0,
 		const String& path = nullptr, const String& query = nullptr, const String& fragment = nullptr)
 		: Scheme(scheme), User(user), Password(password), Host(host), Port(port), Path(path), Query(query),

--- a/Sming/SmingCore/Network/Url.h
+++ b/Sming/SmingCore/Network/Url.h
@@ -4,11 +4,11 @@
  * http://github.com/anakod/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * URL.h
+ * Url.h
  *
  ****/
 
-/** @defgroup   url URL
+/** @defgroup   url Url
  *  @brief      Provides URL handling
  *  @ingroup    httpserver
  *  @ingroup    httpclient
@@ -24,11 +24,11 @@
 #define HTTPS_URL_PROTOCOL _F("https")
 #define WEBSOCKET_SECURE_URL_PROTOCOL _F("wss")
 
-class URL
+class Url
 {
 public:
-	URL();
-	URL(const String& urlString);
+	Url();
+	Url(const String& urlString);
 
 	inline String toString()
 	{
@@ -51,6 +51,8 @@ public:
 	String Path;
 	String Query;
 };
+
+typedef Url URL SMING_DEPRECATED; ///< @deprecated Use `Url` instead
 
 /** @} */
 #endif /* _SMING_CORE_NETWORK_URL_H_ */

--- a/Sming/SmingCore/Network/Url.h
+++ b/Sming/SmingCore/Network/Url.h
@@ -83,6 +83,10 @@ public:
 		: Scheme(scheme), User(user), Password(password), Host(host), Port(port), Path(path), Query(query),
 		  Fragment(fragment)
 	{
+		Scheme.toLowerCase();
+		if(Port == 0) {
+			Port = getDefaultPort(Scheme);
+		}
 	}
 
 	/** @brief Copy assignment operator
@@ -105,6 +109,15 @@ public:
 	 *  @retval int 0 if scheme is not recognised or has no standard port defined
 	 */
 	static int getDefaultPort(const String& scheme);
+
+	/** @brief Obtain the actual port number to be used
+	 *  @retval int
+	 *  @note If not specified, the default scheme port is returned
+	 */
+	int getPort() const
+	{
+		return Port ?: getDefaultPort(Scheme);
+	}
 
 	/** @brief Get hostname+port part of URL string
 	 *  @retval String

--- a/Sming/SmingCore/Network/Url.h
+++ b/Sming/SmingCore/Network/Url.h
@@ -102,6 +102,15 @@ public:
 	 */
 	Url& operator=(String urlString);
 
+	/** @brief Copy assignment operator, for C-style strings
+	 *  @param urlString Escaped URL
+	 */
+	Url& operator=(const char* urlString)
+	{
+		*this = String(urlString);
+		return *this;
+	}
+
 	/** @brief Get escaped URL
 	 * 	@retval String
 	 */

--- a/Sming/SmingCore/Network/Url.h
+++ b/Sming/SmingCore/Network/Url.h
@@ -6,6 +6,13 @@
  *
  * Url.h
  *
+ * @author Feb 2019 mikee47 <mike@sillyhouse.net>
+ *
+ * Support added for escaped URLs and standard schemes.
+ *
+ * @see https://en.m.wikipedia.org/wiki/URL
+ * @see https://en.m.wikipedia.org/wiki/URL_normalization
+ *
  ****/
 
 /** @defgroup   url Url
@@ -19,37 +26,126 @@
 #define _SMING_CORE_NETWORK_URL_H_
 
 #include "WString.h"
+#include "Http/HttpParams.h"
 
-#define DEFAULT_URL_PROTOCOL _F("http")
-#define HTTPS_URL_PROTOCOL _F("https")
-#define WEBSOCKET_SECURE_URL_PROTOCOL _F("wss")
+/*
+ * Common URL schemes (name, scheme, port)
+ * 	name: 	Used for string identifier
+ * 	scheme:	String to be used in a URL, normalised (i.e. lower case)
+ * 	port: 	Offical default port definition for the scheme, 0 if not applicable
+ */
+#define URI_SCHEME_MAP(XX)                                                                                             \
+	XX(HTTP, http, 80)                                                                                                 \
+	XX(HTTP_SECURE, https, 443)                                                                                        \
+	XX(WEBSOCKET, ws, 80)                                                                                              \
+	XX(WEBSOCKET_SECURE, wss, 443)                                                                                     \
+	XX(MQTT, mqtt, 1883)                                                                                               \
+	XX(MQTT_SECURE, mqtts, 8883)                                                                                       \
+	XX(SMTP, smtp, 25)                                                                                                 \
+	XX(SMTP_SECURE, smtps, 465)                                                                                        \
+	XX(FTP, ftp, 21)                                                                                                   \
+	XX(MAIL_TO, mailto, 0)                                                                                             \
+	XX(FILE, file, 0)                                                                                                  \
+	XX(DATA, data, 0)
 
+/**
+ * @brief Common URI scheme strings
+ */
+#define XX(name, str, port) DECLARE_FSTR(URI_SCHEME_##name)
+URI_SCHEME_MAP(XX)
+#undef XX
+
+class Print;
+
+/** @brief Class to manage URL instance
+ *  @note The various URL components are stored in un-escaped format for ease of editing.
+ *  Unless otherwise indicated, methods act on un-escaped text.
+ *  Methods used to obtain escaped versions are clearly marked.
+ *  Any attached fragment (marked bv '#') in the URL is discarded
+ */
 class Url
 {
 public:
-	Url();
-	Url(const String& urlString);
+	Url() = default;
 
-	inline String toString()
+	Url(const Url& url) = default;
+
+	/** @brief Construct a URL object from a regular escaped string
+	 *  @urlString Escaped URL
+	 */
+	Url(const String& urlString)
 	{
-		return Protocol + "://" + Host + (Port != 0 ? ":" + String(Port) : "") + getPathWithQuery();
+		*this = urlString;
 	}
-	inline String getPathWithQuery()
+
+	Url(const String& scheme, const String& user, const String& password, const String& host, int port = 0,
+		const String& path = nullptr, const String& query = nullptr, const String& fragment = nullptr)
+		: Scheme(scheme), User(user), Password(password), Host(host), Port(port), Path(path), Query(query),
+		  Fragment(fragment)
 	{
-		if(Path.length() + Query.length() > 0)
-			return Path + Query;
-		else
-			return "/";
 	}
+
+	/** @brief Copy assignment operator
+	 *  @param urlString Escaped URL
+	 *  @note urlString is modified by so no point in passing const reference
+	 */
+	Url& operator=(String urlString);
+
+	/** @brief Get escaped URL
+	 * 	@retval String
+	 */
+	String toString() const;
+
+	operator String() const
+	{
+		return toString();
+	}
+
+	/** @brief Obtain the default port for a given scheme
+	 *  @retval int 0 if scheme is not recognised or has no standard port defined
+	 */
+	static int getDefaultPort(const String& scheme);
+
+	/** @brief Get hostname+port part of URL string
+	 *  @retval String
+	 *  @note Neither of these is subject to escaping
+	 */
+	String getHostWithPort() const;
+
+	/** @brief Get path without leading separator
+	 *  @retval String
+	 */
+	String getRelativePath() const
+	{
+		return (Path[0] == '/') ? Path.substring(1) : Path;
+	}
+
+	/** @brief Get path with any query parameters attached
+	 *  @retval String
+	 *  @note Both path and query values are escaped
+	 */
+	String getPathWithQuery() const;
+
+	/** @brief Obtain the filename part of the URL path
+	 *  @retval String
+	 */
+	String getFileName() const;
+
+	/**
+	 * @brief Printable output for debugging
+	 * @param p
+	 */
+	void debugPrintTo(Print& p) const;
 
 public:
-	String Protocol;
+	String Scheme; ///< without ":" and "//"
 	String User;
 	String Password;
-	String Host;
-	int Port;
-	String Path;
-	String Query;
+	String Host;  ///< hostname or IP address
+	int Port = 0; ///< Undefined by default
+	String Path;  ///< with leading "/"
+	HttpParams Query;
+	String Fragment; ///< Without '#'
 };
 
 typedef Url URL SMING_DEPRECATED; ///< @deprecated Use `Url` instead

--- a/Sming/SmingCore/Network/WebsocketClient.cpp
+++ b/Sming/SmingCore/Network/WebsocketClient.cpp
@@ -31,7 +31,7 @@ HttpConnection* WebsocketClient::getHttpConnection()
 
 bool WebsocketClient::connect(const String& url, uint32_t sslOptions)
 {
-	uri = URL(url);
+	uri = url;
 	bool useSsl = false;
 	if(uri.Protocol == WEBSOCKET_SECURE_URL_PROTOCOL) {
 		useSsl = true;

--- a/Sming/SmingCore/Network/WebsocketClient.cpp
+++ b/Sming/SmingCore/Network/WebsocketClient.cpp
@@ -46,7 +46,7 @@ bool WebsocketClient::connect(const String& url, uint32_t sslOptions)
 		return false;
 	}
 
-	httpConnection->connect(uri.Host, uri.Port, useSsl, sslOptions);
+	httpConnection->connect(uri.Host, uri.getPort(), useSsl, sslOptions);
 
 	state = eWSCS_Ready;
 

--- a/Sming/SmingCore/Network/WebsocketClient.cpp
+++ b/Sming/SmingCore/Network/WebsocketClient.cpp
@@ -33,7 +33,7 @@ bool WebsocketClient::connect(const String& url, uint32_t sslOptions)
 {
 	uri = url;
 	bool useSsl = false;
-	if(uri.Protocol == WEBSOCKET_SECURE_URL_PROTOCOL) {
+	if(uri.Scheme == URI_SCHEME_WEBSOCKET_SECURE) {
 		useSsl = true;
 	}
 

--- a/Sming/SmingCore/Network/WebsocketClient.cpp
+++ b/Sming/SmingCore/Network/WebsocketClient.cpp
@@ -29,7 +29,7 @@ HttpConnection* WebsocketClient::getHttpConnection()
 	return connection;
 }
 
-bool WebsocketClient::connect(const String& url, uint32_t sslOptions)
+bool WebsocketClient::connect(const Url& url, uint32_t sslOptions)
 {
 	uri = url;
 	bool useSsl = false;

--- a/Sming/SmingCore/Network/WebsocketClient.h
+++ b/Sming/SmingCore/Network/WebsocketClient.h
@@ -48,7 +48,7 @@ public:
 	HttpConnection* getHttpConnection();
 
 	/**  @brief  Connects websocket client to server
-	  *  @param  url URL address of websocket server
+	  *  @param  url Url address of websocket server
 	  *  @param  sslOptions Specify the SSL options to be used when calling websocket server over SSL
 	  */
 	bool connect(const String& url, uint32_t sslOptions = 0);
@@ -95,7 +95,7 @@ protected:
 	int verifyKey(HttpConnection& connection, HttpResponse& response);
 
 private:
-	URL uri;
+	Url uri;
 	String key;
 };
 

--- a/Sming/SmingCore/Network/WebsocketClient.h
+++ b/Sming/SmingCore/Network/WebsocketClient.h
@@ -51,7 +51,7 @@ public:
 	  *  @param  url Url address of websocket server
 	  *  @param  sslOptions Specify the SSL options to be used when calling websocket server over SSL
 	  */
-	bool connect(const String& url, uint32_t sslOptions = 0);
+	bool connect(const Url& url, uint32_t sslOptions = 0);
 
 	using WebsocketConnection::send;
 	using WebsocketConnection::sendBinary;

--- a/Sming/SmingCore/Network/rBootHttpUpdate.cpp
+++ b/Sming/SmingCore/Network/rBootHttpUpdate.cpp
@@ -15,7 +15,7 @@
 
 #include "rBootHttpUpdate.h"
 #include "Platform/System.h"
-#include "URL.h"
+#include "Url.h"
 #include "Platform/WDT.h"
 
 /* rBootItemOutputStream */
@@ -80,9 +80,9 @@ void rBootHttpUpdate::start()
 		HttpRequest* request;
 		if(baseRequest != nullptr) {
 			request = baseRequest->clone();
-			request->setURL(URL(it.url));
+			request->setURL(it.url);
 		} else {
-			request = new HttpRequest(URL(it.url));
+			request = new HttpRequest(it.url);
 		}
 
 		request->setMethod(HTTP_GET);

--- a/Sming/SmingCore/SmingCore.h
+++ b/Sming/SmingCore/SmingCore.h
@@ -52,7 +52,7 @@
 #include "Network/TcpConnection.h"
 #include "Network/UdpConnection.h"
 #include "Network/rBootHttpUpdate.h"
-#include "Network/URL.h"
+#include "Network/Url.h"
 
 #include "Data/Stream/JsonObjectStream.h"
 #include "Data/Stream/FileStream.h"

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -130,9 +130,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 
 void onFile(HttpRequest& request, HttpResponse& response)
 {
-	String file = request.uri.Path;
-	if(file[0] == '/')
-		file = file.substring(1);
+	String file = request.uri.getRelativePath();
 
 	if(file[0] == '.')
 		response.code = HTTP_STATUS_FORBIDDEN;

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -95,7 +95,7 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 
 	debugf("Connected. Got IP: %s", ip.toString().c_str());
 
-	HttpRequest* request = new HttpRequest(URL(F("https://www.grc.com/fingerprints.htm")));
+	HttpRequest* request = new HttpRequest(F("https://www.grc.com/fingerprints.htm"));
 	request->setSslOptions(SSL_SERVER_VERIFY_LATER);
 
 	/*

--- a/samples/Basic_WebSkeletonApp/app/webserver.cpp
+++ b/samples/Basic_WebSkeletonApp/app/webserver.cpp
@@ -65,9 +65,7 @@ void onConfiguration_json(HttpRequest& request, HttpResponse& response)
 }
 void onFile(HttpRequest& request, HttpResponse& response)
 {
-	String file = request.uri.Path;
-	if(file[0] == '/')
-		file = file.substring(1);
+	String file = request.uri.getRelativePath();
 
 	if(file[0] == '.')
 		response.code = HTTP_STATUS_FORBIDDEN;

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -29,9 +29,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 
 void onFile(HttpRequest& request, HttpResponse& response)
 {
-	String file = request.uri.Path;
-	if(file[0] == '/')
-		file = file.substring(1);
+	String file = request.uri.getRelativePath();
 
 	if(file[0] == '.')
 		response.code = HTTP_STATUS_FORBIDDEN;

--- a/samples/HttpClient/app/application.cpp
+++ b/samples/HttpClient/app/application.cpp
@@ -128,7 +128,7 @@ void connectOk(IPAddress ip, IPAddress mask, IPAddress gateway)
 	// First: The HttpRequest object contains all the data that needs to be sent
 	//    	  to the remote server.
 
-	HttpRequest* getRequest = new HttpRequest(URL("https://httpbin.org/get"));
+	HttpRequest* getRequest = new HttpRequest(F("https://httpbin.org/get"));
 	getRequest->setMethod(HTTP_GET); // << you may set the method. If not set the default HTTP_GET method will be used
 
 	// Headers: if you need to set custom headers then you can do something like ...
@@ -156,7 +156,7 @@ void connectOk(IPAddress ip, IPAddress mask, IPAddress gateway)
 	// [ POST request: the example below shows how to set a POST request with form data and files. ]
 	FileStream* fileStream = new FileStream("5K.txt");
 
-	HttpRequest* postRequest = new HttpRequest(URL("https://httpbin.org/post"));
+	HttpRequest* postRequest = new HttpRequest(F("https://httpbin.org/post"));
 	// For this request we will use a slightly improved syntax
 	postRequest
 		->setMethod(HTTP_POST)					  // << we set the method to POST
@@ -171,7 +171,7 @@ void connectOk(IPAddress ip, IPAddress mask, IPAddress gateway)
 	// [PUT request with raw data: We will send the data.txt content without any additional content encoding ]
 	FileStream* fileStream1 = new FileStream("20K.txt");
 
-	HttpRequest* putRequest = new HttpRequest(URL("https://httpbin.org/put"));
+	HttpRequest* putRequest = new HttpRequest(F("https://httpbin.org/put"));
 	putRequest->setMethod(HTTP_PUT)
 		->setBody(fileStream1) // << we set the complete HTTP body
 		->onRequestComplete(onDownload);

--- a/samples/HttpClient_Instapush/app/application.cpp
+++ b/samples/HttpClient_Instapush/app/application.cpp
@@ -39,7 +39,7 @@ public:
 	{
 		debugf("preparing request");
 
-		HttpRequest* request = new HttpRequest(URL(url));
+		HttpRequest* request = new HttpRequest(String(url));
 
 		HttpHeaders requestHeaders;
 		requestHeaders[HTTP_HEADER_CONTENT_TYPE] = ContentType::toString(MIME_JSON);

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -35,8 +35,18 @@ void sendData()
 	// Read our sensor value :)
 	sensorValue++;
 
-	thingSpeak.downloadString("http://api.thingspeak.com/update?key=7XXUJWCWYTMXKN3L&field1=" + String(sensorValue),
-							  onDataSent);
+	/*
+	   Here is an alternative method of URL construction, which is helpful for more complex URLs.
+	   The resulting URL string is equivalent to:
+
+	     "http://api.thingspeak.com/update?key=7XXUJWCWYTMXKN3L&field1=" + String(sensorValue)
+	 */
+	Url url;
+	url.Host = "api.thingspeak.com";
+	url.Path = "/update";
+	url.Query["key"] = "7XXUJWCWYTMXKN3L";
+	url.Query["field1"] = String(sensorValue);
+	thingSpeak.downloadString(url, onDataSent);
 }
 
 // Will be called when WiFi station timeout was reached

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -24,9 +24,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 
 void onFile(HttpRequest& request, HttpResponse& response)
 {
-	String file = request.uri.Path;
-	if(file[0] == '/')
-		file = file.substring(1);
+	String file = request.uri.getRelativePath();
 
 	if(file[0] == '.')
 		response.code = HTTP_STATUS_FORBIDDEN;

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -36,9 +36,7 @@ void onHello(HttpRequest& request, HttpResponse& response)
 
 void onFile(HttpRequest& request, HttpResponse& response)
 {
-	String file = request.uri.Path;
-	if(file[0] == '/')
-		file = file.substring(1);
+	String file = request.uri.getRelativePath();
 
 	if(file[0] == '.')
 		response.code = HTTP_STATUS_FORBIDDEN;

--- a/samples/HttpServer_ConfigNetwork/app/application.cpp
+++ b/samples/HttpServer_ConfigNetwork/app/application.cpp
@@ -73,9 +73,7 @@ void onFile(HttpRequest& request, HttpResponse& response)
 		return;
 	}
 
-	String file = request.uri.Path;
-	if(file[0] == '/')
-		file = file.substring(1);
+	String file = request.uri.getRelativePath();
 
 	if(file[0] == '.')
 		response.code = HTTP_STATUS_FORBIDDEN;

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -24,10 +24,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 
 void onFile(HttpRequest& request, HttpResponse& response)
 {
-	String file = request.uri.Path;
-	if(file[0] == '/') {
-		file = file.substring(1);
-	}
+	String file = request.uri.getRelativePath();
 
 	if(file[0] == '.') {
 		response.code = HTTP_STATUS_FORBIDDEN;

--- a/samples/MeteoControl/app/webserver.cpp
+++ b/samples/MeteoControl/app/webserver.cpp
@@ -59,9 +59,7 @@ void onConfiguration(HttpRequest& request, HttpResponse& response)
 
 void onFile(HttpRequest& request, HttpResponse& response)
 {
-	String file = request.uri.Path;
-	if(file[0] == '/')
-		file = file.substring(1);
+	String file = request.uri.getRelativePath();
 
 	if(file[0] == '.')
 		response.code = HTTP_STATUS_FORBIDDEN;

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -8,9 +8,6 @@
 
 Timer publishTimer;
 
-String mqttUrl = "mqtt://" + String(LOG) + ":" + String(PASS) + "@" + String(MQTT_SERVER) + ":" + String(MQTT_PORT);
-Url url(mqttUrl);
-
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway);
 
 void init()
@@ -54,6 +51,7 @@ void onMessageReceived(String topic, String message)
 // Run MQTT client
 void startMqttClient()
 {
+	Url url(URI_SCHEME_MQTT, F(LOG), F(PASS), F(MQTT_SERVER), MQTT_PORT);
 	mqtt.connect(url, CLIENT);
 	Serial.println("Connected to MQTT server");
 	mqtt.subscribe(SUB_TOPIC);

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -9,7 +9,7 @@
 Timer publishTimer;
 
 String mqttUrl = "mqtt://" + String(LOG) + ":" + String(PASS) + "@" + String(MQTT_SERVER) + ":" + String(MQTT_PORT);
-URL url(mqttUrl);
+Url url(mqttUrl);
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway);
 

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -14,7 +14,7 @@
 
 #define MQTT_URL MQTT_URL1
 
-const URL url(MQTT_URL);
+const Url url(MQTT_URL);
 
 // Forward declarations
 void startMqttClient();
@@ -92,7 +92,7 @@ void startMqttClient()
 #endif
 
 	// 2. [Connect]
-	URL url(MQTT_URL);
+	Url url(MQTT_URL);
 	Serial.printf("Connecting to \t%s\n", url.toString().c_str());
 	mqtt.connect(url, "esp8266");
 	mqtt.subscribe("main/status/#");

--- a/samples/SmtpClient/app/application.cpp
+++ b/samples/SmtpClient/app/application.cpp
@@ -11,10 +11,10 @@
 // Make sure to change those to your desired values
 #define MAIL_FROM "admin@sming.com"
 #define MAIL_TO "slav@attachix.com"
-#define SMTP_USERNAME
-#define SMTP_PASSWORD
+#define SMTP_USERNAME nullptr
+#define SMTP_PASSWORD nullptr
 #define SMTP_HOST "attachix.com"
-#define SMTP_PORT 25
+#define SMTP_PORT 0 // Use default port
 #define SMTP_USE_SSL false
 
 SmtpClient client;
@@ -51,13 +51,9 @@ void onConnected(IPAddress ip, IPAddress mask, IPAddress gateway)
 
 	client.onServerError(onServerError);
 
-	String dsn = "smtp";
-	if(SMTP_USE_SSL) {
-		dsn += "s";
-	}
-
-	dsn += String("://") + SMTP_USERNAME + ":" + SMTP_PASSWORD + "@" + SMTP_HOST + ":" + SMTP_PORT;
-	debugf("Connecting to SMTP server using: %s", dsn.c_str());
+	Url dsn(SMTP_USE_SSL ? URI_SCHEME_SMTP_SECURE : URI_SCHEME_SMTP, SMTP_USERNAME, SMTP_PASSWORD, SMTP_HOST,
+			SMTP_PORT);
+	debugf("Connecting to SMTP server using: %s", String(dsn).c_str());
 
 	client.connect(dsn);
 

--- a/samples/SmtpClient/app/application.cpp
+++ b/samples/SmtpClient/app/application.cpp
@@ -59,7 +59,7 @@ void onConnected(IPAddress ip, IPAddress mask, IPAddress gateway)
 	dsn += String("://") + SMTP_USERNAME + ":" + SMTP_PASSWORD + "@" + SMTP_HOST + ":" + SMTP_PORT;
 	debugf("Connecting to SMTP server using: %s", dsn.c_str());
 
-	client.connect(URL(dsn));
+	client.connect(dsn);
 
 	MailMessage* mail = new MailMessage();
 	mail->from = MAIL_FROM;

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -65,9 +65,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 
 void onFile(HttpRequest& request, HttpResponse& response)
 {
-	String file = request.uri.Path;
-	if(file[0] == '/')
-		file = file.substring(1);
+	String file = request.uri.getRelativePath();
 
 	if(file[0] == '.')
 		response.code = HTTP_STATUS_FORBIDDEN;


### PR DESCRIPTION
Revise `HttpRequest` copy constructor
* Remove debug warning and revise comment
* Include `postParams` in copy
* Deprecate `HttpRequest` copy assignment operator
* Define appropriate copy constructors for `HttpHeaders` and `HttpParams`

Revise `URL` and `HttpParams` to support escaped text
* Rename `URL` to `Url` - deprecate `URL`
* Decompose URL using third-party library `libyuarel`
* Integrate escaping/unescaping

Add support for common URL schemes
* [BC] Rename `Protocol` to `Scheme` as per RFC
* Define common URL schemes in tablular form with default port numbers
* Replace use of ad-hoc names with `URI_SCHEME_*`

Other additions
* Add support for URL fragment
* Add constructor to `Url` with individual components
* Provide implicit `String()` operator for `Url` (useful for print, etc.)
* Add `getRelativePath()` and `getFileName()` to simplify application code
* Revise `HttpBodyParser()` to un-escape parameter data