### PR TITLE
Change fileSetContent() to return a result

### DIFF
--- a/Sming/SmingCore/FileSystem.cpp
+++ b/Sming/SmingCore/FileSystem.cpp
@@ -115,17 +115,17 @@ void fileClearLastError(file_t fd)
 	SPIFFS_clearerr(&_filesystemStorageHandle);
 }
 
-signed int fileSetContent(const String& fileName, const String& content)
+int fileSetContent(const String& fileName, const String& content)
 {
 	return fileSetContent(fileName, content.c_str());
 }
 
-signed int fileSetContent(const String& fileName, const char* content)
+int fileSetContent(const String& fileName, const char* content)
 {
-	signed int res;
+	int res;
 
 	file_t file = fileOpen(fileName.c_str(), eFO_CreateNewAlways | eFO_WriteOnly);
-	if( file < 0 ) {
+	if(file < 0) {
 		return file;
 	}
 	res = fileWrite(file, content, strlen(content));

--- a/Sming/SmingCore/FileSystem.cpp
+++ b/Sming/SmingCore/FileSystem.cpp
@@ -115,14 +115,14 @@ void fileClearLastError(file_t fd)
 	SPIFFS_clearerr(&_filesystemStorageHandle);
 }
 
-signed short fileSetContent(const String& fileName, const String& content)
+signed int fileSetContent(const String& fileName, const String& content)
 {
 	return fileSetContent(fileName, content.c_str());
 }
 
-signed short fileSetContent(const String& fileName, const char* content)
+signed int fileSetContent(const String& fileName, const char* content)
 {
-	signed short res;
+	signed int res;
 
 	file_t file = fileOpen(fileName.c_str(), eFO_CreateNewAlways | eFO_WriteOnly);
 	if( file < 0 ) {

--- a/Sming/SmingCore/FileSystem.cpp
+++ b/Sming/SmingCore/FileSystem.cpp
@@ -129,9 +129,6 @@ signed short fileSetContent(const String& fileName, const char* content)
 		return file;
 	}
 	res = fileWrite(file, content, strlen(content));
-	if( res < 0 ) {
-		return res;
-	}
 	fileClose(file);
 	return res;
 }

--- a/Sming/SmingCore/FileSystem.cpp
+++ b/Sming/SmingCore/FileSystem.cpp
@@ -115,16 +115,25 @@ void fileClearLastError(file_t fd)
 	SPIFFS_clearerr(&_filesystemStorageHandle);
 }
 
-void fileSetContent(const String& fileName, const String& content)
+signed short fileSetContent(const String& fileName, const String& content)
 {
-	fileSetContent(fileName, content.c_str());
+	return fileSetContent(fileName, content.c_str());
 }
 
-void fileSetContent(const String& fileName, const char* content)
+signed short fileSetContent(const String& fileName, const char* content)
 {
+	signed short res;
+
 	file_t file = fileOpen(fileName.c_str(), eFO_CreateNewAlways | eFO_WriteOnly);
-	fileWrite(file, content, strlen(content));
+	if( file < 0 ) {
+		return file;
+	}
+	res = fileWrite(file, content, strlen(content));
+	if( res < 0 ) {
+		return res;
+	}
 	fileClose(file);
+	return res;
 }
 
 uint32_t fileGetSize(const String& fileName)

--- a/Sming/SmingCore/FileSystem.h
+++ b/Sming/SmingCore/FileSystem.h
@@ -116,7 +116,7 @@ void fileClearLastError(file_t fd);
  *  @param  fileName Name of file to create or replace
  *  @param  content Pointer to c-string containing content to populate file with
  *  @retval int Positive integer represents the numbers of bytes written.
- *	@retval int Negative integer represents the error code of last file system operation.
+ *  @retval int Negative integer represents the error code of last file system operation.
  *  @note   This function creates a new file or replaces an existing file and
             populates the file with the content of a c-string buffer.
             Remember to terminate your c-string buffer with a null (0).
@@ -127,7 +127,7 @@ int fileSetContent(const String& fileName, const char* content);
  *  @param  fileName Name of file to create or replace
  *  @param  content String containing content to populate file with
  *  @retval int Positive integer represents the numbers of bytes written.
- *	@retval int Negative integer represents the error code of last file system operation.
+ *  @retval int Negative integer represents the error code of last file system operation.
  *  @note   This function creates a new file or replaces an existing file and
             populates the file with the content of a string.
  */

--- a/Sming/SmingCore/FileSystem.h
+++ b/Sming/SmingCore/FileSystem.h
@@ -115,6 +115,8 @@ void fileClearLastError(file_t fd);
 /** @brief  Create or replace file with defined content
  *  @param  fileName Name of file to create or replace
  *  @param  content Pointer to c-string containing content to populate file with
+ *  @retval int Positive integer represents the numbers of bytes written.
+ *	@retval int Negative integer represents the error code of last file system operation.
  *  @note   This function creates a new file or replaces an existing file and
             populates the file with the content of a c-string buffer.
             Remember to terminate your c-string buffer with a null (0).
@@ -124,6 +126,8 @@ int fileSetContent(const String& fileName, const char* content);
 /** @brief  Create or replace file with defined content
  *  @param  fileName Name of file to create or replace
  *  @param  content String containing content to populate file with
+ *  @retval int Positive integer represents the numbers of bytes written.
+ *	@retval int Negative integer represents the error code of last file system operation.
  *  @note   This function creates a new file or replaces an existing file and
             populates the file with the content of a string.
  */

--- a/Sming/SmingCore/FileSystem.h
+++ b/Sming/SmingCore/FileSystem.h
@@ -119,7 +119,7 @@ void fileClearLastError(file_t fd);
             populates the file with the content of a c-string buffer.
             Remember to terminate your c-string buffer with a null (0).
  */
-signed int fileSetContent(const String& fileName, const char* content);
+int fileSetContent(const String& fileName, const char* content);
 
 /** @brief  Create or replace file with defined content
  *  @param  fileName Name of file to create or replace
@@ -127,7 +127,7 @@ signed int fileSetContent(const String& fileName, const char* content);
  *  @note   This function creates a new file or replaces an existing file and
             populates the file with the content of a string.
  */
-signed int fileSetContent(const String& fileName, const String& content);
+int fileSetContent(const String& fileName, const String& content);
 
 /** @brief  Get size of file
  *  @param  fileName Name of file

--- a/Sming/SmingCore/FileSystem.h
+++ b/Sming/SmingCore/FileSystem.h
@@ -119,7 +119,7 @@ void fileClearLastError(file_t fd);
             populates the file with the content of a c-string buffer.
             Remember to terminate your c-string buffer with a null (0).
  */
-void fileSetContent(const String& fileName, const char* content);
+signed short fileSetContent(const String& fileName, const char* content);
 
 /** @brief  Create or replace file with defined content
  *  @param  fileName Name of file to create or replace
@@ -127,7 +127,7 @@ void fileSetContent(const String& fileName, const char* content);
  *  @note   This function creates a new file or replaces an existing file and
             populates the file with the content of a string.
  */
-void fileSetContent(const String& fileName, const String& content);
+signed short fileSetContent(const String& fileName, const String& content);
 
 /** @brief  Get size of file
  *  @param  fileName Name of file

--- a/Sming/SmingCore/FileSystem.h
+++ b/Sming/SmingCore/FileSystem.h
@@ -119,7 +119,7 @@ void fileClearLastError(file_t fd);
             populates the file with the content of a c-string buffer.
             Remember to terminate your c-string buffer with a null (0).
  */
-signed short fileSetContent(const String& fileName, const char* content);
+signed int fileSetContent(const String& fileName, const char* content);
 
 /** @brief  Create or replace file with defined content
  *  @param  fileName Name of file to create or replace
@@ -127,7 +127,7 @@ signed short fileSetContent(const String& fileName, const char* content);
  *  @note   This function creates a new file or replaces an existing file and
             populates the file with the content of a string.
  */
-signed short fileSetContent(const String& fileName, const String& content);
+signed int fileSetContent(const String& fileName, const String& content);
 
 /** @brief  Get size of file
  *  @param  fileName Name of file


### PR DESCRIPTION
Instead of void, fileSetContent() now returns a result of the operation (fileOpen or fileWrite) and in case of error, the error code (available in third-party/spiffs/src/spiffs.h) will be returned.