### PR TITLE
Minor gdb fixes

### DIFF
--- a/Sming/SmingCore/Data/Stream/GdbFileStream.cpp
+++ b/Sming/SmingCore/Data/Stream/GdbFileStream.cpp
@@ -47,7 +47,7 @@ bool GdbFileStream::open(const String& fileName, FileOpenFlags openFlags)
 			this->size = size;
 			gdb_syscall_lseek(fd, 0, SEEK_SET);
 			pos = 0;
-			debug_d("opened file: '%s' (%u bytes) #0x%08X", fileName().c_str(), size, this);
+			debug_d("opened file: '%s' (%u bytes) #0x%08X", fileName.c_str(), size, this);
 		}
 		return true;
 	}

--- a/Sming/SmingCore/HardwareSerial.cpp
+++ b/Sming/SmingCore/HardwareSerial.cpp
@@ -178,6 +178,8 @@ bool HardwareSerial::updateUartCallback()
 	statusMask = mask;
 
 	setUartCallback(mask == 0 ? nullptr : staticCallbackHandler, this);
+
+	return mask != 0;
 }
 
 void HardwareSerial::commandProcessing(bool reqEnable)

--- a/Sming/appspecific/gdb/gdb_hooks.cpp
+++ b/Sming/appspecific/gdb/gdb_hooks.cpp
@@ -72,6 +72,7 @@ void debug_print_stack(uint32_t start, uint32_t end)
 void debug_crash_callback(const rst_info* rst_info, uint32_t stack, uint32_t stack_end)
 {
 #ifdef ENABLE_GDB
+	gdbFlushUserData();
 	if(gdb_state.attached) {
 		m_setPuts(gdbWriteConsole);
 	}
@@ -159,6 +160,8 @@ static void __attribute__((noinline)) gdbstub_exception_handler_flash(UserFrame*
 	gdbstub_savedRegs.a[1] = uint32_t(frame) + EXCEPTION_GDB_SP_OFFSET;
 
 #if defined(ENABLE_GDB) && GDBSTUB_BREAK_ON_EXCEPTION
+	gdbFlushUserData();
+
 	// If GDB is attached, temporarily redirect m_printf calls to the console
 	nputs_callback_t oldPuts = nullptr;
 	if(gdb_state.attached) {

--- a/Sming/system/uart.cpp
+++ b/Sming/system/uart.cpp
@@ -567,9 +567,11 @@ uint8_t uart_get_status(uart_t* uart)
 		uart->status = 0;
 		// Read raw status register directly from real uart, masking out non-error bits
 		uart = get_physical(uart);
-		status |= USIR(uart->uart_nr) & (_BV(UIBD) | _BV(UIOF) | _BV(UIFR) | _BV(UIPE));
-		// Clear errors
-		USIC(uart->uart_nr) = status;
+		if(uart != nullptr) {
+			status |= USIR(uart->uart_nr) & (_BV(UIBD) | _BV(UIOF) | _BV(UIFR) | _BV(UIPE));
+			// Clear errors
+			USIC(uart->uart_nr) = status;
+		}
 		uart_restore_interrupts();
 	}
 	return status;


### PR DESCRIPTION
* `HardwareSerial::updateUartCallback()` requires a return value (warning in STRICT mode)
* Bad debug statement in `GdbFileStream::open()` - only causes an issue if building gdbstub in debug mode
* Make sure any buffered debug output appears before exception message in GDB console