### PR TITLE
Add support in m_printf() for flash strings

### DIFF
--- a/Sming/SmingCore/Network/Ssl/SslFingerprints.cpp
+++ b/Sming/SmingCore/Network/Ssl/SslFingerprints.cpp
@@ -12,13 +12,6 @@
 
 #include "SslFingerprints.h"
 #include <user_config.h>
-#include "flashmem.h"
-
-static inline bool isFlashPtr(const uint8_t* ptr)
-{
-	auto addr = reinterpret_cast<uint32_t>(ptr);
-	return addr >= INTERNAL_FLASH_START_ADDRESS;
-}
 
 static inline void freeValue(const uint8_t*& ptr)
 {

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -4,7 +4,7 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * Support for reading flash memory the FlashString structure and associated macros for efficient flash memory string access.
+ * Support for reading flash memory
  *
  ****/
 
@@ -13,6 +13,9 @@
 
 #include "m_printf.h"
 #include "c_types.h"
+
+// Simple check to determine if a pointer refers to flash memory
+#define isFlashPtr(ptr) (uint32_t(ptr) >= 0x4020000)
 
 #define PGM_P  const char *
 

--- a/Sming/compiler/ld/common.ld
+++ b/Sming/compiler/ld/common.ld
@@ -117,6 +117,11 @@ SECTIONS
   *libsmingssl.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
   *libmqttc.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
 
+	/* __FUNCTION__ locals */
+    *(.rodata._ZZ*__FUNCTION__)
+    *(.rodata._ZZ*__PRETTY_FUNCTION__)
+    *(.rodata._ZZ*__func__)
+
     _irom0_text_end = ABSOLUTE(.);
     _flash_code_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -10,6 +10,7 @@ Descr: embedded very simple version of printf with float support
 #include "stringconversion.h"
 #include "stringutil.h"
 #include <algorithm>
+#include "FakePgmSpace.h"
 
 #define MPRINTF_BUF_SIZE 256
 
@@ -164,15 +165,20 @@ int m_vsnprintf(char *buf, size_t maxLen, const char *fmt, va_list args)
                 continue;
 
             case 's': {
-                s = va_arg(args, char *);
+                s = va_arg(args, const char *);
 
                 if (!s) s = "(null)";
-                size_t len = strlen(s);
+                bool isFlash = isFlashPtr(s);
+                size_t len = isFlash ? strlen_P(s) : strlen(s);
                 if (precision >= 0 && (int)len > precision) len = precision;
 
                 int padding = width - len;
                 while (!minus && padding-- > 0) add(' ');
-                while (len--)                   add(*s++);
+                if(isFlash) {
+                	while (len--)                   add(pgm_read_byte(s++));
+                } else {
+                	while (len--)                   add(*s++);
+                }
                 while (minus && padding-- > 0)  add(' ');
                 continue;
             }

--- a/Sming/system/m_printf.cpp
+++ b/Sming/system/m_printf.cpp
@@ -6,6 +6,7 @@ Date: 20.07.2015
 Descr: embedded very simple version of printf with float support
 */
 
+#include <user_config.h>
 #include "m_printf.h"
 #include "stringconversion.h"
 #include "stringutil.h"


### PR DESCRIPTION
* Move `__PRETTY_FUNCTION__` and `__FUNCTION__` definitions into flash.
* Add `isFlashPtr` macro to `FakePgmSpace.h` - this was implemented as an inline function in `SslFingerprints.cpp`
* Revise `m_vsnprintf`handling of `%s` to detect and handle flash strings correctly

The changes also allow `m_printf`, `debug_*`, etc. to use flash strings directly without having to load them into RAM first, however the main point of this PR is to allow the `__PRETTY_FUNCTION__` and `__FUNCTION__` to be used without consuming RAM.

Example:

```
void MyClass::testMethod()
{
  debug_i("Entering %s", __PRETTY_FUNCTION__);
  debug_i("%s\r\n", PSTR("This is a flash string"));
}
```
