### PR TITLE
Disable SPIFFS init in spiffs_mount_internal()

### DIFF
--- a/Sming/Components/spiffs/spiffs_sming.c
+++ b/Sming/Components/spiffs/spiffs_sming.c
@@ -107,18 +107,6 @@ static void spiffs_mount_internal(spiffs_config *cfg)
   cfg->hal_write_f = api_spiffs_write;
   cfg->hal_erase_f = api_spiffs_erase;
   
-  uint32_t dat;
-  bool writeFirst = false;
-  flashmem_read(&dat, cfg->phys_addr, 4);
-  //debugf("%X", dat);
-
-  if (dat == UINT32_MAX)
-  {
-	  debugf("First init file system");
-	  spiffs_format_internal(cfg);
-	  writeFirst = true;
-  }
-
   int res = SPIFFS_mount(&_filesystemStorageHandle,
     cfg,
     spiffs_work_buf,
@@ -128,18 +116,6 @@ static void spiffs_mount_internal(spiffs_config *cfg)
     sizeof(spiffs_cache),
     NULL);
   debugf("mount res: %d\n", res);
-
-  if (writeFirst)
-  {
-	  spiffs_file fd = SPIFFS_open(&_filesystemStorageHandle, "initialize_fs_header.dat", SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
-	  SPIFFS_write(&_filesystemStorageHandle, fd, (u8_t *)"1", 1);
-	  SPIFFS_fremove(&_filesystemStorageHandle, fd);
-	  SPIFFS_close(&_filesystemStorageHandle, fd);
-  }
-
-  //dat=0;
-  //flashmem_read(&dat, cfg.phys_addr, 4);
-  //debugf("%X", dat);
 }
 
 void spiffs_mount()


### PR DESCRIPTION
Dead simple solution to the problems in #1660 and childish solution in #1663.

I'm considering these scenarios:
1. Flashing a firmware almost always requires something like a ```flashinit```.
2. If flash wasn't erased, probably there is some reason not to have been erased, probably there is already existing spiffs.
3. If it is an example or other working application that requires flash (contents), probably it already flashes its own image.

If it is not any of the cases above, the current code checks the first 4 bytes of the beginning of the partition, if they're 0xFF (explicitly UINT32_MAX), which is the expected state for erased flash, then it does erase the flash again, which doesn't make sense. (This is assumption).

If there was some non spiffs data and the flash wasn't erased (like my try to mount random-data) a user should notice non-functioning fs and will probably take care (most probably this will be the developer).

If it is working application that has been tested and it was working for some time, if some unexpected data appears in the spiffs address space, then there is some worse problem - software bug or hardware failure.

---------

What do we get now?
1. If the flash was (most probably) erased, we erase it again in order to achieve:
2. Granted data loss once the partition was filled (due to the wear-leveling technique).

This is very quick workaround before better method for mount/erase/check is implemented.
