### PR TITLE
Fix exception related to `ENABLE_CMD_EXECUTOR` definition

### DIFF
--- a/Sming/SmingCore/HardwareSerial.h
+++ b/Sming/SmingCore/HardwareSerial.h
@@ -48,9 +48,7 @@ typedef Delegate<void(Stream& source, char arrivedChar, uint16_t availableCharsC
  */
 typedef Delegate<void(HardwareSerial& serial)> TransmitCompleteDelegate;
 
-#if ENABLE_CMD_EXECUTOR
 class CommandExecutor;
-#endif
 
 enum SerialConfig {
 	SERIAL_5N1 = UART_5N1,
@@ -438,9 +436,7 @@ private:
 	int uartNr = -1;
 	TransmitCompleteDelegate transmitComplete = nullptr; ///< Callback for transmit completion
 	StreamDataReceivedDelegate HWSDelegate = nullptr;	///< Callback for received data
-#if ENABLE_CMD_EXECUTOR
-	CommandExecutor* commandExecutor = nullptr; ///< Callback for command execution (received data)
-#endif
+	CommandExecutor* commandExecutor = nullptr;			 ///< Callback for command execution (received data)
 	uart_t* uart = nullptr;
 	uart_options_t options = _BV(UART_OPT_TXWAIT);
 	size_t txSize = DEFAULT_TX_BUFFER_SIZE;


### PR DESCRIPTION
If framework is built with `ENABLE_CMD_EXECUTOR` disabled (0), but application is built with it enabled, serial receive causes an exception.
This happens because the member data for `HardwareSerial` gets shifted by 4 bytes, so `uart` becomes invalid (we get `options` instead, usually 1).

It is safer to always build with `HardwareSerial::commandExecutor` included.