### PR TITLE
Fix FileStream write caching

### DIFF
--- a/Sming/Core/Data/Stream/FileStream.cpp
+++ b/Sming/Core/Data/Stream/FileStream.cpp
@@ -91,9 +91,7 @@ size_t FileStream::write(const uint8_t* buffer, size_t size)
 	int written = fileWrite(handle, buffer, size);
 	if(check(written)) {
 		pos += size_t(written);
-		if(pos > this->size) {
-			this->size = pos;
-		}
+		this->size = pos;
 	}
 
 	return written;

--- a/Sming/Core/Data/Stream/FileStream.cpp
+++ b/Sming/Core/Data/Stream/FileStream.cpp
@@ -79,12 +79,14 @@ size_t FileStream::write(const uint8_t* buffer, size_t size)
 		return 0;
 	}
 
-	int writePos = fileSeek(handle, 0, eSO_FileEnd);
-	if(!check(writePos)) {
-		return 0;
-	}
+	if(pos != this->size) {
+		int writePos = fileSeek(handle, 0, eSO_FileEnd);
+		if(!check(writePos)) {
+			return 0;
+		}
 
-	pos = size_t(writePos);
+		pos = size_t(writePos);
+	}
 
 	int written = fileWrite(handle, buffer, size);
 	if(check(written)) {


### PR DESCRIPTION
Add position check in `FileStream::write` before calling `fileSeek` to avoid flushing SPIFFS write cache.

Fixes #1679