### PR TITLE
File system revisions

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/include/esp_systemapi.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/esp_systemapi.h
@@ -123,5 +123,3 @@ extern void xt_enable_interrupts();
 
 extern void ets_isr_mask(unsigned intr);
 extern void ets_isr_unmask(unsigned intr);
-
-typedef signed short file_t;

--- a/Sming/Arch/Esp8266/Components/spiffs/spiffs_sming.c
+++ b/Sming/Arch/Esp8266/Components/spiffs/spiffs_sming.c
@@ -135,7 +135,7 @@ static void spiffs_mount_internal(spiffs_config *cfg)
 
   if (writeFirst)
   {
-	  file_t fd = SPIFFS_open(&_filesystemStorageHandle, "initialize_fs_header.dat", SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
+	  spiffs_file fd = SPIFFS_open(&_filesystemStorageHandle, "initialize_fs_header.dat", SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
 	  SPIFFS_write(&_filesystemStorageHandle, fd, (u8_t *)"1", 1);
 	  SPIFFS_fremove(&_filesystemStorageHandle, fd);
 	  SPIFFS_close(&_filesystemStorageHandle, fd);

--- a/Sming/Components/.patches/spiffs.patch
+++ b/Sming/Components/.patches/spiffs.patch
@@ -1,0 +1,72 @@
+diff --git a/src/spiffs.h b/src/spiffs.h
+index 534c3df..eddeb7d 100644
+--- a/src/spiffs.h
++++ b/src/spiffs.h
+@@ -496,6 +496,15 @@ s32_t SPIFFS_remove(spiffs *fs, const char *path);
+  */
+ s32_t SPIFFS_fremove(spiffs *fs, spiffs_file fh);
+ 
++/**
++ * Truncates a file at given size
++ * @param fs            the file system struct
++ * @param fh            the filehandle of the file to truncate
++ * @param new_size      the new size, must be less than existing file size
++ * @retval s32_t        error code
++ */
++s32_t SPIFFS_ftruncate(spiffs* fs, spiffs_file fh, u32_t new_size);
++
+ /**
+  * Gets file status by path
+  * @param fs            the file system struct
+
+diff --git a/src/spiffs_hydrogen.c b/src/spiffs_hydrogen.c
+index 235aaaa..4df4b4e 100644
+--- a/src/spiffs_hydrogen.c
++++ b/src/spiffs_hydrogen.c
+@@ -724,6 +724,45 @@ s32_t SPIFFS_fremove(spiffs *fs, spiffs_file fh) {
+ #endif // SPIFFS_READ_ONLY
+ }
+ 
++s32_t SPIFFS_ftruncate(spiffs* fs, spiffs_file fh, u32_t new_size) {
++#if SPIFFS_READ_ONLY
++  (void)fs; (void)fh; (void)new_size;
++  return SPIFFS_ERR_RO_NOT_IMPL;
++#else
++  SPIFFS_API_CHECK_CFG(fs);
++  SPIFFS_API_CHECK_MOUNT(fs);
++  SPIFFS_LOCK(fs);
++
++  spiffs_fd* fd;
++
++  fh = SPIFFS_FH_UNOFFS(fs, fh);
++  s32_t res = spiffs_fd_get(fs, fh, &fd);
++  SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
++
++  if ((fd->flags & SPIFFS_O_WRONLY) == 0) {
++    res = SPIFFS_ERR_NOT_WRITABLE;
++    SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
++  }
++
++#if SPIFFS_CACHE_WR
++  spiffs_fflush_cache(fs, fh);
++#endif
++
++  s32_t file_size = (fd->size == SPIFFS_UNDEFINED_LEN) ? 0 : fd->size;
++  if (new_size == file_size) {
++    res = SPIFFS_OK;
++  } else if (new_size > file_size) {
++    res = SPIFFS_ERR_END_OF_OBJECT; // Same error we'd get from SPIFFS_lseek
++  } else {
++    res = spiffs_object_truncate(fd, new_size, 0);
++  }
++  SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
++
++  SPIFFS_UNLOCK(fs);
++  return SPIFFS_OK;
++#endif
++}
++
+ static s32_t spiffs_stat_pix(spiffs *fs, spiffs_page_ix pix, spiffs_file fh, spiffs_stat *s) {
+   (void)fh;
+   spiffs_page_object_ix_header objix_hdr;
+

--- a/Sming/Core/Data/Stream/FileStream.cpp
+++ b/Sming/Core/Data/Stream/FileStream.cpp
@@ -35,12 +35,10 @@ bool FileStream::open(const String& fileName, FileOpenFlags openFlags)
 	}
 
 	// Get size
-	if(check(fileSeek(file, 0, eSO_FileEnd))) {
-		int size = fileTell(file);
-		if(check(size)) {
-			attach(file, size);
-			return true;
-		}
+	int size = fileSeek(file, 0, eSO_FileEnd);
+	if(check(size)) {
+		attach(file, size);
+		return true;
 	}
 
 	fileClose(file);
@@ -97,19 +95,16 @@ size_t FileStream::write(const uint8_t* buffer, size_t size)
 	return written;
 }
 
-bool FileStream::seek(int len)
+int FileStream::lseek(int offset, SeekOriginFlags origin)
 {
-	int newpos = fileSeek(handle, len, eSO_CurrentPos);
-	if(!check(newpos)) {
-		return false;
+	int newpos = fileSeek(handle, offset, origin);
+	if(check(newpos)) {
+		pos = size_t(newpos);
+		if(pos > size) {
+			size = pos;
+		}
 	}
-
-	pos = size_t(newpos);
-	if(pos > size) {
-		size = pos;
-	}
-
-	return true;
+	return newpos;
 }
 
 String FileStream::fileName() const
@@ -130,4 +125,16 @@ String FileStream::id() const
 			   strlen(reinterpret_cast<const char*>(stat.name)));
 
 	return String(buf);
+}
+
+bool FileStream::truncate(size_t newSize)
+{
+	bool res = check(fileTruncate(handle, newSize));
+	if(res) {
+		size = newSize;
+		if(pos > size) {
+			pos = size;
+		}
+	}
+	return res;
 }

--- a/Sming/Core/Data/Stream/FileStream.h
+++ b/Sming/Core/Data/Stream/FileStream.h
@@ -75,8 +75,18 @@ public:
 	//Use base class documentation
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
+	/** @brief Change position in file stream
+	 *  @param offset
+	 *  @param origin
+	 *  @retval New position, < 0 on error
+	 */
+	int lseek(int offset, SeekOriginFlags origin);
+
 	//Use base class documentation
-	bool seek(int len) override;
+	bool seek(int len) override
+	{
+		return lseek(len, eSO_CurrentPos) > 0;
+	}
 
 	//Use base class documentation
 	bool isFinished() override
@@ -115,7 +125,15 @@ public:
 		return pos;
 	}
 
-	/**	@brief Return the total length of the stream
+	/** @brief  Get the total file size
+     *  @retval size_t File size
+     */
+	size_t getSize() const
+	{
+		return size;
+	}
+
+	/**	@brief Return the maximum bytes available to read, from current position
 	 * 	@retval int -1 is returned when the size cannot be determined
 	 */
 	int available() override
@@ -132,6 +150,12 @@ public:
 	{
 		return lastError;
 	}
+
+	/** @brief Reduce the file size
+	 *  @param newSize
+	 *  @retval bool true on success
+	 */
+	bool truncate(size_t newSize);
 
 private:
 	/** @brief Check file operation result and note error code

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -203,3 +203,20 @@ int fileGetContent(const String& fileName, char* buffer, int bufSize)
 	buffer[size] = '\0';
 	return size;
 }
+
+int fileTruncate(file_t file, size_t newSize)
+{
+	return SPIFFS_ftruncate(&_filesystemStorageHandle, file, newSize);
+}
+
+int fileTruncate(const String& fileName, size_t newSize)
+{
+	file_t file = fileOpen(fileName, eFO_WriteOnly);
+	if(file < 0) {
+		return file;
+	}
+
+	int res = fileTruncate(file, newSize);
+	fileClose(file);
+	return res;
+}

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -117,18 +117,19 @@ void fileClearLastError(file_t fd)
 
 int fileSetContent(const String& fileName, const String& content)
 {
-	return fileSetContent(fileName, content.c_str());
+	return fileSetContent(fileName, content.c_str(), content.length());
 }
 
-int fileSetContent(const String& fileName, const char* content)
+int fileSetContent(const String& fileName, const char* content, int length)
 {
-	int res;
-
 	file_t file = fileOpen(fileName.c_str(), eFO_CreateNewAlways | eFO_WriteOnly);
 	if(file < 0) {
 		return file;
 	}
-	res = fileWrite(file, content, strlen(content));
+	if(length < 0) {
+		length = strlen(content);
+	}
+	int res = fileWrite(file, content, length);
 	fileClose(file);
 	return res;
 }

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -168,21 +168,20 @@ Vector<String> fileList()
 
 String fileGetContent(const String& fileName)
 {
+	String res;
 	file_t file = fileOpen(fileName.c_str(), eFO_ReadOnly);
 	// Get size
-	fileSeek(file, 0, eSO_FileEnd);
-	int size = fileTell(file);
-	if(size <= 0) {
-		fileClose(file);
-		return nullptr;
+	int size = fileSeek(file, 0, eSO_FileEnd);
+	if(size == 0) {
+		res = String::empty;
+	} else if(size > 0) {
+		fileSeek(file, 0, eSO_FileStart);
+		res.setLength(size);
+		if(fileRead(file, res.begin(), res.length()) != size) {
+			res = nullptr;
+		}
 	}
-	fileSeek(file, 0, eSO_FileStart);
-	char* buffer = new char[size + 1];
-	buffer[size] = 0;
-	fileRead(file, buffer, size);
 	fileClose(file);
-	String res(buffer, size);
-	delete[] buffer;
 	return res;
 }
 
@@ -191,19 +190,19 @@ int fileGetContent(const String& fileName, char* buffer, int bufSize)
 	if(buffer == nullptr || bufSize == 0) {
 		return 0;
 	}
-	*buffer = 0;
 
 	file_t file = fileOpen(fileName.c_str(), eFO_ReadOnly);
 	// Get size
-	fileSeek(file, 0, eSO_FileEnd);
-	int size = fileTell(file);
+	int size = fileSeek(file, 0, eSO_FileEnd);
 	if(size <= 0 || bufSize <= size) {
-		fileClose(file);
-		return 0;
+		size = 0;
+	} else {
+		fileSeek(file, 0, eSO_FileStart);
+		if(fileRead(file, buffer, size) != size) {
+			size = 0;
+		}
 	}
-	buffer[size] = 0;
-	fileSeek(file, 0, eSO_FileStart);
-	fileRead(file, buffer, size);
 	fileClose(file);
+	buffer[size] = '\0';
 	return size;
 }

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -138,10 +138,9 @@ uint32_t fileGetSize(const String& fileName)
 {
 	file_t file = fileOpen(fileName.c_str(), eFO_ReadOnly);
 	// Get size
-	fileSeek(file, 0, eSO_FileEnd);
-	int size = fileTell(file);
+	int size = fileSeek(file, 0, eSO_FileEnd);
 	fileClose(file);
-	return size;
+	return (size < 0) ? 0 : size;
 }
 
 void fileRename(const String& oldName, const String& newName)

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -36,22 +36,20 @@ void fileClose(file_t file)
 	SPIFFS_close(&_filesystemStorageHandle, file);
 }
 
-size_t fileWrite(file_t file, const void* data, size_t size)
+int fileWrite(file_t file, const void* data, size_t size)
 {
 	int res = SPIFFS_write(&_filesystemStorageHandle, file, (void*)data, size);
 	if(res < 0) {
 		debugf("write errno %d\n", SPIFFS_errno(&_filesystemStorageHandle));
-		return res;
 	}
 	return res;
 }
 
-size_t fileRead(file_t file, void* data, size_t size)
+int fileRead(file_t file, void* data, size_t size)
 {
 	int res = SPIFFS_read(&_filesystemStorageHandle, file, data, size);
 	if(res < 0) {
 		debugf("read errno %d\n", SPIFFS_errno(&_filesystemStorageHandle));
-		return res;
 	}
 	return res;
 }
@@ -63,7 +61,7 @@ int fileSeek(file_t file, int offset, SeekOriginFlags origin)
 
 bool fileIsEOF(file_t file)
 {
-	return SPIFFS_eof(&_filesystemStorageHandle, file);
+	return SPIFFS_eof(&_filesystemStorageHandle, file) != 0;
 }
 
 int32_t fileTell(file_t file)
@@ -143,9 +141,9 @@ uint32_t fileGetSize(const String& fileName)
 	return (size < 0) ? 0 : size;
 }
 
-void fileRename(const String& oldName, const String& newName)
+int fileRename(const String& oldName, const String& newName)
 {
-	SPIFFS_rename(&_filesystemStorageHandle, oldName.c_str(), newName.c_str());
+	return SPIFFS_rename(&_filesystemStorageHandle, oldName.c_str(), newName.c_str());
 }
 
 Vector<String> fileList()

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -60,17 +60,17 @@ void fileClose(file_t file);
  *  @param  file File ID
  *  @param  data Pointer to data to write to file
  *  @param  size Quantity of data elements to write to file
- *  @retval size_t Quantity of data elements actually written to file or negative error code
+ *  @retval int Quantity of data elements actually written to file or negative error code
  */
-size_t fileWrite(file_t file, const void* data, size_t size);
+int fileWrite(file_t file, const void* data, size_t size);
 
 /** @brief  Read from file
  *  @param  file File ID
  *  @param  data Pointer to data buffer in to which to read data
  *  @param  size Quantity of data elements to read from file
- *  @retval size_t Quantity of data elements actually read from file or negative error code
+ *  @retval int Quantity of data elements actually read from file or negative error code
  */
-size_t fileRead(file_t file, void* data, size_t size);
+int fileRead(file_t file, void* data, size_t size);
 
 /** @brief  Position file cursor
  *  @param  file File ID
@@ -142,8 +142,9 @@ uint32_t fileGetSize(const String& fileName);
 /** @brief  Rename file
  *  @param  oldName Original name of file to rename
  *  @param  newName New name for file
+ *  @retval int error code
  */
-void fileRename(const String& oldName, const String& newName);
+int fileRename(const String& oldName, const String& newName);
 
 /** @brief  Get list of files on file system
  *  @retval Vector<String> Vector of strings.

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -154,7 +154,9 @@ Vector<String> fileList();
 /** @brief  Read content of a file
  *  @param  fileName Name of file to read from
  *  @retval String String variable in to which to read the file content
- *  @note   After calling this function the content of the file is placed in to a string
+ *  @note   After calling this function the content of the file is placed in to a string.
+ *  The result will be an invalid String (equates to `false`) if the file could not be read.
+ *  If the file exists, but is empty, the result will be an empty string "".
  */
 String fileGetContent(const String& fileName);
 
@@ -166,6 +168,7 @@ String fileGetContent(const String& fileName);
  *  @note   After calling this function the content of the file is placed in to a c-string
             Ensure there is sufficient space in the buffer for file content
             plus extra trailing null, i.e. at least bufSize + 1
+    @note   Returns 0 if the file could not be read
  */
 int fileGetContent(const String& fileName, char* buffer, int bufSize);
 

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -139,6 +139,24 @@ int fileSetContent(const String& fileName, const String& content);
  */
 uint32_t fileGetSize(const String& fileName);
 
+/** @brief Truncate (reduce) the size of an open file
+ *  @param file Open file handle, must have Write access
+ *  @param newSize
+ *  @retval int error code
+ *  @note In POSIX `ftruncate()` can also make the file bigger, however SPIFFS can only
+ *  reduce the file size and will return an error if newSize > fileSize
+ */
+int fileTruncate(file_t file, size_t newSize);
+
+/** @brief Truncate (reduce) the size of a file
+ *  @param fileName
+ *  @param newSize
+ *  @retval int error code
+ *  @note In POSIX `truncate()` can also make the file bigger, however SPIFFS can only
+ *  reduce the file size and will return an error if newSize > fileSize
+ */
+int fileTruncate(const String& fileName, size_t newSize);
+
 /** @brief  Rename file
  *  @param  oldName Original name of file to rename
  *  @param  newName New name for file

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -20,6 +20,8 @@
 
 class String;
 
+typedef signed short file_t; ///< File handle
+
 /// File open flags
 enum FileOpenFlags {
 	eFO_ReadOnly = SPIFFS_RDONLY,							  ///< Read only file

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -114,13 +114,14 @@ void fileClearLastError(file_t fd);
 /** @brief  Create or replace file with defined content
  *  @param  fileName Name of file to create or replace
  *  @param  content Pointer to c-string containing content to populate file with
+ *  @param  length (optional) number of characters to write
  *  @retval int Positive integer represents the numbers of bytes written.
  *  @retval int Negative integer represents the error code of last file system operation.
  *  @note   This function creates a new file or replaces an existing file and
             populates the file with the content of a c-string buffer.
             Remember to terminate your c-string buffer with a null (0).
  */
-int fileSetContent(const String& fileName, const char* content);
+int fileSetContent(const String& fileName, const char* content, int length = -1);
 
 /** @brief  Create or replace file with defined content
  *  @param  fileName Name of file to create or replace


### PR DESCRIPTION
Revise `fileSetContent` functions

* Add length parameter to `const char*` variant
* Fix `String` variant to use `length()`

Revise `fileGetContent` functions:

* Remove redundant buffer allocation from `String` variant. Instead, read directly into pre-allocated String object. Also, do not return invalid String if file is just empty.
* Add additional check on `fileRead`, returning empty/invalid result on failure

Revise `fileGetSize()`

* Return 0 in the event of error, rather than casting negative error code to size_t
* `fileSeek` returns the position so don't need additional `fileTell()` call

Return `int` from `fileWrite()`, `fileRead()` and `fileRename()`

Implement `fileTruncate()` for both file handle and file name

* Add patch to SPIFFS to implement `SPIFFS_ftruncate`

Move definition of `file_t` into `FileSystem.h`

Revise `FileStream` class

* Remove redundant `fileTell()` call from `open` method
* Add `lseek()` method - called by `seek()` but don't use same name as return value is different
* Add `getSize()` method
* Add `truncate()` method
