### PR TITLE
File System revisions

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/include/esp_systemapi.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/esp_systemapi.h
@@ -123,5 +123,3 @@ extern void xt_enable_interrupts();
 
 extern void ets_isr_mask(unsigned intr);
 extern void ets_isr_unmask(unsigned intr);
-
-typedef signed short file_t;

--- a/Sming/Arch/Esp8266/Components/spiffs/spiffs_sming.c
+++ b/Sming/Arch/Esp8266/Components/spiffs/spiffs_sming.c
@@ -135,7 +135,7 @@ static void spiffs_mount_internal(spiffs_config *cfg)
 
   if (writeFirst)
   {
-	  file_t fd = SPIFFS_open(&_filesystemStorageHandle, "initialize_fs_header.dat", SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
+	  spiffs_file fd = SPIFFS_open(&_filesystemStorageHandle, "initialize_fs_header.dat", SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
 	  SPIFFS_write(&_filesystemStorageHandle, fd, (u8_t *)"1", 1);
 	  SPIFFS_fremove(&_filesystemStorageHandle, fd);
 	  SPIFFS_close(&_filesystemStorageHandle, fd);

--- a/Sming/Components/.patches/spiffs.patch
+++ b/Sming/Components/.patches/spiffs.patch
@@ -1,0 +1,72 @@
+diff --git a/src/spiffs.h b/src/spiffs.h
+index 534c3df..eddeb7d 100644
+--- a/src/spiffs.h
++++ b/src/spiffs.h
+@@ -496,6 +496,15 @@ s32_t SPIFFS_remove(spiffs *fs, const char *path);
+  */
+ s32_t SPIFFS_fremove(spiffs *fs, spiffs_file fh);
+ 
++/**
++ * Truncates a file at given size
++ * @param fs            the file system struct
++ * @param fh            the filehandle of the file to truncate
++ * @param new_size      the new size, must be less than existing file size
++ * @retval s32_t        error code
++ */
++s32_t SPIFFS_ftruncate(spiffs* fs, spiffs_file fh, u32_t new_size);
++
+ /**
+  * Gets file status by path
+  * @param fs            the file system struct
+
+diff --git a/src/spiffs_hydrogen.c b/src/spiffs_hydrogen.c
+index 235aaaa..4df4b4e 100644
+--- a/src/spiffs_hydrogen.c
++++ b/src/spiffs_hydrogen.c
+@@ -724,6 +724,45 @@ s32_t SPIFFS_fremove(spiffs *fs, spiffs_file fh) {
+ #endif // SPIFFS_READ_ONLY
+ }
+ 
++s32_t SPIFFS_ftruncate(spiffs* fs, spiffs_file fh, u32_t new_size) {
++#if SPIFFS_READ_ONLY
++  (void)fs; (void)fh; (void)new_size;
++  return SPIFFS_ERR_RO_NOT_IMPL;
++#else
++  SPIFFS_API_CHECK_CFG(fs);
++  SPIFFS_API_CHECK_MOUNT(fs);
++  SPIFFS_LOCK(fs);
++
++  spiffs_fd* fd;
++
++  fh = SPIFFS_FH_UNOFFS(fs, fh);
++  s32_t res = spiffs_fd_get(fs, fh, &fd);
++  SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
++
++  if ((fd->flags & SPIFFS_O_WRONLY) == 0) {
++    res = SPIFFS_ERR_NOT_WRITABLE;
++    SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
++  }
++
++#if SPIFFS_CACHE_WR
++  spiffs_fflush_cache(fs, fh);
++#endif
++
++  s32_t file_size = (fd->size == SPIFFS_UNDEFINED_LEN) ? 0 : fd->size;
++  if (new_size == file_size) {
++    res = SPIFFS_OK;
++  } else if (new_size > file_size) {
++    res = SPIFFS_ERR_END_OF_OBJECT; // Same error we'd get from SPIFFS_lseek
++  } else {
++    res = spiffs_object_truncate(fd, new_size, 0);
++  }
++  SPIFFS_API_CHECK_RES_UNLOCK(fs, res);
++
++  SPIFFS_UNLOCK(fs);
++  return SPIFFS_OK;
++#endif
++}
++
+ static s32_t spiffs_stat_pix(spiffs *fs, spiffs_page_ix pix, spiffs_file fh, spiffs_stat *s) {
+   (void)fh;
+   spiffs_page_object_ix_header objix_hdr;
+

--- a/Sming/Core/Data/Stream/FileStream.h
+++ b/Sming/Core/Data/Stream/FileStream.h
@@ -75,8 +75,18 @@ public:
 	//Use base class documentation
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
+	/** @brief Change position in file stream
+	 *  @param offset
+	 *  @param origin
+	 *  @retval New position, < 0 on error
+	 */
+	int seekFrom(int offset, SeekOriginFlags origin);
+
 	//Use base class documentation
-	bool seek(int len) override;
+	bool seek(int offset) override
+	{
+		return seekFrom(offset, eSO_CurrentPos) >= 0;
+	}
 
 	//Use base class documentation
 	bool isFinished() override
@@ -115,7 +125,15 @@ public:
 		return pos;
 	}
 
-	/**	@brief Return the total length of the stream
+	/** @brief  Get the total file size
+     *  @retval size_t File size
+     */
+	size_t getSize() const
+	{
+		return size;
+	}
+
+	/**	@brief Return the maximum bytes available to read, from current position
 	 * 	@retval int -1 is returned when the size cannot be determined
 	 */
 	int available() override
@@ -131,6 +149,20 @@ public:
 	int getLastError()
 	{
 		return lastError;
+	}
+
+	/** @brief Reduce the file size
+	 *  @param newSize
+	 *  @retval bool true on success
+	 */
+	bool truncate(size_t newSize);
+
+	/** @brief Truncate file at current position
+	 *  @retval bool true on success
+	 */
+	bool truncate()
+	{
+		return truncate(pos);
 	}
 
 private:

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -117,18 +117,19 @@ void fileClearLastError(file_t fd)
 
 int fileSetContent(const String& fileName, const String& content)
 {
-	return fileSetContent(fileName, content.c_str());
+	return fileSetContent(fileName, content.c_str(), content.length());
 }
 
-int fileSetContent(const String& fileName, const char* content)
+int fileSetContent(const String& fileName, const char* content, int length)
 {
-	int res;
-
 	file_t file = fileOpen(fileName.c_str(), eFO_CreateNewAlways | eFO_WriteOnly);
 	if(file < 0) {
 		return file;
 	}
-	res = fileWrite(file, content, strlen(content));
+	if(length < 0) {
+		length = strlen(content);
+	}
+	int res = fileWrite(file, content, length);
 	fileClose(file);
 	return res;
 }

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -13,8 +13,6 @@
 
 file_t fileOpen(const String& name, FileOpenFlags flags)
 {
-	int res;
-
 	// Special fix to prevent known spifFS bug: manual delete file
 	if((flags & eFO_CreateNewAlways) == eFO_CreateNewAlways) {
 		if(fileExist(name)) {
@@ -23,7 +21,7 @@ file_t fileOpen(const String& name, FileOpenFlags flags)
 		flags = (FileOpenFlags)((int)flags & ~eFO_Truncate);
 	}
 
-	res = SPIFFS_open(&_filesystemStorageHandle, name.c_str(), (spiffs_flags)flags, 0);
+	int res = SPIFFS_open(&_filesystemStorageHandle, name.c_str(), (spiffs_flags)flags, 0);
 	if(res < 0) {
 		debugf("open errno %d\n", SPIFFS_errno(&_filesystemStorageHandle));
 	}
@@ -36,22 +34,20 @@ void fileClose(file_t file)
 	SPIFFS_close(&_filesystemStorageHandle, file);
 }
 
-size_t fileWrite(file_t file, const void* data, size_t size)
+int fileWrite(file_t file, const void* data, size_t size)
 {
 	int res = SPIFFS_write(&_filesystemStorageHandle, file, (void*)data, size);
 	if(res < 0) {
 		debugf("write errno %d\n", SPIFFS_errno(&_filesystemStorageHandle));
-		return res;
 	}
 	return res;
 }
 
-size_t fileRead(file_t file, void* data, size_t size)
+int fileRead(file_t file, void* data, size_t size)
 {
 	int res = SPIFFS_read(&_filesystemStorageHandle, file, data, size);
 	if(res < 0) {
 		debugf("read errno %d\n", SPIFFS_errno(&_filesystemStorageHandle));
-		return res;
 	}
 	return res;
 }
@@ -63,7 +59,7 @@ int fileSeek(file_t file, int offset, SeekOriginFlags origin)
 
 bool fileIsEOF(file_t file)
 {
-	return SPIFFS_eof(&_filesystemStorageHandle, file);
+	return SPIFFS_eof(&_filesystemStorageHandle, file) != 0;
 }
 
 int32_t fileTell(file_t file)
@@ -142,9 +138,9 @@ uint32_t fileGetSize(const String& fileName)
 	return (size < 0) ? 0 : size;
 }
 
-void fileRename(const String& oldName, const String& newName)
+int fileRename(const String& oldName, const String& newName)
 {
-	SPIFFS_rename(&_filesystemStorageHandle, oldName.c_str(), newName.c_str());
+	return SPIFFS_rename(&_filesystemStorageHandle, oldName.c_str(), newName.c_str());
 }
 
 Vector<String> fileList()

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -137,11 +137,9 @@ int fileSetContent(const String& fileName, const char* content, int length)
 uint32_t fileGetSize(const String& fileName)
 {
 	file_t file = fileOpen(fileName.c_str(), eFO_ReadOnly);
-	// Get size
-	fileSeek(file, 0, eSO_FileEnd);
-	int size = fileTell(file);
+	int size = fileSeek(file, 0, eSO_FileEnd);
 	fileClose(file);
-	return size;
+	return (size < 0) ? 0 : size;
 }
 
 void fileRename(const String& oldName, const String& newName)

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -198,3 +198,26 @@ size_t fileGetContent(const String& fileName, char* buffer, size_t bufSize)
 	buffer[size] = '\0';
 	return size;
 }
+
+int fileTruncate(file_t file, size_t newSize)
+{
+	return SPIFFS_ftruncate(&_filesystemStorageHandle, file, newSize);
+}
+
+int fileTruncate(file_t file)
+{
+	int pos = fileTell(file);
+	return (pos < 0) ? pos : fileTruncate(file, pos);
+}
+
+int fileTruncate(const String& fileName, size_t newSize)
+{
+	file_t file = fileOpen(fileName, eFO_WriteOnly);
+	if(file < 0) {
+		return file;
+	}
+
+	int res = fileTruncate(file, newSize);
+	fileClose(file);
+	return res;
+}

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -114,13 +114,14 @@ void fileClearLastError(file_t fd);
 /** @brief  Create or replace file with defined content
  *  @param  fileName Name of file to create or replace
  *  @param  content Pointer to c-string containing content to populate file with
- *  @retval int Positive integer represents the numbers of bytes written.
- *  @retval int Negative integer represents the error code of last file system operation.
+ *  @param  length (optional) number of characters to write
+ *  @retval int Positive value (>= 0) represents the numbers of bytes written
+ *  			Negative value (< 0) indicates error
  *  @note   This function creates a new file or replaces an existing file and
-            populates the file with the content of a c-string buffer.
-            Remember to terminate your c-string buffer with a null (0).
+ *  		populates the file with the content of a c-string buffer.
+            If you do not specify `length`, remember to terminate your c-string buffer with a NUL ('\0').
  */
-int fileSetContent(const String& fileName, const char* content);
+int fileSetContent(const String& fileName, const char* content, int length = -1);
 
 /** @brief  Create or replace file with defined content
  *  @param  fileName Name of file to create or replace

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -154,7 +154,9 @@ Vector<String> fileList();
 /** @brief  Read content of a file
  *  @param  fileName Name of file to read from
  *  @retval String String variable in to which to read the file content
- *  @note   After calling this function the content of the file is placed in to a string
+ *  @note   After calling this function the content of the file is placed in to a string.
+ *  The result will be an invalid String (equates to `false`) if the file could not be read.
+ *  If the file exists, but is empty, the result will be an empty string "".
  */
 String fileGetContent(const String& fileName);
 
@@ -162,12 +164,13 @@ String fileGetContent(const String& fileName);
  *  @param  fileName Name of file to read from
  *  @param  buffer Pointer to a character buffer in to which to read the file content
  *  @param  bufSize Quantity of bytes to read from file
- *  @retval int Quantity of bytes read from file or zero on failure
+ *  @retval size_t Quantity of bytes read from file or zero on failure
  *  @note   After calling this function the content of the file is placed in to a c-string
             Ensure there is sufficient space in the buffer for file content
             plus extra trailing null, i.e. at least bufSize + 1
+    @note   Returns 0 if the file could not be read
  */
-int fileGetContent(const String& fileName, char* buffer, int bufSize);
+size_t fileGetContent(const String& fileName, char* buffer, size_t bufSize);
 
 /** brief   Get file statistics
  *  @param  name File name

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -60,17 +60,17 @@ void fileClose(file_t file);
  *  @param  file File ID
  *  @param  data Pointer to data to write to file
  *  @param  size Quantity of data elements to write to file
- *  @retval size_t Quantity of data elements actually written to file or negative error code
+ *  @retval int Quantity of data elements actually written to file or negative error code
  */
-size_t fileWrite(file_t file, const void* data, size_t size);
+int fileWrite(file_t file, const void* data, size_t size);
 
 /** @brief  Read from file
  *  @param  file File ID
  *  @param  data Pointer to data buffer in to which to read data
  *  @param  size Quantity of data elements to read from file
- *  @retval size_t Quantity of data elements actually read from file or negative error code
+ *  @retval int Quantity of data elements actually read from file or negative error code
  */
-size_t fileRead(file_t file, void* data, size_t size);
+int fileRead(file_t file, void* data, size_t size);
 
 /** @brief  Position file cursor
  *  @param  file File ID
@@ -143,8 +143,9 @@ uint32_t fileGetSize(const String& fileName);
 /** @brief  Rename file
  *  @param  oldName Original name of file to rename
  *  @param  newName New name for file
+ *  @retval int error code
  */
-void fileRename(const String& oldName, const String& newName);
+int fileRename(const String& oldName, const String& newName);
 
 /** @brief  Get list of files on file system
  *  @retval Vector<String> Vector of strings.

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -20,6 +20,8 @@
 
 class String;
 
+typedef signed short file_t; ///< File handle
+
 /// File open flags
 enum FileOpenFlags {
 	eFO_ReadOnly = SPIFFS_RDONLY,							  ///< Read only file

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -136,6 +136,7 @@ int fileSetContent(const String& fileName, const String& content);
 /** @brief  Get size of file
  *  @param  fileName Name of file
  *  @retval uint32_t Size of file in bytes
+ *  @note	Returns 0 if error occurs
  */
 uint32_t fileGetSize(const String& fileName);
 

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -140,6 +140,30 @@ int fileSetContent(const String& fileName, const String& content);
  */
 uint32_t fileGetSize(const String& fileName);
 
+/** @brief Truncate (reduce) the size of an open file
+ *  @param file Open file handle, must have Write access
+ *  @param newSize
+ *  @retval int error code
+ *  @note In POSIX `ftruncate()` can also make the file bigger, however SPIFFS can only
+ *  reduce the file size and will return an error if newSize > fileSize
+ */
+int fileTruncate(file_t file, size_t newSize);
+
+/** @brief Truncate an open file at the current cursor position
+ *  @param file Open file handle, must have Write access
+ *  @retval int error code
+ */
+int fileTruncate(file_t file);
+
+/** @brief Truncate (reduce) the size of a file
+ *  @param fileName
+ *  @param newSize
+ *  @retval int error code
+ *  @note In POSIX `truncate()` can also make the file bigger, however SPIFFS can only
+ *  reduce the file size and will return an error if newSize > fileSize
+ */
+int fileTruncate(const String& fileName, size_t newSize);
+
 /** @brief  Rename file
  *  @param  oldName Original name of file to rename
  *  @param  newName New name for file


### PR DESCRIPTION
Revise `fileSetContent` functions

* Add length parameter to `const char*` variant
* Fix `String` variant to use `length()`

Revise `fileGetContent` functions:

* Remove redundant buffer allocation from `String` variant. Instead, read directly into pre-allocated String object. Also, do not return invalid String if file is just empty.
* Add additional check on `fileRead`, returning empty/invalid result on failure

Revise `fileGetSize()`

* Return 0 in the event of error, rather than casting negative error code to size_t
* `fileSeek` returns the position so don't need additional `fileTell()` call

Return `int` from `fileWrite()`, `fileRead()` and `fileRename()`

Implement `fileTruncate()` for both file handle and file name

* Add patch to SPIFFS to implement `SPIFFS_ftruncate`

Move definition of `file_t` into `FileSystem.h`

Revise `FileStream` class

* Remove redundant `fileTell()` call from `open` method
* Add `seekFrom()` method
* Add `getSize()` method
* Add `truncate()` methods
