### PR TITLE
Fix multipart stream boundary value calculation

### DIFF
--- a/Sming/Core/Data/Stream/MultipartStream.cpp
+++ b/Sming/Core/Data/Stream/MultipartStream.cpp
@@ -57,7 +57,7 @@ const char* MultipartStream::getBoundary()
 		int len = sizeof(boundary);
 		memset(boundary, 0, len);
 		for(int i = 0; i < len - 1; ++i) {
-			boundary[i] = pool[os_random() % (sizeof(pool) - 1)];
+			boundary[i] = pool[os_random() % (sizeof(PSTR_pool) - 1)];
 		}
 		boundary[len - 1] = 0;
 	}

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -229,10 +229,20 @@ extern "C"
 
 /*
  * Define a flash string and load it into a named array buffer on the stack.
- * This allows sizeof(_name) to work as if the string were defined thus:
+ * For example, this:
  *
- * 	char _name[] = "text";
+ * 		PSTR_ARRAY(myText, "some text");
+ *
+ * is roughly equivalent to this:
+ *
+ * 		char myText[ALIGNED_SIZE] = "some text";
+ *
+ * where ALIGNED_SIZE is the length of the text (including NUL terminator) rounded up to the next word boundary.
+ * To get the length of the text, excluding NUL terminator, use:
+ *
+ * 		sizeof(PSTR_myText) - 1
+ *
  */
-#define PSTR_ARRAY(_name, _str)                                                                                        \
-	static DEFINE_PSTR(_##_name, _str);                                                                                       \
-	LOAD_PSTR(_name, _##_name)
+#define PSTR_ARRAY(name, str)                                                                                        \
+	static DEFINE_PSTR(PSTR_##name, str);                                                                                       \
+	LOAD_PSTR(name, PSTR_##name)

--- a/samples/Basic_ProgMem/app/TestProgmem.cpp
+++ b/samples/Basic_ProgMem/app/TestProgmem.cpp
@@ -69,9 +69,9 @@ void testPSTR(Print& out)
 	out.print("> PSTR_ARRAY: ");
 	PSTR_ARRAY(psarr, DEMO_TEST_TEXT);
 	out.print('"');
-	out.write(psarr, sizeof(psarr) - 1);
+	out.write(psarr, sizeof(PSTR_psarr) - 1);
 	out.println('"');
-	m_printHex("hex", psarr, sizeof(psarr));
+	m_printHex("hex", psarr, sizeof(PSTR_psarr));
 
 	//
 	out.println("< testPSTR() end\n");


### PR DESCRIPTION
* May contain invalid characters (probably NULs) because `sizeof(pool)` is 64, but actual size is 63.
* Clarify use of `PSTR_ARRAY` and getting correct size by re-defining flash data using `PSTR_` prefix.