### PR TITLE
Fix `const` references consuming RAM

### DIFF
--- a/Sming/Arch/Esp8266/Compiler/ld/common.ld
+++ b/Sming/Arch/Esp8266/Compiler/ld/common.ld
@@ -122,6 +122,12 @@ SECTIONS
     *(.rodata._ZZ*__PRETTY_FUNCTION__)
     *(.rodata._ZZ*__func__)
 
+    /* debug_e() string pointers */
+    *(.rodata._ZZ*log_string)
+
+    /* const references, mainly in templated code */
+    *(.rodata._ZN*)
+
     _irom0_text_end = ABSOLUTE(.);
     _flash_code_end = ABSOLUTE(.);
   } >irom0_0_seg :irom0_0_phdr

--- a/Sming/Arch/Esp8266/Components/gdbstub/appcode/gdb_hooks.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/appcode/gdb_hooks.cpp
@@ -32,7 +32,7 @@ const uint8_t gdb_exception_signals[] GDB_PROGMEM = {
 };
 
 // List of exception names
-#define XX(ex, sig, desc) static DEFINE_PSTR(exception_str_##ex, #ex)
+#define XX(ex, sig, desc) DEFINE_PSTR_LOCAL(exception_str_##ex, #ex)
 SYSTEM_EXCEPTION_MAP(XX)
 #undef XX
 static PGM_P const exceptionNames[] PROGMEM = {

--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbstub.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbstub.cpp
@@ -54,7 +54,7 @@ enum DebugCause {
 };
 
 // Register names
-#define XX(num, name) static DEFINE_PSTR(xtreg_str_##name, #name)
+#define XX(num, name) DEFINE_PSTR_LOCAL(xtreg_str_##name, #name)
 XT_REGISTER_MAP(XX)
 #undef XX
 static PGM_P const registerNames[] PROGMEM = {

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -12,8 +12,8 @@
 
 #define LEAP_YEAR(year) ((year % 4) == 0)
 
-static DEFINE_FSTR(flashMonthNames, LOCALE_MONTH_NAMES);
-static DEFINE_FSTR(flashDayNames, LOCALE_DAY_NAMES);
+DEFINE_FSTR_LOCAL(flashMonthNames, LOCALE_MONTH_NAMES);
+DEFINE_FSTR_LOCAL(flashDayNames, LOCALE_DAY_NAMES);
 
 /* We can more efficiently compare text of 4 character length by comparing as words */
 union FourDigitName {

--- a/Sming/Core/Network/Http/HttpCommon.cpp
+++ b/Sming/Core/Network/Http/HttpCommon.cpp
@@ -15,7 +15,7 @@
 #include "HttpCommon.h"
 
 // Define flash strings and lookup table for HTTP error names
-#define XX(_n, _s) static DEFINE_FSTR(hpename_##_n, "HPE_" #_n);
+#define XX(_n, _s) DEFINE_FSTR_LOCAL(hpename_##_n, "HPE_" #_n);
 HTTP_ERRNO_MAP(XX)
 #undef XX
 
@@ -34,7 +34,7 @@ String httpGetErrorName(enum http_errno err)
 }
 
 // Define flash strings and lookup table for HTTP error descriptions
-#define XX(_n, _s) static DEFINE_FSTR(hpedesc_##_n, _s);
+#define XX(_n, _s) DEFINE_FSTR_LOCAL(hpedesc_##_n, _s);
 HTTP_ERRNO_MAP(XX)
 #undef XX
 
@@ -53,7 +53,7 @@ String httpGetErrorDescription(enum http_errno err)
 }
 
 // Define flash strings for HTTP status codes
-#define XX(_num, _name, _string) static DEFINE_FSTR(hpsText_##_num, #_string);
+#define XX(_num, _name, _string) DEFINE_FSTR_LOCAL(hpsText_##_num, #_string);
 HTTP_STATUS_MAP(XX)
 #undef XX
 

--- a/Sming/Core/Network/Http/HttpHeaders.cpp
+++ b/Sming/Core/Network/Http/HttpHeaders.cpp
@@ -13,7 +13,7 @@
 #include "HttpHeaders.h"
 
 // Define field name strings and a lookup table
-#define XX(_tag, _str, _comment) static DEFINE_FSTR(hhfnStr_##_tag, _str);
+#define XX(_tag, _str, _comment) DEFINE_FSTR_LOCAL(hhfnStr_##_tag, _str);
 HTTP_HEADER_FIELDNAME_MAP(XX)
 #undef XX
 

--- a/Sming/Core/Network/NetUtils.cpp
+++ b/Sming/Core/Network/NetUtils.cpp
@@ -163,17 +163,17 @@ bool NetUtils::FixNetworkRouting()
 /////////////////////////////////
 
 // enum tcp_state, see file /include/lwip/tcp.h
-static DEFINE_FSTR(deb_tcp_state_str, "CLOSED\0"	  // 0  CLOSED
-									  "LISTEN\0"	  // 1  LISTEN
-									  "SYN_SENT\0"	// 2  SYN_SENT
-									  "SYN_RCVD\0"	// 3  SYN_RCVD
-									  "ESTABLISHED\0" // 4  ESTABLISHED
-									  "FIN_WAIT_1\0"  // 5  FIN_WAIT_1
-									  "FIN_WAIT_2\0"  // 6  FIN_WAIT_2
-									  "CLOSE_WAIT\0"  // 7  CLOSE_WAIT
-									  "CLOSING\0"	 // 8  CLOSING
-									  "LAST_ACK\0"	// 9  LAST_ACK
-									  "TIME_WAIT");   // 10 TIME_WAIT
+DEFINE_FSTR_LOCAL(deb_tcp_state_str, "CLOSED\0"		 // 0  CLOSED
+									 "LISTEN\0"		 // 1  LISTEN
+									 "SYN_SENT\0"	// 2  SYN_SENT
+									 "SYN_RCVD\0"	// 3  SYN_RCVD
+									 "ESTABLISHED\0" // 4  ESTABLISHED
+									 "FIN_WAIT_1\0"  // 5  FIN_WAIT_1
+									 "FIN_WAIT_2\0"  // 6  FIN_WAIT_2
+									 "CLOSE_WAIT\0"  // 7  CLOSE_WAIT
+									 "CLOSING\0"	 // 8  CLOSING
+									 "LAST_ACK\0"	// 9  LAST_ACK
+									 "TIME_WAIT");   // 10 TIME_WAIT
 
 static void debugPrintTcp(const char* type, const struct tcp_pcb* pcb)
 {

--- a/Sming/Core/Network/WebConstants.cpp
+++ b/Sming/Core/Network/WebConstants.cpp
@@ -14,7 +14,7 @@
 namespace ContentType
 {
 // MIME type strings
-#define XX(_name, _ext, _mime) static DEFINE_FSTR(mimestr_##_name, _mime);
+#define XX(_name, _ext, _mime) DEFINE_FSTR_LOCAL(mimestr_##_name, _mime);
 MIME_TYPE_MAP(XX)
 #undef XX
 
@@ -25,7 +25,7 @@ static FSTR_TABLE(mimeStrings) = {
 };
 
 // File extensions
-#define XX(_name, _ext, _mime) static DEFINE_FSTR(extstr_##_name, _ext);
+#define XX(_name, _ext, _mime) DEFINE_FSTR_LOCAL(extstr_##_name, _ext);
 MIME_TYPE_MAP(XX)
 #undef XX
 

--- a/Sming/System/include/debug_progmem.h
+++ b/Sming/System/include/debug_progmem.h
@@ -71,19 +71,21 @@ extern "C" {
 #endif
 
 //A static const char[] is defined having a unique name (log_ prefix, filename and line number)
-//This will be stored in the irom section(on flash) feeing up the RAM
+//This will be stored in the irom section(on flash) freeing up the RAM
 //Next special version of printf from FakePgmSpace is called to fetch and print the message
 #if DEBUG_PRINT_FILENAME_AND_LINE
 #define debug_e(fmt, ...)                                                                                              \
 	(__extension__({                                                                                                   \
 		static const char log_string[] PROGMEM_DEBUG = "[" MACROQUOTE(CUST_FILE_BASE) ":%d] " fmt "\n";                \
-		printf_P(log_string, __LINE__, ##__VA_ARGS__);                                                                 \
+		LOAD_PSTR(fmtbuf, log_string);                                                                                 \
+		m_printf(fmtbuf, __LINE__, ##__VA_ARGS__);                                                                     \
 	}))
 #else
 #define debug_e(fmt, ...)                                                                                              \
 	(__extension__({                                                                                                   \
 		static const char log_string[] PROGMEM_DEBUG = "%u " fmt "\n";                                                 \
-		printf_P(log_string, system_get_time(), ##__VA_ARGS__);                                                        \
+		LOAD_PSTR(fmtbuf, log_string);                                                                                 \
+		m_printf(fmtbuf, system_get_time(), ##__VA_ARGS__);                                                            \
 	}))
 #endif
 

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -50,7 +50,7 @@ typedef uint32_t prog_uint32_t;
  */
 #define PSTR(_str)                                                                                                     \
 	(__extension__({                                                                                                   \
-		static DEFINE_PSTR(__c, _str);                                                                                 \
+		DEFINE_PSTR_LOCAL(__c, _str);                                                                                  \
 		&__c[0];                                                                                                       \
 	}))
 
@@ -60,7 +60,7 @@ typedef uint32_t prog_uint32_t;
  */
 #define _F(_str)                                                                                                       \
 	(__extension__({                                                                                                   \
-		static DEFINE_PSTR(_flash_str, _str);                                                                          \
+		DEFINE_PSTR_LOCAL(_flash_str, _str);                                                                           \
 		LOAD_PSTR(_buf, _flash_str);                                                                                   \
 		_buf;                                                                                                          \
 	}))
@@ -198,9 +198,14 @@ extern "C"
 /** @brief define a PSTR
  *  @param _name name of string
  *  @param _str the string data
- *  @note may also be used for byte arrays { 1, 2, 3 } etc.
  */
 #define DEFINE_PSTR(_name, _str) const char _name[] PROGMEM = _str;
+
+/** @brief define a PSTR for local (static) use
+ *  @param _name name of string
+ *  @param _str the string data
+ */
+#define DEFINE_PSTR_LOCAL(_name, _str) static DEFINE_PSTR(_name, _str)
 
 // Declare a global reference to a PSTR instance
 #define DECLARE_PSTR(_name) extern const char _name[] PROGMEM;

--- a/Sming/Wiring/FlashString.h
+++ b/Sming/Wiring/FlashString.h
@@ -36,7 +36,7 @@
  *	memory so must be accessed using the appropriate xxx_P function.
  *
  *	LOAD_PSTR(_name, _flash_str) - loads pre-defined PSTR into buffer on stack
- *		static DEFINE_PSTR(testFlash, "This is a test string\n"); // Function scope requires static allocation
+ *		DEFINE_PSTR_LOCAL(testFlash, "This is a test string\n"); // Function scope requires static allocation
  *		LOAD_PSTR(test, testFlash)
  *		m_printf(test);
  *
@@ -90,8 +90,16 @@
  *  The data includes the nul terminator but the length does not.
  */
 #define DEFINE_FSTR(_name, _str)                                                                                       \
-	DEFINE_FSTR_STRUCT(_##_name, _str)                                                                                 \
-	const FlashString& _name = _##_name.fstr;
+	DEFINE_FSTR_STRUCT(_##_name, _str);                                                                                \
+	const FlashString& _name PROGMEM = _##_name.fstr;
+
+/** @Brief Define a FlashString for local (static) use
+ *  @param _name variable to identify the string
+ *  @param _str content of the string
+ */
+#define DEFINE_FSTR_LOCAL(_name, _str)                                                                                 \
+	static DEFINE_FSTR_STRUCT(_##_name, _str);                                                                         \
+	static const FlashString& _name PROGMEM = _##_name.fstr;
 
 #define DEFINE_FSTR_STRUCT(_name, _str)                                                                                \
 	constexpr struct {                                                                                                 \
@@ -145,7 +153,7 @@
  * 	char _name[] = "text";
  */
 #define FSTR_ARRAY(_name, _str)                                                                                        \
-	static DEFINE_FSTR(_##_name, _str);                                                                                \
+	DEFINE_FSTR_LOCAL(_##_name, _str);                                                                                 \
 	LOAD_FSTR(_name, _##_name)
 
 /** @brief Define a FlashString containing data from an external file

--- a/samples/Basic_ProgMem/app/TestProgmem.cpp
+++ b/samples/Basic_ProgMem/app/TestProgmem.cpp
@@ -12,9 +12,9 @@
 // Note: contains nulls which won't display, but will be stored
 #define DEMO_TEST_TEXT "This is a flash string -\0Second -\0Third -\0Fourth."
 
-static DEFINE_FSTR(demoFSTR1, DEMO_TEST_TEXT);
-static DEFINE_FSTR(demoFSTR2, DEMO_TEST_TEXT);
-static DEFINE_PSTR(demoPSTR1, DEMO_TEST_TEXT);
+DEFINE_FSTR_LOCAL(demoFSTR1, DEMO_TEST_TEXT);
+DEFINE_FSTR_LOCAL(demoFSTR2, DEMO_TEST_TEXT);
+DEFINE_PSTR_LOCAL(demoPSTR1, DEMO_TEST_TEXT);
 
 static const char demoText[] = DEMO_TEST_TEXT;
 
@@ -133,8 +133,8 @@ void testFSTR(Print& out)
 
 	// FSTR table
 
-	static DEFINE_FSTR(fstr1, "Test string #1");
-	static DEFINE_FSTR(fstr2, "Test string #2");
+	DEFINE_FSTR_LOCAL(fstr1, "Test string #1");
+	DEFINE_FSTR_LOCAL(fstr2, "Test string #2");
 
 	static FSTR_TABLE(table) = {
 		FSTR_PTR(fstr1),

--- a/samples/LiveDebug/app/application.cpp
+++ b/samples/LiveDebug/app/application.cpp
@@ -543,11 +543,11 @@ COMMAND_HANDLER(help)
 
 COMMAND_HANDLER(jsontest)
 {
-	static DEFINE_FSTR(flashString1, "FlashString-1");
-	static DEFINE_FSTR(flashString2, "FlashString-2");
-	static DEFINE_FSTR(formatStrings, "Compact\0Pretty\0MessagePack");
-	static DEFINE_FSTR(test_json, "test.json");
-	static DEFINE_FSTR(test_msgpack, "test.msgpack");
+	DEFINE_FSTR_LOCAL(flashString1, "FlashString-1");
+	DEFINE_FSTR_LOCAL(flashString2, "FlashString-2");
+	DEFINE_FSTR_LOCAL(formatStrings, "Compact\0Pretty\0MessagePack");
+	DEFINE_FSTR_LOCAL(test_json, "test.json");
+	DEFINE_FSTR_LOCAL(test_msgpack, "test.msgpack");
 
 	spiffs_mount();
 


### PR DESCRIPTION
Move const references from `.rodata` into `.irom0.text`

* Although the strings themselves are in flash, every instance of `debug_e()` creates a `log_string` pointer which ends up in .rodata (as `.rodata._ZZ*log_string`)
* Template code puts a lot of stuff into `.rodata._ZN*` - explains the inflated `.rodata` section with ArduinoJson6 !

Put `FlashString` references into flash

* An oversight, although the actual strings are in flash the generated `const FlashString&` references are not
* Add `DEFINE_FSTR_LOCAL` macro to allow correct use inside function definitions (static DEFINE_FSTR doesn't work)

Add `DEFINE_PSTR_LOCAL` macro to use instead of `static DEFINE_PSTR`