### PR TITLE
Simplify include paths

### DIFF
--- a/Sming/Arch/Esp8266/Core/Network/rBootHttpUpdate.cpp
+++ b/Sming/Arch/Esp8266/Core/Network/rBootHttpUpdate.cpp
@@ -15,7 +15,7 @@
 
 #include "rBootHttpUpdate.h"
 #include "Platform/System.h"
-#include "Url.h"
+#include "Network/Url.h"
 #include "Platform/WDT.h"
 
 /* rBootItemOutputStream */

--- a/Sming/Arch/Esp8266/sming.mk
+++ b/Sming/Arch/Esp8266/sming.mk
@@ -9,13 +9,17 @@ $(SDK_COMPONENT)/bin/esp_init_data_default.bin:
 	$(Q) cp -f $(dir $@)esp_init_data_default_v08.bin $@
 endif
 
-EXTRA_INCDIR	+= $(ARCH_COMPONENTS)
-
 MODULES			+= $(ARCH_COMPONENTS)/esp8266
-EXTRA_INCDIR	+= $(ARCH_COMPONENTS)/esp8266/include
+EXTRA_INCDIR	+= $(ARCH_COMPONENTS)/esp8266/include $(SDK_INCDIR)
+
+MODULES			+= $(ARCH_COMPONENTS)/spi_flash
+EXTRA_INCDIR	+= $(ARCH_COMPONENTS)/spi_flash/include
 
 MODULES			+= $(ARCH_COMPONENTS)/driver
 EXTRA_INCDIR	+= $(ARCH_COMPONENTS)/driver/include
+
+MODULES			+= $(ARCH_COMPONENTS)/esp_wifi
+EXTRA_INCDIR	+= $(ARCH_COMPONENTS)/esp_wifi/include
 
 MODULES			+= $(ARCH_COMPONENTS)/fatfs
 
@@ -29,6 +33,7 @@ SPIFFS_SMING	:= $(ARCH_COMPONENTS)/spiffs
 SPIFFS_BASE		:= $(COMPONENTS)/spiffs
 SUBMODULES		+= $(SPIFFS_BASE)
 MODULES			+= $(SPIFFS_SMING) $(SPIFFS_BASE)/src
+EXTRA_INCDIR	+= $(SPIFFS_SMING) $(SPIFFS_BASE)/src
 
 
 # => ESP8266_new_pwm
@@ -43,7 +48,7 @@ ifeq ($(ENABLE_CUSTOM_PWM), 1)
 	CLEAN			+= pwm-clean
 
 $(call UserLibPath,$(LIBPWM)): | $(PWM_BASE)/.submodule
-	$(Q) $(CC) $(INCDIR) $(MODULE_INCDIR) $(EXTRA_INCDIR) $(CFLAGS) -c $(PWM_BASE)/pwm.c -o $(PWM_BASE)/pwm.o
+	$(Q) $(CC) $(INCDIR) $(CFLAGS) -c $(PWM_BASE)/pwm.c -o $(PWM_BASE)/pwm.o
 	$(Q) $(AR) rcs $@ $(PWM_BASE)/pwm.o
 
 .PHONY: pwm-clean
@@ -148,10 +153,6 @@ $(call UserLibPath,$(LIBAXTLS)): | $(AXTLS_BASE)/.submodule
 axtls-clean:
 	-$(Q) $(AXTLS_BUILD) clean
 endif
-
-
-# => GDB
-EXTRA_INCDIR += $(ARCH_COMPONENTS)/gdbstub/include
 
 
 # Tools

--- a/Sming/Core/Data/Buffer/CircularBuffer.h
+++ b/Sming/Core/Data/Buffer/CircularBuffer.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include "Stream/ReadWriteStream.h"
+#include "Data/Stream/ReadWriteStream.h"
 
 /**
  * @brief      Circular stream class

--- a/Sming/Core/Network/Ftp/FtpDataStream.h
+++ b/Sming/Core/Network/Ftp/FtpDataStream.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "FtpServerConnection.h"
-#include "TcpConnection.h"
+#include "Network/TcpConnection.h"
 
 class FtpDataStream : public TcpConnection
 {

--- a/Sming/Core/Network/Ftp/FtpServerConnection.cpp
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.cpp
@@ -13,7 +13,7 @@
 #include "FtpDataRetrieve.h"
 #include "FtpDataFileList.h"
 #include "../FtpServer.h"
-#include "NetUtils.h"
+#include "Network/NetUtils.h"
 
 err_t FtpServerConnection::onReceive(pbuf* buf)
 {

--- a/Sming/Core/Network/Ftp/FtpServerConnection.h
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "TcpConnection.h"
+#include "Network/TcpConnection.h"
 #include "IPAddress.h"
 #include "WString.h"
 

--- a/Sming/Core/Network/Http/HttpBodyParser.cpp
+++ b/Sming/Core/Network/Http/HttpBodyParser.cpp
@@ -15,7 +15,7 @@
  ****/
 
 #include "HttpBodyParser.h"
-#include "WebHelpers/escape.h"
+#include "Network/WebHelpers/escape.h"
 
 /*
  * Content is received in chunks which we need to reassemble into name=value pairs.

--- a/Sming/Core/Network/Http/HttpParams.cpp
+++ b/Sming/Core/Network/Http/HttpParams.cpp
@@ -11,7 +11,7 @@
  ****/
 
 #include "HttpParams.h"
-#include "WebHelpers/escape.h"
+#include "Network/WebHelpers/escape.h"
 #include "Print.h"
 #include "libyuarel/yuarel.h"
 

--- a/Sming/Core/Network/Http/HttpRequestAuth.cpp
+++ b/Sming/Core/Network/Http/HttpRequestAuth.cpp
@@ -12,7 +12,7 @@
 
 #include "HttpRequestAuth.h"
 #include "HttpRequest.h"
-#include "WebHelpers/base64.h"
+#include "Network/WebHelpers/base64.h"
 
 // Basic Auth
 void HttpBasicAuth::setRequest(HttpRequest* request)

--- a/Sming/Core/Network/Http/HttpServerConnection.cpp
+++ b/Sming/Core/Network/Http/HttpServerConnection.cpp
@@ -12,9 +12,9 @@
 
 #include "HttpServerConnection.h"
 #include "HttpResourceTree.h"
-#include "HttpServer.h"
-#include "TcpServer.h"
-#include "WebConstants.h"
+#include "Network/HttpServer.h"
+#include "Network/TcpServer.h"
+#include "Network/WebConstants.h"
 #include "Data/Stream/ChunkedStream.h"
 
 int HttpServerConnection::onMessageBegin(http_parser* parser)

--- a/Sming/Core/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Core/Network/Http/Websocket/WebsocketConnection.cpp
@@ -10,8 +10,8 @@
 
 #include "WebsocketConnection.h"
 
-#include "WebHelpers/aw-sha1.h"
-#include "WebHelpers/base64.h"
+#include "Network/WebHelpers/aw-sha1.h"
+#include "Network/WebHelpers/base64.h"
 
 DEFINE_FSTR(WSSTR_CONNECTION, "connection")
 DEFINE_FSTR(WSSTR_UPGRADE, "upgrade")

--- a/Sming/Core/Network/NetUtils.cpp
+++ b/Sming/Core/Network/NetUtils.cpp
@@ -9,7 +9,7 @@
  ****/
 
 #include "NetUtils.h"
-#include "CStringArray.h"
+#include "Data/CStringArray.h"
 
 #include "WString.h"
 #ifdef __linux__

--- a/Sming/Core/Network/WebHelpers/base64.cpp
+++ b/Sming/Core/Network/WebHelpers/base64.cpp
@@ -11,8 +11,8 @@
 
 #include "base64.h"
 
-#include "../libb64/cencode.h"
-#include "../libb64/cdecode.h"
+#include "libb64/cencode.h"
+#include "libb64/cdecode.h"
 
 // Base-64 encoding produces 3 output bytes for every 2 input bytes
 #define MIN_ENCODE_LEN(_in_len) (((_in_len)*3 + 1) / 2)

--- a/Sming/Core/Network/WebsocketClient.cpp
+++ b/Sming/Core/Network/WebsocketClient.cpp
@@ -14,7 +14,7 @@
  ****/
 
 #include "WebsocketClient.h"
-#include "Network/Http/HttpHeaders.h"
+#include "Http/HttpHeaders.h"
 #include "WebHelpers/aw-sha1.h"
 #include "WebHelpers/base64.h"
 

--- a/Sming/Core/SmingCore.h
+++ b/Sming/Core/SmingCore.h
@@ -56,6 +56,7 @@
 #include "Data/Stream/JsonObjectStream.h"
 #include "Data/Stream/FileStream.h"
 #include "Data/Stream/TemplateFileStream.h"
+#include "Data/Stream/FlashMemoryStream.h"
 
 #include "DateTime.h"
 

--- a/Sming/Libraries/.patches/Adafruit_BME280_Library.patch
+++ b/Sming/Libraries/.patches/Adafruit_BME280_Library.patch
@@ -1,0 +1,13 @@
+diff --git a/Adafruit_BME280.h b/Adafruit_BME280.h
+index 61aeeed..383c8c8 100644
+--- a/Adafruit_BME280.h
++++ b/Adafruit_BME280.h
+@@ -23,7 +23,7 @@
+  #include "WProgram.h"
+ #endif
+ 
+-#include <Adafruit_Sensor.h>
++#include <Libraries/Adafruit_Sensor/Adafruit_Sensor.h>
+ #include <Wire.h>
+ 
+ /*=========================================================================

--- a/Sming/Libraries/.patches/Adafruit_SSD1306.patch
+++ b/Sming/Libraries/.patches/Adafruit_SSD1306.patch
@@ -1,8 +1,14 @@
 diff --git a/Adafruit_SSD1306.cpp b/Adafruit_SSD1306.cpp
-index 570a335..d2bb269 100644
+index 570a335..efcc3eb 100644
 --- a/Adafruit_SSD1306.cpp
 +++ b/Adafruit_SSD1306.cpp
-@@ -38,6 +38,33 @@ All text above, and the splash screen below must be included in any redistributi
+@@ -32,12 +32,38 @@ All text above, and the splash screen below must be included in any redistributi
+ 
+ #include <Wire.h>
+ #include <SPI.h>
+-#include "Adafruit_GFX.h"
+ #include "Adafruit_SSD1306.h"
+ 
  // the memory buffer for the LCD
  
  static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8] = {
@@ -36,7 +42,7 @@ index 570a335..d2bb269 100644
  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-@@ -71,7 +98,7 @@ static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8] = {
+@@ -71,7 +97,7 @@ static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8] = {
  0x00, 0x03, 0x03, 0x00, 0x00, 0x00, 0x03, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
  0x03, 0x03, 0x03, 0x03, 0x03, 0x01, 0x00, 0x00, 0x00, 0x01, 0x03, 0x01, 0x00, 0x00, 0x00, 0x03,
  0x03, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -45,7 +51,7 @@ index 570a335..d2bb269 100644
  0x00, 0x00, 0x00, 0x80, 0xC0, 0xE0, 0xF0, 0xF9, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x3F, 0x1F, 0x0F,
  0x87, 0xC7, 0xF7, 0xFF, 0xFF, 0x1F, 0x1F, 0x3D, 0xFC, 0xF8, 0xF8, 0xF8, 0xF8, 0x7C, 0x7D, 0xFF,
  0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F, 0x3F, 0x0F, 0x07, 0x00, 0x30, 0x30, 0x00, 0x00,
-@@ -106,6 +133,7 @@ static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8] = {
+@@ -106,6 +132,7 @@ static uint8_t buffer[SSD1306_LCDHEIGHT * SSD1306_LCDWIDTH / 8] = {
  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
  #endif
  #endif
@@ -53,7 +59,7 @@ index 570a335..d2bb269 100644
  };
  
  #define ssd1306_swap(a, b) { int16_t t = a; a = b; b = t; }
-@@ -252,7 +280,7 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
+@@ -252,7 +279,7 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
    ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
    ssd1306_command(0x8F);
  
@@ -62,7 +68,7 @@ index 570a335..d2bb269 100644
    ssd1306_command(SSD1306_SETCOMPINS);                    // 0xDA
    ssd1306_command(0x12);
    ssd1306_command(SSD1306_SETCONTRAST);                   // 0x81
-@@ -270,6 +298,15 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
+@@ -270,6 +297,15 @@ void Adafruit_SSD1306::begin(uint8_t vccstate, uint8_t i2caddr, bool reset) {
    else
      { ssd1306_command(0xAF); }
  
@@ -78,7 +84,7 @@ index 570a335..d2bb269 100644
  #endif
  
    ssd1306_command(SSD1306_SETPRECHARGE);                  // 0xd9
-@@ -417,21 +454,52 @@ void Adafruit_SSD1306::dim(boolean dim) {
+@@ -417,21 +453,52 @@ void Adafruit_SSD1306::dim(boolean dim) {
  }
  
  void Adafruit_SSD1306::display(void) {
@@ -136,7 +142,7 @@ index 570a335..d2bb269 100644
  
    if (sid != -1)
    {
-@@ -482,6 +550,7 @@ void Adafruit_SSD1306::display(void) {
+@@ -482,6 +549,7 @@ void Adafruit_SSD1306::display(void) {
      TWBR = twbrbackup;
  #endif
    }
@@ -145,9 +151,18 @@ index 570a335..d2bb269 100644
  
  // clear everything
 diff --git a/Adafruit_SSD1306.h b/Adafruit_SSD1306.h
-index 1162f87..c3f7050 100644
+index 1162f87..28d783f 100644
 --- a/Adafruit_SSD1306.h
 +++ b/Adafruit_SSD1306.h
+@@ -46,7 +46,7 @@ All text above, and the splash screen must be included in any redistribution
+ #endif
+ 
+ #include <SPI.h>
+-#include <Adafruit_GFX.h>
++#include <Libraries/Adafruit_GFX/Adafruit_GFX.h>
+ 
+ #define BLACK 0
+ #define WHITE 1
 @@ -69,20 +69,29 @@ All text above, and the splash screen must be included in any redistribution
  
      SSD1306_96_16

--- a/Sming/Libraries/.patches/Adafruit_ST7735.patch
+++ b/Sming/Libraries/.patches/Adafruit_ST7735.patch
@@ -1,0 +1,13 @@
+diff --git a/Adafruit_ST7735.h b/Adafruit_ST7735.h
+index b1e85fd..b10d01c 100755
+--- a/Adafruit_ST7735.h
++++ b/Adafruit_ST7735.h
+@@ -26,7 +26,7 @@ as well as Adafruit raw 1.8" TFT display
+ 
+ #include "Arduino.h"
+ #include "Print.h"
+-#include <Adafruit_GFX.h>
++#include <Libraries/Adafruit_GFX/Adafruit_GFX.h>
+ 
+ #if defined(__AVR__) || defined(CORE_TEENSY)
+   #include <avr/pgmspace.h>

--- a/Sming/Libraries/.patches/IR.patch
+++ b/Sming/Libraries/.patches/IR.patch
@@ -313,7 +313,7 @@ index a5f2166..e254a61 100644
  #define __STDC_LIMIT_MACROS
  #include <stdint.h>
 +#define ARDUINO_ARCH_ESP8266
-+#include <RingBufCPP/RingBufCPP.h>
++#include <Libraries/RingBufCPP/RingBufCPP.h>
  #include "IRremoteESP8266.h"
  
  // Constants

--- a/Sming/Libraries/.patches/TM1637.patch
+++ b/Sming/Libraries/.patches/TM1637.patch
@@ -1,0 +1,13 @@
+diff --git a/TM1637Display.cpp b/TM1637Display.cpp
+index 5e82c94..4feab77 100644
+--- a/TM1637Display.cpp
++++ b/TM1637Display.cpp
+@@ -21,7 +21,7 @@ extern "C" {
+   #include <inttypes.h>
+ }
+ 
+-#include <TM1637Display.h>
++#include "TM1637Display.h"
+ #include <Arduino.h>
+ 
+ #define TM1637_I2C_COMM1    0x40

--- a/Sming/Libraries/Adafruit_GFX/glcdfont.c
+++ b/Sming/Libraries/Adafruit_GFX/glcdfont.c
@@ -5,7 +5,7 @@
  #include <avr/io.h>
  #include <avr/pgmspace.h>
 #elif defined(__ESP8266_EX__)
- #include "../../Wiring/WiringFrameworkDependencies.h"
+ #include <WiringFrameworkDependencies.h>
 #else
  #define PROGMEM
 #endif

--- a/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.h
+++ b/Sming/Libraries/Adafruit_ILI9341/Adafruit_ILI9341.h
@@ -26,7 +26,7 @@
 #else
  #include "WProgram.h"
 #endif
-#include "../Adafruit_GFX/Adafruit_GFX.h"
+#include <Libraries/Adafruit_GFX/Adafruit_GFX.h>
 
 extern "C"
 {

--- a/Sming/Libraries/Adafruit_PCD8544/Adafruit_PCD8544.cpp
+++ b/Sming/Libraries/Adafruit_PCD8544/Adafruit_PCD8544.cpp
@@ -38,7 +38,6 @@ All text above, and the splash screen below must be included in any redistributi
 #include <stdlib.h>
 
 #include <Wire.h>
-#include "../Adafruit_GFX/Adafruit_GFX.h"
 
 
 // the memory buffer for the LCD

--- a/Sming/Libraries/Adafruit_PCD8544/Adafruit_PCD8544.h
+++ b/Sming/Libraries/Adafruit_PCD8544/Adafruit_PCD8544.h
@@ -26,7 +26,7 @@ All text above, and the splash screen must be included in any redistribution
 #endif
 
 #include <SPI.h>
-#include "../Adafruit_GFX/Adafruit_GFX.h"
+#include <Libraries/Adafruit_GFX/Adafruit_GFX.h>
 
 #ifdef __SAM3X8E__
  typedef volatile RwReg PortReg;

--- a/Sming/Libraries/ArduCAM/ArduCAMStream.h
+++ b/Sming/Libraries/ArduCAM/ArduCAMStream.h
@@ -10,7 +10,7 @@
 
 #include "ArduCAM.h"
 
-#include "../../Services/HexDump/HexDump.h"
+#include <Services/HexDump/HexDump.h>
 
 
 class ArduCAMStream: public IDataSourceStream {

--- a/Sming/Libraries/DS18S20/ds18s20.cpp
+++ b/Sming/Libraries/DS18S20/ds18s20.cpp
@@ -6,7 +6,7 @@
  */
 
 #include "Arduino.h"
-#include "OneWire.h"
+#include <Libraries/OneWire/OneWire.h>
 #include "ds18s20.h"
 
 #define DEBUG_DS18S20

--- a/Sming/Libraries/DS3232RTC/DS3232RTC.cpp
+++ b/Sming/Libraries/DS3232RTC/DS3232RTC.cpp
@@ -35,7 +35,7 @@
  * CC BY-SA 4.0, http://creativecommons.org/licenses/by-sa/4.0/         *
  *----------------------------------------------------------------------*/ 
 
-#include <DS3232RTC.h>
+#include "DS3232RTC.h"
 
 //define release-independent I2C functions
 #if defined(__AVR_ATtiny44__) || defined(__AVR_ATtiny84__) || defined(__AVR_ATtiny45__) || defined(__AVR_ATtiny85__)

--- a/Sming/Libraries/HMC5883L/HMC5883L.h
+++ b/Sming/Libraries/HMC5883L/HMC5883L.h
@@ -35,7 +35,7 @@ THE SOFTWARE.
 #ifndef _HMC5883L_H_
 #define _HMC5883L_H_
 
-#include "../I2Cdev/I2Cdev.h"
+#include <Libraries/I2Cdev/I2Cdev.h>
 
 #define HMC5883L_ADDRESS            0x1E // this device only has one address
 #define HMC5883L_DEFAULT_ADDRESS    0x1E

--- a/Sming/Libraries/MFRC522/MFRC522.cpp
+++ b/Sming/Libraries/MFRC522/MFRC522.cpp
@@ -3,7 +3,7 @@
 * NOTE: Please also check the comments in MFRC522.h - they provide useful hints and background information.
 * Released into the public domain.
 */
-#include <MFRC522.h>
+#include "MFRC522.h"
 
 /////////////////////////////////////////////////////////////////////////////////////
 // Functions for setting up the Arduino

--- a/Sming/Libraries/TFT_ILI9163C/TFT_ILI9163C.h
+++ b/Sming/Libraries/TFT_ILI9163C/TFT_ILI9163C.h
@@ -92,7 +92,7 @@
 #define YELLOW          0xFFE0
 #define WHITE           0xFFFF
 
-#include "../Adafruit_GFX/Adafruit_GFX.h"
+#include <Libraries/Adafruit_GFX/Adafruit_GFX.h>
 
 //----- Define here witch display you own
 //#define __144_RED_PCB__//128x128

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -40,13 +40,11 @@ MODULES :=
 # List of dependent submodule directories which may require updating/patching
 SUBMODULES :=
 
-# Include directories additional to APPCODE / MODULES
-EXTRA_INCDIR :=
-
 #
 SAMPLES_DIRS := $(shell ls -1 ../samples)
 DOXYGEN	:= $(shell command -v doxygen 2> /dev/null)
 
+# => WPS
 CONFIG_VARS += ENABLE_WPS
 ifeq ($(ENABLE_WPS), 1)
    CFLAGS += -DENABLE_WPS=1
@@ -107,14 +105,14 @@ LIBRARY_SUBMODULES	:= $(foreach lib,$(LIBRARY_SUBMODULES),Libraries/$(lib)/.subm
 # which modules (subdirectories) to include in compiling
 SMING_MODULES	:= $(ARCH_CORE) $(ARCH_BASE)/Platform Platform Core
 SMING_MODULES	:= $(foreach mod,$(SMING_MODULES),$(call ScanModuleDirs,$(mod)))
-MODULES			:= System $(ARCH_SYS) Wiring $(SMING_MODULES) $(MODULES)
+MODULES			:= $(ARCH_SYS) System Wiring $(SMING_MODULES) $(MODULES)
 MODULES			+= $(wildcard Services/*/)
 MODULES			+= $(foreach lib,$(ARDUINO_LIBRARIES),Libraries/$(lib) Libraries/$(lib)/src)
 MODULES			:= $(MODULES:/=)
 
-EXTRA_INCDIR	:=	System/include Wiring Libraries Core \
-					$(ARCH_BASE) $(ARCH_SYS)/include \
-					$(COMPONENTS) . $(EXTRA_INCDIR)
+EXTRA_INCDIR	:=	$(ARCH_BASE) $(ARCH_CORE) $(ARCH_SYS)/include \
+					$(ARCH_COMPONENTS) $(COMPONENTS) System/include Wiring Core \
+					. $(EXTRA_INCDIR)
 
 include $(SMING_HOME)/modules.mk
 

--- a/Sming/Makefile-app.mk
+++ b/Sming/Makefile-app.mk
@@ -48,11 +48,11 @@ TARGET = app
 MODULES      ?= app     # default to app if not set by user
 EXTRA_INCDIR ?= include # default to include if not set by user
 
-SMING_INCDIR := System/include Wiring Libraries Core Platform \
-				Libraries/Adafruit_GFX Libraries/Adafruit_Sensor
+SMING_INCDIR := System/include Wiring Core
 
-EXTRA_INCDIR += $(SMING_HOME) $(addprefix $(SMING_HOME)/,$(SMING_INCDIR)) \
-				$(ARCH_BASE) $(ARCH_SYS)/include $(ARCH_CORE) $(COMPONENTS)
+EXTRA_INCDIR += $(SMING_HOME) $(ARCH_BASE) $(ARCH_CORE) $(ARCH_SYS)/include \
+				$(ARCH_COMPONENTS) $(COMPONENTS) \
+				$(addprefix $(SMING_HOME)/,$(SMING_INCDIR))
 
 # we will use global WiFi settings from Eclipse Environment Variables, if possible
 CONFIG_VARS	+= WIFI_SSID WIFI_PWD

--- a/Sming/Services/Yeelight/YeelightBulb.cpp
+++ b/Sming/Services/Yeelight/YeelightBulb.cpp
@@ -6,8 +6,10 @@
  ****/
 
 #include "YeelightBulb.h"
-#include "TcpClient.h"
-#include <SmingCore.h>
+#include "Network/TcpClient.h"
+#include "Digital.h"
+#include "Data/ArduinoJson.h"
+#include "WCharacter.h"
 
 YeelightBulb::~YeelightBulb()
 {

--- a/Sming/Services/Yeelight/YeelightBulb.h
+++ b/Sming/Services/Yeelight/YeelightBulb.h
@@ -6,8 +6,6 @@
  ****/
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
-#include "WHashMap.h"
 #include "WVector.h"
 #include "WString.h"
 #include "IPAddress.h"

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -81,6 +81,9 @@ ARCH_COMPONENTS	= $(ARCH_BASE)/Components
 USER_LIBDIR		= $(ARCH_BASE)/Compiler/lib
 COMPONENTS		:= Components
 
+BUILD_BASE		:= out/build/$(SMING_ARCH)
+FW_BASE			:= out/firmware
+
 # Git command
 GIT ?= git
 
@@ -131,6 +134,10 @@ else ifeq ($(ENABLE_GDB), 1)
 else
 	CFLAGS += -Os -g
 endif
+
+#
+CONFIG_VARS	+= USER_CFLAGS
+CFLAGS		+= $(USER_CFLAGS)
 
 #Append debug options
 CONFIG_VARS += SMING_RELEASE

--- a/Sming/modules.mk
+++ b/Sming/modules.mk
@@ -15,28 +15,27 @@ OBJ :=
 APP_AR			:= $(addprefix $(BUILD_BASE)/,$(TARGET)_app.a)
 TARGET_OUT		:= $(addprefix $(BUILD_BASE)/,$(TARGET).out)
 
-INCDIR			:= -I$(SDK_INCDIR) $(addprefix -I,$(APPCODE) $(MODULES))
-EXTRA_INCDIR	:= $(addprefix -I,$(EXTRA_INCDIR))
+INCDIR	:= $(addprefix -I,$(EXTRA_INCDIR))
 
 # $1 -> directory containing source files
 # $2 -> output build directory
 define GenerateCompileTargets
 $2/%.o: $1/%.s
 	$(vecho) "AS $$<"
-	$(AS) $(INCDIR) -I$1/include $(EXTRA_INCDIR) $(CFLAGS) -c $$< -o $$@
+	$(AS) $(INCDIR) $(CFLAGS) -c $$< -o $$@
 $2/%.o: $1/%.S
 	$(vecho) "AS $$<"
-	$(AS) $(INCDIR) -I$1/include $(EXTRA_INCDIR) $(CFLAGS) -c $$< -o $$@
+	$(AS) $(INCDIR) $(CFLAGS) -c $$< -o $$@
 $2/%.o: $1/%.c $2/%.c.d
 	$(vecho) "CC $$<"
-	$(CC) $(INCDIR) -I$1/include $(EXTRA_INCDIR) $(CFLAGS) -c $$< -o $$@
+	$(CC) $(INCDIR) $(CFLAGS) -c $$< -o $$@
 $2/%.o: $1/%.cpp $2/%.cpp.d
 	$(vecho) "C+ $$<"
-	$(CXX) $(INCDIR) -I$1/include $(EXTRA_INCDIR) $(CXXFLAGS) -c $$< -o $$@
+	$(CXX) $(INCDIR) $(CXXFLAGS) -c $$< -o $$@
 $2/%.c.d: $1/%.c
-	$(CC) $(INCDIR) -I$1/include $(EXTRA_INCDIR) $(CFLAGS) -MM -MT $2/$$*.o $$< -o $$@
+	$(CC) $(INCDIR) $(CFLAGS) -MM -MT $2/$$*.o $$< -o $$@
 $2/%.cpp.d: $1/%.cpp
-	$(CXX) $(INCDIR) -I$1/include $(EXTRA_INCDIR) $(CXXFLAGS) -MM -MT $2/$$*.o $$< -o $$@
+	$(CXX) $(INCDIR) $(CXXFLAGS) -MM -MT $2/$$*.o $$< -o $$@
 
 .PRECIOUS: $2/%.c.d $2/%.cpp.d
 endef

--- a/samples/Accelerometer_MMA7455/app/application.cpp
+++ b/samples/Accelerometer_MMA7455/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/MMA_7455/MMA_7455.h>
 

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -1,10 +1,6 @@
-#include <user_config.h>
 #include <SmingCore.h>
-//#include <Network/WebConstants.h>
 #include <Network/TelnetServer.h>
 #include <Debug.h>
-//#include <Libraries/ArduCAM/ArduCAM.h>
-//#include <Libraries/ArduCAM/ov2640_regs.h>
 
 //#include "CamSettings.h"
 #include <ArduCamCommand.h>

--- a/samples/Arducam/include/ArduCamCommand.h
+++ b/samples/Arducam/include/ArduCamCommand.h
@@ -7,8 +7,8 @@
 #define ARDUCAM_COMMAND_H_
 
 #include "WString.h"
-#include "../Services/CommandProcessing/CommandProcessingIncludes.h"
-#include "../Services/CommandProcessing/CommandOutput.h"
+#include <Services/CommandProcessing/CommandProcessingIncludes.h>
+#include <Services/CommandProcessing/CommandOutput.h>
 #include <Libraries/ArduCAM/ArduCAM.h>
 
 class ArduCamCommand

--- a/samples/Basic_APA102/app/application.cpp
+++ b/samples/Basic_APA102/app/application.cpp
@@ -10,7 +10,6 @@
  * software SPI: user defined
  * 
  */
-#include "user_config.h"
 #include <SmingCore.h>
 
 // SPI: if defined use software SPI, else hardware SPI

--- a/samples/Basic_Blink/app/application.cpp
+++ b/samples/Basic_Blink/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 #define LED_PIN 2 // GPIO2

--- a/samples/Basic_Capsense/app/application.cpp
+++ b/samples/Basic_Capsense/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 #include <Libraries/CapacitiveSensor/CapacitiveSensor.h>

--- a/samples/Basic_DateTime/app/application.cpp
+++ b/samples/Basic_DateTime/app/application.cpp
@@ -4,7 +4,6 @@
 	Provides serial interface, accepting Unix timestamp
 	Prints each type of DateTime::format option
 */
-#include <user_config.h>
 #include <SmingCore.h>
 
 time_t timestamp = 0;

--- a/samples/Basic_Delegates/app/application.cpp
+++ b/samples/Basic_Delegates/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 void plainOldOrdinaryFunction()

--- a/samples/Basic_HwPWM/app/application.cpp
+++ b/samples/Basic_HwPWM/app/application.cpp
@@ -15,7 +15,6 @@
  * See also ESP8266 Technical Reference, Chapter 12:
  * http://espressif.com/sites/default/files/documentation/esp8266-technical_reference_en.pdf
  */
-#include <user_config.h>
 #include <SmingCore.h>
 #include <HardwarePWM.h>
 

--- a/samples/Basic_Interrupts/app/application.cpp
+++ b/samples/Basic_Interrupts/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // Input pin for demonstrating a call to a low-level interrupt handler callback

--- a/samples/Basic_NFC/app/application.cpp
+++ b/samples/Basic_NFC/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/MFRC522/MFRC522.h>
 

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 #include <Libraries/Adafruit_NeoPixel/Adafruit_NeoPixel.h>

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -1,7 +1,7 @@
 #include <user_config.h>
 #include <SmingCore.h>
 
-#include <Adafruit_NeoPixel/Adafruit_NeoPixel.h>
+#include <Libraries/Adafruit_NeoPixel/Adafruit_NeoPixel.h>
 
 #ifndef WIFI_SSID
 #define WIFI_SSID "XXX" // Put you SSID and Password here

--- a/samples/Basic_ProgMem/app/application.cpp
+++ b/samples/Basic_ProgMem/app/application.cpp
@@ -7,7 +7,6 @@
 // program memory back into RAM, so we can do something useful with it.
 //
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <stdio.h>
 

--- a/samples/Basic_ScannerI2C/app/application.cpp
+++ b/samples/Basic_ScannerI2C/app/application.cpp
@@ -27,7 +27,6 @@
 // Devices with higher bit address might not be seen properly.
 //
 
-#include <user_config.h>
 #include <SmingCore.h>
 
 Timer procTimer;

--- a/samples/Basic_Serial/app/application.cpp
+++ b/samples/Basic_Serial/app/application.cpp
@@ -2,7 +2,6 @@
  * application.cpp
  */
 
-#include <user_config.h>
 #include "SerialReadingDelegateDemo.h"
 #include "SerialTransmitDemo.h"
 

--- a/samples/Basic_Servo/app/application.cpp
+++ b/samples/Basic_Servo/app/application.cpp
@@ -3,7 +3,6 @@
  *
 */
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/Servo/ServoChannel.h>
 

--- a/samples/Basic_SmartConfig/app/application.cpp
+++ b/samples/Basic_SmartConfig/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 void smartConfigCallback(sc_status status, void* pdata)

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -7,7 +7,6 @@
  * make ENABLE_SSL=1
  */
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include "Data/HexString.h"
 

--- a/samples/Basic_WebSkeletonApp/app/application.cpp
+++ b/samples/Basic_WebSkeletonApp/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <tytherm.h>
 
 Timer counterTimer;

--- a/samples/Basic_WebSkeletonApp/include/configuration.h
+++ b/samples/Basic_WebSkeletonApp/include/configuration.h
@@ -1,7 +1,6 @@
 #ifndef INCLUDE_CONFIGURATION_H_
 #define INCLUDE_CONFIGURATION_H_
 
-#include <user_config.h>
 #include <SmingCore.h>
 
 const char THERM_CONFIG_FILE[] = ".therm.conf"; // leading point for security reasons :)

--- a/samples/Basic_WiFi/app/application.cpp
+++ b/samples/Basic_WiFi/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/Basic_rBoot/app/application.cpp
+++ b/samples/Basic_rBoot/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // download urls, set appropriately

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Network/TelnetServer.h>
 #include <Network/Http/Websocket/WebsocketResource.h>

--- a/samples/CommandProcessing_Debug/include/ExampleCommand.h
+++ b/samples/CommandProcessing_Debug/include/ExampleCommand.h
@@ -7,7 +7,7 @@
 #define SMINGCORE_EXAMPLE_COMMAND_H_
 
 #include "WString.h"
-#include "../Services/CommandProcessing/CommandProcessingIncludes.h"
+#include <Services/CommandProcessing/CommandProcessingIncludes.h>
 
 class ExampleCommand
 {

--- a/samples/Compass_HMC5883L/app/application.cpp
+++ b/samples/Compass_HMC5883L/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/HMC5883L/HMC5883L.h>
 

--- a/samples/DNSCaptivePortal/app/application.cpp
+++ b/samples/DNSCaptivePortal/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 DNSServer dnsServer;

--- a/samples/DS3232RTC_NTP_Setter/app/application.cpp
+++ b/samples/DS3232RTC_NTP_Setter/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 #include <Wire.h>

--- a/samples/Echo_Ssl/app/application.cpp
+++ b/samples/Echo_Ssl/app/application.cpp
@@ -13,7 +13,6 @@
  *
  */
 
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/Gesture_APDS-9960/app/application.cpp
+++ b/samples/Gesture_APDS-9960/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 #include <Libraries/SparkFun_APDS9960/SparkFun_APDS9960.h>

--- a/samples/Gesture_APDS-9960/app/application.cpp
+++ b/samples/Gesture_APDS-9960/app/application.cpp
@@ -1,7 +1,7 @@
 #include <user_config.h>
 #include <SmingCore.h>
 
-#include <SparkFun_APDS9960/SparkFun_APDS9960.h>
+#include <Libraries/SparkFun_APDS9960/SparkFun_APDS9960.h>
 
 SparkFun_APDS9960 apds = SparkFun_APDS9960();
 

--- a/samples/HttpClient/app/application.cpp
+++ b/samples/HttpClient/app/application.cpp
@@ -7,7 +7,6 @@
  * make ENABLE_SSL=1
  */
 
-#include <user_config.h>
 #include <SmingCore.h>
 
 #include "Network/HttpClient.h"

--- a/samples/HttpClient_Instapush/app/application.cpp
+++ b/samples/HttpClient_Instapush/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 /*** Direct PUSH notifications on your mobile phone!

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/HttpServer_ConfigNetwork/app/application.cpp
+++ b/samples/HttpServer_ConfigNetwork/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <AppSettings.h>
 #include "Data/Stream/TemplateFlashMemoryStream.h"

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Network/Http/Websocket/WebsocketResource.h>
 #include "CUserData.h"

--- a/samples/HttpServer_WebSockets/include/CUserData.h
+++ b/samples/HttpServer_WebSockets/include/CUserData.h
@@ -1,7 +1,6 @@
 #ifndef C_USER_DATA_H_SAMPLE
 #define C_USER_DATA_H_SAMPLE
 
-#include <user_config.h>
 #include <SmingCore.h>
 
 //Simplified container modelling a user session

--- a/samples/Humidity_AM2321/app/application.cpp
+++ b/samples/Humidity_AM2321/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include "Libraries/AM2321/AM2321.h"
 

--- a/samples/Humidity_DHT22/app/application.cpp
+++ b/samples/Humidity_DHT22/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/DHTesp/DHTesp.h>
 

--- a/samples/Humidity_SI7021/app/application.cpp
+++ b/samples/Humidity_SI7021/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/SI7021/SI7021.h>
 #include <math.h>

--- a/samples/IR_lib/app/application.cpp
+++ b/samples/IR_lib/app/application.cpp
@@ -2,7 +2,6 @@
   A simple example on how to use the IR library
  ****************************************************/
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/IR/src/IRrecv.h>
 #include <Libraries/IR/src/IRsend.h>

--- a/samples/LED_WS2812/app/application.cpp
+++ b/samples/LED_WS2812/app/application.cpp
@@ -1,5 +1,3 @@
-#include <user_config.h>
-
 #include <Libraries/WS2812/WS2812.h>
 
 #define LED_PIN 2 // GPIO2

--- a/samples/LED_WS2812/app/application.cpp
+++ b/samples/LED_WS2812/app/application.cpp
@@ -1,6 +1,6 @@
 #include <user_config.h>
 
-#include <WS2812/WS2812.h>
+#include <Libraries/WS2812/WS2812.h>
 
 #define LED_PIN 2 // GPIO2
 

--- a/samples/LED_YeelightBulb/app/application.cpp
+++ b/samples/LED_YeelightBulb/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/Light_BH1750/app/application.cpp
+++ b/samples/Light_BH1750/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/BH1750FVI/BH1750FVI.h>
 

--- a/samples/LiquidCrystal_44780/app/application.cpp
+++ b/samples/LiquidCrystal_44780/app/application.cpp
@@ -4,7 +4,6 @@
 // * GPIO2 SDA
 // Can be changed by call Wire.pins(...)
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/LiquidCrystal/LiquidCrystal_I2C.h>
 

--- a/samples/LiveDebug/app/application.cpp
+++ b/samples/LiveDebug/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include "HardwareTimer.h"
 #include <gdb/gdb_syscall.h>

--- a/samples/MeteoControl/app/application.cpp
+++ b/samples/MeteoControl/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/LiquidCrystal/LiquidCrystal_I2C.h>
 #include <Libraries/DHTesp/DHTesp.h>

--- a/samples/MeteoControl/app/application.cpp
+++ b/samples/MeteoControl/app/application.cpp
@@ -5,7 +5,7 @@
 
 ///////////////////////////////////////////////////////////////////
 // Set your SSID & Pass for initial configuration
-#include "../include/configuration.h" // application configuration
+#include "configuration.h" // application configuration
 ///////////////////////////////////////////////////////////////////
 
 #include "special_chars.h"

--- a/samples/MeteoControl/app/configuration.cpp
+++ b/samples/MeteoControl/app/configuration.cpp
@@ -1,4 +1,4 @@
-#include "../include/configuration.h"
+#include "configuration.h"
 
 #include <SmingCore.h>
 

--- a/samples/MeteoControl/app/webserver.cpp
+++ b/samples/MeteoControl/app/webserver.cpp
@@ -1,7 +1,7 @@
 #include <user_config.h>
 #include <SmingCore.h>
 
-#include "../include/configuration.h"
+#include "configuration.h"
 
 bool serverStarted = false;
 HttpServer server;

--- a/samples/MeteoControl/app/webserver.cpp
+++ b/samples/MeteoControl/app/webserver.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 #include "configuration.h"

--- a/samples/MeteoControl/include/configuration.h
+++ b/samples/MeteoControl/include/configuration.h
@@ -1,7 +1,6 @@
 #ifndef INCLUDE_CONFIGURATION_H_
 #define INCLUDE_CONFIGURATION_H_
 
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -1,10 +1,10 @@
 #include <user_config.h>
 #include <SmingCore.h>
 
-#include "../include/configuration.h" // application configuration
+#include "configuration.h" // application configuration
 
-#include "../app/bmp180.cpp" // bmp180 configuration
-#include "../app/si7021.cpp" // htu21d configuration
+#include "bmp180.cpp" // bmp180 configuration
+#include "si7021.cpp" // htu21d configuration
 
 Timer publishTimer;
 

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 #include "configuration.h" // application configuration

--- a/samples/MeteoControl_mqtt/app/bmp180.cpp
+++ b/samples/MeteoControl_mqtt/app/bmp180.cpp
@@ -1,7 +1,6 @@
 #ifndef INCLUDE_BMP180_H_
 #define INCLUDE_BMP180_H_
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/BMP180/BMP180.h>
 

--- a/samples/MeteoControl_mqtt/app/si7021.cpp
+++ b/samples/MeteoControl_mqtt/app/si7021.cpp
@@ -1,7 +1,6 @@
 #ifndef INCLUDE_SI7021_H_
 #define INCLUDE_SI7021_H_
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/SI7021/SI7021.h>
 

--- a/samples/MeteoControl_mqtt/include/configuration.h
+++ b/samples/MeteoControl_mqtt/include/configuration.h
@@ -1,7 +1,6 @@
 #ifndef INCLUDE_CONFIGURATION_H_
 #define INCLUDE_CONFIGURATION_H_
 
-#include <user_config.h>
 #include <SmingCore.h>
 
 //////////////////////////// Wi-Fi config ///////////////////////////////////////

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/PortExpander_MCP23017/app/application.cpp
+++ b/samples/PortExpander_MCP23017/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/MCP23017/MCP23017.h>
 

--- a/samples/PortExpander_MCP23S17/app/application.cpp
+++ b/samples/PortExpander_MCP23S17/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Wire.h>
 #include <SPI.h>

--- a/samples/Pressure_BMP180/app/application.cpp
+++ b/samples/Pressure_BMP180/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/BMP180/BMP180.h>
 

--- a/samples/Radio_RCSwitch/app/application.cpp
+++ b/samples/Radio_RCSwitch/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/RCSwitch/RCSwitch.h>
 

--- a/samples/Radio_nRF24L01/app/application.cpp
+++ b/samples/Radio_nRF24L01/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/TFT_ILI9163C/TFT_ILI9163C.h>
 #include <Libraries/RF24/nRF24L01.h>

--- a/samples/Radio_si4432/app/application.cpp
+++ b/samples/Radio_si4432/app/application.cpp
@@ -7,7 +7,6 @@ Descr: Example applicatin for radio module Si4432 aka RF22 driver
 Link: http://www.electrodragon.com/w/SI4432_433M-Wireless_Transceiver_Module_%281.5KM_Range,_Shield-Protected%29
 */
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/si4432/si4432.h>
 #include <string.h>

--- a/samples/SDCard/app/application.cpp
+++ b/samples/SDCard/app/application.cpp
@@ -5,7 +5,6 @@ License: MIT
 Date: 17.07.2015
 Descr: SDCard/FAT file usage and write benchmark.
 */
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/SDCard/SDCard.h>
 #include <string.h>

--- a/samples/ScreenLCD_5110/app/application.cpp
+++ b/samples/ScreenLCD_5110/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/Adafruit_PCD8544/Adafruit_PCD8544.h>
 

--- a/samples/ScreenOLED_SSD1306/app/application.cpp
+++ b/samples/ScreenOLED_SSD1306/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/Adafruit_SSD1306/Adafruit_SSD1306.h>
 

--- a/samples/ScreenTFT_ILI9163C/app/application.cpp
+++ b/samples/ScreenTFT_ILI9163C/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/TFT_ILI9163C/TFT_ILI9163C.h>
 

--- a/samples/ScreenTFT_ILI9340-ILI9341/app/BMPDraw.cpp
+++ b/samples/ScreenTFT_ILI9340-ILI9341/app/BMPDraw.cpp
@@ -26,7 +26,6 @@ as well as Adafruit raw 1.8" TFT display
  * hbottc@gmail.com
  ***************************************************/
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/Adafruit_ILI9341/Adafruit_ILI9341.h>
 

--- a/samples/ScreenTFT_ILI9340-ILI9341/app/application.cpp
+++ b/samples/ScreenTFT_ILI9340-ILI9341/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/Adafruit_ILI9341/Adafruit_ILI9341.h>
 

--- a/samples/ScreenTFT_ST7735/app/BMPDraw.cpp
+++ b/samples/ScreenTFT_ST7735/app/BMPDraw.cpp
@@ -26,7 +26,6 @@ as well as Adafruit raw 1.8" TFT display
  * hbottc@gmail.com
  ***************************************************/
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/Adafruit_ST7735/Adafruit_ST7735.h>
 #include "BPMDraw.h"

--- a/samples/ScreenTFT_ST7735/app/application.cpp
+++ b/samples/ScreenTFT_ST7735/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/Adafruit_ST7735/Adafruit_ST7735.h>
 

--- a/samples/SmtpClient/app/application.cpp
+++ b/samples/SmtpClient/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Network/SmtpClient.h>
 

--- a/samples/SystemClock_NTP/app/application.cpp
+++ b/samples/SystemClock_NTP/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 #include "NtpClientDelegateDemo.h"

--- a/samples/TcpClient_NarodMon/app/application.cpp
+++ b/samples/TcpClient_NarodMon/app/application.cpp
@@ -2,7 +2,6 @@
  * By JustACat http://esp8266.ru/forum/members/120/
  * 23.04.2015
  */
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/Telnet_TCPServer_TCPClient/app/application.cpp
+++ b/samples/Telnet_TCPServer_TCPClient/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Network/TelnetServer.h>
 #include "Services/CommandProcessing/CommandProcessingIncludes.h"

--- a/samples/Temperature_DS1820/app/application.cpp
+++ b/samples/Temperature_DS1820/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/OneWire/OneWire.h>
 

--- a/samples/UdpServer_Echo/app/application.cpp
+++ b/samples/UdpServer_Echo/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 /*** mDNS Demo (instruction for usage)

--- a/samples/Ultrasonic_HCSR04/app/application.cpp
+++ b/samples/Ultrasonic_HCSR04/app/application.cpp
@@ -8,7 +8,6 @@
  * By nik.sharky http://esp8266.ru/forum/members/sharky.396/
  */
 
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Libraries/Ultrasonic/Ultrasonic.h>
 

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -9,7 +9,6 @@
  * This demo shows connecton, closing , reconnection methods of
  * websocket client.
  */
-#include <user_config.h>
 #include <SmingCore.h>
 #include <Network/WebsocketClient.h>
 

--- a/samples/Wifi_Sniffer/app/application.cpp
+++ b/samples/Wifi_Sniffer/app/application.cpp
@@ -1,4 +1,3 @@
-#include <user_config.h>
 #include <SmingCore.h>
 
 #include "Platform/WifiSniffer.h"


### PR DESCRIPTION
Restrict number of directories when building libraries and modules to only those absolutely necessary
Remove `#include <user_config.h>` from all applications - not required
Add `FlashMemoryStream.h` to `SmingCore.h` so applications don't need to add it specially