### PR TITLE
Fix/build revisions

### DIFF
--- a/Sming/Arch/Esp8266/Compiler/ld/common.ld
+++ b/Sming/Arch/Esp8266/Compiler/ld/common.ld
@@ -112,7 +112,7 @@ SECTIONS
 
      *(.rodata._ZTV*) /* C++ vtables */
     *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.debug.*)
-    out/build/app_app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
+    */app.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
   *libsming.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
   *libsmingssl.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)
   *libmqttc.a:*(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.* .irom.debug.*)

--- a/Sming/Arch/Esp8266/app.mk
+++ b/Sming/Arch/Esp8266/app.mk
@@ -266,7 +266,7 @@ LIBS += $(LIBPWM)
 
 
 #
-LIBS := microc microgcc hal phy pp net80211 mqttc wpa $(LIBSMING) crypto smartconfig $(EXTRA_LIBS) $(LIBS)
+LIBS := microc microgcc hal phy pp net80211 wpa $(LIBSMING) crypto smartconfig $(EXTRA_LIBS) $(LIBS)
 
 # linker flags used to generate the main object file
 LDFLAGS	= -nostdlib -u call_user_start -u Cache_Read_Enable_New -u spiffs_get_storage_config -u custom_crash_callback \

--- a/Sming/Arch/Esp8266/build.mk
+++ b/Sming/Arch/Esp8266/build.mk
@@ -75,4 +75,4 @@ SDK_INCDIR	:= $(SDK_BASE)/include
 # => Tools
 ESPTOOL2	= $(ARCH_TOOLS)/esptool2/esptool2$(TOOL_EXT)
 SPIFFY		= $(ARCH_TOOLS)/spiffy/spiffy$(TOOL_EXT)
-
+MEMANALYZER = python $(ARCH_TOOLS)/memanalyzer.py $(OBJDUMP)$(TOOL_EXT)

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -27,12 +27,10 @@ all: checkdirs libsming tools ##(default) Build the Sming library, user librarie
 
 include $(SMING_HOME)/build.mk
 
-BUILD_BASE := $(ARCH_BASE)/out/build
+# name for the target project
+TARGET := lib$(LIBSMING)
 
 RELOAD_MKFILE = 0
-
-# name for the target project
-TARGET		= app
 
 # List of directories containing source code to build
 MODULES :=
@@ -156,7 +154,6 @@ dist-clean: clean submodules-clean tools-clean user-lib-clean samples-clean ##Cl
 .PHONY: clean
 clean: $(CLEAN) ##Remove all generated build files
 	$(Q) rm -f $(APP_AR)
-	$(Q) rm -f $(TARGET_OUT)
 	$(Q) rm -rf $(BUILD_BASE)
 
 .PHONY: user-lib-clean

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -61,20 +61,8 @@ MODULES			+= $(COMPONENTS)/ws_parser
 
 # => mqtt-codec
 SUBMODULES		+= $(COMPONENTS)/mqtt-codec
+MODULES			+= $(COMPONENTS)/mqtt-codec/src
 EXTRA_INCDIR	+= $(COMPONENTS)/mqtt-codec/src
-LIBMQTTC		:= mqttc
-LIBS			+= $(LIBMQTTC)
-BUILD_MQTTC		:= $(MAKE) -C $(COMPONENTS)/mqtt-codec MQTT_ENABLE_SERVER=0 MQTT_ENABLE_CLIENT=1 CC=$(CC) AR=$(AR) \
-				CFLAGS_EXTRA="-ISystem/include $(CFLAGS_COMMON)" \
-				LIB_FOLDER="$(SMING_HOME)/$(USER_LIBDIR)"
-CLEAN			+= mqttc-clean
-
-$(call UserLibPath,$(LIBMQTTC)):
-	$(Q) $(BUILD_MQTTC) lib
-
-.PHONY: mqttc-clean
-mqttc-clean:
-	-$(Q) $(BUILD_MQTTC) clean
 
 
 # => yuarel

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -126,11 +126,9 @@ $(foreach lib,$(LIBS),$(eval $(call UserLibrary,$(lib))))
 
 
 .PHONY: libsming
-libsming: $(APP_AR) $(CUSTOM_TARGETS) ##Build the Sming framework and user libraries
+libsming: $(LIBSMING_DST)
 
-$(APP_AR): $(OBJ)
-	$(vecho) "AR $@"
-	$(AR) cru $@ $^
+$(LIBSMING_DST): $(APP_AR) $(CUSTOM_TARGETS) ##Build the Sming framework and user libraries
 	$(vecho) "Installing '$(LIBSMING)' library"
 ifeq ($(ENABLE_SSL), 1)
 	$(vecho) "+ SSL support is enabled"
@@ -140,10 +138,14 @@ endif
 	$(Q) cp -r $(APP_AR) $(LIBSMING_DST)
 	$(vecho) "Done"
 
-.PHONY: checkdirs
-checkdirs: submodules reload | $(BUILD_DIR)
+$(APP_AR): $(OBJ)
+	$(vecho) "AR $@"
+	$(AR) cru $@ $^
 
-$(BUILD_DIR):
+.PHONY: checkdirs
+checkdirs: submodules reload | $(BUILD_DIR) $(USER_LIBDIR)
+
+$(BUILD_DIR) $(USER_LIBDIR):
 	$(Q) mkdir -p $@
 
 ##@Cleaning
@@ -159,7 +161,7 @@ clean: $(CLEAN) ##Remove all generated build files
 .PHONY: user-lib-clean
 user-lib-clean: ##Remove generated user libraries
 	-$(Q) rm -f $(wildcard $(USER_LIBDIR)/lib*.a) $(APP_AR)
-	$(Q) $(GIT) checkout $(USER_LIBDIR)
+	-$(Q) $(GIT) checkout $(USER_LIBDIR)
 
 ##@Building
 

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -140,7 +140,7 @@ endif
 
 $(APP_AR): $(OBJ)
 	$(vecho) "AR $@"
-	$(AR) cru $@ $^
+	$(AR) cr $@ $^
 
 .PHONY: checkdirs
 checkdirs: submodules reload | $(BUILD_DIR) $(USER_LIBDIR)

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -208,11 +208,9 @@ submodules: | $(LIBRARY_SUBMODULES) $(addsuffix /.submodule,$(SUBMODULES)) ##Fet
 
 ##@Cleaning
 submodules-clean: ##Reset state of all third-party submodules
-	-$(Q) rm -rf $(SUBMODULES)
+	$(Q) rm -rf $(call ListSubmodules)
+	-$(Q) rm -rf $(addprefix $(BUILD_BASE),$(call ListSubmodules))
 	$(GIT) checkout Components
-	-$(Q) rm -rf Libraries
-	-$(Q) rm -rf $(BUILD_BASE)/Libraries
-	-$(Q) mkdir -p Libraries
 	$(GIT) checkout Libraries
 
 # Update and patch submodule

--- a/Sming/Makefile-app.mk
+++ b/Sming/Makefile-app.mk
@@ -23,11 +23,11 @@ COM_SPEED_SERIAL  ?= $(COM_SPEED)
 
 include $(SMING_HOME)/build.mk
 
+# name for the target project
+TARGET			:= app
+
 ARCH_BASE		:= $(SMING_HOME)/$(ARCH_BASE)
 COMPONENTS		:= $(SMING_HOME)/$(COMPONENTS)
-
-BUILD_BASE		:= out/build
-FW_BASE			:= out/firmware
 
 CONFIG_VARS		+= CURDIR MAKE_VERSION SHELL
 
@@ -39,9 +39,6 @@ SPIFF_FILES		?= files
 FW_MEMINFO_NEW		:= $(FW_BASE)/fwMeminfo.new
 FW_MEMINFO_OLD		:= $(FW_BASE)/fwMeminfo.old
 FW_MEMINFO_SAVED	:= out/fwMeminfo
-
-# name for the target project
-TARGET = app
 
 # which modules (subdirectories) of the project to include in compiling
 # define your custom directories in the project's own Makefile before including this one
@@ -74,10 +71,6 @@ endif
 # => Serial
 CONFIG_VARS	+= COM_SPEED_SERIAL
 CFLAGS		+= -DCOM_SPEED_SERIAL=$(COM_SPEED_SERIAL)
-
-#
-CONFIG_VARS	+= USER_CFLAGS
-CFLAGS		+= $(USER_CFLAGS)
 
 include $(ARCH_BASE)/app.mk
 

--- a/Sming/Makefile-bsd.mk
+++ b/Sming/Makefile-bsd.mk
@@ -13,4 +13,3 @@ ESPTOOL		 ?= $(ESP_HOME)/esptool/esptool.py
 KILL_TERM    ?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 GET_FILESIZE ?= stat -f "%-15z"
 TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
-MEMANALYZER  ?= python $(ARCH_TOOLS)/memanalyzer.py $(OBJDUMP)

--- a/Sming/Makefile-linux.mk
+++ b/Sming/Makefile-linux.mk
@@ -13,4 +13,3 @@ ESPTOOL		 ?= $(ESP_HOME)/esptool/esptool.py
 KILL_TERM    ?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 GET_FILESIZE ?= stat -c %s
 TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
-MEMANALYZER  ?= python $(ARCH_TOOLS)/memanalyzer.py $(OBJDUMP)

--- a/Sming/Makefile-macos.mk
+++ b/Sming/Makefile-macos.mk
@@ -13,4 +13,3 @@ ESPTOOL		 ?= $(ESP_HOME)/esptool/esptool.py
 KILL_TERM    ?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 GET_FILESIZE ?= stat -L -f%z
 TERMINAL     ?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
-MEMANALYZER  ?= python $(ARCH_TOOLS)/memanalyzer.py $(OBJDUMP)

--- a/Sming/Makefile-windows.mk
+++ b/Sming/Makefile-windows.mk
@@ -13,4 +13,3 @@ ESPTOOL		 ?= $(SDK_TOOLS)/ESP8266/esptool.exe
 KILL_TERM    ?= taskkill.exe -f -im Terminal.exe || exit 0
 GET_FILESIZE ?= stat --printf="%s"
 TERMINAL     ?= $(SDK_TOOLS)/Terminal.exe $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
-MEMANALYZER  ?= python $(ARCH_TOOLS)/memanalyzer.py $(OBJDUMP).exe

--- a/Sming/modules.mk
+++ b/Sming/modules.mk
@@ -12,8 +12,8 @@ BUILD_DIR :=
 # List of object files
 OBJ :=
 
-APP_AR			:= $(addprefix $(BUILD_BASE)/,$(TARGET)_app.a)
-TARGET_OUT		:= $(addprefix $(BUILD_BASE)/,$(TARGET).out)
+# Intermediate linker target
+APP_AR	:= $(BUILD_BASE)/$(TARGET).a
 
 INCDIR	:= $(addprefix -I,$(EXTRA_INCDIR))
 


### PR DESCRIPTION
* Change build directories so object files are out of source tree (revert to using `out` directory)
* Rename build targets as `libsming.a` and `app.a` instead of `app_app.a` for both
* Fix rules for building libsming for more reliable building/cleaning
* Move `MEMANALYZER` definition into Arch/build.mk
* Fix intermittent problem with missing objects when linking applications
* Add mqttc as a module so object files are out of source tree (doesn't need to be a library)
* Fix `dist-clean` so every submodule gets cleaned even when it's not used
