### PR TITLE
Command handler improvements

### DIFF
--- a/Sming/Core/HardwareSerial.cpp
+++ b/Sming/Core/HardwareSerial.cpp
@@ -124,7 +124,10 @@ void HardwareSerial::invokeCallbacks()
 		}
 #if ENABLE_CMD_EXECUTOR
 		if(commandExecutor) {
-			commandExecutor->executorReceive(receivedChar);
+			int c;
+			while((c = uart_read_char(uart)) >= 0) {
+				commandExecutor->executorReceive(c);
+			}
 		}
 #endif
 	}

--- a/Sming/Services/CommandProcessing/CommandExecutor.cpp
+++ b/Sming/Services/CommandProcessing/CommandExecutor.cpp
@@ -78,8 +78,7 @@ int CommandExecutor::executorReceive(char recvChar)
 {
 	if (recvChar == 27) // ESC -> delete current commandLine
 	{
-		commandIndex = 0;
-		commandBuf[commandIndex] = 0;
+		commandBuf.clear();
 		if (commandHandler.getVerboseMode() == VERBOSE)
 		{
 			commandOutput->print("\r\n");
@@ -88,16 +87,19 @@ int CommandExecutor::executorReceive(char recvChar)
 	}
 	else if (recvChar == commandHandler.getCommandEOL())
 	{
-
-		processCommandLine(String(commandBuf));
-		commandIndex = 0;
+		String command(commandBuf.getBuffer(), commandBuf.getLength());
+		commandBuf.clear();
+		processCommandLine(command);
+	}
+	else if (recvChar == '\b' || recvChar == 0x7f) {
+		if(commandBuf.backspace()) {
+			commandOutput->print(_F("\b \b"));
+		}
 	}
 	else
 	{
-		if ((commandIndex < MAX_COMMANDSIZE) && (isprint(recvChar)))
-		{
-			commandBuf[commandIndex++] = recvChar;
-			commandBuf[commandIndex] = 0;
+		if(commandBuf.addChar(recvChar)) {
+			commandOutput->print(recvChar);
 		}
 
 	}

--- a/Sming/Services/CommandProcessing/CommandExecutor.cpp
+++ b/Sming/Services/CommandProcessing/CommandExecutor.cpp
@@ -60,7 +60,7 @@ int CommandExecutor::executorReceive(char *recvData, int recvSize)
 	return receiveReturn;
 }
 
-int CommandExecutor::executorReceive(String recvString)
+int CommandExecutor::executorReceive(const String& recvString)
 {
 	int receiveReturn = 0;
 	for (unsigned recvIdx=0;recvIdx<recvString.length();recvIdx++)
@@ -106,7 +106,7 @@ int CommandExecutor::executorReceive(char recvChar)
 	return 0;
 }
 
-void CommandExecutor::processCommandLine(String cmdString)
+void CommandExecutor::processCommandLine(const String& cmdString)
 {
 	debugf("Received full Command line, size = %d,cmd = %s",cmdString.length(),cmdString.c_str());
 	String cmdCommand;

--- a/Sming/Services/CommandProcessing/CommandExecutor.cpp
+++ b/Sming/Services/CommandProcessing/CommandExecutor.cpp
@@ -18,7 +18,7 @@ CommandExecutor::CommandExecutor(TcpClient* cmdClient) : CommandExecutor()
 	commandOutput = new CommandOutput(cmdClient);
 	if (commandHandler.getVerboseMode() != SILENT)
 	{
-		commandOutput->print(_F("Welcome to the Tcp Command executor\r\n"));
+		commandOutput->println(_F("Welcome to the Tcp Command executor"));
 	}
 }
 
@@ -27,7 +27,7 @@ CommandExecutor::CommandExecutor(Stream* reqStream) : CommandExecutor()
 	commandOutput = new CommandOutput(reqStream);
 	if (commandHandler.getVerboseMode() != SILENT)
 	{
-		commandOutput->print(_F("Welcome to the Stream Command executor\r\n"));
+		commandOutput->println(_F("Welcome to the Stream Command executor"));
 	}
 }
 
@@ -81,7 +81,7 @@ int CommandExecutor::executorReceive(char recvChar)
 		commandBuf.clear();
 		if (commandHandler.getVerboseMode() == VERBOSE)
 		{
-			commandOutput->print("\r\n");
+			commandOutput->println();
 			commandOutput->print(commandHandler.getCommandPrompt());
 		}
 	}

--- a/Sming/Services/CommandProcessing/CommandExecutor.h
+++ b/Sming/Services/CommandProcessing/CommandExecutor.h
@@ -26,7 +26,6 @@ public:
 	int executorReceive(char *recvData, int recvSize);
 	int executorReceive(char recvChar);
 	int executorReceive(const String& recvString);
-	void setCommandPrompt(String reqPrompt);
 	void setCommandEOL(char reqEOL);
 
 private :

--- a/Sming/Services/CommandProcessing/CommandExecutor.h
+++ b/Sming/Services/CommandProcessing/CommandExecutor.h
@@ -25,13 +25,13 @@ public:
 
 	int executorReceive(char *recvData, int recvSize);
 	int executorReceive(char recvChar);
-	int executorReceive(String recvString);
+	int executorReceive(const String& recvString);
 	void setCommandPrompt(String reqPrompt);
 	void setCommandEOL(char reqEOL);
 
 private :
 	CommandExecutor();
-	void processCommandLine(String cmdString);
+	void processCommandLine(const String& cmdString);
 	LineBuffer<MAX_COMMANDSIZE+1> commandBuf;
 	CommandOutput* commandOutput = nullptr;
 };

--- a/Sming/Services/CommandProcessing/CommandExecutor.h
+++ b/Sming/Services/CommandProcessing/CommandExecutor.h
@@ -11,6 +11,7 @@
 #include "Network/TcpClient.h"
 #include "CommandHandler.h"
 #include "CommandOutput.h"
+#include <Data/Buffer/LineBuffer.h>
 
 #define MAX_COMMANDSIZE 64
 
@@ -31,7 +32,6 @@ public:
 private :
 	CommandExecutor();
 	void processCommandLine(String cmdString);
-	char commandBuf [MAX_COMMANDSIZE+1];
-	uint16_t commandIndex = 0;
+	LineBuffer<MAX_COMMANDSIZE+1> commandBuf;
 	CommandOutput* commandOutput = nullptr;
 };

--- a/Sming/Services/CommandProcessing/CommandHandler.cpp
+++ b/Sming/Services/CommandProcessing/CommandHandler.cpp
@@ -14,7 +14,7 @@
 #endif
 
 CommandHandler::CommandHandler()
-	: currentPrompt(F("Sming>")), currentWelcomeMessage(F("Welcome to the Sming CommandProcessing\r\n"))
+	: currentPrompt(F("Sming> ")), currentWelcomeMessage(F("Welcome to the Sming CommandProcessing\r\n"))
 {
 	registeredCommands = new HashMap<String, CommandDelegate>;
 }
@@ -144,7 +144,7 @@ void CommandHandler::procesStatusCommand(String commandLine, CommandOutput* comm
 	commandOutput->print(_F("ESP SDK version : "));
 	commandOutput->print(system_get_sdk_version());
 	commandOutput->print("\r\n");
-	commandOutput->printf(_F("lwIP version : %d.%d.%d(%s)\n"), LWIP_VERSION_MAJOR, LWIP_VERSION_MINOR,
+	commandOutput->printf(_F("lwIP version : %d.%d.%d(%s)\r\n"), LWIP_VERSION_MAJOR, LWIP_VERSION_MINOR,
 						  LWIP_VERSION_REVISION, LWIP_HASH_STR);
 	commandOutput->print(_F("Time = "));
 	commandOutput->print(SystemClock.getSystemTimeString());

--- a/Sming/Services/CommandProcessing/CommandHandler.cpp
+++ b/Sming/Services/CommandProcessing/CommandHandler.cpp
@@ -14,16 +14,14 @@
 #endif
 
 CommandHandler::CommandHandler()
-	: currentPrompt(F("Sming> ")), currentWelcomeMessage(F("Welcome to the Sming CommandProcessing\r\n"))
+	: currentPrompt(F("Sming>")), currentWelcomeMessage(F("Welcome to the Sming CommandProcessing\r\n"))
 {
 	registeredCommands = new HashMap<String, CommandDelegate>;
 }
 
 CommandHandler::~CommandHandler()
 {
-	if(registeredCommands != nullptr) {
-		delete registeredCommands;
-	}
+	delete registeredCommands;
 }
 
 void CommandHandler::registerSystemCommands()
@@ -37,7 +35,7 @@ void CommandHandler::registerSystemCommands()
 	registerCommand(CommandDelegate(F("command"), F("Use verbose/silent/prompt as command options"), system, commandFunctionDelegate(&CommandHandler::processCommandOptions, this)));
 }
 
-CommandDelegate CommandHandler::getCommandDelegate(String commandString)
+CommandDelegate CommandHandler::getCommandDelegate(const String& commandString)
 {
 	if (registeredCommands->contains(commandString))
 	{
@@ -85,7 +83,7 @@ bool CommandHandler::unregisterCommand(CommandDelegate reqDelegate)
 void CommandHandler::procesHelpCommand(String commandLine, CommandOutput* commandOutput)
 {
 	debugf("HelpCommand entered");
-	commandOutput->print(_F("Commands available are : \r\n"));
+	commandOutput->println(_F("Commands available are :"));
 	for (unsigned idx = 0;idx < registeredCommands->count();idx++)
 	{
 		commandOutput->printf(registeredCommands->valueAt(idx).commandName.c_str());
@@ -100,16 +98,16 @@ void CommandHandler::procesHelpCommand(String commandLine, CommandOutput* comman
 void CommandHandler::procesStatusCommand(String commandLine, CommandOutput* commandOutput)
 {
 	debugf("StatusCommand entered");
-	commandOutput->print(_F("System information : ESP8266 Sming Framework\r\n"));
-	commandOutput->print(_F("Sming Framework Version : " SMING_VERSION "\r\n"));
+	commandOutput->println(_F("System information : ESP8266 Sming Framework"));
+	commandOutput->println(_F("Sming Framework Version : " SMING_VERSION));
 	commandOutput->print(_F("ESP SDK version : "));
 	commandOutput->print(system_get_sdk_version());
-	commandOutput->print("\r\n");
+	commandOutput->println();
 	commandOutput->printf(_F("lwIP version : %d.%d.%d(%s)\r\n"), LWIP_VERSION_MAJOR, LWIP_VERSION_MINOR,
 						  LWIP_VERSION_REVISION, LWIP_HASH_STR);
 	commandOutput->print(_F("Time = "));
 	commandOutput->print(SystemClock.getSystemTimeString());
-	commandOutput->print("\r\n");
+	commandOutput->println();
 	commandOutput->printf(_F("System Start Reason : %d\r\n"), system_get_rst_info()->reason);
 }
 
@@ -118,22 +116,22 @@ void CommandHandler::procesEchoCommand(String commandLine, CommandOutput* comman
 	debugf("HelpCommand entered");
 	commandOutput->print(_F("You entered : '"));
 	commandOutput->print(commandLine);
-	commandOutput->print(_F("'\r\n"));
+	commandOutput->println('\'');
 }
 
 void CommandHandler::procesDebugOnCommand(String commandLine, CommandOutput* commandOutput)
 {
 	Serial.systemDebugOutput(true);
-	commandOutput->print(_F("Debug set to : On\r\n"));
+	commandOutput->println(_F("Debug set to : On"));
 }
 
 void CommandHandler::procesDebugOffCommand(String commandLine, CommandOutput* commandOutput)
 {
 	Serial.systemDebugOutput(false);
-	commandOutput->print(_F("Debug set to : Off\r\n"));
+	commandOutput->println(_F("Debug set to : Off"));
 }
 
-void CommandHandler::processCommandOptions(String commandLine  ,CommandOutput* commandOutput)
+void CommandHandler::processCommandOptions(String commandLine, CommandOutput* commandOutput)
 {
 	Vector<String> commandToken;
 	int numToken = splitString(commandLine, ' ' , commandToken);
@@ -150,13 +148,13 @@ void CommandHandler::processCommandOptions(String commandLine  ,CommandOutput* c
 			if (commandToken[1] == _F("verbose"))
 			{
 				commandHandler.setVerboseMode(VERBOSE);
-				commandOutput->print(_F("Verbose mode selected\r\n"));
+				commandOutput->println(_F("Verbose mode selected"));
 				break;
 			}
 			if (commandToken[1] == _F("silent"))
 			{
 				commandHandler.setVerboseMode(SILENT);
-				commandOutput->print(_F("Silent mode selected\r\n"));
+				commandOutput->println(_F("Silent mode selected"));
 				break;
 			}
 			errorCommand = true;
@@ -170,7 +168,7 @@ void CommandHandler::processCommandOptions(String commandLine  ,CommandOutput* c
 			commandHandler.setCommandPrompt(commandToken[2]);
 			commandOutput->print(_F("Prompt set to : "));
 			commandOutput->print(commandToken[2]);
-			commandOutput->print("\r\n");
+			commandOutput->println();
 			break;
 		default :
 			errorCommand = true;
@@ -179,14 +177,14 @@ void CommandHandler::processCommandOptions(String commandLine  ,CommandOutput* c
 	{
 		commandOutput->print(_F("Unknown command : "));
 		commandOutput->print(commandLine);
-		commandOutput->print("\r\n");
+		commandOutput->println();
 	}
 	if (printUsage)
 	{
-		commandOutput->print(_F("command usage : \r\n\r\n"));
-		commandOutput->print(_F("command verbose : Set verbose mode\r\n"));
-		commandOutput->print(_F("command silent : Set silent mode\r\n"));
-		commandOutput->print(_F("command prompt 'new prompt' : Set prompt to use\r\n"));
+		commandOutput->println(_F("command usage : \r\n"));
+		commandOutput->println(_F("command verbose : Set verbose mode"));
+		commandOutput->println(_F("command silent : Set silent mode"));
+		commandOutput->println(_F("command prompt 'new prompt' : Set prompt to use"));
 	}
 }
 

--- a/Sming/Services/CommandProcessing/CommandHandler.cpp
+++ b/Sming/Services/CommandProcessing/CommandHandler.cpp
@@ -82,45 +82,6 @@ bool CommandHandler::unregisterCommand(CommandDelegate reqDelegate)
 	}
 }
 
-VerboseMode CommandHandler::getVerboseMode()
-{
-	return verboseMode;
-}
-
-void CommandHandler::setVerboseMode(VerboseMode reqVerboseMode)
-{
-	verboseMode = reqVerboseMode;
-}
-
-String CommandHandler::getCommandPrompt()
-{
-	return currentPrompt;
-}
-
-void CommandHandler::setCommandPrompt(String reqPrompt)
-{
-	currentPrompt = reqPrompt;
-}
-
-char CommandHandler::getCommandEOL()
-{
-	return currentEOL;
-}
-
-void CommandHandler::setCommandEOL(char reqEOL)
-{
-	currentEOL = reqEOL;
-}
-
-String CommandHandler::getCommandWelcomeMessage()
-{
-	return currentWelcomeMessage;
-}
-void CommandHandler::setCommandWelcomeMessage(String reqWelcomeMessage)
-{
-	currentWelcomeMessage = reqWelcomeMessage;
-}
-
 void CommandHandler::procesHelpCommand(String commandLine, CommandOutput* commandOutput)
 {
 	debugf("HelpCommand entered");

--- a/Sming/Services/CommandProcessing/CommandHandler.h
+++ b/Sming/Services/CommandProcessing/CommandHandler.h
@@ -75,7 +75,7 @@ public:
 	 *  @param  commandString Command to query
 	 *  @retval CommandDelegate The command delegate matchin the command
 	 */
-	CommandDelegate getCommandDelegate(String commandString);
+	CommandDelegate getCommandDelegate(const String& commandString);
 
 	/** @brief  Get the verbose mode
 	 *  @retval VerboseMode Verbose mode

--- a/Sming/Services/CommandProcessing/CommandHandler.h
+++ b/Sming/Services/CommandProcessing/CommandHandler.h
@@ -80,50 +80,75 @@ public:
 	/** @brief  Get the verbose mode
 	 *  @retval VerboseMode Verbose mode
 	 */
-	VerboseMode getVerboseMode();
+	VerboseMode getVerboseMode()
+	{
+		return verboseMode;
+	}
 
 	/** @brief  Set the verbose mode
 	 *  @param  reqVerboseMode Verbose mode to set
 	 */
-	void setVerboseMode(VerboseMode reqVerboseMode);
+	void setVerboseMode(VerboseMode reqVerboseMode)
+	{
+		verboseMode = reqVerboseMode;
+	}
 
 	/** @brief  Get the command line prompt
 	 *  @retval String The command line prompt
 	 *  @note   This is what is shown on the command line before user input
 	 *          Default is Sming>
 	 */
-	String getCommandPrompt();
+	String getCommandPrompt()
+	{
+		return currentPrompt;
+	}
 
 	/** @brief  Set the command line prompt
 	 *  @param  reqPrompt The command line prompt
 	 *  @note   This is what is shown on the command line before user input
 	 *          Default is Sming>
 	 */
-	void setCommandPrompt(String reqPrompt);
+	void setCommandPrompt(const String& reqPrompt)
+	{
+		currentPrompt = reqPrompt;
+	}
 
 	/** @brief  Get the end of line character
 	 *  @retval char The EOL character
 	 *  @note   Only supports one EOL, unlike Windows
 	 */
-	char getCommandEOL();
+	char getCommandEOL()
+	{
+		return currentEOL;
+	}
 
 	/** @brief  Set the end of line character
 	 *  @param  reqEOL The EOL character
 	 *  @note   Only supports one EOL, unlike Windows
 	 */
-	void setCommandEOL(char reqEOL);
+	void setCommandEOL(char reqEOL)
+	{
+		currentEOL = reqEOL;
+	}
 
 	/** @brief  Get the welcome message
 	 *  @retval String The welcome message that is shown when clients connect
 	 *  @note   Only if verbose mode is enabled
 	 */
-	String getCommandWelcomeMessage();
+	String getCommandWelcomeMessage()
+	{
+		return currentWelcomeMessage;
+	}
 
 	/** @brief  Set the welcome message
 	 *  @param  reqWelcomeMessage The welcome message that is shown when clients connect
 	 *  @note   Only if verbose mode is enabled
 	 */
-	void setCommandWelcomeMessage(String reqWelcomeMessage);
+	void setCommandWelcomeMessage(const String& reqWelcomeMessage)
+	{
+		currentWelcomeMessage = reqWelcomeMessage;
+	}
+
 
 //	int deleteGroup(String reqGroup);
 

--- a/Sming/System/include/debug_progmem.h
+++ b/Sming/System/include/debug_progmem.h
@@ -76,14 +76,14 @@ extern "C" {
 #if DEBUG_PRINT_FILENAME_AND_LINE
 #define debug_e(fmt, ...)                                                                                              \
 	(__extension__({                                                                                                   \
-		static const char log_string[] PROGMEM_DEBUG = "[" MACROQUOTE(CUST_FILE_BASE) ":%d] " fmt "\n";                \
+		static const char log_string[] PROGMEM_DEBUG = "[" MACROQUOTE(CUST_FILE_BASE) ":%d] " fmt "\r\n";                \
 		LOAD_PSTR(fmtbuf, log_string);                                                                                 \
 		m_printf(fmtbuf, __LINE__, ##__VA_ARGS__);                                                                     \
 	}))
 #else
 #define debug_e(fmt, ...)                                                                                              \
 	(__extension__({                                                                                                   \
-		static const char log_string[] PROGMEM_DEBUG = "%u " fmt "\n";                                                 \
+		static const char log_string[] PROGMEM_DEBUG = "%u " fmt "\r\n";                                                 \
 		LOAD_PSTR(fmtbuf, log_string);                                                                                 \
 		m_printf(fmtbuf, system_get_time(), ##__VA_ARGS__);                                                            \
 	}))


### PR DESCRIPTION
Don't bother with 'command not found' if input is empty, just show new prompt
Fix `debug_e()`, use `\r\n` instead of `\n`
Echo received characters and use LineBuffer for simple line editing