### PR TITLE
Makefile updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # generated binaries
 out
-Sming/compiler/lib/lib*.a
+Sming/Arch/**/Compiler/lib/**/lib*.a
 
 # generated documentation
 docs/api
@@ -19,3 +19,4 @@ GPATH
 vssver2.scc
 
 .metadata
+.submodule

--- a/Sming/Arch/Esp8266/app.mk
+++ b/Sming/Arch/Esp8266/app.mk
@@ -302,7 +302,7 @@ $(RBOOT_ROM_1): $(TARGET_OUT_1)
 
 $(TARGET_OUT_0): $(APP_AR)
 	$(vecho) "LD $@"
-	$(LD) -L$(USER_LIBDIR) -L$(SDK_LIBDIR) -L$(BUILD_BASE) -L$(ARCH_BASE)/Compiler/ld \
+	$(Q) $(LD) -L$(USER_LIBDIR) -L$(SDK_LIBDIR) -L$(BUILD_BASE) -L$(ARCH_BASE)/Compiler/ld \
 		-T$(RBOOT_LD_0) $(LDFLAGS) -Wl,--start-group $(APP_AR) $(addprefix -l,$(LIBS)) -Wl,--end-group -o $@
 
 	$(Q) $(MEMANALYZER) $@ > $(FW_MEMINFO_NEW)
@@ -326,14 +326,14 @@ $(TARGET_OUT_0): $(APP_AR)
 
 $(TARGET_OUT_1): $(APP_AR)
 	$(vecho) "LD $@"
-	$(LD) -L$(USER_LIBDIR) -L$(SDK_LIBDIR) -L$(BUILD_BASE) -L$(ARCH_BASE)/Compiler/ld \
+	$(Q) $(LD) -L$(USER_LIBDIR) -L$(SDK_LIBDIR) -L$(BUILD_BASE) -L$(ARCH_BASE)/Compiler/ld \
 		-T$(RBOOT_LD_1) $(LDFLAGS) -Wl,--start-group $(APP_AR) $(addprefix -l,$(LIBS)) -Wl,--end-group -o $@
 
 # recreate it from 0, since you get into problems with same filenames
 $(APP_AR): $(OBJ)
 	$(vecho) "AR $@"
 	$(Q) test ! -f $@ || rm $@
-	$(AR) rcsP $@ $^
+	$(Q) $(AR) rcsP $@ $^
 
 .PHONY: libsming
 libsming: $(LIBSMING_DST) ##Build the Sming framework and user libraries

--- a/Sming/Arch/Esp8266/build.mk
+++ b/Sming/Arch/Esp8266/build.mk
@@ -4,6 +4,8 @@
 #
 ##############
 
+CFLAGS += -DARCH_ESP8266
+
 ifndef ESP_HOME
 $(error ESP_HOME variable is not set to a valid directory.)
 endif

--- a/Sming/Arch/Esp8266/build.mk
+++ b/Sming/Arch/Esp8266/build.mk
@@ -23,11 +23,10 @@ endif
 
 CONFIG_VARS	+= ESP_HOME
 ESP_HOME	:= $(call FixPath,$(ESP_HOME))
-
 export ESP_HOME
 
-export PATH			:= $(ESP_HOME)/xtensa-lx106-elf/bin:$(PATH)
 XTENSA_TOOLS_ROOT	:= $(ESP_HOME)/xtensa-lx106-elf/bin
+export PATH			:= $(XTENSA_TOOLS_ROOT):$(PATH)
 CONFIG_TOOLPREFIX	:= xtensa-lx106-elf-
 TOOLSPEC			:= $(XTENSA_TOOLS_ROOT)/$(CONFIG_TOOLPREFIX)
 
@@ -47,12 +46,7 @@ CFLAGS			+= -D__ets__ -DICACHE_FLASH -DUSE_OPTIMIZE_PRINTF -DESP8266=1
 CONFIG_VARS += MFORCE32
 MFORCE32 := $(shell $(CC) --help=target | grep mforce-l32)
 ifneq ($(MFORCE32),)
-    # Your compiler supports the -mforce-l32 flag which means that
-    # constants can be stored in flash (program) memory instead of SRAM.
-    # See: https://www.arduino.cc/en/Reference/PROGMEM
-    CFLAGS += -DPROGMEM_L32="__attribute__((aligned(4))) __attribute__((section(\".irom.text\")))" -mforce-l32
-else
-    CFLAGS += -DPROGMEM_L32=""
+	CFLAGS += -DMFORCE32 -mforce-l32
 endif
 
 # => 'Internal' SDK - for SDK Version 3+ as submodule in Sming repository

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -128,7 +128,7 @@ endif
 
 $(APP_AR): $(OBJ)
 	$(vecho) "AR $@"
-	$(AR) cr $@ $^
+	$(Q) $(AR) cr $@ $^
 
 .PHONY: checkdirs
 checkdirs: submodules reload | $(BUILD_DIR) $(USER_LIBDIR)

--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -81,6 +81,15 @@ endef
 ARDUINO_LIBRARIES	?= $(patsubst Libraries/%,%,$(wildcard Libraries/*/))
 ARDUINO_LIBRARIES	:= $(ARDUINO_LIBRARIES:/=)
 
+# Optionally, apply library exclusion list (e.g. not compatible with architecture)
+EXCLUDE_LIBRARIES := $(filter $(EXCLUDE_LIBRARIES),$(ARDUINO_LIBRARIES))
+ifneq (,$(EXCLUDE_LIBRARIES))
+ARDUINO_LIBRARIES := $(filter-out $(EXCLUDE_LIBRARIES),$(ARDUINO_LIBRARIES))
+ifeq ("$(V)","1")
+$(warning Excluded libraries: $(EXCLUDE_LIBRARIES))
+endif
+endif
+
 # Identify which libraries have submodules
 LIBRARY_SUBMODULES	:= $(call ListSubmodules,Libraries)
 LIBRARY_SUBMODULES	:= $(patsubst Libraries/%,%,$(LIBRARY_SUBMODULES))

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -39,6 +39,16 @@ typedef uint32_t prog_uint32_t;
 // Align a size down to the nearest word boundary
 #define ALIGNDOWN(_n) ((_n) & ~3)
 
+#ifdef MFORCE32
+// Your compiler supports the -mforce-l32 flag which means that
+// constants can be stored in flash (program) memory instead of SRAM.
+// See: https://www.arduino.cc/en/Reference/PROGMEM
+#define PROGMEM_L32 PROGMEM
+#else
+#define PROGMEM_L32
+#endif
+
+
 #ifdef ICACHE_FLASH
 
 #ifndef PROGMEM

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -155,12 +155,6 @@ endif
 
 include $(SMING_HOME)/$(ARCH_BASE)/build.mk
 
-AS	:= $(Q)$(AS)
-CC	:= $(Q)$(CC)
-CXX	:= $(Q)$(CXX)
-AR	:= $(Q)$(AR)
-LD	:= $(Q)$(LD)
-
 # Declare target for user library
 # $1 -> Name of library
 define UserLibPath

--- a/Sming/modules.mk
+++ b/Sming/modules.mk
@@ -22,20 +22,20 @@ INCDIR	:= $(addprefix -I,$(EXTRA_INCDIR))
 define GenerateCompileTargets
 $2/%.o: $1/%.s
 	$(vecho) "AS $$<"
-	$(AS) $(INCDIR) $(CFLAGS) -c $$< -o $$@
+	$(Q) $(AS) $(INCDIR) $(CFLAGS) -c $$< -o $$@
 $2/%.o: $1/%.S
 	$(vecho) "AS $$<"
-	$(AS) $(INCDIR) $(CFLAGS) -c $$< -o $$@
+	$(Q) $(AS) $(INCDIR) $(CFLAGS) -c $$< -o $$@
 $2/%.o: $1/%.c $2/%.c.d
 	$(vecho) "CC $$<"
-	$(CC) $(INCDIR) $(CFLAGS) -std=c11 -c $$< -o $$@
+	$(Q) $(CC) $(INCDIR) $(CFLAGS) -std=c11 -c $$< -o $$@
 $2/%.o: $1/%.cpp $2/%.cpp.d
 	$(vecho) "C+ $$<"
-	$(CXX) $(INCDIR) $(CXXFLAGS) -c $$< -o $$@
+	$(Q) $(CXX) $(INCDIR) $(CXXFLAGS) -c $$< -o $$@
 $2/%.c.d: $1/%.c
-	$(CC) $(INCDIR) $(CFLAGS) -std=c11 -MM -MT $2/$$*.o $$< -o $$@
+	$(Q) $(CC) $(INCDIR) $(CFLAGS) -std=c11 -MM -MT $2/$$*.o $$< -o $$@
 $2/%.cpp.d: $1/%.cpp
-	$(CXX) $(INCDIR) $(CXXFLAGS) -MM -MT $2/$$*.o $$< -o $$@
+	$(Q) $(CXX) $(INCDIR) $(CXXFLAGS) -MM -MT $2/$$*.o $$< -o $$@
 
 .PRECIOUS: $2/%.c.d $2/%.cpp.d
 endef


### PR DESCRIPTION
Don't redefine `CC`, etc. as `@CC` - CMake fails if invoked via shell
Move PROGMEM_L32 definition out of makefiles and into `FakePgmSpace.h`
Define `ARCH_ESP8266` for use within framework
Update git ignore for `.submodule` files, and fix for generated `lib*.a` files
Add `EXCLUDE_LIBRARIES` make variable so unsupported libraries can be excluded automatically