### PR TITLE
Fix array bounds issue detected via GCC-8 on Host build

### DIFF
--- a/Sming/Libraries/Adafruit_GFX/glcdfont.c
+++ b/Sming/Libraries/Adafruit_GFX/glcdfont.c
@@ -6,7 +6,7 @@
  #include <avr/pgmspace.h>
 #elif defined(__ESP8266_EX__)
  #include <WiringFrameworkDependencies.h>
-#else
+#elif !defined(PROGMEM)
  #define PROGMEM
 #endif
  

--- a/Sming/Wiring/FakePgmSpace.cpp
+++ b/Sming/Wiring/FakePgmSpace.cpp
@@ -7,7 +7,7 @@ void *memcpy_P(void *dest, const void *src_P, size_t length)
 {
 	// Yes, it seems dest must also be aligned
 	if (IS_ALIGNED(dest) && IS_ALIGNED(src_P) && IS_ALIGNED(length))
-		return memcpy_aligned(dest, src_P, length);
+		return memcpy(dest, src_P, length);
 
 	auto dest0 = reinterpret_cast<char*>(dest);
 	auto src0 = reinterpret_cast<const char*>(src_P);
@@ -122,19 +122,16 @@ char* strcat_P(char* dest, const char* src_P)
 /** @brief copy memory aligned to word boundaries
  *  @param dst
  *  @param src
- *  @param len
- *  @note dst, src and len must all be aligned to word (4-byte) boundaries
+ *  @param len Size of the source data
+ *  @note dst and src must be aligned to word (4-byte) boundaries
+ *  `len` will be rounded up to the nearest word boundary, so the dst
+ *  buffer MUST be large enough for this.
  *
  */
 void* memcpy_aligned(void* dst, const void* src, unsigned len)
 {
-	assert(IS_ALIGNED(dst) && IS_ALIGNED(src) && IS_ALIGNED(len));
-
-	auto pd = (uint32_t*)dst;
-	auto ps = (const uint32_t*)src;
-	auto n = len / 4;
-	while (n--)
-		*pd++ = *ps++;
+	assert(IS_ALIGNED(dst) && IS_ALIGNED(src));
+	memcpy(dst, src, ALIGNUP(len));
 	return dst;
 }
 

--- a/Sming/Wiring/FakePgmSpace.cpp
+++ b/Sming/Wiring/FakePgmSpace.cpp
@@ -114,6 +114,9 @@ char* strcat_P(char* dest, const char* src_P)
 	return dest;
 }
 
+#endif /* ICACHE_FLASH */
+
+
 /*
  * We implement aligned versions of some system functions to be used strictly on
  * data that is word (4-byte) aligned on all parameters.
@@ -158,5 +161,3 @@ int memcmp_aligned(const void* ptr1, const void* ptr2, unsigned len)
 	auto tail2 = pgm_read_dword(reinterpret_cast<const uint8_t*>(ptr2) + len_aligned);
 	return memcmp(&tail1, &tail2, len - len_aligned);
 }
-
-#endif

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -236,7 +236,7 @@ extern "C"
  */
 #define LOAD_PSTR(_name, _flash_str)                                                                                   \
 	char _name[ALIGNUP(sizeof(_flash_str))] __attribute__((aligned(4)));                                               \
-	memcpy_aligned(_name, _flash_str, sizeof(_name));
+	memcpy_aligned(_name, _flash_str, sizeof(_flash_str));
 
 #define _FLOAD(_pstr)                                                                                                  \
 	(__extension__({                                                                                                   \

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -55,27 +55,6 @@ typedef uint32_t prog_uint32_t;
 #define PROGMEM __attribute__((aligned(4))) __attribute__((section(".irom.text")))
 #endif
 
-/*
- * Define and use a flash string inline
- */
-#define PSTR(_str)                                                                                                     \
-	(__extension__({                                                                                                   \
-		DEFINE_PSTR_LOCAL(__c, _str);                                                                                  \
-		&__c[0];                                                                                                       \
-	}))
-
-/*
- * Declare and use a flash string inline.
- * Returns a pointer to a stack-allocated buffer of the precise size required.
- */
-#define _F(_str)                                                                                                       \
-	(__extension__({                                                                                                   \
-		DEFINE_PSTR_LOCAL(_flash_str, _str);                                                                           \
-		LOAD_PSTR(_buf, _flash_str);                                                                                   \
-		_buf;                                                                                                          \
-	}))
-
-
 // flash memory must be read using 32 bit aligned addresses else a processor exception will be triggered
 // order within the 32 bit values are
 // --------------
@@ -120,8 +99,6 @@ static inline uint16_t pgm_read_word_inlined(const void* addr)
 extern "C"
 {
 #endif
-	void* memcpy_aligned(void* dst, const void* src, unsigned len);
-	int memcmp_aligned(const void* ptr1, const void* ptr2, unsigned len);
 	void *memcpy_P(void *dest, const void *src_P, size_t length);
 	size_t strlen_P(const char * src_P);
 	char *strcpy_P(char * dest, const char * src_P);
@@ -170,18 +147,13 @@ extern "C"
 
 #else /* ICACHE_FLASH */
 
-#define PROGMEM
-
-#define PSTR(_str) (_str)
-#define _F(_str) (_str)
+#define PROGMEM __attribute__((aligned(4)))
 
 #define pgm_read_byte(addr) (*(const unsigned char *)(addr))
 #define pgm_read_word(addr) (*(const unsigned short *)(addr))
 #define pgm_read_dword(addr) (*(const unsigned long *)(addr))
 #define pgm_read_float(addr) (*(const float *)(addr))
 
-#define memcpy_aligned(dst, src, len) memcpy(dst, src, len)
-#define memcmp_aligned(ptr1, ptr2, len) memcmp(ptr1, ptr2, len)
 #define memcpy_P(dest, src, num) memcpy((dest), (src), (num))
 #define strlen_P(a) strlen((a))
 #define strcpy_P(dest, src) strcpy((dest), (src))
@@ -196,6 +168,27 @@ extern "C"
 
 #endif /* ICACHE_FLASH */
 
+/*
+ * Define and use a flash string inline
+ */
+#define PSTR(_str)                                                                                                     \
+	(__extension__({                                                                                                   \
+		DEFINE_PSTR_LOCAL(__c, _str);                                                                                  \
+		&__c[0];                                                                                                       \
+	}))
+
+/*
+ * Declare and use a flash string inline.
+ * Returns a pointer to a stack-allocated buffer of the precise size required.
+ */
+#define _F(_str)                                                                                                       \
+	(__extension__({                                                                                                   \
+		DEFINE_PSTR_LOCAL(_flash_str, _str);                                                                           \
+		LOAD_PSTR(_buf, _flash_str);                                                                                   \
+		_buf;                                                                                                          \
+	}))
+
+
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)
 #define pgm_read_word_near(addr) pgm_read_word(addr)
 #define pgm_read_dword_near(addr) pgm_read_dword(addr)
@@ -204,6 +197,9 @@ extern "C"
 #define pgm_read_word_far(addr) pgm_read_word(addr)
 #define pgm_read_dword_far(addr) pgm_read_dword(addr)
 #define pgm_read_float_far(addr) pgm_read_float(addr)
+
+void* memcpy_aligned(void* dst, const void* src, unsigned len);
+int memcmp_aligned(const void* ptr1, const void* ptr2, unsigned len);
 
 /** @brief define a PSTR
  *  @param _name name of string

--- a/Sming/Wiring/FlashString.h
+++ b/Sming/Wiring/FlashString.h
@@ -144,7 +144,7 @@
  */
 #define LOAD_FSTR(_name, _fstr)                                                                                        \
 	char _name[(_fstr).size()] __attribute__((aligned(4)));                                                            \
-	memcpy_aligned(_name, (_fstr).data(), sizeof(_name));
+	memcpy_aligned(_name, (_fstr).data(), (_fstr).length());
 
 /*
  * Define a flash string and load it into a named char[] buffer on the stack.

--- a/Sming/Wiring/FlashString.h
+++ b/Sming/Wiring/FlashString.h
@@ -241,7 +241,7 @@ struct FlashString {
 			return false;
 		if(flashData == str.flashData)
 			return true;
-		return memcmp_aligned(flashData, str.flashData, ALIGNUP(flashLength)) == 0;
+		return memcmp_aligned(flashData, str.flashData, flashLength) == 0;
 	}
 
 	bool isEqual(const String& str) const

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -211,7 +211,7 @@ String &String::copy(flash_string_t pstr, unsigned int length)
 	}
 	else
 	{
-		memcpy_aligned(buffer, (PGM_P)pstr, length_aligned);
+		memcpy_aligned(buffer, (PGM_P)pstr, length);
 		buffer[length] = '\0';
 		len = length;
 	}


### PR DESCRIPTION
Closes #1706

* Change `memcpy_aligned` to use the non-aligned source data length. On Host platform it's just a regular `memcpy`, but for `Esp8266` we use the aligned length.
* Replace custom copying code with a regular `memcpy` call - it's actually faster.

Revise `memcmp_aligned` to behaves exactly like a regular `memcmp`, and consistent with memcpy_aligned.

Use implementations of `memcpy_aligned` and `memcmp_aligned` in Host build so they can be properly tested

* Define `PROGMEM` to ensure data is word-aligned
* Always compile `memcpy_aligned` and `memcmp_aligned`
* Use full `PSTR()` and `_F()` macros for Host

Builds and runs `HostTests` on Host/Esp8266 platforms.