### PR TITLE
Use explicit signed types in base64_decode

### DIFF
--- a/Sming/Components/libb64/cdecode.c
+++ b/Sming/Components/libb64/cdecode.c
@@ -6,14 +6,16 @@ For details, see http://sourceforge.net/projects/libb64
 */
 
 #include "cdecode.h"
+#include <stdint.h>
 
-int base64_decode_value(char value_in)
+int8_t base64_decode_value(char value_in)
 {
-	static const char decoding[] = {62,-1,-1,-1,63,52,53,54,55,56,57,58,59,60,61,-1,-1,-1,-2,-1,-1,-1,0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,-1,-1,-1,-1,-1,-1,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51};
-	static const char decoding_size = sizeof(decoding);
-	value_in -= 43;
-	if (value_in < 0 || value_in >= decoding_size) return -1;
-	return decoding[(int)value_in];
+	static const int8_t decoding[] = {62, -1, -1, -1, 63, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -2, -1,
+									  -1, -1, 0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10, 11, 12, 13, 14, 15, 16, 17,
+									  18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, -1, -1, 26, 27, 28, 29, 30, 31,
+									  32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51};
+	unsigned idx = (unsigned)value_in - 43U;
+	return (idx < sizeof(decoding)) ? decoding[idx] : -1;
 }
 
 void base64_init_decodestate(base64_decodestate* state_in)
@@ -26,7 +28,7 @@ unsigned base64_decode_block(const char* code_in, const int length_in, char* pla
 {
 	const char* codechar = code_in;
 	char* plainchar = plaintext_out;
-	char fragment;
+	int8_t fragment;
 
 	*plainchar = state_in->plainchar;
 
@@ -42,7 +44,7 @@ unsigned base64_decode_block(const char* code_in, const int length_in, char* pla
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar    = (fragment & 0x03f) << 2;
 	case step_b:
@@ -53,7 +55,7 @@ unsigned base64_decode_block(const char* code_in, const int length_in, char* pla
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x030) >> 4;
 			*plainchar    = (fragment & 0x00f) << 4;
@@ -65,7 +67,7 @@ unsigned base64_decode_block(const char* code_in, const int length_in, char* pla
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x03c) >> 2;
 			*plainchar    = (fragment & 0x003) << 6;
@@ -77,7 +79,7 @@ unsigned base64_decode_block(const char* code_in, const int length_in, char* pla
 					state_in->plainchar = *plainchar;
 					return plainchar - plaintext_out;
 				}
-				fragment = (char)base64_decode_value(*codechar++);
+				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar++   |= (fragment & 0x03f);
 		}


### PR DESCRIPTION
Code breaks if compiler doesn't default to signed chars, therefore explicit types must be used. In this case, the `int8_t` type is more appropriate than char. Fixes #1725.