### PR TITLE
Fixes ibraries/MFRC522/MFRC522.cpp:1460:4: error: 'invertedError' may…

### DIFF
--- a/Sming/Libraries/MFRC522/MFRC522.cpp
+++ b/Sming/Libraries/MFRC522/MFRC522.cpp
@@ -1371,6 +1371,7 @@ void MFRC522::PICC_DumpMifareClassicSectorToSerial(Uid *uid,			///< Pointer to U
 	byte buffer[18];
 	byte blockAddr;
 	isSectorTrailer = true;
+	invertedError = false; // Avoid "unused variable" warning.
 	for (int8_t blockOffset = no_of_blocks - 1; blockOffset >= 0; blockOffset--) {
 		blockAddr = firstBlock + blockOffset;
 		// Sector number - only on first line


### PR DESCRIPTION
… be used uninitialized in this function [-Werror=maybe-uninitialized]

The library should be probably updated though...