### PR TITLE
Wemos D1 mini has pin 16, so change test to allow 16 as a valid pin

### DIFF
--- a/Sming/Arch/Host/Core/Digital.cpp
+++ b/Sming/Arch/Host/Core/Digital.cpp
@@ -16,7 +16,8 @@ static uint8 pinModes[PIN_MAX];
 
 static inline bool checkPin(uint16_t pin)
 {
-	if(pin < 16) {
+	// Wemos D1 mini has pin 16
+	if(pin <= 16) {
 		return true;
 	} else {
 		hostmsg("BAD PIN %u", pin);


### PR DESCRIPTION
Pin 16 is a valid pin for a Wemos D1 mini, so include it in the range of valid pins