### PR TITLE
Revise `Delegate` to use `std::function`

### DIFF
--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbuart.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbuart.cpp
@@ -406,8 +406,6 @@ bool ATTR_GDBINIT gdb_uart_init()
 	auto uart1 = uart_init(UART1, SERIAL_BAUD_RATE, UART_8N1, UART_TX_ONLY, 1, 0, 0);
 	if(uart1 != nullptr) {
 		uart_set_debug(UART1);
-
-		using namespace std::placeholders;
 		m_setPuts(std::bind(&uart_write, uart1, _1, _2));
 	}
 

--- a/Sming/Arch/Esp8266/app.mk
+++ b/Sming/Arch/Esp8266/app.mk
@@ -8,6 +8,7 @@
 LIBS += \
 	microc \
 	microgcc \
+	stdc++ \
 	hal \
 	phy \
 	pp \

--- a/Sming/Core/AtClient.cpp
+++ b/Sming/Core/AtClient.cpp
@@ -134,7 +134,7 @@ void AtClient::sendDirect(AtCommand command)
 	stream->print(command.text);
 	debugf("Sent: timeout: %d, current %d ms, name: %s", currentCommand.timeout, millis(),
 		   command.text.substring(0, 20).c_str());
-	commandTimer.initializeMs(currentCommand.timeout, std::bind(&AtClient::ticker, this)).startOnce();
+	commandTimer.initializeMs(currentCommand.timeout, TimerDelegate(&AtClient::ticker, this)).startOnce();
 }
 
 // Low Level Queue Functions

--- a/Sming/Core/AtClient.cpp
+++ b/Sming/Core/AtClient.cpp
@@ -20,7 +20,7 @@
 
 AtClient::AtClient(HardwareSerial* stream) : stream(stream)
 {
-	this->stream->setCallback(StreamDataReceivedDelegate(&AtClient::processor, this));
+	this->stream->onDataReceived(StreamDataReceivedDelegate(&AtClient::processor, this));
 }
 
 void AtClient::processor(Stream& source, char arrivedChar, uint16_t availableCharsCount)

--- a/Sming/Core/AtClient.h
+++ b/Sming/Core/AtClient.h
@@ -17,7 +17,6 @@
 
 #include "HardwareSerial.h"
 #include "FILO.h"
-#include "Delegate.h"
 #include "Timer.h"
 
 #define AT_REPLY_OK "OK"

--- a/Sming/Core/AtClient.h
+++ b/Sming/Core/AtClient.h
@@ -34,13 +34,13 @@ typedef Delegate<bool(AtClient& atClient, String& reply)> AtCompleteCallback;
 //     finished successfully processing the command
 
 typedef struct {
-	String text;					   ///< the actual AT command
-	String response2;				   ///< alternative successful response
-	unsigned timeout;				   ///< timeout in milliseconds
-	unsigned retries;				   ///< number of retries before giving up
-	bool breakOnError = true;		   ///< stop executing next command if that one has failed
-	AtReceiveCallback onReceive = 0;   ///< if set you can process manually all incoming data in a callback
-	AtCompleteCallback onComplete = 0; ///< if set then you can process the complete response manually
+	String text;				   ///< the actual AT command
+	String response2;			   ///< alternative successful response
+	unsigned timeout;			   ///< timeout in milliseconds
+	unsigned retries;			   ///< number of retries before giving up
+	bool breakOnError = true;	  ///< stop executing next command if that one has failed
+	AtReceiveCallback onReceive;   ///< if set you can process manually all incoming data in a callback
+	AtCompleteCallback onComplete; ///< if set then you can process the complete response manually
 } AtCommand;
 
 typedef enum { eAtOK = 0, eAtRunning, eAtError } AtState;

--- a/Sming/Core/Data/Stream/MultipartStream.h
+++ b/Sming/Core/Data/Stream/MultipartStream.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include "MultiStream.h"
-#include "Delegate.h"
 #include "Network/Http/HttpHeaders.h"
 
 /**

--- a/Sming/Core/Data/StreamTransformer.h
+++ b/Sming/Core/Data/StreamTransformer.h
@@ -25,8 +25,7 @@
  * @brief Callback specification for the stream transformers
  * @note See StreamTransformer::transform() method for details
  */
-typedef std::function<size_t(const uint8_t* in, size_t inLength, uint8_t* out, size_t outLength)>
-	StreamTransformerCallback;
+typedef Delegate<size_t(const uint8_t* in, size_t inLength, uint8_t* out, size_t outLength)> StreamTransformerCallback;
 
 class StreamTransformer : public IDataSourceStream
 {

--- a/Sming/Core/Debug.cpp
+++ b/Sming/Core/Debug.cpp
@@ -20,7 +20,7 @@ void DebugClass::initCommand()
 {
 #if ENABLE_CMD_EXECUTOR
 	commandHandler.registerCommand(CommandDelegate(F("debug"), F("New debug in development"), F("Debug"),
-												   commandFunctionDelegate(&DebugClass::processDebugCommands, this)));
+												   CommandFunctionDelegate(&DebugClass::processDebugCommands, this)));
 #endif
 }
 

--- a/Sming/Core/Delegate.h
+++ b/Sming/Core/Delegate.h
@@ -10,236 +10,36 @@
 
 /** @defgroup   delegate Delegate
  *  @brief      Delegates are event handlers
- *              Several handlers may be triggered for each event
  *  @{
  */
 #pragma once
 
-#include <user_config.h>
+#include <functional>
+using namespace std::placeholders;
 
-/** @brief  IDelegateCaller class
- *  @todo   Provide more informative brief description of IDelegateCaller
- */
-template <class ReturnType, typename... ParamsList> class IDelegateCaller
-{
-public:
-	virtual ~IDelegateCaller() = default;
-
-	/** @brief  Invode the delegate
-     *  @param  ParamList Delegate parameters
-     *  @retval ReturnType Delegate return value
-     */
-	virtual ReturnType invoke(ParamsList...) = 0;
-
-	/** @brief  Increase the quantity of delegate caller references by one
-     */
-	__forceinline void increase()
-	{
-		references++;
-	}
-
-	/** @brief  Decrease the quantity of delegate caller references by one
-     *  @note   If no references remain the delegate caller object is deleted
-     */
-	__forceinline void decrease()
-	{
-		references--;
-		if(references == 0) {
-			delete this;
-		}
-	}
-
-private:
-	uint32_t references = 1;
-};
-
-template <class> class MethodCaller; /* undefined */
-
-/** @brief  Delegate method caller class
-*/
-template <class ClassType, class ReturnType, typename... ParamsList>
-class MethodCaller<ReturnType (ClassType::*)(ParamsList...)> : public IDelegateCaller<ReturnType, ParamsList...>
-{
-	/** @brief  Defines the return type for a delegate method
-     *  @todo   Better describe delegate MethodCaller ReturnType
-     */
-	typedef ReturnType (ClassType::*MethodDeclaration)(ParamsList...);
-
-public:
-	/** @brief  Instantiate a delegate method caller object
-     *  @param  c Pointer to the method class type
-     *  @param  m Declaration of the method
-     */
-	MethodCaller(ClassType* c, MethodDeclaration m) : mClass(c), mMethod(m)
-	{
-	}
-
-	/** @brief  Invoke the delegate method
-     *  @param  args The delegate method parameters
-     *  @retval ReturnType The return value from the invoked method
-     */
-	ReturnType invoke(ParamsList... args) override
-	{
-		return (mClass->*mMethod)(args...);
-	}
-
-private:
-	ClassType* mClass;
-	MethodDeclaration mMethod;
-};
-
-/** @brief  Delegate function caller class
-*/
-template <class MethodDeclaration, class ReturnType, typename... ParamsList>
-class FunctionCaller : public IDelegateCaller<ReturnType, ParamsList...>
-{
-public:
-	/** @brief  Instantiate a delegate function caller object
-     *  @param  m Method declaration
-     */
-	FunctionCaller(MethodDeclaration m) : mMethod(m)
-	{
-	}
-
-	/** @brief  Invoke the delegate function
-     *  @param  args The delegate function parameters
-     *  @retval ReturnType The return value from the invoked function
-     */
-	ReturnType invoke(ParamsList... args) override
-	{
-		return (mMethod)(args...);
-	}
-
-private:
-	MethodDeclaration mMethod;
-};
-
-template <class> class Delegate; /* undefined */
+template <typename> class Delegate; /* undefined */
 
 /** @brief  Delegate class
 */
-template <class ReturnType, class... ParamsList> class Delegate<ReturnType(ParamsList...)>
+template <typename ReturnType, typename... ParamTypes>
+class Delegate<ReturnType(ParamTypes...)> : public std::function<ReturnType(ParamTypes...)>
 {
-	/** @brief  Defines the return type of a delegate function declaration
-     */
-	typedef ReturnType (*FunctionDeclaration)(ParamsList...);
-
-	template <typename ClassType> using MethodDeclaration = ReturnType (ClassType::*)(ParamsList...);
+	using StdFunc = std::function<ReturnType(ParamTypes...)>;
 
 public:
-	/** @brief  Instantiate a delegate object
-    */
-	__forceinline Delegate()
-	{
-	}
+	using StdFunc::function;
 
-	// Class method
+	Delegate() = default;
+
 	/** @brief  Delegate a class method
 	 *  @param m Method declaration to delegate
 	 *  @param  c Pointer to the class type
 	 */
-	template <class ClassType> __forceinline Delegate(MethodDeclaration<ClassType> m, ClassType* c)
+	template <class ClassType>
+	Delegate(ReturnType (ClassType::*m)(ParamTypes...), ClassType* c)
+		: StdFunc([m, c](ParamTypes... params) -> ReturnType { return (c->*m)(params...); })
 	{
-		if(m != nullptr) {
-			impl = new MethodCaller<MethodDeclaration<ClassType>>(c, m);
-		}
 	}
-
-	// Function
-	/** @brief  Delegate a function
-	 *  @param  m Function declaration to delegate
-	 */
-	__forceinline Delegate(FunctionDeclaration m)
-	{
-		if(m != nullptr) {
-			impl = new FunctionCaller<FunctionDeclaration, ReturnType, ParamsList...>(m);
-		}
-	}
-
-	__forceinline ~Delegate()
-	{
-		if(impl != nullptr) {
-			impl->decrease();
-		}
-	}
-
-	/** @brief  Invoke a delegate
-     *  @param  params Delegate parameters
-     *  @retval ReturnType Return value from delgate
-     */
-	__forceinline ReturnType operator()(ParamsList... params) const
-	{
-		return impl->invoke(params...);
-	}
-
-	/** @brief  Move a delegate from another object
-     *  @param  that Pointer to the delegate to move
-     */
-	__forceinline Delegate(Delegate&& that)
-	{
-		impl = that.impl;
-		that.impl = nullptr;
-	}
-
-	/** @brief  Copy a delegate from another Delegate object
-	 *  @param  that The delegate to copy
-	 */
-	__forceinline Delegate(const Delegate& that)
-	{
-		copy(that);
-	}
-
-	/** @brief  Copy a delegate from another Delegate object
-     *  @param  that The delegate to copy
-     *  @retval Delegate Pointer to the copied delegate
-     */
-	__forceinline Delegate& operator=(const Delegate& that) // copy assignment
-	{
-		copy(that);
-		return *this;
-	}
-
-	/** @brief  Move a delegate from another Delegate object
-     *  @param  that Delegate to move and assign
-     *  @retval Delegate Pointer to the moved delegate
-     */
-	Delegate& operator=(Delegate&& that) // move assignment
-	{
-		if(this != &that) {
-			if(impl != nullptr) {
-				impl->decrease();
-			}
-
-			impl = that.impl;
-			that.impl = nullptr;
-		}
-		return *this;
-	}
-
-	/** @brief Check for null pointer
-     *  @retval bool False if null pointer
-     */
-	__forceinline operator bool() const
-	{
-		return impl != nullptr;
-	}
-
-protected:
-	void copy(const Delegate& other)
-	{
-		if(impl != other.impl) {
-			if(impl != nullptr) {
-				impl->decrease();
-			}
-			impl = other.impl;
-			if(impl != nullptr) {
-				impl->increase();
-			}
-		}
-	}
-
-private:
-	IDelegateCaller<ReturnType, ParamsList...>* impl = nullptr;
 };
 
 /** @} */

--- a/Sming/Core/HardwareSerial.cpp
+++ b/Sming/Core/HardwareSerial.cpp
@@ -90,7 +90,6 @@ void HardwareSerial::systemDebugOutput(bool enabled)
 	if(enabled) {
 		if(uart_tx_enabled(uart)) {
 			uart_set_debug(uartNr);
-			using namespace std::placeholders;
 			m_setPuts(std::bind(&uart_write, uart, _1, _2));
 		} else {
 			uart_set_debug(UART_NO);

--- a/Sming/Core/HardwareSerial.h
+++ b/Sming/Core/HardwareSerial.h
@@ -17,7 +17,6 @@
 
 #include "WiringFrameworkDependencies.h"
 #include "Data/Stream/ReadWriteStream.h"
-#include "Delegate.h"
 #include "driver/uart.h"
 
 #define UART_ID_0 0 ///< ID of UART 0

--- a/Sming/Core/HardwareSerial.h
+++ b/Sming/Core/HardwareSerial.h
@@ -320,8 +320,9 @@ public:
 	/** @brief  Set handler for received data
 	 *  @param  dataReceivedDelegate Function to handle received data
 	 *  @retval bool Returns true if the callback was set correctly
+	 *  @deprecated Use `onDataReceived` instead
 	 */
-	bool setCallback(StreamDataReceivedDelegate dataReceivedDelegate)
+	bool setCallback(StreamDataReceivedDelegate dataReceivedDelegate) SMING_DEPRECATED
 	{
 		return onDataReceived(dataReceivedDelegate);
 	}

--- a/Sming/Core/HardwareTimer.h
+++ b/Sming/Core/HardwareTimer.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "Interrupts.h"
-#include "Delegate.h"
 
 #define MAX_HW_TIMER_INTERVAL_US 0x7fffff ///< Maximum timer interval in microseconds
 #define MIN_HW_TIMER_INTERVAL_US 0x32	 ///< Minimum hardware interval in microseconds

--- a/Sming/Core/Interrupts.h
+++ b/Sming/Core/Interrupts.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "WiringFrameworkDependencies.h"
-#include "Delegate.h"
 
 #define ESP_MAX_INTERRUPTS 16
 

--- a/Sming/Core/Interrupts.h
+++ b/Sming/Core/Interrupts.h
@@ -39,7 +39,7 @@ void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode);
  *  The delegate function is called via the system task queue so does not need any special consideration.
  *  Note that this type of interrupt handler is not suitable for timing-sensitive applications.
  */
-void attachInterrupt(uint8_t pin, Delegate<void()> delegateFunction, uint8_t mode);
+void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, uint8_t mode);
 
 /** @brief  Attach a function to a GPIO interrupt
  *  @param  pin GPIO to configure
@@ -56,7 +56,7 @@ void attachInterrupt(uint8_t pin, InterruptCallback callback, GPIO_INT_TYPE mode
  *  @param  mode Interrupt mode
  *  @note   Delegate function method
  */
-void attachInterrupt(uint8_t pin, Delegate<void()> delegateFunction, GPIO_INT_TYPE mode); // ESP compatible version
+void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, GPIO_INT_TYPE mode); // ESP compatible version
 
 /** @brief  Enable interrupts on GPIO pin
  *  @param  pin GPIO to enable interrupts for

--- a/Sming/Core/Network/Http/HttpResource.h
+++ b/Sming/Core/Network/Http/HttpResource.h
@@ -14,7 +14,6 @@
 
 #include "WString.h"
 #include "Data/ObjectMap.h"
-#include "Delegate.h"
 
 #include "HttpResponse.h"
 #include "HttpRequest.h"

--- a/Sming/Core/Network/Http/HttpServerConnection.h
+++ b/Sming/Core/Network/Http/HttpServerConnection.h
@@ -37,7 +37,7 @@ class HttpServerConnection;
 
 typedef Delegate<void(HttpServerConnection& connection)> HttpServerConnectionDelegate;
 
-typedef std::function<bool()> HttpServerProtocolUpgradeCallback;
+typedef Delegate<bool()> HttpServerProtocolUpgradeCallback;
 
 class HttpServerConnection : public HttpConnection
 {

--- a/Sming/Core/Network/Http/Websocket/WebsocketResource.cpp
+++ b/Sming/Core/Network/Http/Websocket/WebsocketResource.cpp
@@ -34,7 +34,7 @@ int WebsocketResource::checkHeaders(HttpServerConnection& connection, HttpReques
 
 	connection.setTimeOut(USHRT_MAX); //Disable disconnection on connection idle (no rx/tx)
 	connection.userData = (void*)socket;
-	connection.setUpgradeCallback(std::bind(&WebsocketConnection::onConnected, socket));
+	connection.setUpgradeCallback(HttpServerProtocolUpgradeCallback(&WebsocketConnection::onConnected, socket));
 
 	// TODO: Re-Enable Command Executor...
 

--- a/Sming/Core/Network/Http/Websocket/WebsocketResource.cpp
+++ b/Sming/Core/Network/Http/Websocket/WebsocketResource.cpp
@@ -12,8 +12,6 @@
 
 #include "WebsocketResource.h"
 
-#include <functional>
-
 int WebsocketResource::checkHeaders(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
 {
 	WebsocketConnection* socket = new WebsocketConnection(&connection, false);

--- a/Sming/Core/Network/HttpServer.h
+++ b/Sming/Core/Network/HttpServer.h
@@ -20,7 +20,6 @@
 
 #include "TcpServer.h"
 #include "WString.h"
-#include "Delegate.h"
 #include "Http/HttpResourceTree.h"
 #include "Http/HttpServerConnection.h"
 #include "Http/HttpBodyParser.h"

--- a/Sming/Core/Network/Mqtt/MqttPayloadParser.h
+++ b/Sming/Core/Network/Mqtt/MqttPayloadParser.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include "Delegate.h"
+#include <esp_systemapi.h>
 #include "mqtt-codec/src/message.h"
 
 /** @defgroup   mqttpayload Provides MQTT payload parser

--- a/Sming/Core/Network/MqttClient.h
+++ b/Sming/Core/Network/MqttClient.h
@@ -106,7 +106,7 @@ public:
 	 *         but in order to prevent running out of memory we have a "sane" payload parser
 	 *         that will read up to 1K of payload
 	 */
-	void setPayloadParser(MqttPayloadParser payloadParser = 0)
+	void setPayloadParser(MqttPayloadParser payloadParser = nullptr)
 	{
 		this->payloadParser = payloadParser;
 	}

--- a/Sming/Core/Network/MqttClient.h
+++ b/Sming/Core/Network/MqttClient.h
@@ -43,7 +43,7 @@ enum MqttClientState { eMCS_Ready = 0, eMCS_SendingData };
 
 class MqttClient;
 
-typedef std::function<int(MqttClient& client, mqtt_message_t* message)> MqttDelegate;
+typedef Delegate<int(MqttClient& client, mqtt_message_t* message)> MqttDelegate;
 typedef ObjectQueue<mqtt_message_t, MQTT_REQUEST_POOL_SIZE> MqttRequestQueue;
 
 #ifndef MQTT_NO_COMPAT

--- a/Sming/Core/Network/NtpClient.h
+++ b/Sming/Core/Network/NtpClient.h
@@ -20,7 +20,6 @@
 #include "Platform/System.h"
 #include "Timer.h"
 #include "DateTime.h"
-#include "Delegate.h"
 
 #define NTP_PORT 123
 #define NTP_PACKET_SIZE 48

--- a/Sming/Core/Network/SmtpClient.h
+++ b/Sming/Core/Network/SmtpClient.h
@@ -86,7 +86,7 @@ enum SmtpState {
 
 class SmtpClient;
 
-typedef std::function<int(SmtpClient& client, int code, char* status)> SmtpClientCallback;
+typedef Delegate<int(SmtpClient& client, int code, char* status)> SmtpClientCallback;
 
 class SmtpClient : protected TcpClient
 {

--- a/Sming/Core/Network/SmtpClient.h
+++ b/Sming/Core/Network/SmtpClient.h
@@ -35,8 +35,6 @@
 #include "WebConstants.h"
 #include "Data/ObjectQueue.h"
 
-#include <functional>
-
 /* Maximum waiting emails in the mail queue */
 #define SMTP_QUEUE_SIZE 5
 

--- a/Sming/Core/Network/Ssl/SslValidator.h
+++ b/Sming/Core/Network/Ssl/SslValidator.h
@@ -20,7 +20,6 @@
 #include "ssl/ssl.h"
 #include "ssl/tls1.h"
 
-#include <functional>
 #include "WVector.h"
 
 #include "SslFingerprints.h"

--- a/Sming/Core/Network/Ssl/SslValidator.h
+++ b/Sming/Core/Network/Ssl/SslValidator.h
@@ -32,7 +32,7 @@
  *  @note Callback must ALWAYS release any allocate memory before returning.
  *  If called with ssl = NULL then just release memory and return false.
  */
-typedef std::function<bool(SSL* ssl, void* data)> SslValidatorCallback;
+typedef Delegate<bool(SSL* ssl, void* data)> SslValidatorCallback;
 
 struct SslValidator {
 	SslValidatorCallback callback;

--- a/Sming/Core/Network/TcpClient.h
+++ b/Sming/Core/Network/TcpClient.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "TcpConnection.h"
-#include "Delegate.h"
 
 #ifdef ENABLE_SSL
 #include "Ssl/SslValidator.h"

--- a/Sming/Core/Network/TcpConnection.h
+++ b/Sming/Core/Network/TcpConnection.h
@@ -23,7 +23,6 @@
 
 #include "WiringFrameworkDependencies.h"
 #include "IPAddress.h"
-#include "Delegate.h"
 
 #define NETWORK_DEBUG
 

--- a/Sming/Core/Network/TelnetServer.h
+++ b/Sming/Core/Network/TelnetServer.h
@@ -20,7 +20,6 @@
 #pragma once
 
 #include <user_config.h>
-#include "Delegate.h"
 #include "TcpClient.h"
 #include "TcpServer.h"
 #include "SystemClock.h"

--- a/Sming/Core/Network/UdpConnection.h
+++ b/Sming/Core/Network/UdpConnection.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "WiringFrameworkDependencies.h"
-#include "Delegate.h"
 #include "IPAddress.h"
 
 class UdpConnection;

--- a/Sming/Core/SmingCore.h
+++ b/Sming/Core/SmingCore.h
@@ -12,8 +12,6 @@
 
 #define SMING_VERSION "3.8.0" // Major Minor Sub
 
-#include <functional>
-
 #include "gdb/gdb_hooks.h"
 #include "WiringFrameworkIncludes.h"
 

--- a/Sming/Core/Timer.cpp
+++ b/Sming/Core/Timer.cpp
@@ -38,20 +38,6 @@ Timer& Timer::initializeUs(uint32_t microseconds, TimerDelegate delegateFunction
 	return *this;
 }
 
-Timer& Timer::initializeMs(uint32_t milliseconds, TimerDelegateStdFunction delegateFunction)
-{
-	setCallback(delegateFunction);
-	setIntervalMs(milliseconds);
-	return *this;
-}
-
-Timer& Timer::initializeUs(uint32_t microseconds, TimerDelegateStdFunction delegateFunction)
-{
-	setCallback(delegateFunction);
-	setIntervalUs(microseconds);
-	return *this;
-}
-
 void Timer::start(bool repeating)
 {
 	this->repeating = repeating;
@@ -123,7 +109,6 @@ void Timer::setCallback(InterruptCallback interrupt)
 	}
 
 	delegateFunc = nullptr;
-	delegateStdFunc = nullptr;
 	callback = interrupt;
 }
 
@@ -134,19 +119,7 @@ void Timer::setCallback(TimerDelegate delegateFunction)
 	}
 
 	callback = nullptr;
-	delegateStdFunc = nullptr;
 	delegateFunc = delegateFunction;
-}
-
-void Timer::setCallback(const TimerDelegateStdFunction& delegateFunction)
-{
-	if(!delegateFunction) {
-		stop();
-	}
-
-	callback = nullptr;
-	delegateFunc = nullptr;
-	delegateStdFunc = delegateFunction;
 }
 
 void Timer::processing()
@@ -178,8 +151,6 @@ void Timer::tick()
 		callback();
 	} else if(delegateFunc) {
 		delegateFunc();
-	} else if(delegateStdFunc) {
-		delegateStdFunc();
 	} else {
 		stop();
 	}

--- a/Sming/Core/Timer.h
+++ b/Sming/Core/Timer.h
@@ -20,7 +20,9 @@
 #include "SimpleTimer.h"
 
 typedef Delegate<void()> TimerDelegate;
-typedef std::function<void()> TimerDelegateStdFunction;
+
+/** @deprecated Use `TimerDelegate` */
+typedef std::function<void()> TimerDelegateStdFunction SMING_DEPRECATED;
 
 class Timer
 {
@@ -61,31 +63,15 @@ public:
      *  @param  milliseconds Duration of timer in milliseconds
      *  @param  delegateFunction Function to call when timer triggers
      *  @note   Delegate callback method
-     *  @deprecated Use `initializeMs(uint32_t, TimerDelegateStdFunction)` instead
      */
-	Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, TimerDelegate delegateFunction = nullptr) SMING_DEPRECATED;
-
-	/** @brief  Initialise microsecond timer
-     *  @param  microseconds Duration of timer in milliseconds
-     *  @param  delegateFunction Function to call when timer triggers
-     *  @note   Delegate callback method
-     *  @deprecated Use `initializeMs(uint32_t, TimerDelegateStdFunction)` instead
-     */
-	Timer& IRAM_ATTR initializeUs(uint32_t microseconds, TimerDelegate delegateFunction = nullptr) SMING_DEPRECATED;
-
-	/** @brief  Initialise millisecond timer
-     *  @param  milliseconds Duration of timer in milliseconds
-     *  @param  delegateFunction Function to call when timer triggers
-     *  @note   Delegate callback method
-     */
-	Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, TimerDelegateStdFunction delegateFunction = nullptr);
+	Timer& IRAM_ATTR initializeMs(uint32_t milliseconds, TimerDelegate delegateFunction = nullptr);
 
 	/** @brief  Initialise microsecond timer
      *  @param  microseconds Duration of timer in milliseconds
      *  @param  delegateFunction Function to call when timer triggers
      *  @note   Delegate callback method
      */
-	Timer& IRAM_ATTR initializeUs(uint32_t microseconds, TimerDelegateStdFunction delegateFunction = nullptr);
+	Timer& IRAM_ATTR initializeUs(uint32_t microseconds, TimerDelegate delegateFunction = nullptr);
 
 	/** @brief  Start timer running
      *  @param  repeating Set to true for repeating timer. Set to false for one-shot.
@@ -160,12 +146,6 @@ public:
 	*/
 	void IRAM_ATTR setCallback(TimerDelegate delegateFunction);
 
-	/** @brief  Set timer trigger function
-	*  @param  delegateFunction Function to be called on timer trigger
-	*  @note   Delegate callback method
-	*/
-	void IRAM_ATTR setCallback(const TimerDelegateStdFunction& delegateFunction);
-
 protected:
 	void IRAM_ATTR processing();
 
@@ -181,7 +161,6 @@ private:
 	uint32_t interval = 0;
 	InterruptCallback callback = nullptr;
 	TimerDelegate delegateFunc = nullptr;
-	TimerDelegateStdFunction delegateStdFunc = nullptr;
 	bool repeating = false;
 	bool started = false;
 

--- a/Sming/Core/Timer.h
+++ b/Sming/Core/Timer.h
@@ -13,10 +13,7 @@
 */
 #pragma once
 
-#include <functional>
 #include "Interrupts.h"
-#include "Delegate.h"
-
 #include "SimpleTimer.h"
 
 typedef Delegate<void()> TimerDelegate;

--- a/Sming/Core/Timer.h
+++ b/Sming/Core/Timer.h
@@ -160,7 +160,7 @@ private:
 	SimpleTimer simpleTimer; ///< We use a SimpleTimer to access the hardware
 	uint32_t interval = 0;
 	InterruptCallback callback = nullptr;
-	TimerDelegate delegateFunc = nullptr;
+	TimerDelegate delegateFunc;
 	bool repeating = false;
 	bool started = false;
 

--- a/Sming/Libraries/DS18S20/ds18s20.cpp
+++ b/Sming/Libraries/DS18S20/ds18s20.cpp
@@ -266,6 +266,6 @@ void DS18S20::RegisterEndCallback(DS18S20CompletedDelegate callback)
 
 void DS18S20::UnRegisterCallback()
 {
-	readEndCallback = 0;
+	readEndCallback = nullptr;
 }
 

--- a/Sming/Libraries/DS18S20/ds18s20.cpp
+++ b/Sming/Libraries/DS18S20/ds18s20.cpp
@@ -51,7 +51,7 @@ void DS18S20::StartMeasure()
 		InProgress=true;
 		ds->begin();
 		ds->reset_search();
-		DelaysTimer.initializeMs(150, std::bind(&DS18S20::DoSearch, this)).start(false);
+		DelaysTimer.initializeMs(150, TimerDelegate(&DS18S20::DoSearch, this)).start(false);
 	}
 
 }
@@ -146,7 +146,7 @@ void DS18S20::StartReadNext()
 	  ds->select(addr);
 	  ds->write(STARTCONVO, 1);        // start conversion, with parasite power on at the end
 
-	  DelaysTimer.initializeMs(900, std::bind(&DS18S20::DoMeasure, this)).start(false);
+	  DelaysTimer.initializeMs(900, TimerDelegate(&DS18S20::DoMeasure, this)).start(false);
    }
    else
    {
@@ -210,7 +210,7 @@ void DS18S20::DoMeasure()
 	debugx("  DBG: Temperature = %f Celsius, %f Fahrenheit",celsius[numberOfread],fahrenheit[numberOfread]);
 
 	numberOfread++;
-	DelaysTimer.initializeMs(100, std::bind(&DS18S20::StartReadNext, this)).start(false);
+	DelaysTimer.initializeMs(100, TimerDelegate(&DS18S20::StartReadNext, this)).start(false);
 
 }
 

--- a/Sming/Platform/Station.h
+++ b/Sming/Platform/Station.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "System.h"
-#include "Delegate.h"
 #include "WString.h"
 #include "WVector.h"
 #include "IPAddress.h"

--- a/Sming/Platform/System.h
+++ b/Sming/Platform/System.h
@@ -23,7 +23,7 @@
 */
 #pragma once
 
-#include "Delegate.h"
+#include <esp_systemapi.h>
 
 /** @brief default number of tasks in global queue
  *  @note tasks are usually short-lived and executed very promptly. If necessary this

--- a/Sming/Platform/WifiEvents.h
+++ b/Sming/Platform/WifiEvents.h
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include "Delegate.h"
 #include "WString.h"
 #include "IPAddress.h"
 

--- a/Sming/Platform/WifiSniffer.h
+++ b/Sming/Platform/WifiSniffer.h
@@ -83,9 +83,9 @@ public:
 	}
 };
 
-typedef std::function<void(uint8_t* data, uint16_t length)> WifiSnifferCallback;
-typedef std::function<void(const BeaconInfo& beacon)> WifiBeaconCallback;
-typedef std::function<void(const ClientInfo& client)> WifiClientCallback;
+typedef Delegate<void(uint8_t* data, uint16_t length)> WifiSnifferCallback;
+typedef Delegate<void(const BeaconInfo& beacon)> WifiBeaconCallback;
+typedef Delegate<void(const ClientInfo& client)> WifiClientCallback;
 
 class WifiSniffer : public ISystemReadyHandler
 {

--- a/Sming/Services/CommandProcessing/CommandDelegate.cpp
+++ b/Sming/Services/CommandProcessing/CommandDelegate.cpp
@@ -12,7 +12,7 @@ CommandDelegate::CommandDelegate()
 
 }
 
-CommandDelegate::CommandDelegate(String reqName, String reqHelp, String reqGroup, commandFunctionDelegate reqFunction)
+CommandDelegate::CommandDelegate(String reqName, String reqHelp, String reqGroup, CommandFunctionDelegate reqFunction)
 : commandName(reqName), commandHelp(reqHelp), commandGroup(reqGroup), commandFunction(reqFunction)
 {
 }

--- a/Sming/Services/CommandProcessing/CommandDelegate.h
+++ b/Sming/Services/CommandProcessing/CommandDelegate.h
@@ -19,10 +19,13 @@
 /** @brief  Command delegate function
  *  @param  commandLine Command line entered by user at CLI, including command and parameters
  *  @param  commandOutput Pointer to the CLI print stream
- *  @note   commandFunctionDelegate defines the structure of a function that handles individual commands
+ *  @note   CommandFunctionDelegate defines the structure of a function that handles individual commands
  *  @note   Can use standard print functions on commandOutput
  */
-typedef Delegate<void(String commandLine, CommandOutput* commandOutput)> commandFunctionDelegate;
+typedef Delegate<void(String commandLine, CommandOutput* commandOutput)> CommandFunctionDelegate;
+
+/** @deprecated Use `CommandFunctionDelegate` instead */
+typedef CommandFunctionDelegate commandFunctionDelegate SMING_DEPRECATED;
 
 /** @brief  Command delegate class */
 class CommandDelegate
@@ -36,13 +39,13 @@ public:
      *  @param  reqGroup The command group to which this command belongs
      *  @param  reqFunction Delegate that should be invoked (triggered) when the command is entered by a user
      */
-	CommandDelegate(String reqName, String reqHelp, String reqGroup, commandFunctionDelegate reqFunction);
+	CommandDelegate(String reqName, String reqHelp, String reqGroup, CommandFunctionDelegate reqFunction);
 	~CommandDelegate();
 
 	String commandName; ///< Command name
 	String commandHelp; ///< Command help
 	String commandGroup; ///< Command group
-	commandFunctionDelegate commandFunction; ///< Command Delegate (function that is called when command is invoked)
+	CommandFunctionDelegate commandFunction; ///< Command Delegate (function that is called when command is invoked)
 
 private :
 	CommandDelegate();

--- a/Sming/Services/CommandProcessing/CommandDelegate.h
+++ b/Sming/Services/CommandProcessing/CommandDelegate.h
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "WString.h"
-#include "Delegate.h"
 #include "Network/TcpClient.h"
 #include "WiringFrameworkIncludes.h"
 #include "CommandOutput.h"

--- a/Sming/Services/CommandProcessing/CommandHandler.cpp
+++ b/Sming/Services/CommandProcessing/CommandHandler.cpp
@@ -45,7 +45,7 @@ CommandDelegate CommandHandler::getCommandDelegate(const String& commandString)
 	else
 	{
 		debugf("Command %s not recognized, returning NULL\r\n",commandString.c_str());
-		return CommandDelegate("","","",NULL);
+		return CommandDelegate("","","",nullptr);
 	}
 }
 

--- a/Sming/Services/CommandProcessing/CommandHandler.cpp
+++ b/Sming/Services/CommandProcessing/CommandHandler.cpp
@@ -27,12 +27,12 @@ CommandHandler::~CommandHandler()
 void CommandHandler::registerSystemCommands()
 {
 	String system = F("system");
-	registerCommand(CommandDelegate(F("status"), F("Displays System Information"), system, commandFunctionDelegate(&CommandHandler::procesStatusCommand,this)));
-	registerCommand(CommandDelegate(F("echo"), F("Displays command entered"), system, commandFunctionDelegate(&CommandHandler::procesEchoCommand,this)));
-	registerCommand(CommandDelegate(F("help"), F("Displays all available commands"), system, commandFunctionDelegate(&CommandHandler::procesHelpCommand,this)));
-	registerCommand(CommandDelegate(F("debugon"), F("Set Serial debug on"), system, commandFunctionDelegate(&CommandHandler::procesDebugOnCommand,this)));
-	registerCommand(CommandDelegate(F("debugoff"), F("Set Serial debug off"), system, commandFunctionDelegate(&CommandHandler::procesDebugOffCommand,this)));
-	registerCommand(CommandDelegate(F("command"), F("Use verbose/silent/prompt as command options"), system, commandFunctionDelegate(&CommandHandler::processCommandOptions, this)));
+	registerCommand(CommandDelegate(F("status"), F("Displays System Information"), system, CommandFunctionDelegate(&CommandHandler::procesStatusCommand,this)));
+	registerCommand(CommandDelegate(F("echo"), F("Displays command entered"), system, CommandFunctionDelegate(&CommandHandler::procesEchoCommand,this)));
+	registerCommand(CommandDelegate(F("help"), F("Displays all available commands"), system, CommandFunctionDelegate(&CommandHandler::procesHelpCommand,this)));
+	registerCommand(CommandDelegate(F("debugon"), F("Set Serial debug on"), system, CommandFunctionDelegate(&CommandHandler::procesDebugOnCommand,this)));
+	registerCommand(CommandDelegate(F("debugoff"), F("Set Serial debug off"), system, CommandFunctionDelegate(&CommandHandler::procesDebugOffCommand,this)));
+	registerCommand(CommandDelegate(F("command"), F("Use verbose/silent/prompt as command options"), system, CommandFunctionDelegate(&CommandHandler::processCommandOptions, this)));
 }
 
 CommandDelegate CommandHandler::getCommandDelegate(const String& commandString)

--- a/Sming/System/include/m_printf.h
+++ b/Sming/System/include/m_printf.h
@@ -15,7 +15,7 @@ Descr: embedded very simple version of printf with float support
 
 extern "C++" {
 
-#include <functional>
+#include <Delegate.h>
 
 /** @brief callback type to output a string of data
  *  @param param
@@ -24,7 +24,7 @@ extern "C++" {
  *  @retval number of characters written, which may be less than the requested size
  *  @note data does not need to be nul terminated and may contain any 8-bit values including nul
  */
-typedef std::function<size_t(const char* str, size_t length)> nputs_callback_t;
+typedef Delegate<size_t(const char* str, size_t length)> nputs_callback_t;
 
 /** @brief set the character output routine
  *  @param callback

--- a/samples/Arducam/app/ArduCamCommand.cpp
+++ b/samples/Arducam/app/ArduCamCommand.cpp
@@ -18,10 +18,10 @@ ArduCamCommand::~ArduCamCommand()
 void ArduCamCommand::initCommand()
 {
 	commandHandler.registerCommand(CommandDelegate("set", "ArduCAM config commands", "Application",
-												   commandFunctionDelegate(&ArduCamCommand::processSetCommands, this)));
+												   CommandFunctionDelegate(&ArduCamCommand::processSetCommands, this)));
 	//	commandHandler.registerCommand(
 	//			CommandDelegate("out", "ArduCAM output commands", "Application",
-	//					commandFunctionDelegate(&ArduCamCommand::processOutCommands,this)));
+	//					CommandFunctionDelegate(&ArduCamCommand::processOutCommands,this)));
 }
 
 void ArduCamCommand::showSettings(CommandOutput* commandOutput)

--- a/samples/Basic_Delegates/app/application.cpp
+++ b/samples/Basic_Delegates/app/application.cpp
@@ -1,11 +1,13 @@
 #include <SmingCore.h>
 
+void evaluateSpeed();
+
 void plainOldOrdinaryFunction()
 {
 	debugf("plainOldOrdinaryFunction");
 }
 
-void functionWithMoreComlicatedSignature(int a, String b)
+void functionWithMoreComplicatedSignature(int a, String b)
 {
 	debugf("functionWithMoreComlicatedSignature %d %s", a, b.c_str());
 }
@@ -34,11 +36,10 @@ public:
 	// This example shows how to use std::bind to make us of a function that has more parameters than our signature has
 	void showHowToUseBind()
 	{
-		auto b = std::bind(functionWithMoreComlicatedSignature, 2, "parameters");
+		auto b = std::bind(functionWithMoreComplicatedSignature, 2, "parameters");
 		taskTimer.initializeMs(taskInterval, b).start();
 	}
 
-	// Sming now allows the use of std::function
 	// This example shows how to use a lamda expression as a callback
 	void callLamda()
 	{
@@ -87,6 +88,8 @@ Task task5;
 void init()
 {
 	Serial.begin(COM_SPEED_SERIAL);
+
+	evaluateSpeed();
 
 	task2.setTimer(1600);
 	task2.callPlainOldOrdinaryFunction();

--- a/samples/Basic_Delegates/app/application.cpp
+++ b/samples/Basic_Delegates/app/application.cpp
@@ -64,10 +64,7 @@ public:
 	{
 		// A non-static member function must be called with an object.
 		// That is, it always implicitly passes "this" pointer as its argument.
-		// But because our callback specifies that we don't take any arguments (<void(void)>),
-		// you must use std::bind to bind the first (and the only) argument.
-
-		TimerDelegate b = std::bind(&Task::callbackMemberFunction, this);
+		auto b = TimerDelegate(&Task::callbackMemberFunction, this);
 		taskTimer.initializeMs(taskInterval, b).start();
 	}
 

--- a/samples/Basic_Delegates/app/application.cpp
+++ b/samples/Basic_Delegates/app/application.cpp
@@ -26,7 +26,7 @@ public:
 	// This example shows how to use a plain old ordinary function as a callback
 	void callPlainOldOrdinaryFunction()
 	{
-		taskTimer.initializeMs(taskInterval, TimerDelegateStdFunction(plainOldOrdinaryFunction)).start();
+		taskTimer.initializeMs(taskInterval, plainOldOrdinaryFunction).start();
 		// or just
 		// taskTimer.initializeMs(taskInterval, plainOldOrdinaryFunction).start();
 	}
@@ -67,7 +67,7 @@ public:
 		// But because our callback specifies that we don't take any arguments (<void(void)>),
 		// you must use std::bind to bind the first (and the only) argument.
 
-		TimerDelegateStdFunction b = std::bind(&Task::callbackMemberFunction, this);
+		TimerDelegate b = std::bind(&Task::callbackMemberFunction, this);
 		taskTimer.initializeMs(taskInterval, b).start();
 	}
 

--- a/samples/Basic_Delegates/app/callbacks.cpp
+++ b/samples/Basic_Delegates/app/callbacks.cpp
@@ -1,0 +1,14 @@
+
+#include "callbacks.h"
+
+int testCounter;
+
+void TestClass::callbackTest(int arg)
+{
+	testCounter += arg;
+}
+
+void callbackTest(int arg)
+{
+	testCounter += arg;
+}

--- a/samples/Basic_Delegates/app/callbacks.cpp
+++ b/samples/Basic_Delegates/app/callbacks.cpp
@@ -1,4 +1,3 @@
-
 #include "callbacks.h"
 
 int testCounter;

--- a/samples/Basic_Delegates/app/callbacks.h
+++ b/samples/Basic_Delegates/app/callbacks.h
@@ -1,0 +1,8 @@
+
+class TestClass
+{
+public:
+	void callbackTest(int arg);
+};
+
+void callbackTest(int arg);

--- a/samples/Basic_Delegates/app/speed.cpp
+++ b/samples/Basic_Delegates/app/speed.cpp
@@ -1,0 +1,72 @@
+/*
+ * Evaluates relative speeds of various types of callback
+ */
+
+#include <SmingCore.h>
+#include <Services/Profiling/ElapseTimer.h>
+#include "callbacks.h"
+
+#ifdef ARCH_HOST
+const unsigned ITERATIONS = 10000000;
+#else
+const unsigned ITERATIONS = 100000;
+#endif
+
+typedef Delegate<void(int)> TestDelegate;
+typedef void (*TestCallback)(int);
+
+void evaluateSpeed()
+{
+	Serial.println();
+	Serial.println();
+	Serial.printf("Timings are in ns per loop, averaged over %u iterations\r\n", ITERATIONS);
+
+	auto printTime = [](const char* name, unsigned elapsed) {
+		unsigned ns = ((1000 * elapsed) + (ITERATIONS / 2)) / ITERATIONS;
+		Serial.printf("%s: %u\r\n", name, ns);
+	};
+
+	const int testParam = 123;
+
+	{
+		TestCallback callback = callbackTest;
+		ElapseTimer timer;
+		for(unsigned i = 0; i < ITERATIONS; ++i) {
+			callback(testParam);
+		}
+		auto elapsed = timer.elapsed();
+		printTime("Callback", elapsed);
+	}
+
+	{
+		TestDelegate callback = callbackTest;
+		ElapseTimer timer;
+		for(unsigned i = 0; i < ITERATIONS; ++i) {
+			callback(testParam);
+		}
+		auto elapsed = timer.elapsed();
+		printTime("Delegate (function)", elapsed);
+	}
+
+	{
+		TestClass cls;
+		auto callback = TestDelegate(&TestClass::callbackTest, &cls);
+		ElapseTimer timer;
+		for(unsigned i = 0; i < ITERATIONS; ++i) {
+			callback(testParam);
+		}
+		auto elapsed = timer.elapsed();
+		printTime("Delegate (method)", elapsed);
+	}
+
+	{
+		TestClass cls;
+		TestDelegate callback = std::bind(&TestClass::callbackTest, &cls, _1);
+		ElapseTimer timer;
+		for(unsigned i = 0; i < ITERATIONS; ++i) {
+			callback(testParam);
+		}
+		auto elapsed = timer.elapsed();
+		printTime("Delegate (bind)", elapsed);
+	}
+}

--- a/samples/Basic_Delegates/app/speed.cpp
+++ b/samples/Basic_Delegates/app/speed.cpp
@@ -15,58 +15,59 @@ const unsigned ITERATIONS = 100000;
 typedef Delegate<void(int)> TestDelegate;
 typedef void (*TestCallback)(int);
 
+static uint32_t __forceinline getCycleCount()
+{
+#ifdef ARCH_ESP8266
+	uint32_t ccount;
+	__asm__ __volatile__("rsr %0,ccount" : "=a"(ccount));
+	return ccount;
+#else
+	return NOW();
+#endif
+}
+
+static void printTime(const char* name, unsigned elapsed)
+{
+	Serial.printf("%s: %u\r\n", name, elapsed / ITERATIONS);
+}
+
+static void __attribute__((noinline)) evaluateCallback(const char* name, TestCallback callback, int testParam)
+{
+	unsigned startTicks = getCycleCount();
+	for(unsigned i = 0; i < ITERATIONS; ++i) {
+		callback(testParam);
+	}
+	unsigned elapsed = getCycleCount() - startTicks;
+	printTime(name, elapsed);
+}
+
+static void __attribute__((noinline)) evaluateDelegate(const char* name, TestDelegate delegate, int testParam)
+{
+	unsigned startTicks = getCycleCount();
+	for(unsigned i = 0; i < ITERATIONS; ++i) {
+		delegate(testParam);
+	}
+	unsigned elapsed = getCycleCount() - startTicks;
+	printTime(name, elapsed);
+}
+
 void evaluateSpeed()
 {
 	Serial.println();
 	Serial.println();
-	Serial.printf("Timings are in ns per loop, averaged over %u iterations\r\n", ITERATIONS);
+	Serial.printf("Timings are in CPU cycles per loop, averaged over %u iterations\r\n", ITERATIONS);
 
-	auto printTime = [](const char* name, unsigned elapsed) {
-		unsigned ns = ((1000 * elapsed) + (ITERATIONS / 2)) / ITERATIONS;
-		Serial.printf("%s: %u\r\n", name, ns);
-	};
+	int testParam = 123;
 
-	const int testParam = 123;
+	evaluateCallback("Callback", callbackTest, testParam);
 
-	{
-		TestCallback callback = callbackTest;
-		ElapseTimer timer;
-		for(unsigned i = 0; i < ITERATIONS; ++i) {
-			callback(testParam);
-		}
-		auto elapsed = timer.elapsed();
-		printTime("Callback", elapsed);
-	}
+	evaluateDelegate("Delegate (function)", callbackTest, testParam);
 
-	{
-		TestDelegate callback = callbackTest;
-		ElapseTimer timer;
-		for(unsigned i = 0; i < ITERATIONS; ++i) {
-			callback(testParam);
-		}
-		auto elapsed = timer.elapsed();
-		printTime("Delegate (function)", elapsed);
-	}
+	auto lambda = [testParam](int) { callbackTest(testParam); };
+	evaluateDelegate("Delegate (lambda)", lambda, 0);
 
-	{
-		TestClass cls;
-		auto callback = TestDelegate(&TestClass::callbackTest, &cls);
-		ElapseTimer timer;
-		for(unsigned i = 0; i < ITERATIONS; ++i) {
-			callback(testParam);
-		}
-		auto elapsed = timer.elapsed();
-		printTime("Delegate (method)", elapsed);
-	}
+	TestClass cls;
+	evaluateDelegate("Delegate (method)", TestDelegate(&TestClass::callbackTest, &cls), testParam);
 
-	{
-		TestClass cls;
-		TestDelegate callback = std::bind(&TestClass::callbackTest, &cls, _1);
-		ElapseTimer timer;
-		for(unsigned i = 0; i < ITERATIONS; ++i) {
-			callback(testParam);
-		}
-		auto elapsed = timer.elapsed();
-		printTime("Delegate (bind)", elapsed);
-	}
+	evaluateDelegate("Delegate (bind)", std::bind(&TestClass::callbackTest, &cls, _1), testParam);
 }

--- a/samples/Basic_Serial/app/SerialReadingDelegateDemo.cpp
+++ b/samples/Basic_Serial/app/SerialReadingDelegateDemo.cpp
@@ -19,7 +19,7 @@ void echoCallback(Stream& stream, char arrivedChar, unsigned short availableChar
 void SerialReadingDelegateDemo::begin(HardwareSerial& serial)
 {
 	this->serial = &serial;
-	serial.setCallback(StreamDataReceivedDelegate(&SerialReadingDelegateDemo::onData, this));
+	serial.onDataReceived(StreamDataReceivedDelegate(&SerialReadingDelegateDemo::onData, this));
 	debugf("hwsDelegateDemo instantiated, waiting for data");
 }
 

--- a/samples/Basic_Serial/app/application.cpp
+++ b/samples/Basic_Serial/app/application.cpp
@@ -301,9 +301,9 @@ void init()
 	/// Reading callback example:
 	//  * Option 1
 	//	Set Serial Callback to global routine:
-	//	   Serial.setCallback(onDataCallback);
+	//	   Serial.onDataReceived(onDataCallback);
 	// If you want to test local echo set the following callback
-	//	   Serial.setCallback(echoCallback);
+	//	   Serial.onDataReceived(echoCallback);
 
 	// 	* Option 2
 	//  Instantiate hwsDelegateDemo which includes Serial Delegate class

--- a/samples/Basic_Serial/include/SerialReadingDelegateDemo.h
+++ b/samples/Basic_Serial/include/SerialReadingDelegateDemo.h
@@ -3,7 +3,7 @@
 
 #include <SmingCore.h>
 
-typedef std::function<void(const String& command)> CommandCallbackFunction;
+typedef Delegate<void(const String& command)> CommandCallbackFunction;
 
 //*** Example of class callback processing
 class SerialReadingDelegateDemo

--- a/samples/Basic_Servo/app/application.cpp
+++ b/samples/Basic_Servo/app/application.cpp
@@ -12,7 +12,7 @@
 ServoChannel* channel;
 
 Timer procTimer;
-TimerDelegateStdFunction procDelegate;
+TimerDelegate procDelegate;
 
 uint16 centerdelay = 0;
 uint32 value = 0;

--- a/samples/Basic_rBoot/app/application.cpp
+++ b/samples/Basic_rBoot/app/application.cpp
@@ -213,5 +213,5 @@ void init()
 	Serial.println("Type 'help' and press enter for instructions.");
 	Serial.println();
 
-	Serial.setCallback(serialCallBack);
+	Serial.onDataReceived(serialCallBack);
 }

--- a/samples/CommandProcessing_Debug/app/ExampleCommand.cpp
+++ b/samples/CommandProcessing_Debug/app/ExampleCommand.cpp
@@ -18,7 +18,7 @@ void ExampleCommand::initCommand()
 {
 	commandHandler.registerCommand(
 		CommandDelegate("example", "Example Command from Class", "Application",
-						commandFunctionDelegate(&ExampleCommand::processExampleCommands, this)));
+						CommandFunctionDelegate(&ExampleCommand::processExampleCommands, this)));
 }
 
 void ExampleCommand::processExampleCommands(String commandLine, CommandOutput* commandOutput)

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -34,7 +34,6 @@ String ws_Url = "wss://echo.websocket.org";
 String ws_Url = "ws://echo.websocket.org";
 #endif /* ENABLE_SSL */
 
-void wsDisconnected(WebsocketConnection& wsConnection, bool success);
 void wsMessageSent();
 
 void wsConnected(WebsocketConnection& wsConnection)


### PR DESCRIPTION
Trying to use both `std::function` and `Delegate` causes issues, and they seem to do the same job anyway.

Further to #1337, #1732 and #1733, this PR is a rewrite of the `Delegate` class based on `std::function`.

__Improvements__

* Full compatibility with `std::function`, `std::bind` and lambdas
* `std::bind` is not required for standard callbacks, so existing code does not require modifying
* When invoking class methods, Deprecate uses lambda functions instead of `std::bind`
* No heap usage

__Call types__

* `Basic_Delegates` updated with speed testing to show performance of various call methods with a single parameter. Indicative results on an Esp8266:

	Method | CPU cycles per call | current Delegate
	--- | --- | ---
	Callback | 23 | 23
	Delegate (function) | 45 | 46
	Delegate (lambda) | 43 | -
	Delegate (method) | 51 | 51
	Delegate (bind) | 51 | -

* Note that `std::bind` _may_ also use the heap, and there is anecdotal evidence that type inferences can sometimes go wrong. It's generally safer to use lambdas.
* `std::bind` is only required to bind callbacks to functions or class methods where parameter lists differ.

__Notes__

* Reference counting is not supported any more
* Clearing a Delegate must be done using `nullptr`, not `0` or `NULL`
* `stdc++` library has been added for Esp8266 builds as it may be required for placeholders when building with optimisations disabled

__Deprecations__

* `TimerDelegateStdFunction` not required, just use `TimerDelegate` instead
* Rename `commandFunctionDelegate` to `CommandFunctionDelegate`
* Use `HardwareSerial::onDataReceived` instead of `setCallback`

__Additional changes__

* Replace `std::function` types with `Delegate`
* Replace `std::bind` with Delegate, simpler and uses lambdas
* Remove redundant declarations and includes
