### PR TITLE
Host fixes / additions

### DIFF
--- a/Sming/Arch/Host/Components/esp_hal/include/esp_system.h
+++ b/Sming/Arch/Host/Components/esp_hal/include/esp_system.h
@@ -54,6 +54,8 @@ void os_delay_us(uint32_t us);
 
 const char* system_get_sdk_version(void);
 
+uint32 system_get_chip_id(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/Arch/Host/Components/esp_hal/system.cpp
+++ b/Sming/Arch/Host/Components/esp_hal/system.cpp
@@ -65,6 +65,11 @@ const char* system_get_sdk_version(void)
 	return version_string;
 }
 
+uint32 system_get_chip_id(void)
+{
+	return 0xC001BEAF;
+}
+
 /* Interrupts */
 
 void ets_intr_lock()

--- a/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
@@ -45,6 +45,7 @@ bool host_flashmem_init(const FlashmemConfig& config)
 	if(res < 0) {
 		hostmsg("Error seeking \"%s\"", flashFileName);
 		close(flashFile);
+		flashFile = -1;
 		return false;
 	}
 

--- a/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
@@ -101,6 +101,11 @@ static int writeFlashFile(uint32_t offset, const void* data, size_t count)
 //{
 //}
 
+uint32 spi_flash_get_id(void)
+{
+	return 0xFA1E0008;
+}
+
 uint32_t flashmem_get_size_bytes()
 {
 	return flashFileSize;

--- a/Sming/Arch/Host/Components/spi_flash/include/esp_spi_flash.h
+++ b/Sming/Arch/Host/Components/spi_flash/include/esp_spi_flash.h
@@ -1,4 +1,15 @@
-
 #define SPI_FLASH_SEC_SIZE 4096
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <c_types.h>
+
+uint32_t spi_flash_get_id(void);
+
+#ifdef __cplusplus
+}
+#endif
 
 #include_next <esp_spi_flash.h>

--- a/Sming/Arch/Host/Core/Digital.cpp
+++ b/Sming/Arch/Host/Core/Digital.cpp
@@ -12,7 +12,7 @@
 #include "WiringFrameworkIncludes.h"
 
 #define PIN_MAX 16
-static uint8 pinModes[PIN_MAX];
+static uint8 pinModes[PIN_MAX + 1];
 
 static inline bool checkPin(uint16_t pin)
 {

--- a/Sming/Arch/Host/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Host/Core/HardwarePWM.cpp
@@ -1,0 +1,55 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HardwarePWM.cpp
+ *
+ * Original Author: https://github.com/hrsavla
+ *
+ * This HardwarePWM library enables Sming framework user to use ESP SDK PWM API
+ * Period of PWM is fixed to 1000us / Frequency = 1khz
+ * Duty at 100% = 22222. Duty at 0% = 0
+ * You can use function setPeriod() to change frequency/period.
+ * Calculate the max duty as per the formulae give in ESP8266 SDK
+ * Max Duty = (Period * 1000) / 45
+ *
+ * PWM can be generated on upto 8 pins (ie All pins except pin 16)
+ * Created on August 17, 2015, 2:27 PM
+ *
+ * See also ESP8266 Technical Reference, Chapter 12:
+ * http://espressif.com/sites/default/files/documentation/esp8266-technical_reference_en.pdf
+ *
+ */
+
+#include "HardwarePWM.h"
+
+HardwarePWM::HardwarePWM(uint8* pins, uint8 no_of_pins) :
+		channel_count(no_of_pins) {
+}
+
+HardwarePWM::~HardwarePWM() {
+}
+
+uint8 HardwarePWM::getChannel(uint8 pin) {
+	return PWM_BAD_CHANNEL;
+}
+
+uint32 HardwarePWM::getDutyChan(uint8 chan) {
+	return 0;
+}
+
+bool HardwarePWM::setDutyChan(uint8 chan, uint32 duty, bool update) {
+	return false;
+}
+
+uint32 HardwarePWM::getPeriod() {
+	return 0;
+}
+
+void HardwarePWM::setPeriod(uint32 period) {
+}
+
+void HardwarePWM::update() {
+}


### PR DESCRIPTION
bug fixes

* In host `Digital.cpp`, pinModes array too small, pin 16 overwrites other globals
* Set `flashFile` invalid if `host_flashmem_init()` fails

Add dummy code:

* `spi_flash_get_id()` and `system_get_chip_id()` functions (from Esp8266 arch).
* `HardwarePWM` class

