### PR TITLE
Fix memory leak in MqttClient

### DIFF
--- a/Sming/Core/Network/MqttClient.h
+++ b/Sming/Core/Network/MqttClient.h
@@ -302,6 +302,7 @@ private:
 	// messages
 	MqttRequestQueue requestQueue;
 	mqtt_message_t connectMessage;
+	bool connectQueued = false; ///< True if our connect message needs to be sent
 	mqtt_message_t* outgoingMessage = nullptr;
 	mqtt_message_t incomingMessage;
 


### PR DESCRIPTION
If request queue is full due to non-responsive server then allocated message will never be freed.

A new `MqttRequestQueue` class handles all message queueing. Only one connect message may be queued, and it always takes priority over others.

Should fix #1740