### PR TITLE
Add malloc_count Component to track heap usage

### DIFF
--- a/Sming/Arch/Host/Components/heap/component.mk
+++ b/Sming/Arch/Host/Components/heap/component.mk
@@ -1,0 +1,9 @@
+# We require malloc_count to keep track of heap usage for system_get_free_heap_size()
+# If using valgrind, for example, disabling hooking provides a cleaner trace
+COMPONENT_VARS			:= ENABLE_MALLOC_COUNT
+ENABLE_MALLOC_COUNT		?= 1
+
+ifeq ($(ENABLE_MALLOC_COUNT),1)
+GLOBAL_CFLAGS			+= -DENABLE_MALLOC_COUNT
+COMPONENT_DEPENDS		:= malloc_count
+endif

--- a/Sming/Arch/Host/Components/heap/heap.c
+++ b/Sming/Arch/Host/Components/heap/heap.c
@@ -1,7 +1,0 @@
-
-#include "include/heap.h"
-
-uint32_t system_get_free_heap_size(void)
-{
-	return (uint32_t)-1;
-}

--- a/Sming/Arch/Host/Components/heap/heap.cpp
+++ b/Sming/Arch/Host/Components/heap/heap.cpp
@@ -1,0 +1,18 @@
+
+#include "include/heap.h"
+#ifdef ENABLE_MALLOC_COUNT
+#include <malloc_count.h>
+#endif
+
+// Notional RAM available
+const uint32_t memorySize = 128 * 1024;
+
+uint32_t system_get_free_heap_size(void)
+{
+#ifdef ENABLE_MALLOC_COUNT
+	uint32_t current = MallocCount::getCurrent();
+	return (current < memorySize) ? (memorySize - current) : 0;
+#else
+	return memorySize;
+#endif
+}

--- a/Sming/Arch/Host/Components/hostlib/hostmsg.c
+++ b/Sming/Arch/Host/Components/hostlib/hostmsg.c
@@ -45,8 +45,10 @@ void host_printf(const char* fmt, ...)
 {
 	va_list args;
 	va_start(args, fmt);
-	vfprintf(stderr, fmt, args);
+	char buffer[1024];
+	vsnprintf(buffer, sizeof(buffer), fmt, args);
 	va_end(args);
+	host_puts(buffer);
 }
 
 void host_printfp(const char* fmt, const char* pretty_function, ...)

--- a/Sming/Components/malloc_count/component.mk
+++ b/Sming/Components/malloc_count/component.mk
@@ -1,0 +1,16 @@
+# Hook all the memory allocation functions we need to monitor heap activity
+ifeq ($(SMING_ARCH),Host)
+EXTRA_LDFLAGS := \
+	-Wl,-wrap,malloc \
+	-Wl,-wrap,calloc \
+	-Wl,-wrap,realloc \
+	-Wl,-wrap,free
+else
+EXTRA_LDFLAGS := \
+	-Wl,-wrap,pvPortMalloc \
+	-Wl,-wrap,pvPortCalloc \
+	-Wl,-wrap,pvPortRealloc \
+	-Wl,-wrap,pvPortZalloc \
+	-Wl,-wrap,pvPortZallocIram \
+	-Wl,-wrap,vPortFree
+endif

--- a/Sming/Components/malloc_count/include/malloc_count.h
+++ b/Sming/Components/malloc_count/include/malloc_count.h
@@ -1,0 +1,63 @@
+/******************************************************************************
+ * malloc_count.h
+ *
+ * Header containing prototypes of user-callable functions to retrieve run-time
+ * information about malloc()/free() allocation.
+ *
+ ******************************************************************************
+ * Copyright (C) 2013 Timo Bingmann <tb@panthema.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+#pragma once
+
+#include <stdlib.h>
+#include <stdbool.h>
+#include <functional>
+
+namespace MallocCount
+{
+/* returns the currently allocated amount of memory */
+size_t getCurrent(void);
+
+/* returns the current peak memory allocation */
+size_t getPeak(void);
+
+/* resets the peak memory allocation to current */
+void resetPeak(void);
+
+/* returns the total number of allocations */
+size_t getAllocCount(void);
+
+/* typedef of callback function */
+typedef std::function<void(size_t current)> MallocCountCallback;
+
+/* supply malloc_count with a callback function that is invoked on each change
+ * of the current allocation. The callback function must not use malloc()/realloc()/free()
+ * or it will go into an endless recursive loop! */
+void setCallback(MallocCountCallback callback);
+
+/* dynamically enable/disable logging */
+void enableLogging(bool enable);
+
+/* allocations less than this threshold are never logged */
+void setLogThreshold(size_t threshold);
+
+}; // namespace MallocCount

--- a/Sming/Components/malloc_count/malloc_count.cpp
+++ b/Sming/Components/malloc_count/malloc_count.cpp
@@ -1,0 +1,301 @@
+/******************************************************************************
+ * malloc_count.c
+ *
+ * malloc() allocation counter based on http://ozlabs.org/~jk/code/ and other
+ * code preparing LD_PRELOAD shared objects.
+ *
+ ******************************************************************************
+ * Copyright (C) 2013-2014 Timo Bingmann <tb@panthema.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *****************************************************************************/
+
+/*
+ * @author July 2019 mikee47 <mike@sillyhouse.net>
+ *
+ * 	The original code uses dynamic loading to hook functions, which meant a separate
+ * 	'init' heap was required to track initial usage before this took effect.
+ * 	This has been changed to use function wrappers, so init heap no longer required and
+ * 	code can be simplified.
+ *
+ *	Added user functions:
+ *
+ *		malloc_enable_logging
+ *		malloc_set_log_threshold
+ *
+ */
+
+#include "include/malloc_count.h"
+#include <debug_progmem.h>
+#include <esp_attr.h>
+
+#ifdef ARCH_HOST
+#define F_MALLOC malloc
+#define F_CALLOC calloc
+#define F_REALLOC realloc
+#define F_FREE free
+#else
+#define F_MALLOC pvPortMalloc
+#define F_CALLOC pvPortCalloc
+#define F_REALLOC pvPortRealloc
+#define F_FREE vPortFree
+#endif
+
+#define CONCAT(a, b) a##b
+#define REAL(f) CONCAT(__real_, f)
+#define WRAP(f) CONCAT(__wrap_, f)
+
+extern "C" {
+void* REAL(F_MALLOC)(size_t size);
+void REAL(F_FREE)(void* ptr);
+void* REAL(F_CALLOC)(size_t nmemb, size_t size);
+void* REAL(F_REALLOC)(void* ptr, size_t size);
+};
+
+namespace MallocCount
+{
+/* user-defined options for output malloc()/free() operations to stderr */
+
+static bool logEnabled = false;
+static size_t logThreshold = 256;
+
+void enableLogging(bool enable)
+{
+	logEnabled = enable;
+}
+
+void setLogThreshold(size_t threshold)
+{
+	logThreshold = threshold;
+}
+
+/* to each allocation additional data is added for bookkeeping. due to
+ * alignment requirements, we can optionally add more than just one integer. */
+static const size_t alignment = 16; /* bytes (>= 2*sizeof(size_t)) */
+
+/* a sentinel value prefixed to each allocation */
+static const size_t sentinel = 0xDEADC0DE;
+
+/* Macro to get pointer to sentinel */
+#define GET_SENTINEL(ptr) (size_t*)((char*)ptr - sizeof(size_t))
+
+/* output */
+#define PPREFIX "MC## "
+
+#define log(fmt, ...)                                                                                                  \
+	if(logEnabled) {                                                                                                   \
+		debug_i(PPREFIX fmt, ##__VA_ARGS__);                                                                           \
+	}
+
+/*****************************************/
+/* run-time memory allocation statistics */
+/*****************************************/
+
+static struct {
+	size_t peak;	// Peak memory allocated
+	size_t current; // Current memory allocated
+	size_t total;   // Cumulative memory allocated
+	size_t count;   // Number of allocations called
+} stats;
+
+static MallocCountCallback userCallback = nullptr;
+
+/* add allocation to statistics */
+static void inc_count(size_t inc)
+{
+	stats.current += inc;
+	stats.total += inc;
+	if(stats.current > stats.peak) {
+		stats.peak = stats.current;
+	}
+	++stats.count;
+
+	if(userCallback) {
+		userCallback(stats.current);
+	}
+}
+
+/* decrement allocation to statistics */
+static void dec_count(size_t dec)
+{
+	stats.current -= dec;
+	if(userCallback) {
+		userCallback(stats.current);
+	}
+}
+
+/* user function to return the currently allocated amount of memory */
+size_t getCurrent()
+{
+	return stats.current;
+}
+
+/* user function to return the peak allocation */
+size_t getPeak()
+{
+	return stats.peak;
+}
+
+/* user function to reset the peak allocation to current */
+extern void resetPeak()
+{
+	stats.peak = stats.current;
+}
+
+/* user function to return total number of allocations */
+extern size_t getAllocCount()
+{
+	return stats.count;
+}
+
+/* user function to supply a memory profile callback */
+extern void setCallback(MallocCountCallback callback)
+{
+	userCallback = callback;
+}
+
+/****************************************************/
+/* exported symbols that overlay the libc functions */
+/****************************************************/
+
+/* exported malloc symbol that overrides loading from libc */
+extern "C" void* WRAP(F_MALLOC)(size_t size)
+{
+	if(size == 0) {
+		return nullptr;
+	}
+
+	/* call read malloc procedure in libc */
+	void* ret = REAL(F_MALLOC)(alignment + size);
+
+	/* prepend allocation size and check sentinel */
+	*(size_t*)ret = size;
+	ret = (char*)ret + alignment;
+	*GET_SENTINEL(ret) = sentinel;
+
+	inc_count(size);
+	if(size >= logThreshold) {
+		log("malloc(%u) = %p (cur %u)", size, ret, stats.current);
+	}
+
+	return ret;
+}
+
+#ifndef ARCH_HOST
+extern "C" void* WRAP(pvPortZalloc)(size_t size)
+{
+	auto ptr = WRAP(F_MALLOC)(size);
+	if(ptr != nullptr) {
+		memset(ptr, 0, size);
+	}
+	return ptr;
+}
+
+extern "C" void* WRAP(pvPortZallocIram)(size_t size, const char* file, int line)
+	__attribute__((alias("__wrap_pvPortZalloc")));
+#endif // ARCH_HOST
+
+/* exported free symbol that overrides loading from libc */
+extern "C" void WRAP(F_FREE)(void* ptr)
+{
+	// free(nullptr) is no operation
+	if(ptr == nullptr) {
+		return;
+	}
+
+	size_t* p_sentinel = GET_SENTINEL(ptr);
+	if(*p_sentinel != sentinel) {
+		log("free(%p) has no sentinel !!! memory corruption?", ptr);
+		// ... or memory not allocated by our malloc()
+	} else {
+		*p_sentinel = 0; // Clear sentinel to avoid false-positives
+		ptr = (char*)ptr - alignment;
+
+		size_t size = *(size_t*)ptr;
+		dec_count(size);
+
+		if(size >= logThreshold) {
+			log("free(%p) -> %u (cur %u)", ptr, size, stats.current);
+		}
+	}
+
+	REAL(F_FREE)(ptr);
+}
+
+/* exported calloc() symbol that overrides loading from libc, implemented using our malloc */
+extern "C" void* WRAP(F_CALLOC)(size_t nmemb, size_t size)
+{
+	size *= nmemb;
+	if(size == 0) {
+		return nullptr;
+	}
+
+	void* ret = malloc(size);
+	memset(ret, 0, size);
+	return ret;
+}
+
+/* exported realloc() symbol that overrides loading from libc */
+extern "C" void* WRAP(F_REALLOC)(void* ptr, size_t size)
+{
+	// special case size == 0 -> free()
+	if(size == 0) {
+		WRAP(F_FREE)(ptr);
+		return nullptr;
+	}
+
+	// special case ptr == 0 -> malloc()
+	if(ptr == nullptr) {
+		return WRAP(F_MALLOC)(size);
+	}
+
+	if(*GET_SENTINEL(ptr) != sentinel) {
+		log("free(%p) has no sentinel !!! memory corruption?", ptr);
+		// ... or memory not allocated by our malloc()
+		return REAL(F_REALLOC)(ptr, size);
+	}
+
+	ptr = (char*)ptr - alignment;
+
+	size_t oldsize = *(size_t*)ptr;
+
+	dec_count(oldsize);
+	inc_count(size);
+
+	void* newptr = REAL(F_REALLOC)(ptr, alignment + size);
+
+	if(size >= logThreshold) {
+		if(newptr == ptr) {
+			log("realloc(%u -> %u) = %p (cur %u)", oldsize, size, newptr, stats.current);
+		} else {
+			log("realloc(%u -> %u) = %p -> %p (cur %u)", oldsize, size, ptr, newptr, stats.current);
+		}
+	}
+
+	*(size_t*)newptr = size;
+
+	return (char*)newptr + alignment;
+}
+
+static __attribute__((destructor)) void finish()
+{
+	log("exiting, total: %u, peak: %u, current: %u", stats.total, stats.peak, stats.current);
+}
+
+}; // namespace MallocCount

--- a/Sming/System/include/debug_progmem.h
+++ b/Sming/System/include/debug_progmem.h
@@ -16,7 +16,6 @@
 
 #pragma once
 
-#include <stdarg.h>
 #include "FakePgmSpace.h"
 
 #ifdef __cplusplus
@@ -69,6 +68,8 @@ extern "C" {
 #else
 #define PROGMEM_DEBUG
 #endif
+
+extern uint32_t system_get_time();
 
 //A static const char[] is defined having a unique name (log_ prefix, filename and line number)
 //This will be stored in the irom section(on flash) freeing up the RAM

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -13,6 +13,11 @@
 #include "m_printf.h"
 #include "c_types.h"
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 // Simple check to determine if a pointer refers to flash memory
 #define isFlashPtr(ptr) (uint32_t(ptr) >= 0x40200000)
 
@@ -95,56 +100,49 @@ static inline uint16_t pgm_read_word_inlined(const void* addr)
 #define pgm_read_dword(addr) (*(const unsigned long*)(addr))
 #define pgm_read_float(addr) (*(const float*)(addr))
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
-	void *memcpy_P(void *dest, const void *src_P, size_t length);
-	int memcmp_P(const void *a1, const void *b1, size_t len);
-	size_t strlen_P(const char * src_P);
-	char *strcpy_P(char * dest, const char * src_P);
-	char *strncpy_P(char * dest, const char * src_P, size_t size);
-	int strcmp_P(const char *str1, const char *str2_P);
-	int strncmp_P(const char *str1, const char *str2_P, const size_t size);
-	int strcasecmp_P(const char* str1, const char* str2_P);
-	char* strcat_P(char* dest, const char* src_P);
-	char *strstr_P(char *haystack, const char *needle_P);
+void *memcpy_P(void *dest, const void *src_P, size_t length);
+int memcmp_P(const void *a1, const void *b1, size_t len);
+size_t strlen_P(const char * src_P);
+char *strcpy_P(char * dest, const char * src_P);
+char *strncpy_P(char * dest, const char * src_P, size_t size);
+int strcmp_P(const char *str1, const char *str2_P);
+int strncmp_P(const char *str1, const char *str2_P, const size_t size);
+int strcasecmp_P(const char* str1, const char* str2_P);
+char* strcat_P(char* dest, const char* src_P);
+char *strstr_P(char *haystack, const char *needle_P);
 
-	#define sprintf_P(s, f_P, ...)                                                                                         \
-		(__extension__({                                                                                                   \
-			int len_P = strlen_P(f_P);                                                                                     \
-			int __result = 0;                                                                                              \
-			char* __localF = (char*)malloc(len_P + 1);                                                                     \
-			if(__localF) {                                                                                                 \
-				strcpy_P(__localF, f_P);                                                                                   \
-				__localF[len_P] = '\0';                                                                                    \
-			}                                                                                                              \
-			__result = m_snprintf(s, len_P, __localF, ##__VA_ARGS__);                                                      \
-			free(__localF);                                                                                                \
-			__result;                                                                                                      \
-		}))
+#define sprintf_P(s, f_P, ...)                                                                                         \
+	(__extension__({                                                                                                   \
+		int len_P = strlen_P(f_P);                                                                                     \
+		int __result = 0;                                                                                              \
+		char* __localF = (char*)malloc(len_P + 1);                                                                     \
+		if(__localF) {                                                                                                 \
+			strcpy_P(__localF, f_P);                                                                                   \
+			__localF[len_P] = '\0';                                                                                    \
+		}                                                                                                              \
+		__result = m_snprintf(s, len_P, __localF, ##__VA_ARGS__);                                                      \
+		free(__localF);                                                                                                \
+		__result;                                                                                                      \
+	}))
 
-	#define printf_P_heap(f_P, ...)                                                                                        \
-		(__extension__({                                                                                                   \
-			char* __localF = (char*)malloc(strlen_P(f_P) + 1);                                                             \
-			strcpy_P(__localF, f_P);                                                                                       \
-			int __result = os_printf_plus(__localF, ##__VA_ARGS__);                                                        \
-			free(__localF);                                                                                                \
-			__result;                                                                                                      \
-		}))
+#define printf_P_heap(f_P, ...)                                                                                        \
+	(__extension__({                                                                                                   \
+		char* __localF = (char*)malloc(strlen_P(f_P) + 1);                                                             \
+		strcpy_P(__localF, f_P);                                                                                       \
+		int __result = os_printf_plus(__localF, ##__VA_ARGS__);                                                        \
+		free(__localF);                                                                                                \
+		__result;                                                                                                      \
+	}))
 
-	#define printf_P_stack(f_P, ...)                                                                                       \
-		(__extension__({                                                                                                   \
-			char __localF[256];                                                                                            \
-			strncpy_P(__localF, f_P, sizeof(__localF));                                                                    \
-			__localF[sizeof(__localF) - 1] = '\0';                                                                         \
-			m_printf(__localF, ##__VA_ARGS__);                                                                             \
-		}))
+#define printf_P_stack(f_P, ...)                                                                                       \
+	(__extension__({                                                                                                   \
+		char __localF[256];                                                                                            \
+		strncpy_P(__localF, f_P, sizeof(__localF));                                                                    \
+		__localF[sizeof(__localF) - 1] = '\0';                                                                         \
+		m_printf(__localF, ##__VA_ARGS__);                                                                             \
+	}))
 
-	#define printf_P printf_P_stack
-#ifdef __cplusplus
-}
-#endif
+#define printf_P printf_P_stack
 
 #else /* ICACHE_FLASH */
 
@@ -257,6 +255,10 @@ int memcmp_aligned(const void* ptr1, const void* ptr2, unsigned len);
  * 		sizeof(PSTR_myText) - 1
  *
  */
-#define PSTR_ARRAY(name, str)                                                                                        \
-	static DEFINE_PSTR(PSTR_##name, str);                                                                                       \
+#define PSTR_ARRAY(name, str)                                                                                          \
+	static DEFINE_PSTR(PSTR_##name, str);                                                                              \
 	LOAD_PSTR(name, PSTR_##name)
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Currently, `system_get_free_heap_size()` doesn't return anything meaningful. This PR fixes that using a Component based on `malloc_count` https://panthema.net/2013/malloc_count/.

I've also added a couple of functions to enable logging. To use it, add `#include <malloc_count.h>` and call `MallocCount::enableLogging()` and `MallocCount::setLogThreshold()` as required.

The Component also works for the Esp8266 (standard or custom heaps). Enable by adding `COMPONENT_DEPENDS += malloc_count` to the project's `component.mk` file.

The Component is enabled by default for the Host emulator, but can be disabled using `ENABLE_MALLOC_COUNT=0`.
