### PR TITLE
Fix custom heap

### DIFF
--- a/Sming/Arch/Esp8266/Components/custom_heap/component.mk
+++ b/Sming/Arch/Esp8266/Components/custom_heap/component.mk
@@ -1,7 +1,8 @@
 # umm_malloc (custom heap allocation)
 
 COMPONENT_SUBMODULES	:= umm_malloc
-COMPONENT_SRCDIRS		:= . umm_malloc/src
+COMPONENT_SRCDIRS		:=
+COMPONENT_SRCFILES		:= heap.c umm_malloc/src/umm_malloc.c
 COMPONENT_INCDIRS		:= umm_malloc/src umm_malloc/includes/c-helper-macros
 
 LIBMAIN					= mainmm

--- a/Sming/Arch/Esp8266/Components/custom_heap/component.mk
+++ b/Sming/Arch/Esp8266/Components/custom_heap/component.mk
@@ -9,6 +9,11 @@ LIBMAIN					= mainmm
 LIBMAIN_SRC				= $(COMPONENT_LIBDIR)/libmainmm.a
 COMPONENT_TARGETS		+= $(LIBMAIN_SRC)
 
+COMPONENT_VARS			+= UMM_POISON_CHECK
+ifeq ($(UMM_POISON_CHECK),1)
+GLOBAL_CFLAGS			+= -DUMM_POISON_CHECK
+endif
+
 # Make copy of libmain and remove mem_manager.o module
 $(COMPONENT_RULE)$(LIBMAIN_SRC): $(SDK_LIBDIR)/libmain.a
 	$(info Enabling custom heap implementation)

--- a/Sming/Arch/Esp8266/Components/custom_heap/heap.c
+++ b/Sming/Arch/Esp8266/Components/custom_heap/heap.c
@@ -12,27 +12,27 @@
 
 void* IRAM_ATTR pvPortMalloc(size_t size, const char* file, int line)
 {
-    return malloc(size);
+    return umm_malloc(size);
 }
 
 void IRAM_ATTR vPortFree(void *ptr, const char* file, int line)
 {
-    free(ptr);
+    umm_free(ptr);
 }
 
 void* IRAM_ATTR pvPortCalloc(size_t count, size_t size, const char* file, int line)
 {
-    return calloc(count, size);
+    return umm_calloc(count, size);
 }
 
 void* IRAM_ATTR pvPortRealloc(void *ptr, size_t size, const char* file, int line)
 {
-    return realloc(ptr, size);
+    return umm_realloc(ptr, size);
 }
 
 void* IRAM_ATTR pvPortZalloc(size_t size, const char* file, int line)
 {
-    return calloc(1, size);
+    return umm_calloc(1, size);
 }
 
 void* IRAM_ATTR pvPortZallocIram(size_t size, const char* file, int line) __attribute__ ((weak, alias("pvPortZalloc")));

--- a/Sming/Arch/Esp8266/Components/custom_heap/heap.c
+++ b/Sming/Arch/Esp8266/Components/custom_heap/heap.c
@@ -10,29 +10,36 @@
 
 #define IRAM_ATTR __attribute__((section(".iram.text")))
 
+#ifdef UMM_POISON_CHECK
+#define UMM_FUNC(f) umm_poison_##f
+#else
+#define UMM_FUNC(f) umm_##f
+#endif
+
+
 void* IRAM_ATTR pvPortMalloc(size_t size, const char* file, int line)
 {
-    return umm_malloc(size);
+    return UMM_FUNC(malloc)(size);
 }
 
 void IRAM_ATTR vPortFree(void *ptr, const char* file, int line)
 {
-    umm_free(ptr);
+	UMM_FUNC(free)(ptr);
 }
 
 void* IRAM_ATTR pvPortCalloc(size_t count, size_t size, const char* file, int line)
 {
-    return umm_calloc(count, size);
+    return UMM_FUNC(calloc)(count, size);
 }
 
 void* IRAM_ATTR pvPortRealloc(void *ptr, size_t size, const char* file, int line)
 {
-    return umm_realloc(ptr, size);
+    return UMM_FUNC(realloc)(ptr, size);
 }
 
 void* IRAM_ATTR pvPortZalloc(size_t size, const char* file, int line)
 {
-    return umm_calloc(1, size);
+    return UMM_FUNC(calloc)(1, size);
 }
 
 void* IRAM_ATTR pvPortZallocIram(size_t size, const char* file, int line) __attribute__ ((weak, alias("pvPortZalloc")));

--- a/Sming/Arch/Esp8266/Components/custom_heap/umm_malloc.patch
+++ b/Sming/Arch/Esp8266/Components/custom_heap/umm_malloc.patch
@@ -1,34 +1,33 @@
 diff --git a/src/umm_malloc_cfg.h b/src/umm_malloc_cfg.h
-index fcc4fb1..661b94a 100644
+index 6a5a7fc..a581100 100644
 --- a/src/umm_malloc_cfg.h
 +++ b/src/umm_malloc_cfg.h
-@@ -5,6 +5,25 @@
+@@ -5,6 +5,24 @@
  #ifndef _UMM_MALLOC_CFG_H
  #define _UMM_MALLOC_CFG_H
  
++#include <c_types.h>
++#include <m_printf.h>
++
 +#ifdef __cplusplus
 +extern "C" {
 +#endif
-+#include <c_types.h>
-+#ifdef __cplusplus
-+}
-+#endif
 +
-+#ifdef __ets__
 +// ESP specific code
 +extern void ets_intr_lock();
 +extern void ets_intr_unlock();
-+extern void ets_printf(const char*, ...);
 +
-+#define printf ets_printf
-+#define puts(...) ets_printf("%s",...)
-+#define ICACHE_FLASH_ATTR __attribute__((section(".irom0.text")))
++#ifdef UMM_MALLOC_H
++#define printf m_printf
++#define puts m_puts
 +#endif
++
++#define ICACHE_FLASH_ATTR __attribute__((section(".irom0.text")))
 +
  /*
   * There are a number of defines you can set at compile time that affect how
   * the memory allocator will operate.
-@@ -51,11 +70,11 @@
+@@ -39,11 +57,11 @@
   * ----------------------------------------------------------------------------
   */
  
@@ -43,7 +42,7 @@ index fcc4fb1..661b94a 100644
  
  /* A couple of macros to make packing structures less compiler dependent */
  
-@@ -107,8 +126,8 @@ extern char test_umm_heap[];
+@@ -95,8 +113,8 @@ extern char test_umm_heap[];
   * called from within umm_malloc()
   */
  
@@ -54,7 +53,7 @@ index fcc4fb1..661b94a 100644
  
  /*
   * -D UMM_INTEGRITY_CHECK :
-@@ -163,11 +182,11 @@ extern char test_umm_heap[];
+@@ -151,11 +169,11 @@ extern char test_umm_heap[];
   * callback is called: `UMM_HEAP_CORRUPTION_CB()`
   */
  
@@ -68,10 +67,14 @@ index fcc4fb1..661b94a 100644
  
  #ifdef UMM_POISON_CHECK
     void *umm_poison_malloc( size_t size );
-@@ -180,4 +199,6 @@ extern char test_umm_heap[];
+@@ -168,4 +186,10 @@ extern char test_umm_heap[];
  #  define POISON_CHECK() 0
  #endif
  
 +// #define UMM_HEAP_CORRUPTION_CB() panic()
++
++#ifdef __cplusplus
++}
++#endif
 +
  #endif /* _UMM_MALLOC_CFG_H */


### PR DESCRIPTION
Should call umm_malloc, etc. not malloc().
Update to latest version of umm_malloc, and add support for poison checking.