### PR TITLE
Update esptool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,6 +23,10 @@
 	url = https://github.com/jacketizer/libyuarel.git
 	ignore = dirty
 
+[submodule "esptool"]
+	path = Sming/Arch/Esp8266/Components/esptool/esptool
+	url = https://github.com/espressif/esptool
+	ignore = dirty
 [submodule "ESP8266.rboot"]
 	path = Sming/Arch/Esp8266/Components/rboot/rboot
 	url = https://github.com/raburton/rboot.git

--- a/Sming/Arch/Esp8266/Components/esptool/component.mk
+++ b/Sming/Arch/Esp8266/Components/esptool/component.mk
@@ -58,11 +58,8 @@ CACHE_VARS				+= COM_PORT_ESPTOOL COM_SPEED_ESPTOOL
 COM_PORT_ESPTOOL		?= $(COM_PORT)
 COM_SPEED_ESPTOOL		?= $(COM_SPEED)
 
-ifeq ($(UNAME),Windows)
-ESPTOOL					?= $(SDK_TOOLS)/esptool/esptool.py
-else
-ESPTOOL					?= $(ESP_HOME)/esptool/esptool.py
-endif
+COMPONENT_SUBMODULES	+= esptool
+ESPTOOL					:= $(COMPONENT_PATH)/esptool/esptool.py
 
 ESPTOOL_CMDLINE			:= $(ESPTOOL) -p $(COM_PORT_ESPTOOL) -b $(COM_SPEED_ESPTOOL)
 


### PR DESCRIPTION
Addresses issue in #1746. esptool provided with various SDKs have inconsistent versions, some quite old.
esptool is intended to be installed for python using `pip`, but adding it as a submodule instead avoids any additional setup steps.