### PR TITLE
Bugfix: `JsonObjectStream.h` (version 6), returns empty document

### DIFF
--- a/Sming/Core/Data/Stream/JsonObjectStream.h
+++ b/Sming/Core/Data/Stream/JsonObjectStream.h
@@ -28,6 +28,7 @@ public:
     */
 	JsonObjectStream(Json::SerializationFormat format, size_t capacity = 1024) : doc(capacity), format(format)
 	{
+		doc.to<JsonObject>();
 	}
 
 	/** @brief Create a JSON object stream using default (Compact) format
@@ -35,6 +36,7 @@ public:
     */
 	JsonObjectStream(size_t capacity = 1024) : doc(capacity)
 	{
+		doc.to<JsonObject>();
 	}
 
 	//Use base class documentation


### PR DESCRIPTION
Constructor needs to call `to<JsonObject>` to initialise the JsonDocument ready for writing, otherwise all writes will fail. Fixes #1753.