### PR TITLE
Bugfix: `LOAD_FSTR()` doesn't NUL-terminate buffered string

### DIFF
--- a/Sming/Wiring/FlashString.h
+++ b/Sming/Wiring/FlashString.h
@@ -146,7 +146,8 @@
  */
 #define LOAD_FSTR(_name, _fstr)                                                                                        \
 	char _name[(_fstr).size()] __attribute__((aligned(4)));                                                            \
-	memcpy_aligned(_name, (_fstr).data(), (_fstr).length());
+	memcpy_aligned(_name, (_fstr).data(), (_fstr).length());                                                           \
+	_name[(_fstr).length()] = '\0';
 
 /*
  * Define a flash string and load it into a named char[] buffer on the stack.


### PR DESCRIPTION
Bug introduced in #1709. When a `FlashString` object is loaded into RAM, buffered contents are not NUL-terminated so produces random and unpredictable results, such as failed comparisons. This only happens where the string length is a multiple 4 characters, such as "Content-Type" (12).
Fixes #1755.