### PR TITLE
Remove `UNAME` from output build path, not really needed

### DIFF
--- a/Sming/Arch/Host/build.mk
+++ b/Sming/Arch/Host/build.mk
@@ -21,9 +21,6 @@ CFLAGS += \
 	-m32 \
 	-Wno-deprecated-declarations
 
-# Keep Windows/Linux object files separate to avoid conflict
-OUT_BASE	:= out/$(SMING_ARCH)/$(UNAME)/$(if $(SMING_RELEASE),release,debug)
-
 # => Tools
 MEMANALYZER = size
 


### PR DESCRIPTION
This changes the output paths from:

`out/build/Host/Windows/debug/`

to just

`out/build/Host/debug/`

This was added in the first place to allow the same working tree to be used for both Windows and Linux Host builds to simplify testing. For instance, running Linux in a VM on a Windows machine.

In retrospect it works better if I just use the Windows working tree as the main repo, and clone it in Linux.