### PR TITLE
Fix terminal options

### DIFF
--- a/Sming/Components/terminal/README.rst
+++ b/Sming/Components/terminal/README.rst
@@ -1,9 +1,22 @@
 Terminal
 ========
 
-Provides make targets to support serial terminal for communicating with devices.
+.. highlight:: bash
 
-Defines these options:
+Introduction
+------------
+
+This Component provides make targets to support a serial terminal for communicating with devices.
+
+The default serial terminal is `miniterm <https://pyserial.readthedocs.io/en/latest/tools.html#module-serial.tools.miniterm>`__.
+If you don't have it installed already, do this::
+
+   pip install pyserial
+
+(You'll need `python <https://www.python.org/>`__, of course.)
+
+Options
+-------
 
 .. envvar:: COM_PORT
 
@@ -13,10 +26,16 @@ Defines these options:
 
    Baud rate to use. Default is :envvar:`COM_SPEED`.
 
+.. envvar:: COM_OPTS
+
+   Additional options to pass to the terminal.
+
 .. envvar:: TERMINAL
 
-   Command line to use when running ``make terminal``
+   Command line to use when running ``make terminal``.
+   Redefine if you want to use a different terminal application.
 
 .. envvar:: KILL_TERM
 
    Command line to use to kill the running terminal process
+   If the terminal never runs in the background and the warnings annoy you, just clear it.

--- a/Sming/Components/terminal/component.mk
+++ b/Sming/Components/terminal/component.mk
@@ -14,9 +14,10 @@ endif
 
 
 # Universal python terminal application
-CACHE_VARS		+= KILL_TERM TERMINAL
+CACHE_VARS		+= COM_OPTS KILL_TERM TERMINAL
+COM_OPTS		?= --raw --encoding ascii
 KILL_TERM		?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
-TERMINAL		?= python -m serial.tools.miniterm $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
+TERMINAL		?= python -m serial.tools.miniterm $(COM_OPTS) $(COM_PORT) $(COM_SPEED_SERIAL)
 
 # Alternative for Windows
 #KILL_TERM		?= taskkill.exe -f -im Terminal.exe || exit 0


### PR DESCRIPTION
Addresses #1773. Documentation updated to include `COM_OPTS`, which is placed in command line _before_ the port and speed parameters are per spec.