### PR TITLE
Fix CStringArray edge case. (#1785)

### DIFF
--- a/Sming/SmingCore/Data/CStringArray.cpp
+++ b/Sming/SmingCore/Data/CStringArray.cpp
@@ -45,7 +45,7 @@ int CStringArray::indexOf(const char* str) const
 const char* CStringArray::getValue(unsigned index) const
 {
 	if(index < count()) {
-		for(unsigned offset = 0; offset < length(); --index) {
+		for(unsigned offset = 0; offset <= length(); --index) {
 			const char* s = buffer + offset;
 			if(index == 0)
 				return s;


### PR DESCRIPTION
CStringArray test("abc\0", 4);
test.count() is 2
test[0] = "abc"
test[1] = (null) - should be ""