### PR TITLE
Update `HttpResponse` stream sending for more consistent behaviour

### DIFF
--- a/Sming/Core/Network/Http/HttpResponse.h
+++ b/Sming/Core/Network/Http/HttpResponse.h
@@ -17,8 +17,6 @@
 #include "HttpHeaders.h"
 #include "FileSystem.h"
 
-class TemplateStream;
-
 class HttpResponse
 {
 public:
@@ -75,14 +73,25 @@ public:
 	 * @param allowGzipFileCheck If true, check file extension to see if content commpressed
 	 * @retval bool
 	 */
-	bool sendFile(String fileName, bool allowGzipFileCheck = true);
+	bool sendFile(const String& fileName, bool allowGzipFileCheck = true);
 
 	/**
 	 * @brief Parse and send template file
 	 * @param newTemplateInstance
 	 * @retval bool
+	 * @deprecated Use `sendNamedStream()` instead
 	 */
-	bool sendTemplate(TemplateStream* newTemplateInstance);
+	bool sendTemplate(IDataSourceStream* newTemplateInstance) SMING_DEPRECATED
+	{
+		return sendNamedStream(newTemplateInstance);
+	}
+
+	/**
+	 * @brief Parse and send stream, using the name to determine the content type
+	 * @param newDataStream If not set already, the contentType will be obtained from the name of this stream
+	 * @retval bool
+	 */
+	bool sendNamedStream(IDataSourceStream* newDataStream);
 
 	/** @brief Send data from the given stream object
 	 *  @param newDataStream

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -121,7 +121,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 {
 	TemplateFileStream* tmpl = new TemplateFileStream("index.html");
 	auto& vars = tmpl->variables();
-	response.sendTemplate(tmpl); // will be automatically deleted
+	response.sendNamedStream(tmpl); // will be automatically deleted
 }
 
 void onFile(HttpRequest& request, HttpResponse& response)

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -23,7 +23,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 	TemplateFileStream* tmpl = new TemplateFileStream("index.html");
 	auto& vars = tmpl->variables();
 	//vars["counter"] = String(counter);
-	response.sendTemplate(tmpl); // this template object will be deleted automatically
+	response.sendNamedStream(tmpl); // this template object will be deleted automatically
 }
 
 void onFile(HttpRequest& request, HttpResponse& response)

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -19,7 +19,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 	TemplateFileStream* tmpl = new TemplateFileStream("index.html");
 	auto& vars = tmpl->variables();
 	//vars["counter"] = String(counter);
-	response.sendTemplate(tmpl); // this template object will be deleted automatically
+	response.sendNamedStream(tmpl); // this template object will be deleted automatically
 }
 
 void onFile(HttpRequest& request, HttpResponse& response)

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -23,7 +23,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 	//vars["ledstate"] = (*portOutputRegister(digitalPinToPort(LED_PIN)) & digitalPinToBitMask(LED_PIN)) ? "checked" : "";
 	vars["IP"] = WifiStation.getIP().toString();
 	vars["MAC"] = WifiStation.getMAC();
-	response.sendTemplate(tmpl); // this template object will be deleted automatically
+	response.sendNamedStream(tmpl); // this template object will be deleted automatically
 }
 
 void onHello(HttpRequest& request, HttpResponse& response)

--- a/samples/HttpServer_ConfigNetwork/app/application.cpp
+++ b/samples/HttpServer_ConfigNetwork/app/application.cpp
@@ -19,7 +19,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 {
 	TemplateFileStream* tmpl = new TemplateFileStream("index.html");
 	auto& vars = tmpl->variables();
-	response.sendTemplate(tmpl); // will be automatically deleted
+	response.sendNamedStream(tmpl); // will be automatically deleted
 }
 
 int onIpConfig(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
@@ -61,7 +61,7 @@ int onIpConfig(HttpServerConnection& connection, HttpRequest& request, HttpRespo
 		vars["gateway"] = "192.168.1.1";
 	}
 
-	response.sendTemplate(tmpl); // will be automatically deleted
+	response.sendNamedStream(tmpl); // will be automatically deleted
 
 	return 0;
 }

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -18,7 +18,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 	auto tmpl = new TemplateFileStream(F("index.html"));
 	auto& vars = tmpl->variables();
 	//vars["counter"] = String(counter);
-	response.sendTemplate(tmpl); // this template object will be deleted automatically
+	response.sendNamedStream(tmpl); // this template object will be deleted automatically
 }
 
 void onFile(HttpRequest& request, HttpResponse& response)

--- a/samples/MeteoControl/app/webserver.cpp
+++ b/samples/MeteoControl/app/webserver.cpp
@@ -12,7 +12,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 	auto& vars = tmpl->variables();
 	vars["T"] = StrT;
 	vars["RH"] = StrRH;
-	response.sendTemplate(tmpl);
+	response.sendNamedStream(tmpl);
 }
 
 void onConfiguration(HttpRequest& request, HttpResponse& response)
@@ -53,7 +53,7 @@ void onConfiguration(HttpRequest& request, HttpResponse& response)
 	vars["Trigger"] = String((int)cfg.Trigger);
 	vars["RMin"] = String(cfg.RangeMin, 2);
 	vars["RMax"] = String(cfg.RangeMax, 2);
-	response.sendTemplate(tmpl);
+	response.sendNamedStream(tmpl);
 }
 
 void onFile(HttpRequest& request, HttpResponse& response)
@@ -75,7 +75,7 @@ void onApiDoc(HttpRequest& request, HttpResponse& response)
 	TemplateFileStream* tmpl = new TemplateFileStream("api.html");
 	auto& vars = tmpl->variables();
 	vars["IP"] = (WifiStation.isConnected() ? WifiStation.getIP() : WifiAccessPoint.getIP()).toString();
-	response.sendTemplate(tmpl);
+	response.sendNamedStream(tmpl);
 }
 
 void onApiSensors(HttpRequest& request, HttpResponse& response)

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -59,7 +59,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 	TemplateFileStream* tmpl = new TemplateFileStream("index.html");
 	auto& vars = tmpl->variables();
 	//vars["counter"] = String(counter);
-	response.sendTemplate(tmpl); // this template object will be deleted automatically
+	response.sendNamedStream(tmpl); // this template object will be deleted automatically
 }
 
 void onFile(HttpRequest& request, HttpResponse& response)


### PR DESCRIPTION
* Add `sendNamedStream()` for use when content type may be determined from name, and use for `sendFile()` and `sendTemplate()`
* Deprecated `sendTemplate()` in favour of `sendNamedStream()`
* Set 'not found' error code in `sendDataStream` for invalid stream
* Add chunked encoding check to `sendDataStream()` so its consistently applied if stream size unspecified