### PR TITLE
Add rboot config check at startup, reset to default if invalid

### DIFF
--- a/Sming/Arch/Host/Components/esp_hal/include/esp_attr.h
+++ b/Sming/Arch/Host/Components/esp_hal/include/esp_attr.h
@@ -12,12 +12,6 @@ extern "C" {
 
 #define GDB_IRAM_ATTR
 
-// Weak attributes don't work for PE
-#ifdef __WIN32
-#undef WEAK_ATTR
-#define WEAK_ATTR
-#endif
-
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
@@ -30,10 +30,12 @@ static const char* flashFileName = "flash.bin";
 #define CHECK_ALIGNMENT(_x) assert(((uint32_t)(_x)&0x00000003) == 0)
 #define CHECK_RANGE(_addr, _size) assert((_addr) + (_size) <= flashFileSize);
 
-bool host_flashmem_init(const FlashmemConfig& config)
+bool host_flashmem_init(FlashmemConfig& config)
 {
 	if(config.filename != NULL) {
 		flashFileName = config.filename;
+	} else {
+		config.filename = flashFileName;
 	}
 	flashFile = open(flashFileName, O_CREAT | O_RDWR | O_BINARY, 0644);
 	if(flashFile < 0) {
@@ -64,6 +66,7 @@ bool host_flashmem_init(const FlashmemConfig& config)
 	}
 
 	flashFileSize = res;
+	config.createSize = flashFileSize;
 
 	return true;
 }

--- a/Sming/Arch/Host/Components/spi_flash/flashmem.h
+++ b/Sming/Arch/Host/Components/spi_flash/flashmem.h
@@ -33,7 +33,8 @@ struct FlashmemConfig {
  * @retval bool true if backing file was opened successfully
  * @note Specify nullptr, 0 to use default values
  * All flash operations will be restricted to size of initial backing file
+ * On success, config will be updated with actual values in use
  */
-bool host_flashmem_init(const FlashmemConfig& config);
+bool host_flashmem_init(FlashmemConfig& config);
 
 void host_flashmem_cleanup();

--- a/Sming/System/include/sming_attr.h
+++ b/Sming/System/include/sming_attr.h
@@ -10,17 +10,22 @@
 
 #pragma once
 
-#define __packed        __attribute__((packed))
-#define __forceinline	__attribute__((always_inline)) inline
-#define WEAK_ATTR		__attribute((weak))
+#define __packed __attribute__((packed))
+#define __forceinline __attribute__((always_inline)) inline
+
+// Weak attributes don't work for PE
+#ifdef __WIN32
+#define WEAK_ATTR
+#else
+#define WEAK_ATTR __attribute((weak))
+#endif
 
 /*
  * Use this definition in the cases where a function or a variable is meant to be possibly unused. GCC will not produce a warning for it.
  */
-#define SMING_UNUSED  __attribute__((unused))
+#define SMING_UNUSED __attribute__((unused))
 
 /*
  * Flags a compiler warning when Sming framework methods, functions or types are changed
  */
 #define SMING_DEPRECATED __attribute__((deprecated))
-


### PR DESCRIPTION
This job is normally done by the rboot bootloader.
Also move WEAK_ATTR definition into sming_attr.h