### PR TITLE
Fix Esp8266 partitions, add 8/16Mbyte device support

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/README.rst
+++ b/Sming/Arch/Esp8266/Components/esp8266/README.rst
@@ -7,6 +7,11 @@ Contains startup code, crash handling and additional Esp8266-specific
 support code. Sming may be built using a pre-installed SDK, or by using
 the current version 3 SDK as a submodule.
 
+.. attention::
+
+   At time of writing, SDK 3 does not appear to support use of devices with 256K or 512K memory,
+   such as the ESP-01. For now, please use the default SDK 1.5.4 or SDK 2.0.0.
+
 .. envvar:: SDK_BASE
 
    Points to the location of the Espressif Non-OS SDK. To use the Espressif version 3 SDK, you need

--- a/Sming/Arch/Esp8266/Components/esp8266/startup.cpp
+++ b/Sming/Arch/Esp8266/Components/esp8266/startup.cpp
@@ -56,7 +56,11 @@ extern "C" uint32 ICACHE_FLASH_ATTR  WEAK_ATTR user_rf_cal_sector_set(void)
     enum flash_size_map size_map = system_get_flash_size_map();
     uint32 rf_cal_sec = 0;
 
-    switch (size_map) {
+    switch (int(size_map)) {
+        case FLASH_SIZE_2M:
+            rf_cal_sec = 64 - 5;
+            break;
+
         case FLASH_SIZE_4M_MAP_256_256:
             rf_cal_sec = 128 - 5;
             break;
@@ -73,6 +77,14 @@ extern "C" uint32 ICACHE_FLASH_ATTR  WEAK_ATTR user_rf_cal_sector_set(void)
         case FLASH_SIZE_32M_MAP_512_512:
         case FLASH_SIZE_32M_MAP_1024_1024:
             rf_cal_sec = 1024 - 5;
+            break;
+
+        case 8: // FLASH_SIZE_64M_MAP_1024_1024
+            rf_cal_sec = 2048 - 5;
+            break;
+
+        case 9: // FLASH_SIZE_128M_MAP_1024_1024
+            rf_cal_sec = 4096 - 5;
             break;
 
         default:
@@ -106,7 +118,7 @@ extern "C" void ICACHE_FLASH_ATTR WEAK_ATTR user_pre_init(void)
 	static const partition_item_t partitions[] = {
 			PARTITION_ITEM(SYSTEM_PARTITION_BOOTLOADER,			0,					1),
 			PARTITION_ITEM(SYSTEM_PARTITION_RBOOT_CONFIG,		1,					1),
-			PARTITION_ITEM(SYSTEM_PARTITION_PROGRAM,			2,					MAX_PROGRAM_SECTORS - 2),
+			PARTITION_ITEM(SYSTEM_PARTITION_PROGRAM,			2,					std::min(MAX_PROGRAM_SECTORS, rfCalSector) - 2),
 			PARTITION_ITEM(SYSTEM_PARTITION_RF_CAL,				rfCalSector,		1),
 			PARTITION_ITEM(SYSTEM_PARTITION_PHY_DATA,			rfCalSector + 1,	1),
 			PARTITION_ITEM(SYSTEM_PARTITION_SYSTEM_PARAMETER,	rfCalSector + 2,	3),

--- a/Sming/Arch/Esp8266/Components/esptool/component.mk
+++ b/Sming/Arch/Esp8266/Components/esptool/component.mk
@@ -31,29 +31,15 @@ else
 	flashimageoptions	+= -fm qio
 endif
 
-ifeq ($(SPI_SIZE), 256K)
-	flashimageoptions	+= -fs 256KB
-else ifeq ($(SPI_SIZE), 1M)
-	flashimageoptions	+= -fs 1MB
-	INIT_BIN_ADDR		:= 0x0fc000
-	BLANK_BIN_ADDR		:= 0x0fe000
-else ifeq ($(SPI_SIZE), 2M)
-	flashimageoptions	+= -fs 2MB
-	INIT_BIN_ADDR		:= 0x1fc000
-	BLANK_BIN_ADDR		:= 0x1fe000
-else ifeq ($(SPI_SIZE), 4M)
-	flashimageoptions	+= -fs 4MB
-	INIT_BIN_ADDR		:= 0x3fc000
-	BLANK_BIN_ADDR		:= 0x3fe000
-else
-	flashimageoptions	+= -fs 512KB
-	INIT_BIN_ADDR		:= 0x07c000
-	BLANK_BIN_ADDR		:= 0x04b000
-endif
-
-#
-FLASH_INIT_CHUNKS		+= $(INIT_BIN_ADDR)=$(SDK_BASE)/bin/esp_init_data_default.bin
-FLASH_INIT_CHUNKS		+= $(BLANK_BIN_ADDR)=$(SDK_BASE)/bin/blank.bin
+# Calculate parameters from SPI_SIZE value (esptool will check validity)
+flashimageoptions	+= -fs $(SPI_SIZE)B
+FLASH_SIZE			:= $(subst M,*1024K,$(SPI_SIZE))
+FLASH_SIZE			:= $(subst K,*1024,$(FLASH_SIZE))
+FlashOffset			= $$(($(FLASH_SIZE)-$1))
+FLASH_INIT_CHUNKS += \
+	$(call FlashOffset,0x5000)=$(SDK_BASE)/bin/blank.bin \
+	$(call FlashOffset,0x4000)=$(SDK_BASE)/bin/esp_init_data_default.bin \
+	$(call FlashOffset,0x2000)=$(SDK_BASE)/bin/blank.bin
 
 # Default COM port and speed used for flashing
 CACHE_VARS				+= COM_PORT_ESPTOOL COM_SPEED_ESPTOOL

--- a/Sming/Components/rboot/.patches/esptool2.patch
+++ b/Sming/Components/rboot/.patches/esptool2.patch
@@ -12,7 +12,7 @@ index 2ede742..ce648fb 100644
  typedef uint32_t Elf32_Off;  // File offset
  typedef uint16_t Elf32_Half;
 diff --git a/esptool2.c b/esptool2.c
-index 2342b3b..549fa2d 100644
+index 2342b3b..16ccd61 100644
 --- a/esptool2.c
 +++ b/esptool2.c
 @@ -33,16 +33,16 @@
@@ -39,6 +39,26 @@ index 2342b3b..549fa2d 100644
  } Image_Header;
  
  static const char PADDING[IMAGE_PADDING] = {0};
+@@ -444,6 +444,10 @@ int main(int argc, char *argv[]) {
+ 			size = 5;
+ 		} else if (!strcmp(argv[i], "-4096")) {
+ 			size = 4;
++		} else if (!strcmp(argv[i], "-8192")) {
++			size = 8;
++		} else if (!strcmp(argv[i], "-16384")) {
++			size = 9;
+ 		} else if (!strcmp(argv[i], "-20")) {
+ 			clock = 2;
+ 		} else if (!strcmp(argv[i], "-26.7")) {
+@@ -498,7 +502,7 @@ int main(int argc, char *argv[]) {
+ 		print("          -boot1 = built for bootloader v1.1\r\n");
+ 		print("          -boot2 = built for bootloader v1.2+ (use for rBoot roms)\r\n");
+ 		print("          (elf file must have been linked appropriately for chosen option)\r\n");
+-		print("        spi size (kb): -256 -512 -1024 -2048 -4096 (default -512)\r\n");
++		print("        spi size (kb): -256 -512 -1024 -2048 -4096 -8192 -16384 (default -512)\r\n");
+ 		print("        spi mode: -qio -qout -dio -dout (default -qio)\r\n");
+ 		print("        spi speed: -20 -26.7 -40 -80 (default -40)\r\n");
+ 		print("        include irom in checksum: -iromchksum (also needs enabling in rBoot)\r\n");
 diff --git a/esptool2.h b/esptool2.h
 index 53da0ee..c4f8d0b 100644
 --- a/esptool2.h

--- a/Sming/Components/rboot/.patches/rboot.patch
+++ b/Sming/Components/rboot/.patches/rboot.patch
@@ -1,5 +1,5 @@
 diff --git a/Makefile b/Makefile
-index 0b43474..4c1913e 100644
+index 0b43474..7cb71f4 100644
 --- a/Makefile
 +++ b/Makefile
 @@ -58,6 +58,16 @@ endif
@@ -19,6 +19,18 @@ index 0b43474..4c1913e 100644
  ifneq ($(RBOOT_EXTRA_INCDIR),)
  	CFLAGS += $(addprefix -I,$(RBOOT_EXTRA_INCDIR))
  endif
+@@ -75,6 +85,10 @@ else ifeq ($(SPI_SIZE), 2Mb)
+ 	E2_OPTS += -2048b
+ else ifeq ($(SPI_SIZE), 4M)
+ 	E2_OPTS += -4096
++else ifeq ($(SPI_SIZE), 8M)
++	E2_OPTS += -8192
++else ifeq ($(SPI_SIZE), 16M)
++	E2_OPTS += -16384
+ endif
+ ifeq ($(SPI_MODE), qio)
+ 	E2_OPTS += -qio
+
 diff --git a/rboot.c b/rboot.c
 index d622f97..00ccaeb 100644
 --- a/rboot.c


### PR DESCRIPTION
NOTE: SDK3 will not accept values for 256K or 512K although the values correspond
with those given in the 'getting started' guide.

* Update esptool config so `flashinit` offsets are calculated from given SPI_SIZE.
* Patch rboot makefile/esptool2 to support for 8M/16M (rboot itself already does)