### PR TITLE
Changes to the error handling in HttpServer 

### DIFF
--- a/Sming/Components/MultipartParser/MultipartParser.h
+++ b/Sming/Components/MultipartParser/MultipartParser.h
@@ -23,7 +23,7 @@ public:
 	explicit MultipartParser(HttpRequest* request);
 	~MultipartParser();
 
-	void execute(const char* at, size_t length);
+	size_t execute(const char* at, size_t length);
 
 	static int readHeaderName(multipart_parser_t* p, const char* at, size_t length);
 	static int readHeaderValue(multipart_parser_t* p, const char* at, size_t length);
@@ -44,4 +44,4 @@ private:
 };
 
 
-void formMultipartParser(HttpRequest& request, const char* at, int length);
+size_t formMultipartParser(HttpRequest& request, const char* at, int length);

--- a/Sming/Core/Data/Stream/RbootOutputStream.cpp
+++ b/Sming/Core/Data/Stream/RbootOutputStream.cpp
@@ -52,5 +52,9 @@ size_t RbootOutputStream::write(const uint8_t* data, size_t size)
 
 bool RbootOutputStream::close()
 {
-	return rboot_write_end(&rBootWriteStatus);
+	if(initialized) {
+		return rboot_write_end(&rBootWriteStatus);
+	}
+
+	return true;
 }

--- a/Sming/Core/Network/Http/HttpBodyParser.h
+++ b/Sming/Core/Network/Http/HttpBodyParser.h
@@ -26,8 +26,9 @@ const int PARSE_DATAEND = -2;   ///< End of incoming data
  * @param length Negative lengths have special meanings
  * @see `PARSE_DATASTART`
  * @see `PARSE_DATAEND`
+ * @return parsed bytes
  */
-typedef Delegate<void(HttpRequest& request, const char* at, int length)> HttpBodyParserDelegate;
+typedef Delegate<size_t(HttpRequest& request, const char* at, int length)> HttpBodyParserDelegate;
 
 /**
  * @brief Maps body parsers to a specific content type
@@ -38,11 +39,11 @@ typedef HashMap<String, HttpBodyParserDelegate> BodyParsers;
  * @brief Parses application/x-www-form-urlencoded body data
  * @see `HttpBodyParserDelegate`
  */
-void formUrlParser(HttpRequest& request, const char* at, int length);
+size_t formUrlParser(HttpRequest& request, const char* at, int length);
 
 /**
  * @brief Stores the complete body into memory
  * @see `HttpBodyParserDelegate`
  * @note The content later can be retrieved by calling request.getBody()
  */
-void bodyToStringParser(HttpRequest& request, const char* at, int length);
+size_t bodyToStringParser(HttpRequest& request, const char* at, int length);

--- a/Sming/Core/Network/Http/HttpClientConnection.cpp
+++ b/Sming/Core/Network/Http/HttpClientConnection.cpp
@@ -134,8 +134,8 @@ int HttpClientConnection::onMessageComplete(http_parser* parser)
 	// we are finished with this request
 	int hasError = 0;
 	if(incomingRequest->requestCompletedDelegate) {
-		bool success = (HTTP_PARSER_ERRNO(parser) == HPE_OK) &&		   // false when the parsing has failed
-					   (response.code >= 200 && response.code <= 399); // false when the HTTP status code is not ok
+		bool success = (HTTP_PARSER_ERRNO(parser) == HPE_OK) && // false when the parsing has failed
+					   (response.isSuccess());					// false when the HTTP status code is not ok
 		hasError = incomingRequest->requestCompletedDelegate(*this, success);
 	}
 

--- a/Sming/Core/Network/Http/HttpConnection.cpp
+++ b/Sming/Core/Network/Http/HttpConnection.cpp
@@ -174,6 +174,12 @@ void HttpConnection::onHttpError(http_errno error)
 
 bool HttpConnection::onTcpReceive(TcpClient& client, char* data, int size)
 {
+	if(HTTP_PARSER_ERRNO(&parser) != HPE_OK) {
+		setTimeOut(1);
+		// if the parser is in error state then just ignore the incoming data.
+		return false;
+	}
+
 	int parsedBytes = http_parser_execute(&parser, &parserSettings, data, size);
 	if(HTTP_PARSER_ERRNO(&parser) != HPE_OK) {
 		// we ran into trouble - abort the connection

--- a/Sming/Core/Network/Http/HttpResponse.h
+++ b/Sming/Core/Network/Http/HttpResponse.h
@@ -135,6 +135,11 @@ public:
 	 */
 	void freeStreams();
 
+	bool isSuccess()
+	{
+		return (code >= HTTP_STATUS_OK && code <= 399);
+	}
+
 private:
 	void setStream(IDataSourceStream* stream);
 

--- a/Sming/Core/Network/Http/HttpServerConnection.h
+++ b/Sming/Core/Network/Http/HttpServerConnection.h
@@ -50,6 +50,10 @@ public:
 		if(this->resource != nullptr) {
 			this->resource->shutdown(*this);
 		}
+
+		if(bodyParser) {
+			bodyParser(request, nullptr, PARSE_DATAEND);
+		}
 	}
 
 	void setResourceTree(HttpResourceTree* resourceTree)

--- a/samples/HttpServer_FirmwareUpload/app/application.cpp
+++ b/samples/HttpServer_FirmwareUpload/app/application.cpp
@@ -37,6 +37,11 @@ void onFile(HttpRequest& request, HttpResponse& response)
 
 int onUpload(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
 {
+	if(!response.isSuccess()) {
+		debug_e("Request failed.");
+		return -1;
+	}
+
 	ReadWriteStream* file = request.files["firmware"];
 	if(file == nullptr) {
 		debug_e("Something went wrong with the file upload");


### PR DESCRIPTION
- The body parsers now return the number of parsed bytes
- This allows the server to trigger error as early as possible
- If there is an error `onMessageComplete` callback will still be called. In order to check if we are in error state `response.isSuccess()` can be used.
- On error `onMessageComplete` can provide custom response or return non-zero value to trigger the default error page.