### PR TITLE
Define `-fno-threadsafe-statics` for Esp8266

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/esp_cplusplus.cpp
+++ b/Sming/Arch/Esp8266/Components/esp8266/esp_cplusplus.cpp
@@ -53,17 +53,6 @@ extern "C" void __cxa_deleted_virtual(void)
 	abort();
 }
 
-
-extern "C" void __cxa_guard_acquire(uint64_t* guard_object)
-{
-}
-extern "C" void __cxa_guard_release(uint64_t* guard_object)
-{
-}
-extern "C" void __cxa_guard_abort(uint64_t* guard_object)
-{
-}
-
 namespace std {
     void WEAK_ATTR __throw_bad_function_call()
     {

--- a/Sming/Arch/Esp8266/build.mk
+++ b/Sming/Arch/Esp8266/build.mk
@@ -5,7 +5,7 @@
 ##############
 
 CFLAGS				+= -DARCH_ESP8266
-CXXFLAGS			+= -fno-rtti -fno-exceptions 
+CXXFLAGS			+= -fno-rtti -fno-exceptions -fno-threadsafe-statics
 
 ## ESP_HOME sets the path where ESP tools and SDK are located.
 DEBUG_VARS			+= ESP_HOME


### PR DESCRIPTION
Static variables are initialised on first use and may result in additional calls to `__cxa_guard_acquire()` and `__cxa_guard_release()`.
If statics are contained within an interrupt service routine it may cause it to fail as the guard functions aren't in IRAM.

This isn't necessary and can be disabled using the above compiler flag.