### PR TITLE
Add CycleCounter class

### DIFF
--- a/Sming/Services/Profiling/CycleCounter.h
+++ b/Sming/Services/Profiling/CycleCounter.h
@@ -1,0 +1,62 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * CycleCounter.h - Class to measure elapesd time periods using CPU cycle counter.
+ *
+ * Intended purpose is to evaluate code performance and possibly for _very_ short
+ * time interval requirements.
+ *
+ * Note that the CPU frequency may not be constant. If you require accurate time
+ * period evaluation see `ElapseTimer`.
+ *
+ ****/
+#pragma once
+
+#include <stdint.h>
+#include <sming_attr.h>
+
+#ifdef ARCH_HOST
+#include <x86intrin.h>
+#endif
+
+/**
+ * @brief Class for counting CPU cycles
+ */
+class CycleCounter
+{
+public:
+	__forceinline CycleCounter()
+	{
+		start();
+	}
+
+	/** @brief Get the current CPU cycle count */
+	static uint32_t __forceinline count()
+	{
+#ifdef ARCH_HOST
+		return __rdtsc();
+#else
+		volatile uint32_t ccount;
+		__asm__ volatile("rsr %0, ccount" : "=r"(ccount));
+		return ccount;
+#endif
+	}
+
+	/** @brief Reset the start position to the current cycle count */
+	void __forceinline start()
+	{
+		startCount = count();
+	}
+
+	/** @brief Get elapsed cycle count since start() was last called */
+	uint32_t __forceinline elapsed()
+	{
+		return count() - startCount;
+	}
+
+private:
+	uint32_t startCount;
+};

--- a/samples/Basic_Delegates/app/speed.cpp
+++ b/samples/Basic_Delegates/app/speed.cpp
@@ -3,7 +3,7 @@
  */
 
 #include <SmingCore.h>
-#include <Services/Profiling/ElapseTimer.h>
+#include <Services/Profiling/CycleCounter.h>
 #include "callbacks.h"
 
 #ifdef ARCH_HOST
@@ -15,17 +15,6 @@ const unsigned ITERATIONS = 100000;
 typedef Delegate<void(int)> TestDelegate;
 typedef void (*TestCallback)(int);
 
-static uint32_t __forceinline getCycleCount()
-{
-#ifdef ARCH_ESP8266
-	uint32_t ccount;
-	__asm__ __volatile__("rsr %0,ccount" : "=a"(ccount));
-	return ccount;
-#else
-	return NOW();
-#endif
-}
-
 static void printTime(const char* name, unsigned elapsed)
 {
 	Serial.printf("%s: %u\r\n", name, elapsed / ITERATIONS);
@@ -33,21 +22,21 @@ static void printTime(const char* name, unsigned elapsed)
 
 static void __attribute__((noinline)) evaluateCallback(const char* name, TestCallback callback, int testParam)
 {
-	unsigned startTicks = getCycleCount();
+	CycleCounter counter;
 	for(unsigned i = 0; i < ITERATIONS; ++i) {
 		callback(testParam);
 	}
-	unsigned elapsed = getCycleCount() - startTicks;
+	unsigned elapsed = counter.elapsed();
 	printTime(name, elapsed);
 }
 
 static void __attribute__((noinline)) evaluateDelegate(const char* name, TestDelegate delegate, int testParam)
 {
-	unsigned startTicks = getCycleCount();
+	CycleCounter counter;
 	for(unsigned i = 0; i < ITERATIONS; ++i) {
 		delegate(testParam);
 	}
-	unsigned elapsed = getCycleCount() - startTicks;
+	unsigned elapsed = counter.elapsed();
 	printTime(name, elapsed);
 }
 


### PR DESCRIPTION
Provides a systematic and architecture-independent way to obtain and manage CPU cycle counting.