### PR TITLE
Improve ElapseTimer

### DIFF
--- a/Sming/Services/Profiling/ElapseTimer.h
+++ b/Sming/Services/Profiling/ElapseTimer.h
@@ -4,34 +4,77 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * Simple class for elapse timing
+ * ElapseTimer.h - Class to measure elapsed time periods by polling hardware timer.
  *
  ****/
 #pragma once
 
 #include "HardwareTimer.h"
 
-/*
- * Microsecond elapse timer.
+/**
+ * @brief Microsecond elapse timer to efficiently measure intervals
+ * @note Maintains time using the hardware 'tick' counter values and only performs
+ * conversion to microseconds when necessary.
+ * The class keeps a note of a 'start' time used to determine the `elapsed()` return value.
+ * An 'interval' value may be given is specified, then the `expired()` method returns true.
  */
 class ElapseTimer
 {
 public:
-	ElapseTimer()
+	/**
+	 * @brief Create new ElapseTimer with optional expiry time
+	 * @param interval Microseconds to expiry after last call to start()
+	 * @note Conversion between microseconds and ticks is relatively expensive, so pass 0 if not required.
+	 */
+	__forceinline ElapseTimer(uint32_t interval = 0)
 	{
+		setInterval(interval);
 		start();
 	}
 
-	void start()
+	/**
+	 * @brief Set expiry interval
+	 * @param interval Microseconds to expiry after last call to start()
+	 */
+	void __forceinline setInterval(uint32_t interval)
 	{
-		startTicks = NOW();
+		this->interval = (interval == 0) ? 0 : usToTimerTicks(interval);
 	}
 
-	uint32_t elapsed()
+	/**
+	 * @brief Get the current tick value
+	 */
+	uint32_t __forceinline ticks()
 	{
-		return timerTicksToUs(NOW() - startTicks);
+		return NOW();
+	}
+
+	/**
+	 * @brief re-start the timer
+	 */
+	void __forceinline start()
+	{
+		startTicks = ticks();
+	}
+
+	/**
+	 * @brief Get elapsed time in microseconds since start() was last called
+	 */
+	uint32_t __forceinline elapsed()
+	{
+		return timerTicksToUs(ticks() - startTicks);
+	}
+
+	/**
+	 * @brief Determine if timer has expired
+	 * @retval bool
+	 */
+	bool __forceinline expired()
+	{
+		return (ticks() - startTicks) >= interval;
 	}
 
 private:
 	uint32_t startTicks;
+	uint32_t interval;
 };


### PR DESCRIPTION
* Fix time conversion, overflows in 14 mins (was about 0.5s)
* Optimise calculations
* Add optional `interval` parameter plus `expired()` method for efficent polling