### PR TITLE
WiFi improvements

### DIFF
--- a/Sming/Arch/Esp8266/Platform/AccessPointImpl.cpp
+++ b/Sming/Arch/Esp8266/Platform/AccessPointImpl.cpp
@@ -143,7 +143,7 @@ bool AccessPointImpl::setIP(IPAddress address)
 	return true;
 }
 
-MACAddress AccessPointImpl::getMacAddr() const
+MACAddress AccessPointImpl::getMacAddress() const
 {
 	MACAddress addr;
 	if(wifi_get_macaddr(SOFTAP_IF, &addr[0])) {

--- a/Sming/Arch/Esp8266/Platform/AccessPointImpl.cpp
+++ b/Sming/Arch/Esp8266/Platform/AccessPointImpl.cpp
@@ -97,35 +97,35 @@ bool AccessPointImpl::config(const String& ssid, String password, AUTH_MODE mode
 	return true;
 }
 
-IPAddress AccessPointImpl::getIP() const
+IpAddress AccessPointImpl::getIP() const
 {
 	struct ip_info info = {0};
 	wifi_get_ip_info(SOFTAP_IF, &info);
 	return info.ip;
 }
 
-IPAddress AccessPointImpl::getNetworkBroadcast() const
+IpAddress AccessPointImpl::getNetworkBroadcast() const
 {
 	struct ip_info info = {0};
 	wifi_get_ip_info(SOFTAP_IF, &info);
 	return (info.ip.addr | ~info.netmask.addr);
 }
 
-IPAddress AccessPointImpl::getNetworkMask() const
+IpAddress AccessPointImpl::getNetworkMask() const
 {
 	struct ip_info info = {0};
 	wifi_get_ip_info(SOFTAP_IF, &info);
 	return info.netmask;
 }
 
-IPAddress AccessPointImpl::getNetworkGateway() const
+IpAddress AccessPointImpl::getNetworkGateway() const
 {
 	struct ip_info info = {0};
 	wifi_get_ip_info(SOFTAP_IF, &info);
 	return info.gw;
 }
 
-bool AccessPointImpl::setIP(IPAddress address)
+bool AccessPointImpl::setIP(IpAddress address)
 {
 	if(System.isReady()) {
 		debugf("IP can be changed only in init() method");
@@ -143,9 +143,9 @@ bool AccessPointImpl::setIP(IPAddress address)
 	return true;
 }
 
-MACAddress AccessPointImpl::getMacAddress() const
+MacAddress AccessPointImpl::getMacAddress() const
 {
-	MACAddress addr;
+	MacAddress addr;
 	if(wifi_get_macaddr(SOFTAP_IF, &addr[0])) {
 		return addr;
 	} else {

--- a/Sming/Arch/Esp8266/Platform/AccessPointImpl.h
+++ b/Sming/Arch/Esp8266/Platform/AccessPointImpl.h
@@ -25,12 +25,12 @@ public:
 	bool isEnabled() const override;
 	bool config(const String& ssid, String password, AUTH_MODE mode, bool hidden, int channel,
 				int beaconInterval) override;
-	IPAddress getIP() const override;
-	bool setIP(IPAddress address) override;
-	MACAddress getMacAddress() const override;
-	IPAddress getNetworkMask() const override;
-	IPAddress getNetworkGateway() const override;
-	IPAddress getNetworkBroadcast() const override;
+	IpAddress getIP() const override;
+	bool setIP(IpAddress address) override;
+	MacAddress getMacAddress() const override;
+	IpAddress getNetworkMask() const override;
+	IpAddress getNetworkGateway() const override;
+	IpAddress getNetworkBroadcast() const override;
 	String getSSID() const override;
 	String getPassword() const override;
 

--- a/Sming/Arch/Esp8266/Platform/AccessPointImpl.h
+++ b/Sming/Arch/Esp8266/Platform/AccessPointImpl.h
@@ -27,7 +27,7 @@ public:
 				int beaconInterval) override;
 	IPAddress getIP() const override;
 	bool setIP(IPAddress address) override;
-	MACAddress getMacAddr() const override;
+	MACAddress getMacAddress() const override;
 	IPAddress getNetworkMask() const override;
 	IPAddress getNetworkGateway() const override;
 	IPAddress getNetworkBroadcast() const override;

--- a/Sming/Arch/Esp8266/Platform/StationImpl.cpp
+++ b/Sming/Arch/Esp8266/Platform/StationImpl.cpp
@@ -162,7 +162,7 @@ IPAddress StationImpl::getIP() const
 	return info.ip;
 }
 
-MACAddress StationImpl::getMacAddr() const
+MACAddress StationImpl::getMacAddress() const
 {
 	MACAddress addr;
 	if(wifi_get_macaddr(STATION_IF, &addr[0])) {

--- a/Sming/Arch/Esp8266/Platform/StationImpl.cpp
+++ b/Sming/Arch/Esp8266/Platform/StationImpl.cpp
@@ -155,16 +155,16 @@ String StationImpl::getHostname() const
 	return wifi_station_get_hostname();
 }
 
-IPAddress StationImpl::getIP() const
+IpAddress StationImpl::getIP() const
 {
 	struct ip_info info = {0};
 	wifi_get_ip_info(STATION_IF, &info);
 	return info.ip;
 }
 
-MACAddress StationImpl::getMacAddress() const
+MacAddress StationImpl::getMacAddress() const
 {
-	MACAddress addr;
+	MacAddress addr;
 	if(wifi_get_macaddr(STATION_IF, &addr[0])) {
 		return addr;
 	} else {
@@ -172,28 +172,28 @@ MACAddress StationImpl::getMacAddress() const
 	}
 }
 
-IPAddress StationImpl::getNetworkBroadcast() const
+IpAddress StationImpl::getNetworkBroadcast() const
 {
 	struct ip_info info = {0};
 	wifi_get_ip_info(STATION_IF, &info);
 	return (info.ip.addr | ~info.netmask.addr);
 }
 
-IPAddress StationImpl::getNetworkMask() const
+IpAddress StationImpl::getNetworkMask() const
 {
 	struct ip_info info = {0};
 	wifi_get_ip_info(STATION_IF, &info);
 	return info.netmask;
 }
 
-IPAddress StationImpl::getNetworkGateway() const
+IpAddress StationImpl::getNetworkGateway() const
 {
 	struct ip_info info = {0};
 	wifi_get_ip_info(STATION_IF, &info);
 	return info.gw;
 }
 
-bool StationImpl::setIP(IPAddress address, IPAddress netmask, IPAddress gateway)
+bool StationImpl::setIP(IpAddress address, IpAddress netmask, IpAddress gateway)
 {
 	if(System.isReady()) {
 		debugf("IP can be changed only in init() method");

--- a/Sming/Arch/Esp8266/Platform/StationImpl.h
+++ b/Sming/Arch/Esp8266/Platform/StationImpl.h
@@ -37,7 +37,7 @@ public:
 	void setHostname(const String& hostname) override;
 	String getHostname() const override;
 	IPAddress getIP() const override;
-	MACAddress getMacAddr() const override;
+	MACAddress getMacAddress() const override;
 	IPAddress getNetworkMask() const override;
 	IPAddress getNetworkGateway() const override;
 	IPAddress getNetworkBroadcast() const override;

--- a/Sming/Arch/Esp8266/Platform/StationImpl.h
+++ b/Sming/Arch/Esp8266/Platform/StationImpl.h
@@ -36,12 +36,12 @@ public:
 	void enableDHCP(bool enable) override;
 	void setHostname(const String& hostname) override;
 	String getHostname() const override;
-	IPAddress getIP() const override;
-	MACAddress getMacAddress() const override;
-	IPAddress getNetworkMask() const override;
-	IPAddress getNetworkGateway() const override;
-	IPAddress getNetworkBroadcast() const override;
-	bool setIP(IPAddress address, IPAddress netmask, IPAddress gateway) override;
+	IpAddress getIP() const override;
+	MacAddress getMacAddress() const override;
+	IpAddress getNetworkMask() const override;
+	IpAddress getNetworkGateway() const override;
+	IpAddress getNetworkBroadcast() const override;
+	bool setIP(IpAddress address, IpAddress netmask, IpAddress gateway) override;
 	String getSSID() const override;
 	String getPassword() const override;
 	int8_t getRssi() const override;

--- a/Sming/Arch/Host/Components/esp_wifi/component.mk
+++ b/Sming/Arch/Host/Components/esp_wifi/component.mk
@@ -1,3 +1,5 @@
+COMPONENT_LIBNAME	:=
+
 COMPONENT_DEPENDS	:= lwip
 
 # Options to add for configuring host network behaviour
@@ -5,13 +7,13 @@ CACHE_VARS				+= HOST_NETWORK_OPTIONS
 HOST_NETWORK_OPTIONS	?=
 CLI_TARGET_OPTIONS		+= $(HOST_NETWORK_OPTIONS)
 
-COMPONENT_TARGETS		:= esp-wifi-check
+App-build: esp-wifi-check
 
 .PHONY: esp-wifi-check
-$(COMPONENT_RULE)esp-wifi-check:
+esp-wifi-check:
 ifeq ($(ENABLE_WPS),1)
-	$(warning WPS not supported)
+	$(error WPS not supported)
 endif
 ifeq ($(ENABLE_SMART_CONFIG),1)
-	$(warning 'Smart Config' not supported)
+	$(error 'Smart Config' not supported)
 endif

--- a/Sming/Arch/Host/Platform/AccessPointImpl.cpp
+++ b/Sming/Arch/Host/Platform/AccessPointImpl.cpp
@@ -28,32 +28,32 @@ bool AccessPointImpl::config(const String& ssid, String password, WifiAuthMode m
 	return false;
 }
 
-IPAddress AccessPointImpl::getIP() const
+IpAddress AccessPointImpl::getIP() const
 {
 	return INADDR_NONE;
 }
 
-IPAddress AccessPointImpl::getNetworkBroadcast() const
+IpAddress AccessPointImpl::getNetworkBroadcast() const
 {
 	return INADDR_NONE;
 }
 
-IPAddress AccessPointImpl::getNetworkMask() const
+IpAddress AccessPointImpl::getNetworkMask() const
 {
 	return INADDR_NONE;
 }
 
-IPAddress AccessPointImpl::getNetworkGateway() const
+IpAddress AccessPointImpl::getNetworkGateway() const
 {
 	return INADDR_NONE;
 }
 
-bool AccessPointImpl::setIP(IPAddress address)
+bool AccessPointImpl::setIP(IpAddress address)
 {
 	return false;
 }
 
-MACAddress AccessPointImpl::getMacAddress() const
+MacAddress AccessPointImpl::getMacAddress() const
 {
 	return MACADDR_NONE;
 }

--- a/Sming/Arch/Host/Platform/AccessPointImpl.cpp
+++ b/Sming/Arch/Host/Platform/AccessPointImpl.cpp
@@ -53,7 +53,7 @@ bool AccessPointImpl::setIP(IPAddress address)
 	return false;
 }
 
-MACAddress AccessPointImpl::getMacAddr() const
+MACAddress AccessPointImpl::getMacAddress() const
 {
 	return MACADDR_NONE;
 }

--- a/Sming/Arch/Host/Platform/AccessPointImpl.h
+++ b/Sming/Arch/Host/Platform/AccessPointImpl.h
@@ -19,12 +19,12 @@ public:
 	bool isEnabled() const override;
 	bool config(const String& ssid, String password, WifiAuthMode mode, bool hidden, int channel,
 				int beaconInterval) override;
-	IPAddress getIP() const override;
-	bool setIP(IPAddress address) override;
-	MACAddress getMacAddress() const override;
-	IPAddress getNetworkMask() const override;
-	IPAddress getNetworkGateway() const override;
-	IPAddress getNetworkBroadcast() const override;
+	IpAddress getIP() const override;
+	bool setIP(IpAddress address) override;
+	MacAddress getMacAddress() const override;
+	IpAddress getNetworkMask() const override;
+	IpAddress getNetworkGateway() const override;
+	IpAddress getNetworkBroadcast() const override;
 	String getSSID() const override;
 	String getPassword() const override;
 };

--- a/Sming/Arch/Host/Platform/AccessPointImpl.h
+++ b/Sming/Arch/Host/Platform/AccessPointImpl.h
@@ -21,7 +21,7 @@ public:
 				int beaconInterval) override;
 	IPAddress getIP() const override;
 	bool setIP(IPAddress address) override;
-	MACAddress getMacAddr() const override;
+	MACAddress getMacAddress() const override;
 	IPAddress getNetworkMask() const override;
 	IPAddress getNetworkGateway() const override;
 	IPAddress getNetworkBroadcast() const override;

--- a/Sming/Arch/Host/Platform/StationImpl.cpp
+++ b/Sming/Arch/Host/Platform/StationImpl.cpp
@@ -104,8 +104,8 @@ void StationImpl::initialise(netif* nif)
 	netif_create_ip6_linklocal_address(&nif, 1);
 #endif
 
+	connectionStatus = eSCS_Connecting;
 	if(ip4_addr_isany_val(nif->ip_addr)) {
-		connectionStatus = eSCS_Connecting;
 		dhcp_start(nif);
 	}
 }
@@ -113,15 +113,10 @@ void StationImpl::initialise(netif* nif)
 void StationImpl::statusCallback(netif* nif)
 {
 	if(nif == nullptr) {
-		if(currentAp != nullptr) {
-			wifiEventsImpl.stationDisconnected(*currentAp, WIFI_DISCONNECT_REASON_CONNECTION_FAIL);
-		}
 		return;
 	}
 
 	static uint32_t prev_flags;
-
-	hostmsg("NETIF 0x%08x -> 0x%08x", prev_flags, nif->flags);
 
 	uint32_t changed_flags = prev_flags ^ nif->flags;
 	prev_flags = nif->flags;
@@ -129,16 +124,26 @@ void StationImpl::statusCallback(netif* nif)
 	if(changed_flags & NETIF_FLAG_UP) {
 		assert(currentAp != nullptr);
 		if(nif->flags & NETIF_FLAG_UP) {
+			host_printf("IF_UP, AP: %s\n", currentAp->ssid);
 			wifiEventsImpl.stationConnected(*currentAp);
 		} else {
+			host_printf("IF_DOWN, AP: %s\n", currentAp->ssid);
 			wifiEventsImpl.stationDisconnected(*currentAp, WIFI_DISCONNECT_REASON_CONNECTION_FAIL);
 		}
 	}
 
 	if((nif->flags & NETIF_FLAG_UP) && !ip4_addr_isany_val(nif->ip_addr)) {
 		connectionStatus = eSCS_GotIP;
-		wifiEventsImpl.stationGotIp(nif->ip_addr, nif->netmask, nif->gw);
+		if(ipaddr != nif->ip_addr || netmask != nif->netmask || gateway != nif->gw) {
+			ipaddr = nif->ip_addr;
+			netmask = nif->netmask;
+			gateway = nif->gw;
+			host_printf("IP_CHANGE, ip: %s, netmask: %s, gateway: %s\n", ipaddr.toString().c_str(),
+						netmask.toString().c_str(), gateway.toString().c_str());
+			wifiEventsImpl.stationGotIp(ipaddr, netmask, gateway);
+		}
 	} else {
+		hostmsg("No IP address");
 		connectionStatus = eSCS_ConnectionFailed;
 	}
 }
@@ -238,9 +243,7 @@ String StationImpl::getHostname() const
 
 IPAddress StationImpl::getIP() const
 {
-	netif* nif = netif_default;
-
-	return nif ? nif->ip_addr.addr : IPADDR_NONE;
+	return ipaddr;
 }
 
 MACAddress StationImpl::getMacAddress() const
@@ -256,27 +259,17 @@ MACAddress StationImpl::getMacAddress() const
 
 IPAddress StationImpl::getNetworkBroadcast() const
 {
-	netif* nif = netif_default;
-
-	if(nif == nullptr) {
-		return INADDR_NONE;
-	} else {
-		return nif->ip_addr.addr | ~nif->netmask.addr;
-	}
+	return ipaddr | ~netmask;
 }
 
 IPAddress StationImpl::getNetworkMask() const
 {
-	netif* nif = netif_default;
-
-	return nif ? nif->netmask : INADDR_NONE;
+	return netmask;
 }
 
 IPAddress StationImpl::getNetworkGateway() const
 {
-	netif* nif = netif_default;
-
-	return nif ? nif->gw : INADDR_NONE;
+	return gateway;
 }
 
 bool StationImpl::setIP(IPAddress address, IPAddress netmask, IPAddress gateway)

--- a/Sming/Arch/Host/Platform/StationImpl.cpp
+++ b/Sming/Arch/Host/Platform/StationImpl.cpp
@@ -241,38 +241,38 @@ String StationImpl::getHostname() const
 	return hostName;
 }
 
-IPAddress StationImpl::getIP() const
+IpAddress StationImpl::getIP() const
 {
 	return ipaddr;
 }
 
-MACAddress StationImpl::getMacAddress() const
+MacAddress StationImpl::getMacAddress() const
 {
 	netif* nif = netif_default;
 
 	if(nif == nullptr) {
 		return MACADDR_NONE;
 	} else {
-		return MACAddress(nif->hwaddr);
+		return MacAddress(nif->hwaddr);
 	}
 }
 
-IPAddress StationImpl::getNetworkBroadcast() const
+IpAddress StationImpl::getNetworkBroadcast() const
 {
 	return ipaddr | ~netmask;
 }
 
-IPAddress StationImpl::getNetworkMask() const
+IpAddress StationImpl::getNetworkMask() const
 {
 	return netmask;
 }
 
-IPAddress StationImpl::getNetworkGateway() const
+IpAddress StationImpl::getNetworkGateway() const
 {
 	return gateway;
 }
 
-bool StationImpl::setIP(IPAddress address, IPAddress netmask, IPAddress gateway)
+bool StationImpl::setIP(IpAddress address, IpAddress netmask, IpAddress gateway)
 {
 	netif* nif = netif_default;
 

--- a/Sming/Arch/Host/Platform/StationImpl.cpp
+++ b/Sming/Arch/Host/Platform/StationImpl.cpp
@@ -243,7 +243,7 @@ IPAddress StationImpl::getIP() const
 	return nif ? nif->ip_addr.addr : IPADDR_NONE;
 }
 
-MACAddress StationImpl::getMacAddr() const
+MACAddress StationImpl::getMacAddress() const
 {
 	netif* nif = netif_default;
 

--- a/Sming/Arch/Host/Platform/StationImpl.cpp
+++ b/Sming/Arch/Host/Platform/StationImpl.cpp
@@ -250,7 +250,7 @@ MACAddress StationImpl::getMacAddr() const
 	if(nif == nullptr) {
 		return MACADDR_NONE;
 	} else {
-		return nif->hwaddr;
+		return MACAddress(nif->hwaddr);
 	}
 }
 

--- a/Sming/Arch/Host/Platform/StationImpl.h
+++ b/Sming/Arch/Host/Platform/StationImpl.h
@@ -72,6 +72,7 @@ private:
 private:
 	ApInfo* currentAp;
 	ApInfo* savedAp;
+	IPAddress ipaddr, netmask, gateway;
 
 	struct StationConfig {
 		bool enabled = true;

--- a/Sming/Arch/Host/Platform/StationImpl.h
+++ b/Sming/Arch/Host/Platform/StationImpl.h
@@ -45,7 +45,7 @@ public:
 	void setHostname(const String& hostname) override;
 	String getHostname() const override;
 	IPAddress getIP() const override;
-	MACAddress getMacAddr() const override;
+	MACAddress getMacAddress() const override;
 	IPAddress getNetworkMask() const override;
 	IPAddress getNetworkGateway() const override;
 	IPAddress getNetworkBroadcast() const override;

--- a/Sming/Arch/Host/Platform/StationImpl.h
+++ b/Sming/Arch/Host/Platform/StationImpl.h
@@ -19,7 +19,7 @@ class StationImpl : public StationClass
 public:
 	struct ApInfo {
 		const char* ssid;
-		MACAddress bssid;
+		MacAddress bssid;
 		WifiAuthMode authMode;
 		uint8_t channel;
 		bool hidden;
@@ -44,12 +44,12 @@ public:
 	void enableDHCP(bool enable) override;
 	void setHostname(const String& hostname) override;
 	String getHostname() const override;
-	IPAddress getIP() const override;
-	MACAddress getMacAddress() const override;
-	IPAddress getNetworkMask() const override;
-	IPAddress getNetworkGateway() const override;
-	IPAddress getNetworkBroadcast() const override;
-	bool setIP(IPAddress address, IPAddress netmask, IPAddress gateway) override;
+	IpAddress getIP() const override;
+	MacAddress getMacAddress() const override;
+	IpAddress getNetworkMask() const override;
+	IpAddress getNetworkGateway() const override;
+	IpAddress getNetworkBroadcast() const override;
+	bool setIP(IpAddress address, IpAddress netmask, IpAddress gateway) override;
 	String getSSID() const override;
 	String getPassword() const override;
 	int8_t getRssi() const override;
@@ -72,7 +72,7 @@ private:
 private:
 	ApInfo* currentAp;
 	ApInfo* savedAp;
-	IPAddress ipaddr, netmask, gateway;
+	IpAddress ipaddr, netmask, gateway;
 
 	struct StationConfig {
 		bool enabled = true;

--- a/Sming/Arch/Host/Platform/WifiEventsImpl.h
+++ b/Sming/Arch/Host/Platform/WifiEventsImpl.h
@@ -30,7 +30,7 @@ public:
 		}
 	}
 
-	void stationGotIp(IPAddress ip, IPAddress netmask, IPAddress gw)
+	void stationGotIp(IpAddress ip, IpAddress netmask, IpAddress gw)
 	{
 		if(onSTAGotIP) {
 			onSTAGotIP(ip, netmask, gw);

--- a/Sming/Arch/Host/Platform/WifiEventsImpl.h
+++ b/Sming/Arch/Host/Platform/WifiEventsImpl.h
@@ -30,7 +30,7 @@ public:
 		}
 	}
 
-	void stationGotIp(ip_addr_t ip, ip_addr_t netmask, ip_addr_t gw)
+	void stationGotIp(IPAddress ip, IPAddress netmask, IPAddress gw)
 	{
 		if(onSTAGotIP) {
 			onSTAGotIP(ip, netmask, gw);

--- a/Sming/Core/Network/DNSServer.cpp
+++ b/Sming/Core/Network/DNSServer.cpp
@@ -19,7 +19,7 @@
 #include "UdpConnection.h"
 #include "WString.h"
 
-bool DNSServer::start(uint16_t port, const String& domainName, const IPAddress& resolvedIP)
+bool DNSServer::start(uint16_t port, const String& domainName, const IpAddress& resolvedIP)
 {
 	this->port = port;
 	buffer = nullptr;
@@ -48,7 +48,7 @@ bool DNSServer::requestIncludesOnlyOneQuestion()
 		   dnsHeader->ARCount == 0;
 }
 
-void DNSServer::onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort)
+void DNSServer::onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort)
 {
 	delete[] buffer;
 	buffer = new char[buf->tot_len];

--- a/Sming/Core/Network/DNSServer.h
+++ b/Sming/Core/Network/DNSServer.h
@@ -75,13 +75,13 @@ public:
 	}
 
 	// Returns true if successful, false if there are no sockets available
-	bool start(uint16_t port, const String& domainName, const IPAddress& resolvedIP);
+	bool start(uint16_t port, const String& domainName, const IpAddress& resolvedIP);
 
 	// stops the DNS server
 	void stop();
 
 protected:
-	void onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort) override;
+	void onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort) override;
 
 private:
 	uint16_t port = 0;

--- a/Sming/Core/Network/Ftp/FtpServerConnection.h
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.h
@@ -11,7 +11,7 @@
 #pragma once
 
 #include "Network/TcpConnection.h"
-#include "IPAddress.h"
+#include "IpAddress.h"
 #include "WString.h"
 
 #define MAX_FTP_CMD 255
@@ -58,7 +58,7 @@ private:
 	String userName;
 	String renameFrom;
 
-	IPAddress ip;
+	IpAddress ip;
 	int port = 0;
 	TcpConnection* dataConnection = nullptr;
 	bool canTransfer = true;

--- a/Sming/Core/Network/NtpClient.cpp
+++ b/Sming/Core/Network/NtpClient.cpp
@@ -75,7 +75,7 @@ void NtpClient::requestTime()
 	}
 }
 
-void NtpClient::internalRequestTime(IPAddress serverIp)
+void NtpClient::internalRequestTime(IpAddress serverIp)
 {
 	debug_d("NtpClient::internalRequestTime()");
 
@@ -116,7 +116,7 @@ void NtpClient::setAutoQueryInterval(unsigned seconds)
 	}
 }
 
-void NtpClient::onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort)
+void NtpClient::onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort)
 {
 	debug_d("NtpClient::onReceive(%s:%u)", remoteIP.toString().c_str(), remotePort);
 

--- a/Sming/Core/Network/NtpClient.h
+++ b/Sming/Core/Network/NtpClient.h
@@ -100,12 +100,12 @@ protected:
      *  @param  remoteIP IP address of remote host
      *  @param  remotePort Port number of remote host
      */
-	void onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort) override;
+	void onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort) override;
 
 	/** @brief  Send time request to NTP server
      *  @param  serverIp IP address of NTP server
      */
-	void internalRequestTime(IPAddress serverIp);
+	void internalRequestTime(IpAddress serverIp);
 
 	/** @brief Start the timer running
 	 *  @param milliseconds Time to run in milliseconds

--- a/Sming/Core/Network/TcpClient.cpp
+++ b/Sming/Core/Network/TcpClient.cpp
@@ -42,7 +42,7 @@ bool TcpClient::connect(const String& server, int port, bool useSsl, uint32_t ss
 	return TcpConnection::connect(server.c_str(), port, useSsl, sslOptions);
 }
 
-bool TcpClient::connect(IPAddress addr, uint16_t port, bool useSsl, uint32_t sslOptions)
+bool TcpClient::connect(IpAddress addr, uint16_t port, bool useSsl, uint32_t sslOptions)
 {
 	if(isProcessing()) {
 		return false;

--- a/Sming/Core/Network/TcpClient.h
+++ b/Sming/Core/Network/TcpClient.h
@@ -24,7 +24,7 @@
 
 class TcpClient;
 class ReadWriteStream;
-class IPAddress;
+class IpAddress;
 
 typedef Delegate<void(TcpClient& client, TcpConnectionEvent sourceEvent)> TcpClientEventDelegate;
 typedef Delegate<void(TcpClient& client, bool successful)> TcpClientCompleteDelegate;
@@ -74,7 +74,7 @@ public:
 
 public:
 	bool connect(const String& server, int port, bool useSsl = false, uint32_t sslOptions = 0) override;
-	bool connect(IPAddress addr, uint16_t port, bool useSsl = false, uint32_t sslOptions = 0) override;
+	bool connect(IpAddress addr, uint16_t port, bool useSsl = false, uint32_t sslOptions = 0) override;
 	void close() override;
 
 	/**	@brief	Set or clear the callback for received data

--- a/Sming/Core/Network/TcpConnection.cpp
+++ b/Sming/Core/Network/TcpConnection.cpp
@@ -14,7 +14,7 @@
 #include "Platform/WDT.h"
 #include "NetUtils.h"
 #include "WString.h"
-#include "IPAddress.h"
+#include "IpAddress.h"
 
 #ifdef DEBUG_TCP_EXTENDED
 #define debug_tcp(fmt, ...) debug_d(fmt, ##__VA_ARGS__)
@@ -80,7 +80,7 @@ bool TcpConnection::connect(const String& server, int port, bool useSsl, uint32_
 	return (dnslook == ERR_OK) ? internalConnect(addr, port) : false;
 }
 
-bool TcpConnection::connect(IPAddress addr, uint16_t port, bool useSsl, uint32_t sslOptions)
+bool TcpConnection::connect(IpAddress addr, uint16_t port, bool useSsl, uint32_t sslOptions)
 {
 	if(tcp == nullptr) {
 		initialize(tcp_new());
@@ -389,7 +389,7 @@ void TcpConnection::flush()
 	}
 }
 
-bool TcpConnection::internalConnect(IPAddress addr, uint16_t port)
+bool TcpConnection::internalConnect(IpAddress addr, uint16_t port)
 {
 	NetUtils::FixNetworkRouting();
 	err_t res = tcp_connect(tcp, addr, port, [](void* arg, tcp_pcb* tcp, err_t err) -> err_t {
@@ -630,7 +630,7 @@ void TcpConnection::internalOnError(err_t err)
 void TcpConnection::internalOnDnsResponse(const char* name, LWIP_IP_ADDR_T* ipaddr, int port)
 {
 	if(ipaddr != nullptr) {
-		IPAddress ip = *ipaddr;
+		IpAddress ip = *ipaddr;
 		debug_d("DNS record found: %s = %s", name, ip.toString().c_str());
 
 		internalConnect(ip, port);

--- a/Sming/Core/Network/TcpConnection.h
+++ b/Sming/Core/Network/TcpConnection.h
@@ -22,7 +22,7 @@
 #endif
 
 #include "WiringFrameworkDependencies.h"
-#include "IPAddress.h"
+#include "IpAddress.h"
 
 #define NETWORK_DEBUG
 
@@ -42,7 +42,7 @@ enum TcpConnectionEvent {
 struct pbuf;
 class String;
 class IDataSourceStream;
-class IPAddress;
+class IpAddress;
 class TcpConnection;
 
 typedef Delegate<void(TcpConnection&)> TcpConnectionDestroyedDelegate;
@@ -63,7 +63,7 @@ public:
 
 public:
 	virtual bool connect(const String& server, int port, bool useSsl = false, uint32_t sslOptions = 0);
-	virtual bool connect(IPAddress addr, uint16_t port, bool useSsl = false, uint32_t sslOptions = 0);
+	virtual bool connect(IpAddress addr, uint16_t port, bool useSsl = false, uint32_t sslOptions = 0);
 	virtual void close();
 
 	// return -1 on error
@@ -97,9 +97,9 @@ public:
 
 	void setTimeOut(uint16_t waitTimeOut);
 
-	IPAddress getRemoteIp() const
+	IpAddress getRemoteIp() const
 	{
-		return (tcp == nullptr) ? INADDR_NONE : IPAddress(tcp->remote_ip);
+		return (tcp == nullptr) ? INADDR_NONE : IpAddress(tcp->remote_ip);
 	}
 
 	uint16_t getRemotePort() const
@@ -239,7 +239,7 @@ public:
 
 protected:
 	void initialize(tcp_pcb* pcb);
-	bool internalConnect(IPAddress addr, uint16_t port);
+	bool internalConnect(IpAddress addr, uint16_t port);
 
 	virtual err_t onConnected(err_t err);
 	virtual err_t onReceive(pbuf* buf);

--- a/Sming/Core/Network/UdpConnection.cpp
+++ b/Sming/Core/Network/UdpConnection.cpp
@@ -48,7 +48,7 @@ bool UdpConnection::listen(int port)
 	return res == ERR_OK;
 }
 
-bool UdpConnection::connect(IPAddress ip, uint16_t port)
+bool UdpConnection::connect(IpAddress ip, uint16_t port)
 {
 	if(udp == nullptr) {
 		if(!initialize()) {
@@ -79,7 +79,7 @@ bool UdpConnection::send(const char* data, int length)
 	}
 }
 
-bool UdpConnection::sendTo(IPAddress remoteIP, uint16_t remotePort, const char* data, int length)
+bool UdpConnection::sendTo(IpAddress remoteIP, uint16_t remotePort, const char* data, int length)
 {
 	pbuf* p = pbuf_alloc(PBUF_TRANSPORT, length, PBUF_RAM);
 	if(p == nullptr) {
@@ -92,7 +92,7 @@ bool UdpConnection::sendTo(IPAddress remoteIP, uint16_t remotePort, const char* 
 	}
 }
 
-void UdpConnection::onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort)
+void UdpConnection::onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort)
 {
 	debug_d("UDP received: %d bytes", buf->tot_len);
 	if(onDataCallback) {
@@ -110,7 +110,7 @@ void UdpConnection::staticOnReceive(void* arg, struct udp_pcb* pcb, struct pbuf*
 {
 	auto conn = static_cast<UdpConnection*>(arg);
 	if(conn != nullptr) {
-		IPAddress reip = addr != nullptr ? IPAddress(*addr) : IPAddress();
+		IpAddress reip = addr != nullptr ? IpAddress(*addr) : IpAddress();
 		conn->onReceive(p, reip, port);
 	}
 	pbuf_free(p);

--- a/Sming/Core/Network/UdpConnection.h
+++ b/Sming/Core/Network/UdpConnection.h
@@ -17,11 +17,11 @@
 #pragma once
 
 #include "WiringFrameworkDependencies.h"
-#include "IPAddress.h"
+#include "IpAddress.h"
 
 class UdpConnection;
 
-typedef Delegate<void(UdpConnection& connection, char* data, int size, IPAddress remoteIP, uint16_t remotePort)>
+typedef Delegate<void(UdpConnection& connection, char* data, int size, IpAddress remoteIP, uint16_t remotePort)>
 	UdpConnectionDataDelegate;
 
 class UdpConnection
@@ -43,7 +43,7 @@ public:
 	}
 
 	virtual bool listen(int port);
-	virtual bool connect(IPAddress ip, uint16_t port);
+	virtual bool connect(IpAddress ip, uint16_t port);
 	virtual void close();
 
 	// After connect(..)
@@ -59,20 +59,20 @@ public:
 		return send(data.c_str(), data.length());
 	}
 
-	virtual bool sendTo(IPAddress remoteIP, uint16_t remotePort, const char* data, int length);
+	virtual bool sendTo(IpAddress remoteIP, uint16_t remotePort, const char* data, int length);
 
-	bool sendStringTo(IPAddress remoteIP, uint16_t remotePort, const char* data)
+	bool sendStringTo(IpAddress remoteIP, uint16_t remotePort, const char* data)
 	{
 		return sendTo(remoteIP, remotePort, data, strlen(data));
 	}
 
-	bool sendStringTo(IPAddress remoteIP, uint16_t remotePort, const String& data)
+	bool sendStringTo(IpAddress remoteIP, uint16_t remotePort, const String& data)
 	{
 		return sendTo(remoteIP, remotePort, data.c_str(), data.length());
 	}
 
 protected:
-	virtual void onReceive(pbuf* buf, IPAddress remoteIP, uint16_t remotePort);
+	virtual void onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort);
 
 protected:
 	bool initialize(udp_pcb* pcb = nullptr);

--- a/Sming/Libraries/Yeelight/include/YeelightBulb.h
+++ b/Sming/Libraries/Yeelight/include/YeelightBulb.h
@@ -8,7 +8,7 @@
 
 #include "WVector.h"
 #include "WString.h"
-#include "IPAddress.h"
+#include "IpAddress.h"
 class TcpClient;
 
 enum YeelightBulbState
@@ -23,7 +23,7 @@ enum YeelightBulbState
 class YeelightBulb
 {
 public:
-	YeelightBulb(IPAddress addr) : lamp(addr)
+	YeelightBulb(IpAddress addr) : lamp(addr)
 	{
 	}
 
@@ -58,7 +58,7 @@ protected:
 	void parsePower(const String& resp);
 
 private:
-	IPAddress lamp;
+	IpAddress lamp;
 	uint16_t port = 55443;
 
 	TcpClient* connection = nullptr;

--- a/Sming/Platform/AccessPoint.cpp
+++ b/Sming/Platform/AccessPoint.cpp
@@ -12,6 +12,6 @@
 
 String AccessPointClass::getMAC(char sep) const
 {
-	auto mac = getMacAddr();
+	auto mac = getMacAddress();
 	return mac ? mac.toString(sep) : nullptr;
 }

--- a/Sming/Platform/AccessPoint.h
+++ b/Sming/Platform/AccessPoint.h
@@ -9,11 +9,13 @@
  ****/
 
 /**	@defgroup wifi_ap WiFi Access Point
+ *  @ingroup wifi
  *	@brief	Control and monitoring of WiFi access point interface
  *	@note   The WiFi access point interface provides a WiFi network access point.
             Control of WiFi AP including WiFi SSID and password and
             IP address.
  *  @see    \ref wifi_sta
+ *  @see    \ref wifi_ev
  *  @todo   How is wifi access point dhcp controlled?
 */
 

--- a/Sming/Platform/AccessPoint.h
+++ b/Sming/Platform/AccessPoint.h
@@ -70,7 +70,7 @@ public:
 	/**	@brief	Get WiFi AP MAC address
 	 *	@retval	MACAddress
 	 */
-	virtual MACAddress getMacAddr() const = 0;
+	virtual MACAddress getMacAddress() const = 0;
 
 	/** @brief  Get WiFi AP MAC address
 	 *  @param	sep separator between bytes (e.g. ':')

--- a/Sming/Platform/AccessPoint.h
+++ b/Sming/Platform/AccessPoint.h
@@ -22,8 +22,8 @@
 #pragma once
 
 #include <WString.h>
-#include <IPAddress.h>
-#include <MACAddress.h>
+#include <IpAddress.h>
+#include <MacAddress.h>
 #include "BssInfo.h"
 
 /** @brief  Access point class
@@ -57,20 +57,20 @@ public:
 						int beaconInterval = 200) = 0;
 
 	/** @brief  Get WiFi AP IP address
-     *  @retval IPAddress WiFi AP IP address
+     *  @retval IpAddress WiFi AP IP address
      */
-	virtual IPAddress getIP() const = 0;
+	virtual IpAddress getIP() const = 0;
 
 	/** @brief  Set WiFi AP IP addres
      *  @param  address New IP address for WiFi AP
      *  @retval bool True on success
      */
-	virtual bool setIP(IPAddress address) = 0;
+	virtual bool setIP(IpAddress address) = 0;
 
 	/**	@brief	Get WiFi AP MAC address
-	 *	@retval	MACAddress
+	 *	@retval	MacAddress
 	 */
-	virtual MACAddress getMacAddress() const = 0;
+	virtual MacAddress getMacAddress() const = 0;
 
 	/** @brief  Get WiFi AP MAC address
 	 *  @param	sep separator between bytes (e.g. ':')
@@ -79,19 +79,19 @@ public:
 	String getMAC(char sep = '\0') const;
 
 	/** @brief  Get WiFi AP network mask
-     *  @retval IPAddress WiFi AP network mask
+     *  @retval IpAddress WiFi AP network mask
      */
-	virtual IPAddress getNetworkMask() const = 0;
+	virtual IpAddress getNetworkMask() const = 0;
 
 	/** @brief  Get WiFi AP default gateway
-     *  @retval IPAddress WiFi AP default gateway
+     *  @retval IpAddress WiFi AP default gateway
      */
-	virtual IPAddress getNetworkGateway() const = 0;
+	virtual IpAddress getNetworkGateway() const = 0;
 
 	/** @brief  Get WiFi AP broadcast address
-     *  @retval IPAddress WiFi AP broadcast address
+     *  @retval IpAddress WiFi AP broadcast address
      */
-	virtual IPAddress getNetworkBroadcast() const = 0;
+	virtual IpAddress getNetworkBroadcast() const = 0;
 
 	/**	@brief	Get WiFi access point SSID
 	 *	@retval	String WiFi access point SSID

--- a/Sming/Platform/BssInfo.h
+++ b/Sming/Platform/BssInfo.h
@@ -12,7 +12,7 @@
 
 #include <WString.h>
 #include <WVector.h>
-#include <MACAddress.h>
+#include <MacAddress.h>
 
 #ifdef ARCH_HOST
 enum WifiAuthMode {
@@ -53,7 +53,7 @@ public:
 
 public:
 	String ssid;				///< SSID
-	MACAddress bssid;			///< BSS ID
+	MacAddress bssid;			///< BSS ID
 	WifiAuthMode authorization; ///< Authorisation mode
 	uint8_t channel;			///< Channel number
 	int16_t rssi;				///< RSSI level

--- a/Sming/Platform/Station.cpp
+++ b/Sming/Platform/Station.cpp
@@ -30,10 +30,10 @@ bool StationClass::isConnectionFailed() const
 	return status == eSCS_WrongPassword || status == eSCS_AccessPointNotFound || status == eSCS_ConnectionFailed;
 }
 
-bool StationClass::setIP(IPAddress address)
+bool StationClass::setIP(IpAddress address)
 {
-	IPAddress mask = IPAddress(255, 255, 255, 0);
-	IPAddress gateway = IPAddress(address);
+	IpAddress mask = IpAddress(255, 255, 255, 0);
+	IpAddress gateway = IpAddress(address);
 	gateway[3] = 1; // x.x.x.1
 	return setIP(address, mask, gateway);
 }

--- a/Sming/Platform/Station.cpp
+++ b/Sming/Platform/Station.cpp
@@ -40,7 +40,7 @@ bool StationClass::setIP(IPAddress address)
 
 String StationClass::getMAC(char sep) const
 {
-	auto mac = getMacAddr();
+	auto mac = getMacAddress();
 	return mac ? mac.toString(sep) : nullptr;
 }
 

--- a/Sming/Platform/Station.h
+++ b/Sming/Platform/Station.h
@@ -185,7 +185,7 @@ public:
 	/**	@brief	Get WiFi station MAC address
 	 *	@retval	MACAddress
 	 */
-	virtual MACAddress getMacAddr() const = 0;
+	virtual MACAddress getMacAddress() const = 0;
 
 	/**	@brief	Get WiFi station MAC address
 	 *  @param sep Optional separator between bytes (e.g. ':')

--- a/Sming/Platform/Station.h
+++ b/Sming/Platform/Station.h
@@ -22,8 +22,8 @@
 
 #include <WString.h>
 #include <WVector.h>
-#include <IPAddress.h>
-#include <MACAddress.h>
+#include <IpAddress.h>
+#include <MacAddress.h>
 #include "BssInfo.h"
 
 /** @ingroup constants
@@ -62,7 +62,7 @@ struct SmartConfigEventInfo {
 	String ssid;					 ///< AP SSID
 	String password;				 ///< AP Password
 	bool bssidSet = false;			 ///< true if connection should match both SSID and BSSID
-	MACAddress bssid;				 ///< AP BSSID
+	MacAddress bssid;				 ///< AP BSSID
 };
 
 /// WiFi WPS callback status
@@ -178,14 +178,14 @@ public:
 	virtual String getHostname() const = 0;
 
 	/**	@brief	Get WiFi station IP address
-	 *	@retval	IPAddress IP address of WiFi station
+	 *	@retval	IpAddress IP address of WiFi station
 	 */
-	virtual IPAddress getIP() const = 0;
+	virtual IpAddress getIP() const = 0;
 
 	/**	@brief	Get WiFi station MAC address
-	 *	@retval	MACAddress
+	 *	@retval	MacAddress
 	 */
-	virtual MACAddress getMacAddress() const = 0;
+	virtual MacAddress getMacAddress() const = 0;
 
 	/**	@brief	Get WiFi station MAC address
 	 *  @param sep Optional separator between bytes (e.g. ':')
@@ -194,25 +194,25 @@ public:
 	String getMAC(char sep = '\0') const;
 
 	/**	@brief	Get WiFi station network mask
-	 *	@retval	IPAddress WiFi station network mask
+	 *	@retval	IpAddress WiFi station network mask
 	 */
-	virtual IPAddress getNetworkMask() const = 0;
+	virtual IpAddress getNetworkMask() const = 0;
 
 	/**	@brief	Get WiFi station default gateway
-	 *	@retval	IPAddress WiFi station default gateway
+	 *	@retval	IpAddress WiFi station default gateway
 	 */
-	virtual IPAddress getNetworkGateway() const = 0;
+	virtual IpAddress getNetworkGateway() const = 0;
 
 	/**	@brief	GetWiFi station broadcast address
-	 *	@retval	IPAddress WiFi station broadcast address
+	 *	@retval	IpAddress WiFi station broadcast address
 	 */
-	virtual IPAddress getNetworkBroadcast() const = 0;
+	virtual IpAddress getNetworkBroadcast() const = 0;
 
 	/**	@brief	Set WiFi station IP address
 	 *	@param	address IP address
 	 *	@retval	bool True on success
 	 */
-	bool setIP(IPAddress address);
+	bool setIP(IpAddress address);
 
 	/**	@brief	Set WiFi station IP parameters
 	 *	@param	address IP address
@@ -220,7 +220,7 @@ public:
 	 *	@param	gateway Default gatway
 	 *	@retval	bool True on success
 	 */
-	virtual bool setIP(IPAddress address, IPAddress netmask, IPAddress gateway) = 0;
+	virtual bool setIP(IpAddress address, IpAddress netmask, IpAddress gateway) = 0;
 
 	/**	@brief	Get WiFi station SSID
 	 *	@retval	String WiFi station SSID

--- a/Sming/Platform/Station.h
+++ b/Sming/Platform/Station.h
@@ -9,11 +9,13 @@
  ****/
 
 /**	@defgroup wifi_sta WiFi Station Interface
+ *  @ingroup wifi
  *	@brief	Control and monitoring of WiFi station interface
  *	@note   The WiFi station interface provides client access to a WiFi network.
             Control of WiFi connection including WiFi SSID and password and
             IP address, DHCP, etc.
  *  @see    \ref wifi_ap
+ *  @see    \ref wifi_ev
 */
 
 #pragma once
@@ -202,7 +204,7 @@ public:
 	virtual IPAddress getNetworkGateway() const = 0;
 
 	/**	@brief	GetWiFi station broadcast address
-	 *	@retval	IPAddress WiFi statoin broadcast address
+	 *	@retval	IPAddress WiFi station broadcast address
 	 */
 	virtual IPAddress getNetworkBroadcast() const = 0;
 

--- a/Sming/Platform/WifiEvents.cpp
+++ b/Sming/Platform/WifiEvents.cpp
@@ -1,0 +1,80 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * WifiEvents.cpp
+ *
+ ****/
+
+#include "WifiEvents.h"
+
+/*
+ * Common set of reason codes to ieee 802.11-2007
+ * Codes at 200+ are non-standard defined by Espressif.
+ *
+ * Some acronymns:
+ *
+ * 	IE: Information Element
+ * 	STA: Station
+ * 	AP: Access Point
+ *  RSN:
+ *  AUTH: Authentication
+ */
+#define WIFI_DISCONNECT_REASON_CODES_MAP(XX)                                                                           \
+	XX(UNSPECIFIED, 1, "Unspecified")                                                                                  \
+	XX(AUTH_EXPIRE, 2, "AUTH expired")                                                                                 \
+	XX(AUTH_LEAVE, 3, "Sending STA is leaving, or has left")                                                           \
+	XX(ASSOC_EXPIRE, 4, "Disassociated: inactivity")                                                                   \
+	XX(ASSOC_TOOMANY, 5, "Disassociated: too many clients)")                                                           \
+	XX(NOT_AUTHED, 6, "Class 2 frame received from non-authenticated STA")                                             \
+	XX(NOT_ASSOCED, 7, "Class 3 frame received from non-authenticated STA")                                            \
+	XX(ASSOC_LEAVE, 8, "Disassociated: STA is leaving, or has left")                                                   \
+	XX(ASSOC_NOT_AUTHED, 9, "Disassociated: STA not authenticated")                                                    \
+	XX(DISASSOC_PWRCAP_BAD, 10, "Disassociated: power capability unacceptable")                                        \
+	XX(DISASSOC_SUPCHAN_BAD, 11, "Disassociated: supported channels unacceptable")                                     \
+	XX(IE_INVALID, 13, "Invalid IE")                                                                                   \
+	XX(MIC_FAILURE, 14, "Message Integrity failure")                                                                   \
+	XX(4WAY_HANDSHAKE_TIMEOUT, 15, "4-way Handshake timeout")                                                          \
+	XX(GROUP_KEY_UPDATE_TIMEOUT, 16, "Group Key Handshake timeout")                                                    \
+	XX(IE_IN_4WAY_DIFFERS, 17, "4-way Handshake Information Differs")                                                  \
+	XX(GROUP_CIPHER_INVALID, 18, "Invalid group cypher")                                                               \
+	XX(PAIRWISE_CIPHER_INVALID, 19, "Invalid pairwise cypher")                                                         \
+	XX(AKMP_INVALID, 20, "Invalid AKMP")                                                                               \
+	XX(UNSUPP_RSN_IE_VERSION, 21, "Unsupported RSN IE Version")                                                        \
+	XX(INVALID_RSN_IE_CAP, 22, "Invalid RSN IE capabilities")                                                          \
+	XX(802_1X_AUTH_FAILED, 23, "IEEE 802.1X authentication failed")                                                    \
+	XX(CIPHER_SUITE_REJECTED, 24, "Cipher suite rejected (security policy)")                                           \
+	XX(BEACON_TIMEOUT, 200, "Beacon Timeout")                                                                          \
+	XX(NO_AP_FOUND, 201, "No AP found")                                                                                \
+	XX(AUTH_FAIL, 202, "Authentication failure")                                                                       \
+	XX(ASSOC_FAIL, 203, "Association failure")                                                                         \
+	XX(HANDSHAKE_TIMEOUT, 204, "Handshake timeout")                                                                    \
+	XX(CONNECTION_FAIL, 205, "Connection failure")
+
+String WifiEventsClass::getDisconnectReasonName(WifiDisconnectReason reason)
+{
+	switch(reason) {
+#define XX(tag, code, desc)                                                                                            \
+	case WIFI_DISCONNECT_REASON_##tag:                                                                                 \
+		return F(#tag);
+		WIFI_DISCONNECT_REASON_CODES_MAP(XX)
+#undef XX
+	default:
+		return F("UNKNOWN_") + String(reason);
+	}
+}
+
+String WifiEventsClass::getDisconnectReasonDesc(WifiDisconnectReason reason)
+{
+	switch(reason) {
+#define XX(tag, code, desc)                                                                                            \
+	case WIFI_DISCONNECT_REASON_##tag:                                                                                 \
+		return F(desc);
+		WIFI_DISCONNECT_REASON_CODES_MAP(XX)
+#undef XX
+	default:
+		return F("Unknown reason (") + String(reason) + ')';
+	}
+}

--- a/Sming/Platform/WifiEvents.h
+++ b/Sming/Platform/WifiEvents.h
@@ -11,6 +11,13 @@
  *
  ****/
 
+/**	@defgroup wifi_ev WiFi Events Interface
+ *  @ingroup wifi
+ *	@brief	Event callback interface for WiFi events
+ *  @see    \ref wifi_sta
+ *  @see    \ref wifi_ap
+*/
+
 #pragma once
 
 #include <WString.h>
@@ -19,17 +26,24 @@
 #include <Delegate.h>
 #include "BssInfo.h"
 
-/*
- * Common set of reason codes to ieee 802.11-2007
- * Codes at 200+ are non-standard defined by Espressif.
+/** @ingroup constants
+ *  @{
+ */
+
+/**
+ * @brief Common set of reason codes to IEEE 802.11-2007
  *
- * Some acronymns:
+ * @note Codes at 200+ are non-standard, defined by Espressif.
  *
- * 	IE: Information Element
- * 	STA: Station
- * 	AP: Access Point
- *  RSN:
- *  AUTH: Authentication
+ * @note Some acronymns used here - see the full standard for more precise definitions.
+ *	- SSID: Service Set Identifier (the visible name given to an Access Point)
+ *	- BSSID: Basic Service Set Identifier (a MAC address physically identifying the AP)
+ *	- IE: Information Element (standard piece of information carried within WiFi packets)
+ *	- STA: Station (any device which supports WiFi, including APs though the term commonly refers to a client)
+ *	- AP: Access Point (device to which other stations may be associated)
+ *	- RSN: Robust Security Network
+ *	- AUTH: Authentication (how a station proves its identity to another)
+ *
  */
 #define WIFI_DISCONNECT_REASON_CODES_MAP(XX)                                                                           \
 	XX(UNSPECIFIED, 1, "Unspecified")                                                                                  \
@@ -62,55 +76,165 @@
 	XX(HANDSHAKE_TIMEOUT, 204, "Handshake timeout")                                                                    \
 	XX(CONNECTION_FAIL, 205, "Connection failure")
 
+/**
+ * @brief Reason codes for WiFi station disconnection
+ * @see WIFI_DISCONNECT_REASON_CODES_MAP
+ */
 enum WifiDisconnectReason {
 #define XX(tag, code, desc) WIFI_DISCONNECT_REASON_##tag = code,
 	WIFI_DISCONNECT_REASON_CODES_MAP(XX)
 #undef XX
 };
 
-// Define WifiEvents Delegates types
+/** @} */
+
+/** @ingroup event_handlers
+ *  @{
+ */
+
+/**
+ * @brief Delegate type for 'station connected' event
+ * @param ssid
+ * @param bssid
+ * @param channel
+ * @note This event occurs when the station successfully connects to the target AP. Upon receiving this event,
+ * the DHCP client begins the process of getting an IP address.
+ */
 typedef Delegate<void(const String& ssid, const MACAddress& bssid, uint8_t channel)> StationConnectDelegate;
+
+/**
+ * @brief Delegate type for 'station disconnected' event
+ * @param ssid SSID from which we've disconnected
+ * @param bssid
+ * @param reason Why the connection was dropped
+ * @note This event can be generated in the following scenarios:
+ * 	- When the station is already connected to the AP, and a manual disconnect or re-configuration is taking place. e.g. `WifiStation.disconnect()`
+ * 	- When `WifiStation.connect()` is called, but the Wi-Fi driver fails to set up a connection with the AP due to certain reasons,
+ * 	  e.g. the scan fails to find the target AP, authentication times out, etc. If there are more than one AP with the same SSID,
+ * 	  the disconnected event is raised after the station fails to connect all of the found APs.
+ * 	- When the Wi-Fi connection is disrupted because of specific reasons, e.g., the station continuously loses N beacons, the AP kicks off the station,
+ * 	  the AP's authentication mode is changed, etc.
+ */
 typedef Delegate<void(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)>
 	StationDisconnectDelegate;
+
+/**
+ * @brief Delegate type for 'station authorisation mode changed' event
+ * @param oldMode
+ * @param newMode
+ * @note This event arises when the AP to which the station is connected changes its authentication mode,
+ * e.g., from 'no auth' to WPA. Generally, the application event callback does not need to handle this.
+ */
 typedef Delegate<void(WifiAuthMode oldMode, WifiAuthMode newMode)> StationAuthModeChangeDelegate;
+
+/**
+ * @brief Delegate type for 'station got IP address' event
+ * @param ip
+ * @param netmask
+ * @param gateway
+ * @note This event arises when the DHCP client successfully gets the IPV4 address from the DHCP server,
+ * or when the IPV4 address is changed. The IPV4 may be changed because of the following reasons:
+ *	- The DHCP client fails to renew/rebind the IPV4 address, and the station's IPV4 is reset to 0.
+ *	- The DHCP client rebinds to a different address.
+ *	- The static-configured IPV4 address is changed.
+ */
 typedef Delegate<void(IPAddress ip, IPAddress netmask, IPAddress gateway)> StationGotIPDelegate;
-typedef Delegate<void(const MACAddress& mac, uint8_t aid)> AccessPointConnectDelegate;
-typedef Delegate<void(const MACAddress& mac, uint8_t aid)> AccessPointDisconnectDelegate;
+
+/**
+ * @brief Delegate type for 'Access Point Connect' event
+ * @param mac MAC address of the station
+ * @param aid Association ID representing the connected station
+ * @note This event occurs every time a station is connected to our Access Point.
+ */
+typedef Delegate<void(const MACAddress& mac, uint16_t aid)> AccessPointConnectDelegate;
+
+/**
+ * @brief Delegate type for 'Access Point Disconnect' event
+ * @param mac MAC address of the station
+ * @param aid Association ID assigned to the station
+ * @note This event occurs every time a station is disconnected from our Access Point.
+ */
+typedef Delegate<void(const MACAddress& mac, uint16_t aid)> AccessPointDisconnectDelegate;
+
+/**
+ * @brief Delegate type for 'Access Point Probe Request Received' event
+ * @param rssi Signal strength
+ * @param mac
+ * @note Probe Requests are a low-level management frame which are used to determine
+ * informaton about our Access Point, such as which authentication modes are supported.
+ */
 typedef Delegate<void(int rssi, const MACAddress& mac)> AccessPointProbeReqRecvedDelegate;
 
+/** @} */
+
+/** @brief  WiFi events class
+ *  @addtogroup wifi_ev
+ *  @{
+ */
 class WifiEventsClass
 {
 public:
+	/**
+	 * @brief Set callback for 'station connected' event
+	 */
 	void onStationConnect(StationConnectDelegate delegateFunction)
 	{
 		onSTAConnect = delegateFunction;
 	}
 
+	/**
+	 * @brief Set callback for 'station disconnected' event
+	 */
 	void onStationDisconnect(StationDisconnectDelegate delegateFunction)
 	{
 		onSTADisconnect = delegateFunction;
 	}
 
+	/**
+	 * @brief Get short name for disconnection reason
+	 */
+	static String getDisconnectReasonName(WifiDisconnectReason reason);
+
+	/**
+	 * @brief Get descriptive explanation for disconnect reason
+	 */
+	static String getDisconnectReasonDesc(WifiDisconnectReason reason);
+
+	/**
+	 * @brief Set callback for 'station authorisation mode change' event
+	 */
 	void onStationAuthModeChange(StationAuthModeChangeDelegate delegateFunction)
 	{
 		onSTAAuthModeChange = delegateFunction;
 	}
 
+	/**
+	 * @brief Set callback for 'station connected with IP address' event
+	 */
 	void onStationGotIP(StationGotIPDelegate delegateFunction)
 	{
 		onSTAGotIP = delegateFunction;
 	}
 
+	/**
+	 * @brief Set callback for 'access point client connected' event
+	 */
 	void onAccessPointConnect(AccessPointConnectDelegate delegateFunction)
 	{
 		onSOFTAPConnect = delegateFunction;
 	}
 
+	/**
+	 * @brief Set callback for 'access point client disconnected' event
+	 */
 	void onAccessPointDisconnect(AccessPointDisconnectDelegate delegateFunction)
 	{
 		onSOFTAPDisconnect = delegateFunction;
 	}
 
+	/**
+	 * @brief Set callback for 'access point probe request received' event
+	 */
 	void onAccessPointProbeReqRecved(AccessPointProbeReqRecvedDelegate delegateFunction)
 	{
 		onSOFTAPProbeReqRecved = delegateFunction;
@@ -127,3 +251,5 @@ protected:
 };
 
 extern WifiEventsClass& WifiEvents;
+
+/** @} */

--- a/Sming/Platform/WifiEvents.h
+++ b/Sming/Platform/WifiEvents.h
@@ -21,8 +21,8 @@
 #pragma once
 
 #include <WString.h>
-#include <IPAddress.h>
-#include <MACAddress.h>
+#include <IpAddress.h>
+#include <MacAddress.h>
 #include <Delegate.h>
 #include "BssInfo.h"
 
@@ -100,7 +100,7 @@ enum WifiDisconnectReason {
  * @note This event occurs when the station successfully connects to the target AP. Upon receiving this event,
  * the DHCP client begins the process of getting an IP address.
  */
-typedef Delegate<void(const String& ssid, MACAddress bssid, uint8_t channel)> StationConnectDelegate;
+typedef Delegate<void(const String& ssid, MacAddress bssid, uint8_t channel)> StationConnectDelegate;
 
 /**
  * @brief Delegate type for 'station disconnected' event
@@ -115,7 +115,7 @@ typedef Delegate<void(const String& ssid, MACAddress bssid, uint8_t channel)> St
  * 	- When the Wi-Fi connection is disrupted because of specific reasons, e.g., the station continuously loses N beacons, the AP kicks off the station,
  * 	  the AP's authentication mode is changed, etc.
  */
-typedef Delegate<void(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)> StationDisconnectDelegate;
+typedef Delegate<void(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)> StationDisconnectDelegate;
 
 /**
  * @brief Delegate type for 'station authorisation mode changed' event
@@ -137,7 +137,7 @@ typedef Delegate<void(WifiAuthMode oldMode, WifiAuthMode newMode)> StationAuthMo
  *	- The DHCP client rebinds to a different address.
  *	- The static-configured IPV4 address is changed.
  */
-typedef Delegate<void(IPAddress ip, IPAddress netmask, IPAddress gateway)> StationGotIPDelegate;
+typedef Delegate<void(IpAddress ip, IpAddress netmask, IpAddress gateway)> StationGotIPDelegate;
 
 /**
  * @brief Delegate type for 'Access Point Connect' event
@@ -145,7 +145,7 @@ typedef Delegate<void(IPAddress ip, IPAddress netmask, IPAddress gateway)> Stati
  * @param aid Association ID representing the connected station
  * @note This event occurs every time a station is connected to our Access Point.
  */
-typedef Delegate<void(MACAddress mac, uint16_t aid)> AccessPointConnectDelegate;
+typedef Delegate<void(MacAddress mac, uint16_t aid)> AccessPointConnectDelegate;
 
 /**
  * @brief Delegate type for 'Access Point Disconnect' event
@@ -153,7 +153,7 @@ typedef Delegate<void(MACAddress mac, uint16_t aid)> AccessPointConnectDelegate;
  * @param aid Association ID assigned to the station
  * @note This event occurs every time a station is disconnected from our Access Point.
  */
-typedef Delegate<void(MACAddress mac, uint16_t aid)> AccessPointDisconnectDelegate;
+typedef Delegate<void(MacAddress mac, uint16_t aid)> AccessPointDisconnectDelegate;
 
 /**
  * @brief Delegate type for 'Access Point Probe Request Received' event
@@ -162,7 +162,7 @@ typedef Delegate<void(MACAddress mac, uint16_t aid)> AccessPointDisconnectDelega
  * @note Probe Requests are a low-level management frame which are used to determine
  * informaton about our Access Point, such as which authentication modes are supported.
  */
-typedef Delegate<void(int rssi, MACAddress mac)> AccessPointProbeReqRecvedDelegate;
+typedef Delegate<void(int rssi, MacAddress mac)> AccessPointProbeReqRecvedDelegate;
 
 /** @} */
 

--- a/Sming/Platform/WifiEvents.h
+++ b/Sming/Platform/WifiEvents.h
@@ -100,7 +100,7 @@ enum WifiDisconnectReason {
  * @note This event occurs when the station successfully connects to the target AP. Upon receiving this event,
  * the DHCP client begins the process of getting an IP address.
  */
-typedef Delegate<void(const String& ssid, const MACAddress& bssid, uint8_t channel)> StationConnectDelegate;
+typedef Delegate<void(const String& ssid, MACAddress bssid, uint8_t channel)> StationConnectDelegate;
 
 /**
  * @brief Delegate type for 'station disconnected' event
@@ -115,8 +115,7 @@ typedef Delegate<void(const String& ssid, const MACAddress& bssid, uint8_t chann
  * 	- When the Wi-Fi connection is disrupted because of specific reasons, e.g., the station continuously loses N beacons, the AP kicks off the station,
  * 	  the AP's authentication mode is changed, etc.
  */
-typedef Delegate<void(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)>
-	StationDisconnectDelegate;
+typedef Delegate<void(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)> StationDisconnectDelegate;
 
 /**
  * @brief Delegate type for 'station authorisation mode changed' event
@@ -146,7 +145,7 @@ typedef Delegate<void(IPAddress ip, IPAddress netmask, IPAddress gateway)> Stati
  * @param aid Association ID representing the connected station
  * @note This event occurs every time a station is connected to our Access Point.
  */
-typedef Delegate<void(const MACAddress& mac, uint16_t aid)> AccessPointConnectDelegate;
+typedef Delegate<void(MACAddress mac, uint16_t aid)> AccessPointConnectDelegate;
 
 /**
  * @brief Delegate type for 'Access Point Disconnect' event
@@ -154,7 +153,7 @@ typedef Delegate<void(const MACAddress& mac, uint16_t aid)> AccessPointConnectDe
  * @param aid Association ID assigned to the station
  * @note This event occurs every time a station is disconnected from our Access Point.
  */
-typedef Delegate<void(const MACAddress& mac, uint16_t aid)> AccessPointDisconnectDelegate;
+typedef Delegate<void(MACAddress mac, uint16_t aid)> AccessPointDisconnectDelegate;
 
 /**
  * @brief Delegate type for 'Access Point Probe Request Received' event
@@ -163,7 +162,7 @@ typedef Delegate<void(const MACAddress& mac, uint16_t aid)> AccessPointDisconnec
  * @note Probe Requests are a low-level management frame which are used to determine
  * informaton about our Access Point, such as which authentication modes are supported.
  */
-typedef Delegate<void(int rssi, const MACAddress& mac)> AccessPointProbeReqRecvedDelegate;
+typedef Delegate<void(int rssi, MACAddress mac)> AccessPointProbeReqRecvedDelegate;
 
 /** @} */
 

--- a/Sming/Wiring/IPAddress.cpp
+++ b/Sming/Wiring/IPAddress.cpp
@@ -31,13 +31,6 @@ void IPAddress::fromString(const String& address)
 	}
 }
 
-bool IPAddress::operator==(const uint8_t* addr)
-{
-    ip_addr_t a;
-    IP4_ADDR(&a, addr[0], addr[1], addr[2], addr[3]);
-    return address.addr == a.addr;
-}
-
 size_t IPAddress::printTo(Print& p) const
 {
     size_t n = 0;

--- a/Sming/Wiring/IPAddress.h
+++ b/Sming/Wiring/IPAddress.h
@@ -23,7 +23,6 @@
 #include "Printable.h"
 #include "WString.h"
 
-
 #if LWIP_VERSION_MAJOR == 2
 #define LWIP_IP_ADDR_T const ip_addr_t
 #else
@@ -36,102 +35,141 @@ typedef struct ip_addr ip_addr_t;
 class IPAddress : public Printable
 {
 private:
-    ip_addr_t address = {0}; ///< IPv4 address
+	ip_addr_t address = {0}; ///< IPv4 address
 
 	void fromString(const String& address);
 
 public:
-    // Constructors
-    IPAddress()
+	// Constructors
+	IPAddress()
 	{
 	}
 
-    IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet)
+	IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet)
 	{
 		IP4_ADDR(&address, first_octet, second_octet, third_octet, fourth_octet);
 	}
 
-    IPAddress(uint32_t address)
+	IPAddress(uint32_t address)
 	{
 		this->address.addr = address;
 	}
 
-    IPAddress(ip_addr address)
+	IPAddress(ip_addr address)
 	{
 		this->address.addr = address.addr;
 	}
 
 #if LWIP_VERSION_MAJOR == 2
-    IPAddress(ip_addr_t address)
+	IPAddress(ip_addr_t address)
 	{
 		this->address = address;
 	}
 #endif
 
-    IPAddress(const uint8_t *address)
+	IPAddress(const uint8_t* address)
 	{
 		IP4_ADDR(&this->address, address[0], address[1], address[2], address[3]);
 	}
 
-    IPAddress(const String& address)
-    {
-    	fromString(address);
-    }
+	IPAddress(const String& address)
+	{
+		fromString(address);
+	}
 
-    // Overloaded cast operator to allow IPAddress objects to be used where a pointer
-    // to a four-byte uint8_t array is expected
-    operator uint32_t() const { return address.addr; }
-    operator ip_addr() const { return {address.addr}; }
-    operator ip_addr*() { return reinterpret_cast<ip_addr*>(&address); }
+	// Overloaded cast operator to allow IPAddress objects to be used where a pointer
+	// to a four-byte uint8_t array is expected
+	operator uint32_t() const
+	{
+		return address.addr;
+	}
+
+	operator ip_addr() const
+	{
+		return {address.addr};
+	}
+
+	operator ip_addr*()
+	{
+		return reinterpret_cast<ip_addr*>(&address);
+	}
 
 #if LWIP_VERSION_MAJOR == 2
-    operator ip_addr_t*() { return &address; }
+	operator ip_addr_t*()
+	{
+		return &address;
+	}
 #endif
 
-    bool operator==(const IPAddress& addr) { return address.addr == addr.address.addr; }
-    bool operator==(const uint8_t* addr);
+	bool operator==(const IPAddress& addr) const
+	{
+		return ip_addr_cmp(&address, &addr.address);
+	}
 
-    bool isNull() const { return address.addr == 0; }
-    String toString() const;
+	bool operator==(const uint8_t* addr) const
+	{
+		return *this == IPAddress(addr);
+	}
 
-    bool compare(const IPAddress& addr, const IPAddress& mask) const
-    {
-        return ip_addr_netcmp(&address, &addr.address, &mask.address);
-    }
+	bool operator!=(const IPAddress& addr) const
+	{
+		return !ip_addr_cmp(&address, &addr.address);
+	}
 
-    // Overloaded index operator to allow getting and setting individual octets of the address
-    uint8_t operator[](int index) const
-    {
-        assert(unsigned(index) < sizeof(address));
-        return (unsigned(index) < sizeof(address)) ? reinterpret_cast<const uint8_t*>(&address)[index] : 0;
-    }
+	bool operator!=(const uint8_t* addr) const
+	{
+		return *this != IPAddress(addr);
+	}
 
-    uint8_t& operator[](int index)
-    {
-        assert(unsigned(index) < sizeof(address));
-        return reinterpret_cast<uint8_t*>(&address)[index];
-    }
+	bool isNull() const
+	{
+		return ip_addr_isany(&address);
+	}
 
-    // Overloaded copy operators to allow initialisation of IPAddress objects from other types
-    IPAddress& operator=(const uint8_t *address)
-    {
-        IP4_ADDR(&this->address, address[0], address[1], address[2], address[3]);
-        return *this;
-    }
+	String toString() const;
 
-    IPAddress& operator=(uint32_t address)
-    {
-        this->address.addr = address;
-        return *this;
-    }
+	bool compare(const IPAddress& addr, const IPAddress& mask) const
+	{
+		return ip_addr_netcmp(&address, &addr.address, &mask.address);
+	}
 
-    IPAddress& operator=(const String address)
-    {
-    	fromString(address);
-        return *this;
-    }
+	// Overloaded index operator to allow getting and setting individual octets of the address
+	uint8_t operator[](int index) const
+	{
+		if(unsigned(index) >= sizeof(address)) {
+			abort();
+		}
+		return reinterpret_cast<const uint8_t*>(&address)[index];
+	}
 
-    size_t printTo(Print& p) const override;
+	uint8_t& operator[](int index)
+	{
+		if(unsigned(index) >= sizeof(address)) {
+			abort();
+		}
+		return reinterpret_cast<uint8_t*>(&address)[index];
+	}
+
+	// Overloaded copy operators to allow initialisation of IPAddress objects from other types
+	IPAddress& operator=(const uint8_t* address)
+	{
+		IP4_ADDR(&this->address, address[0], address[1], address[2], address[3]);
+		return *this;
+	}
+
+	IPAddress& operator=(uint32_t address)
+	{
+		this->address.addr = address;
+		return *this;
+	}
+
+	IPAddress& operator=(const String address)
+	{
+		fromString(address);
+		return *this;
+	}
+
+	size_t printTo(Print& p) const override;
 };
 
 // Making this extern saves 100's of bytes; each usage otherwise incurs 4 bytes of BSS

--- a/Sming/Wiring/IpAddress.cpp
+++ b/Sming/Wiring/IpAddress.cpp
@@ -1,5 +1,5 @@
 /*
-  IPAddress.cpp - Base class that provides IPAddress
+  IpAddress.cpp - Base class that provides IpAddress
   Copyright (c) 2011 Adrian McEwen.  All right reserved.
 
   This library is free software; you can redistribute it and/or
@@ -17,10 +17,10 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include "IPAddress.h"
+#include "IpAddress.h"
 #include "Print.h"
 
-void IPAddress::fromString(const String& address)
+void IpAddress::fromString(const String& address)
 {
 	this->address.addr = 0;
 	const char* p = address.c_str();
@@ -31,7 +31,7 @@ void IPAddress::fromString(const String& address)
 	}
 }
 
-size_t IPAddress::printTo(Print& p) const
+size_t IpAddress::printTo(Print& p) const
 {
     size_t n = 0;
     for (unsigned i = 0; i < 3; i++) {
@@ -42,7 +42,7 @@ size_t IPAddress::printTo(Print& p) const
     return n;
 }
 
-String IPAddress::toString() const
+String IpAddress::toString() const
 {
 	String res;
     res.reserve(sizeof(address) * 4);

--- a/Sming/Wiring/IpAddress.h
+++ b/Sming/Wiring/IpAddress.h
@@ -1,5 +1,5 @@
 /*
-  IPAddress.h - Base class that provides IPAddress
+  IpAddress.h - Base class that provides IP Address
   Copyright (c) 2011 Adrian McEwen.  All right reserved.
 
   This library is free software; you can redistribute it and/or
@@ -32,7 +32,7 @@ typedef struct ip_addr ip_addr_t;
 
 // A class to make it easier to handle and pass around IP addresses
 
-class IPAddress : public Printable
+class IpAddress : public Printable
 {
 private:
 	ip_addr_t address = {0}; ///< IPv4 address
@@ -41,43 +41,43 @@ private:
 
 public:
 	// Constructors
-	IPAddress()
+	IpAddress()
 	{
 	}
 
-	IPAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet)
+	IpAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet)
 	{
 		IP4_ADDR(&address, first_octet, second_octet, third_octet, fourth_octet);
 	}
 
-	IPAddress(uint32_t address)
+	IpAddress(uint32_t address)
 	{
 		this->address.addr = address;
 	}
 
-	IPAddress(ip_addr address)
+	IpAddress(ip_addr address)
 	{
 		this->address.addr = address.addr;
 	}
 
 #if LWIP_VERSION_MAJOR == 2
-	IPAddress(ip_addr_t address)
+	IpAddress(ip_addr_t address)
 	{
 		this->address = address;
 	}
 #endif
 
-	IPAddress(const uint8_t* address)
+	IpAddress(const uint8_t* address)
 	{
 		IP4_ADDR(&this->address, address[0], address[1], address[2], address[3]);
 	}
 
-	IPAddress(const String& address)
+	IpAddress(const String& address)
 	{
 		fromString(address);
 	}
 
-	// Overloaded cast operator to allow IPAddress objects to be used where a pointer
+	// Overloaded cast operator to allow IpAddress objects to be used where a pointer
 	// to a four-byte uint8_t array is expected
 	operator uint32_t() const
 	{
@@ -101,24 +101,24 @@ public:
 	}
 #endif
 
-	bool operator==(const IPAddress& addr) const
+	bool operator==(const IpAddress& addr) const
 	{
 		return ip_addr_cmp(&address, &addr.address);
 	}
 
 	bool operator==(const uint8_t* addr) const
 	{
-		return *this == IPAddress(addr);
+		return *this == IpAddress(addr);
 	}
 
-	bool operator!=(const IPAddress& addr) const
+	bool operator!=(const IpAddress& addr) const
 	{
 		return !ip_addr_cmp(&address, &addr.address);
 	}
 
 	bool operator!=(const uint8_t* addr) const
 	{
-		return *this != IPAddress(addr);
+		return *this != IpAddress(addr);
 	}
 
 	bool isNull() const
@@ -128,7 +128,7 @@ public:
 
 	String toString() const;
 
-	bool compare(const IPAddress& addr, const IPAddress& mask) const
+	bool compare(const IpAddress& addr, const IpAddress& mask) const
 	{
 		return ip_addr_netcmp(&address, &addr.address, &mask.address);
 	}
@@ -150,20 +150,20 @@ public:
 		return reinterpret_cast<uint8_t*>(&address)[index];
 	}
 
-	// Overloaded copy operators to allow initialisation of IPAddress objects from other types
-	IPAddress& operator=(const uint8_t* address)
+	// Overloaded copy operators to allow initialisation of IpAddress objects from other types
+	IpAddress& operator=(const uint8_t* address)
 	{
 		IP4_ADDR(&this->address, address[0], address[1], address[2], address[3]);
 		return *this;
 	}
 
-	IPAddress& operator=(uint32_t address)
+	IpAddress& operator=(uint32_t address)
 	{
 		this->address.addr = address;
 		return *this;
 	}
 
-	IPAddress& operator=(const String address)
+	IpAddress& operator=(const String address)
 	{
 		fromString(address);
 		return *this;
@@ -172,5 +172,8 @@ public:
 	size_t printTo(Print& p) const override;
 };
 
+/** @deprecated Use `IpAddress` instead. */
+typedef IpAddress IPAddress SMING_DEPRECATED;
+
 // Making this extern saves 100's of bytes; each usage otherwise incurs 4 bytes of BSS
-#define INADDR_NONE IPAddress()
+#define INADDR_NONE IpAddress()

--- a/Sming/Wiring/MACAddress.cpp
+++ b/Sming/Wiring/MACAddress.cpp
@@ -48,7 +48,7 @@ String MACAddress::toString(char sep) const
 
 bool MACAddress::operator!() const
 {
-	return *this != MACADDR_NONE;
+	return *this == MACADDR_NONE;
 }
 
 uint32_t MACAddress::getHash() const

--- a/Sming/Wiring/MACAddress.h
+++ b/Sming/Wiring/MACAddress.h
@@ -43,9 +43,11 @@ class MACAddress
 	}
 
 public:
+	typedef uint8_t Octets[6];
+
 	MACAddress() = default;
 
-	MACAddress(const uint8_t octets[6])
+	MACAddress(const Octets& octets)
 	{
 		setOctets(octets);
 	}
@@ -53,7 +55,7 @@ public:
 	/**
 	 * @brief Get the octets of the MAC address.
 	 */
-	void getOctets(uint8_t octets[6]) const
+	void getOctets(Octets& octets) const
 	{
 		memcpy(octets, this->octets, 6);
 	}
@@ -61,7 +63,7 @@ public:
 	/**
 	 * @brief Set the octets of the MAC address.
 	 */
-	void setOctets(const uint8_t octets[6])
+	void setOctets(const Octets& octets)
 	{
 		memcpy(this->octets, octets, 6);
 	}
@@ -130,7 +132,7 @@ public:
 	uint32_t getHash() const;
 
 private:
-	uint8_t octets[6] = {0};
+	Octets octets = {0};
 };
 
 #define MACADDR_NONE MACAddress()

--- a/Sming/Wiring/MACAddress.h
+++ b/Sming/Wiring/MACAddress.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "WString.h"
+#include "Print.h"
 #include <stdint.h>
 
 /**
@@ -33,8 +34,7 @@
  * @author mikee47 <mike@sillyhouse.net>
  * 	Sming integration
  */
-
-class MACAddress
+class MACAddress : public Printable
 {
 	// https://www.artima.com/cppsource/safebool.html
 	typedef void (MACAddress::*bool_type)() const;
@@ -84,6 +84,11 @@ public:
 
 	/**
 	 * @brief Return a String representation of the MACAddress.
+	 * @param sep Character to insert between octets
+	 * @note Various conventions exist for display MAC addresses.
+	 * 	- The IEEE standard specifies '-', `"01-02-03-04-05-06"`
+	 * 	- A more common convention (as used in linux) is ':', `"01:02:03:04:05:06"`
+	 * 	- To omit the separator use '\0', `"010203040506"`
 	 */
 	String toString(char sep = ':') const;
 
@@ -130,6 +135,11 @@ public:
 	 * @note This does not uniquely identify the key
 	 */
 	uint32_t getHash() const;
+
+	size_t printTo(Print& p) const override
+	{
+		return p.print(toString());
+	}
 
 private:
 	Octets octets = {0};

--- a/Sming/Wiring/MacAddress.cpp
+++ b/Sming/Wiring/MacAddress.cpp
@@ -20,10 +20,10 @@
    ---------------------------------------------------------------------------
 */
 
-#include "MACAddress.h"
+#include "MacAddress.h"
 #include <Data/HexString.h>
 
-uint8_t MACAddress::operator[](unsigned index) const
+uint8_t MacAddress::operator[](unsigned index) const
 {
 	if(index >= sizeof(octets)) {
 		abort();
@@ -32,7 +32,7 @@ uint8_t MACAddress::operator[](unsigned index) const
 	return octets[index];
 }
 
-uint8_t& MACAddress::operator[](unsigned index)
+uint8_t& MacAddress::operator[](unsigned index)
 {
 	if(index >= sizeof(octets)) {
 		abort();
@@ -41,17 +41,17 @@ uint8_t& MACAddress::operator[](unsigned index)
 	return octets[index];
 }
 
-String MACAddress::toString(char sep) const
+String MacAddress::toString(char sep) const
 {
 	return makeHexString(octets, sizeof(octets), sep);
 }
 
-bool MACAddress::operator!() const
+bool MacAddress::operator!() const
 {
 	return *this == MACADDR_NONE;
 }
 
-uint32_t MACAddress::getHash() const
+uint32_t MacAddress::getHash() const
 {
 	uint32_t a = octets[4] | (octets[5] << 8);
 	uint32_t b = octets[0] | (octets[1] << 8) | (octets[2] << 16) | (octets[3] << 24);

--- a/Sming/Wiring/MacAddress.h
+++ b/Sming/Wiring/MacAddress.h
@@ -34,10 +34,10 @@
  * @author mikee47 <mike@sillyhouse.net>
  * 	Sming integration
  */
-class MACAddress : public Printable
+class MacAddress : public Printable
 {
 	// https://www.artima.com/cppsource/safebool.html
-	typedef void (MACAddress::*bool_type)() const;
+	typedef void (MacAddress::*bool_type)() const;
 	void Testable() const
 	{
 	}
@@ -45,9 +45,9 @@ class MACAddress : public Printable
 public:
 	typedef uint8_t Octets[6];
 
-	MACAddress() = default;
+	MacAddress() = default;
 
-	MACAddress(const Octets& octets)
+	MacAddress(const Octets& octets)
 	{
 		setOctets(octets);
 	}
@@ -83,7 +83,7 @@ public:
 	uint8_t& operator[](unsigned index);
 
 	/**
-	 * @brief Return a String representation of the MACAddress.
+	 * @brief Return a String representation of the MacAddress.
 	 * @param sep Character to insert between octets
 	 * @note Various conventions exist for display MAC addresses.
 	 * 	- The IEEE standard specifies '-', `"01-02-03-04-05-06"`
@@ -95,7 +95,7 @@ public:
 	/**
 	 * @brief Equality operator.
 	 */
-	bool operator==(const MACAddress& other) const
+	bool operator==(const MacAddress& other) const
 	{
 		return memcmp(octets, other.octets, sizeof(octets)) == 0;
 	}
@@ -103,7 +103,7 @@ public:
 	/**
 	 * @brief Inequality operator.
 	 */
-	inline bool operator!=(const MACAddress& other) const
+	inline bool operator!=(const MacAddress& other) const
 	{
 		return !operator==(other);
 	}
@@ -118,7 +118,7 @@ public:
 	 */
 	operator bool_type() const
 	{
-		return operator!() ? nullptr : &MACAddress::Testable;
+		return operator!() ? nullptr : &MacAddress::Testable;
 	}
 
 	/**
@@ -145,4 +145,4 @@ private:
 	Octets octets = {0};
 };
 
-#define MACADDR_NONE MACAddress()
+#define MACADDR_NONE MacAddress()

--- a/Sming/Wiring/WiringFrameworkIncludes.h
+++ b/Sming/Wiring/WiringFrameworkIncludes.h
@@ -24,4 +24,4 @@
 #include "Stream.h"
 #include "Display.h"
 #include "WHashMap.h"
-#include "IPAddress.h"
+#include "IpAddress.h"

--- a/docs/api.dox
+++ b/docs/api.dox
@@ -16,6 +16,10 @@
  *  @brief  Libraries provided by third parties, adapted to work with Sming
  */
 
+/** @defgroup wifi WiFi
+ *  @brief  Sming WiFi support classes and definitions
+ */
+
 /** @mainpage
 
 The API documentation is provided as a set of modules, each describing a logical element of the API. Each module generally relates to a C++ class or group of related global functions. There are also modules for other global elements such as constant values.

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -199,7 +199,7 @@ Embedded HTTP Web Server
      auto &vars = tmpl->variables();
      vars["counter"] = String(counter);
      vars["IP"] = WifiStation.getIP().toString();
-     vars["MAC"] = WifiStation.getMAC();
+     vars["MAC"] = WifiStation.getMacAddress().toString();
      response.sendTemplate(tmpl);
    }
 

--- a/docs/source/upgrading/3.8-4.0.rst
+++ b/docs/source/upgrading/3.8-4.0.rst
@@ -129,7 +129,7 @@ WiFi Classes
 Additions
 ---------
 
-New class to handle MAC addresses: :source:`Sming/Wiring/MACAddress.h`.
+New class to handle MAC addresses: :source:`Sming/Wiring/MacAddress.h`.
 
 :source:`Sming/Platform/StationClass.h`
 ---------------------------------------

--- a/docs/source/upgrading/3.8-4.0.rst
+++ b/docs/source/upgrading/3.8-4.0.rst
@@ -131,14 +131,18 @@ Additions
 
 New class to handle MAC addresses: :source:`Sming/Wiring/MacAddress.h`.
 
-:source:`Sming/Platform/StationClass.h`
----------------------------------------
+:source:`Sming/Platform/Station.h`
+----------------------------------
 
 -  `getConnectionStatusName()` returns String instead of `char*`
 -  `EStationConnectionStatus` renamed to `StationConnectionStatus`
 
-:source:`Sming/Platform/WifiEventsClass.h`
-------------------------------------------
+:source:`Sming/Platform/WifiEvents.h`
+-------------------------------------
 
 - Callback handler parameter lists have changed
 
+Deprecated / Changed types
+==========================
+
+Deprecated types will generate a compiler warning. See `Deprecated List <../api/deprecated.html>`_.

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -242,7 +242,7 @@ void StartServers()
 }
 
 // Will be called when station is fully operational
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	StartServers();
 }

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -140,7 +140,7 @@ void StartDemo()
 	}
 }
 
-void got_IP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void got_IP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	Serial.print("IP: ");
 	Serial.println(ip);
@@ -148,7 +148,7 @@ void got_IP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 }
 
 // Will be called when WiFi station loses connection
-void connect_Fail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connect_Fail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	Serial.println("I'm NOT CONNECTED!");
 }

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -142,7 +142,8 @@ void StartDemo()
 
 void got_IP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
-	Serial.printf("IP: %s\n", ip.toString().c_str());
+	Serial.print("IP: ");
+	Serial.println(ip);
 	//You can put here other job like web,tcp etc.
 }
 

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -147,7 +147,7 @@ void got_IP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 }
 
 // Will be called when WiFi station loses connection
-void connect_Fail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connect_Fail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	Serial.println("I'm NOT CONNECTED!");
 }

--- a/samples/Basic_SmartConfig/README.rst
+++ b/samples/Basic_SmartConfig/README.rst
@@ -1,23 +1,23 @@
-Smart Config
-============
+Basic Smart Config
+==================
 
 Introduction
 ------------
 
-SmartConfig is a mechanism to configure a device as quickly as possible
-with the intermediate help of a smart phone and with least interaction
-from a human as possible.
+SmartConfig is a mechanism to more easily configure an ESP device using a smart phone.
 
-Basically your ESP device looks for Access Points (AP). When it finds an
-AP with special signature it tries to extract data like SSID and
-password from it. Meanwhile your smart phone tries to send that
-information.
+Calling `smartConfigStart()` starts a search for an Access Point (AP) with
+a special signature. It then tries to extract data like SSID and password from it.
+The App on your smart phone sends out that information.
 
 The example here shows how to use ESP_TOUCH method to do smart
-configuration on the device. It is a C++ conversion of the C code that
+configuration on the device. It ported from the C code that
 Espressif provides in the SDK examples.
 
-| What you will need also is the code that has to be run on your smart
-  phone. Espressif already released some sample code and you can try:
-| \* Android - https://github.com/EspressifApp/EsptouchForAndroid \* iOS
-  - https://github.com/EspressifApp/EsptouchForIOS
+You will need an App for your Smart Phone, such as:
+
+-  Android https://github.com/EspressifApp/EsptouchForAndroid
+-  iOS https://github.com/EspressifApp/EsptouchForIOS
+-  ESP8266 SmartConfig (search on Android Play)
+
+See also https://www.espressif.com/en/products/software/esp-touch/overview.

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -73,7 +73,7 @@ int onDownload(HttpConnection& connection, bool success)
 	return 0; // return 0 on success in your callbacks
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	// Use the Gibson Research fingerprints web page as an example. Unlike Google, the fingerprints don't change!
 	static const uint8_t grcSha1Fingerprint[] PROGMEM = {0x15, 0x9A, 0x76, 0xC5, 0xAE, 0xF4, 0x90, 0x15, 0x79, 0xE6,
@@ -114,7 +114,7 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 	downloadClient.send(request);
 }
 
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -114,7 +114,7 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 	downloadClient.send(request);
 }
 
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }

--- a/samples/Basic_WebSkeletonApp/app/application.cpp
+++ b/samples/Basic_WebSkeletonApp/app/application.cpp
@@ -36,7 +36,7 @@ void counterLoop()
 
 void STADisconnect(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
 {
-	debugf("DISCONNECT - SSID: %s, REASON: %d\n", ssid.c_str(), reason);
+	debugf("DISCONNECT - SSID: %s, REASON: %s\n", ssid.c_str(), WifiEvents.getDisconnectReasonDesc(reason).c_str());
 
 	if(!WifiAccessPoint.isEnabled()) {
 		debugf("Starting OWN AP");

--- a/samples/Basic_WebSkeletonApp/app/application.cpp
+++ b/samples/Basic_WebSkeletonApp/app/application.cpp
@@ -4,7 +4,7 @@ Timer counterTimer;
 void counterLoop();
 unsigned long counter = 0;
 
-void STADisconnect(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason);
+void STADisconnect(const String& ssid, MACAddress bssid, WifiDisconnectReason reason);
 void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway);
 
 void init()
@@ -34,7 +34,7 @@ void counterLoop()
 	counter++;
 }
 
-void STADisconnect(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void STADisconnect(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("DISCONNECT - SSID: %s, REASON: %s\n", ssid.c_str(), WifiEvents.getDisconnectReasonDesc(reason).c_str());
 

--- a/samples/Basic_WebSkeletonApp/app/application.cpp
+++ b/samples/Basic_WebSkeletonApp/app/application.cpp
@@ -4,8 +4,8 @@ Timer counterTimer;
 void counterLoop();
 unsigned long counter = 0;
 
-void STADisconnect(const String& ssid, MACAddress bssid, WifiDisconnectReason reason);
-void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway);
+void STADisconnect(const String& ssid, MacAddress bssid, WifiDisconnectReason reason);
+void STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway);
 
 void init()
 {
@@ -34,7 +34,7 @@ void counterLoop()
 	counter++;
 }
 
-void STADisconnect(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void STADisconnect(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("DISCONNECT - SSID: %s, REASON: %s\n", ssid.c_str(), WifiEvents.getDisconnectReasonDesc(reason).c_str());
 
@@ -46,7 +46,7 @@ void STADisconnect(const String& ssid, MACAddress bssid, WifiDisconnectReason re
 	}
 }
 
-void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway)
+void STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway)
 {
 	debugf("GOTIP - IP: %s, MASK: %s, GW: %s\n", ip.toString().c_str(), mask.toString().c_str(),
 		   gateway.toString().c_str());

--- a/samples/Basic_WebSkeletonApp_LTS/README.rst
+++ b/samples/Basic_WebSkeletonApp_LTS/README.rst
@@ -24,6 +24,7 @@ This is how it was done:
    * Add `ARDUINO_LIBRARIES=ArduinoJson6` to the project's component.mk file.
    * Add `#include <JsonObjectStream.h>`. If you're not using the stream class, add `#include <ArduinoJson6.h>` to code.
 9. Update callback function parameter lists for ``STADisconnect`` and ``STAGotIP``.
-   See :source:`Sming/Platform/StationClass.h`.
+   We can also get a description for disconnection reasons, so display that instead of just a number.
+   See :source:`Sming/Platform/WifiEvents.h`.
 
 That's it.

--- a/samples/Basic_WebSkeletonApp_LTS/app/application.cpp
+++ b/samples/Basic_WebSkeletonApp_LTS/app/application.cpp
@@ -36,7 +36,7 @@ void counterLoop()
 
 void STADisconnect(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
 {
-	debugf("DISCONNECT - SSID: %s, REASON: %d\n", ssid.c_str(), reason);
+	debugf("DISCONNECT - SSID: %s, REASON: %s\n", ssid.c_str(), WifiEvents.getDisconnectReasonDesc(reason).c_str());
 
 	if(!WifiAccessPoint.isEnabled()) {
 		debugf("Starting OWN AP");

--- a/samples/Basic_WebSkeletonApp_LTS/app/application.cpp
+++ b/samples/Basic_WebSkeletonApp_LTS/app/application.cpp
@@ -4,8 +4,8 @@ Timer counterTimer;
 void counterLoop();
 unsigned long counter = 0;
 
-void STADisconnect(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason);
-void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway);
+void STADisconnect(const String& ssid, const MacAddress& bssid, WifiDisconnectReason reason);
+void STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway);
 
 void init()
 {
@@ -34,7 +34,7 @@ void counterLoop()
 	counter++;
 }
 
-void STADisconnect(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void STADisconnect(const String& ssid, const MacAddress& bssid, WifiDisconnectReason reason)
 {
 	debugf("DISCONNECT - SSID: %s, REASON: %s\n", ssid.c_str(), WifiEvents.getDisconnectReasonDesc(reason).c_str());
 
@@ -46,7 +46,7 @@ void STADisconnect(const String& ssid, const MACAddress& bssid, WifiDisconnectRe
 	}
 }
 
-void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway)
+void STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway)
 {
 	debugf("GOTIP - IP: %s, MASK: %s, GW: %s\n", ip.toString().c_str(), mask.toString().c_str(),
 		   gateway.toString().c_str());

--- a/samples/Basic_WiFi/README.rst
+++ b/samples/Basic_WiFi/README.rst
@@ -1,4 +1,12 @@
 Basic WiFi
 ==========
 
-WiFi network connection and scanning functionality. Software Access Point.
+Demonstrates WiFi network connection and scanning functionality.
+
+Enables an unsecured Software Access Point called *Sming InternetOfThings*
+which you can connect to from your smart phone (or other WiFi device).
+
+Prints details of any probe requests, so you can see who's scanning your device.
+
+Scans list of available Access Points and displays them.
+

--- a/samples/Basic_WiFi/app/application.cpp
+++ b/samples/Basic_WiFi/app/application.cpp
@@ -30,7 +30,7 @@ void listNetworks(bool succeeded, BssList& list)
 void connectOk(IPAddress ip, IPAddress mask, IPAddress gateway)
 {
 	Serial.print(_F("I'm CONNECTED to "));
-	Serial.println(ip.toString());
+	Serial.println(ip);
 }
 
 // Will be called when WiFi station was disconnected

--- a/samples/Basic_WiFi/app/application.cpp
+++ b/samples/Basic_WiFi/app/application.cpp
@@ -34,7 +34,7 @@ void connectOk(IPAddress ip, IPAddress mask, IPAddress gateway)
 }
 
 // Will be called when WiFi station was disconnected
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	// The different reason codes can be found in user_interface.h. in your SDK.
 	Serial.print(_F("Disconnected from \""));
@@ -79,7 +79,7 @@ void init()
 	WifiStation.setIP(IPAddress(192, 168, 1, 171));
 
 	// Optional: Print details of any incoming probe requests
-	WifiEvents.onAccessPointProbeReqRecved([](int rssi, const MACAddress& mac) {
+	WifiEvents.onAccessPointProbeReqRecved([](int rssi, MACAddress mac) {
 		Serial.print(_F("Probe request: RSSI = "));
 		Serial.print(rssi);
 		Serial.print(_F(", mac = "));

--- a/samples/Basic_WiFi/app/application.cpp
+++ b/samples/Basic_WiFi/app/application.cpp
@@ -27,14 +27,14 @@ void listNetworks(bool succeeded, BssList& list)
 }
 
 // Will be called when WiFi station was connected to AP
-void connectOk(IPAddress ip, IPAddress mask, IPAddress gateway)
+void connectOk(IpAddress ip, IpAddress mask, IpAddress gateway)
 {
 	Serial.print(_F("I'm CONNECTED to "));
 	Serial.println(ip);
 }
 
 // Will be called when WiFi station was disconnected
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	// The different reason codes can be found in user_interface.h. in your SDK.
 	Serial.print(_F("Disconnected from \""));
@@ -75,11 +75,11 @@ void init()
 	WifiStation.config(_F(WIFI_SSID), _F(WIFI_PWD));
 
 	// Optional: Change IP addresses (and disable DHCP)
-	WifiAccessPoint.setIP(IPAddress(192, 168, 2, 1));
-	WifiStation.setIP(IPAddress(192, 168, 1, 171));
+	WifiAccessPoint.setIP(IpAddress(192, 168, 2, 1));
+	WifiStation.setIP(IpAddress(192, 168, 1, 171));
 
 	// Optional: Print details of any incoming probe requests
-	WifiEvents.onAccessPointProbeReqRecved([](int rssi, MACAddress mac) {
+	WifiEvents.onAccessPointProbeReqRecved([](int rssi, MacAddress mac) {
 		Serial.print(_F("Probe request: RSSI = "));
 		Serial.print(rssi);
 		Serial.print(_F(", mac = "));

--- a/samples/Basic_WiFi/app/application.cpp
+++ b/samples/Basic_WiFi/app/application.cpp
@@ -53,7 +53,7 @@ void ready()
 		Serial.print(_F("AP. ip: "));
 		Serial.print(WifiAccessPoint.getIP());
 		Serial.print(_F(" mac: "));
-		Serial.println(WifiAccessPoint.getMacAddr());
+		Serial.println(WifiAccessPoint.getMacAddress());
 	}
 }
 

--- a/samples/Basic_rBoot/app/application.cpp
+++ b/samples/Basic_rBoot/app/application.cpp
@@ -136,7 +136,10 @@ void serialCallBack(Stream& stream, char arrivedChar, unsigned short availableCh
 			WifiStation.enable(true);
 			WifiStation.connect();
 		} else if(!strcmp(str, "ip")) {
-			Serial.printf("ip: %s mac: %s\r\n", WifiStation.getIP().toString().c_str(), WifiStation.getMAC().c_str());
+			Serial.print("ip: ");
+			Serial.print(WifiStation.getIP());
+			Serial.print("mac: ");
+			Serial.println(WifiStation.getMacAddress());
 		} else if(!strcmp(str, "ota")) {
 			OtaUpdate();
 		} else if(!strcmp(str, "switch")) {

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -107,7 +107,7 @@ void startExampleApplicationCommand()
 		CommandDelegate("example", "Example Command from Class", "Application", processApplicationCommands));
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	StartServers();
 

--- a/samples/DS3232RTC_NTP_Setter/app/application.cpp
+++ b/samples/DS3232RTC_NTP_Setter/app/application.cpp
@@ -30,7 +30,7 @@ void onNtpReceive(NtpClient& client, time_t timestamp)
 	Serial.printf("Time synchronized: %s\n", SystemClock.getSystemTimeString().c_str());
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	ntpClient.requestTime();
 }

--- a/samples/Echo_Ssl/app/application.cpp
+++ b/samples/Echo_Ssl/app/application.cpp
@@ -99,17 +99,17 @@ bool onReceive(TcpClient& tcpClient, char* data, int size)
 	return tcpClient.send(data, size);
 }
 
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	debugf("IP: %s", ip.toString().c_str());
 	client = new TcpClient(TcpClientDataDelegate(onReceive));
 	client->addSslOptions(SSL_SERVER_VERIFY_LATER);
-	client->connect(IPAddress(SERVER_IP), 4444, true);
+	client->connect(IpAddress(SERVER_IP), 4444, true);
 }
 
 void init()

--- a/samples/Echo_Ssl/app/application.cpp
+++ b/samples/Echo_Ssl/app/application.cpp
@@ -99,7 +99,7 @@ bool onReceive(TcpClient& tcpClient, char* data, int size)
 	return tcpClient.send(data, size);
 }
 
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -18,7 +18,7 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 }
 
 // Will be called when WiFi station timeout was reached
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	Serial.println("I'm NOT CONNECTED. Need help!!! :(");
 

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -10,7 +10,8 @@ FtpServer ftp;
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
-	Serial.printf("IP: %s\n", ip.toString().c_str());
+	Serial.print("IP: ");
+	Serial.println(ip);
 	// Start FTP server
 	ftp.listen(21);
 	ftp.addUser("me", "123"); // FTP account

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -8,7 +8,7 @@
 
 FtpServer ftp;
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	Serial.print("IP: ");
 	Serial.println(ip);
@@ -19,7 +19,7 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 }
 
 // Will be called when WiFi station timeout was reached
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	Serial.println("I'm NOT CONNECTED. Need help!!! :(");
 

--- a/samples/HttpClient/app/application.cpp
+++ b/samples/HttpClient/app/application.cpp
@@ -111,7 +111,7 @@ void setSslFingerprints(HttpRequest* request)
 	request->pinCertificate(fingerprints);
 }
 
-void connectOk(IPAddress ip, IPAddress mask, IPAddress gateway)
+void connectOk(IpAddress ip, IpAddress mask, IpAddress gateway)
 {
 	// [ GET request: The example below shows how to make HTTP requests ]
 

--- a/samples/HttpClient_Instapush/app/application.cpp
+++ b/samples/HttpClient_Instapush/app/application.cpp
@@ -90,7 +90,7 @@ void publishMessage()
 }
 
 // Will be called when WiFi station was connected to AP
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	Serial.println("I'm CONNECTED");
 

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -49,7 +49,7 @@ void sendData()
 }
 
 // Will be called when WiFi station timeout was reached
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	Serial.println("I'm NOT CONNECTED. Need help :(");
 
@@ -60,7 +60,7 @@ void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reas
 	// .. some you code for configuration ..
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	// Start send data loop
 	procTimer.initializeMs(25 * 1000, sendData).start(); // every 25 seconds

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -49,7 +49,7 @@ void sendData()
 }
 
 // Will be called when WiFi station timeout was reached
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	Serial.println("I'm NOT CONNECTED. Need help :(");
 

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -97,7 +97,7 @@ void startFTP()
 	ftp.addUser("me", "123"); // FTP account
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	startFTP();
 	startWebServer();

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -22,7 +22,7 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 	vars["counter"] = String(counter);
 	//vars["ledstate"] = (*portOutputRegister(digitalPinToPort(LED_PIN)) & digitalPinToBitMask(LED_PIN)) ? "checked" : "";
 	vars["IP"] = WifiStation.getIP().toString();
-	vars["MAC"] = WifiStation.getMAC();
+	vars["MAC"] = WifiStation.getMacAddress().toString();
 	response.sendNamedStream(tmpl); // this template object will be deleted automatically
 }
 

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -73,7 +73,7 @@ void downloadContentFiles()
 								}));
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	if(!fileExist("index.html") || !fileExist("bootstrap.css.gz") || !fileExist("jquery.js.gz")) {
 		// Download server content at first

--- a/samples/HttpServer_ConfigNetwork/app/application.cpp
+++ b/samples/HttpServer_ConfigNetwork/app/application.cpp
@@ -27,7 +27,7 @@ int onIpConfig(HttpServerConnection& connection, HttpRequest& request, HttpRespo
 	if(request.method == HTTP_POST) {
 		debugf("Request coming from IP: %s", connection.getRemoteIp().toString().c_str());
 		// If desired you can also limit the access based on remote IP. Example below:
-		//		if(!(IpAddress("192.168.4.23") == connection.getRemoteIp())) {
+		//		if(IpAddress("192.168.4.23") != connection.getRemoteIp()) {
 		//			return 1; // error
 		//		}
 

--- a/samples/HttpServer_ConfigNetwork/app/application.cpp
+++ b/samples/HttpServer_ConfigNetwork/app/application.cpp
@@ -27,7 +27,7 @@ int onIpConfig(HttpServerConnection& connection, HttpRequest& request, HttpRespo
 	if(request.method == HTTP_POST) {
 		debugf("Request coming from IP: %s", connection.getRemoteIp().toString().c_str());
 		// If desired you can also limit the access based on remote IP. Example below:
-		//		if(!(IPAddress("192.168.4.23") == connection.getRemoteIp())) {
+		//		if(!(IpAddress("192.168.4.23") == connection.getRemoteIp())) {
 		//			return 1; // error
 		//		}
 

--- a/samples/HttpServer_ConfigNetwork/include/AppSettings.h
+++ b/samples/HttpServer_ConfigNetwork/include/AppSettings.h
@@ -19,9 +19,9 @@ struct ApplicationSettingsStorage {
 
 	bool dhcp = true;
 
-	IPAddress ip;
-	IPAddress netmask;
-	IPAddress gateway;
+	IpAddress ip;
+	IpAddress netmask;
+	IpAddress gateway;
 
 	void load()
 	{

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -116,7 +116,7 @@ void startWebServer()
 }
 
 // Will be called when WiFi station becomes fully operational
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	startWebServer();
 }

--- a/samples/LED_YeelightBulb/app/application.cpp
+++ b/samples/LED_YeelightBulb/app/application.cpp
@@ -8,7 +8,7 @@
 #endif
 
 // Enter your bulb IP here:
-YeelightBulb bulb(IPAddress("192.168.1.100"));
+YeelightBulb bulb(IpAddress("192.168.1.100"));
 
 Timer procTimer;
 bool state = false;
@@ -25,7 +25,7 @@ void blink()
 }
 
 // Will be called when WiFi station was connected to AP
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	debugf("I'm CONNECTED");
 

--- a/samples/MeteoControl/app/application.cpp
+++ b/samples/MeteoControl/app/application.cpp
@@ -24,9 +24,9 @@ bool state = true;
 String StrT, StrRH, StrTime;
 
 void process();
-void connectOk(const String& SSID, MACAddress bssid, uint8_t channel);
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason);
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway);
+void connectOk(const String& SSID, MacAddress bssid, uint8_t channel);
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason);
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway);
 
 void init()
 {
@@ -106,13 +106,13 @@ void process()
 		displayTimer.initializeMs(1000, showValues).start();
 }
 
-void connectOk(const String& SSID, MACAddress bssid, uint8_t channel)
+void connectOk(const String& SSID, MacAddress bssid, uint8_t channel)
 {
 	debugf("connected");
 	WifiAccessPoint.enable(false);
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	lcd.clear();
 	lcd.print("\7 ");
@@ -130,7 +130,7 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 		startWebServer();
 }
 
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("connection FAILED: %s", WifiEvents.getDisconnectReasonDesc(reason).c_str());
 	WifiAccessPoint.config("MeteoConfig", "", AUTH_OPEN);

--- a/samples/MeteoControl/app/application.cpp
+++ b/samples/MeteoControl/app/application.cpp
@@ -132,7 +132,7 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 
 void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
 {
-	debugf("connection FAILED");
+	debugf("connection FAILED: %s", WifiEvents.getDisconnectReasonDesc(reason).c_str());
 	WifiAccessPoint.config("MeteoConfig", "", AUTH_OPEN);
 	WifiAccessPoint.enable(true);
 	// Stop main screen output

--- a/samples/MeteoControl/app/application.cpp
+++ b/samples/MeteoControl/app/application.cpp
@@ -116,7 +116,7 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	lcd.clear();
 	lcd.print("\7 ");
-	lcd.print(ip.toString());
+	lcd.print(ip);
 	// Restart main screen output
 	procTimer.restart();
 	displayTimer.stop();

--- a/samples/MeteoControl/app/application.cpp
+++ b/samples/MeteoControl/app/application.cpp
@@ -24,8 +24,8 @@ bool state = true;
 String StrT, StrRH, StrTime;
 
 void process();
-void connectOk(const String& SSID, const MACAddress& bssid, uint8_t channel);
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason);
+void connectOk(const String& SSID, MACAddress bssid, uint8_t channel);
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason);
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway);
 
 void init()
@@ -106,7 +106,7 @@ void process()
 		displayTimer.initializeMs(1000, showValues).start();
 }
 
-void connectOk(const String& SSID, const MACAddress& bssid, uint8_t channel)
+void connectOk(const String& SSID, MACAddress bssid, uint8_t channel)
 {
 	debugf("connected");
 	WifiAccessPoint.enable(false);
@@ -130,7 +130,7 @@ void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 		startWebServer();
 }
 
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("connection FAILED: %s", WifiEvents.getDisconnectReasonDesc(reason).c_str());
 	WifiAccessPoint.config("MeteoConfig", "", AUTH_OPEN);

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -59,7 +59,7 @@ void startMqttClient()
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
 	Serial.print("Connected: ");
-	Serial.println(ip.toString());
+	Serial.println(ip);
 	startMqttClient();
 	publishMessage(); // run once publishMessage
 }

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -7,7 +7,7 @@
 
 Timer publishTimer;
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway);
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway);
 
 void init()
 {
@@ -56,7 +56,7 @@ void startMqttClient()
 	mqtt.subscribe(SUB_TOPIC);
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	Serial.print("Connected: ");
 	Serial.println(ip);

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -92,7 +92,8 @@ void startMqttClient()
 
 	// 2. [Connect]
 	Url url(MQTT_URL);
-	Serial.printf("Connecting to \t%s\n", url.toString().c_str());
+	Serial.print("Connecting to \t");
+	Serial.println(url);
 	mqtt.connect(url, "esp8266");
 	mqtt.subscribe("main/status/#");
 }

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -98,7 +98,7 @@ void startMqttClient()
 	mqtt.subscribe("main/status/#");
 }
 
-void onConnected(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void onConnected(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	// Run MQTT client
 	startMqttClient();

--- a/samples/SmtpClient/app/application.cpp
+++ b/samples/SmtpClient/app/application.cpp
@@ -42,7 +42,7 @@ int onMailSent(SmtpClient& client, int code, char* status)
 	return 0;
 }
 
-void onConnected(IPAddress ip, IPAddress mask, IPAddress gateway)
+void onConnected(IpAddress ip, IpAddress mask, IpAddress gateway)
 {
 #ifdef ENABLE_SSL
 	client.addSslOptions(SSL_SERVER_VERIFY_LATER);

--- a/samples/SystemClock_NTP/app/application.cpp
+++ b/samples/SystemClock_NTP/app/application.cpp
@@ -64,12 +64,12 @@ void onNtpReceive(NtpClient& client, time_t timestamp)
 }
 
 // Will be called when WiFi station timeout was reached
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	// Set specific parameters if started by option 1 or 2
 	// Set client to do automatic time requests every 60 seconds.

--- a/samples/SystemClock_NTP/app/application.cpp
+++ b/samples/SystemClock_NTP/app/application.cpp
@@ -64,7 +64,7 @@ void onNtpReceive(NtpClient& client, time_t timestamp)
 }
 
 // Will be called when WiFi station timeout was reached
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }

--- a/samples/TcpClient_NarodMon/README.rst
+++ b/samples/TcpClient_NarodMon/README.rst
@@ -1,4 +1,9 @@
 TCP Client NarodMon
 ===================
 
-To be completed.
+An example of sending data to narodmon.ru using a TCP client.
+
+https://narodmon.ru was is a geo-information project to display on the world map and control
+(on PCs, smartphones and other gadgets) the sensor readings of its members
+(temperature, humidity, pressure, wind speed and direction, radiation, energy consumption
+and any other values), as well as private and urban webcams for public or private viewing.

--- a/samples/TcpClient_NarodMon/app/application.cpp
+++ b/samples/TcpClient_NarodMon/app/application.cpp
@@ -25,7 +25,7 @@ Timer procTimer;
 
 // Переменная для хранения mac-адреса
 // Variable for storing MAC address
-MACAddress mac;
+MacAddress mac;
 
 // Переменная, в которой у нас хранится температура с датчика
 // Variable to store temperature from sensor
@@ -101,7 +101,7 @@ void sendData()
 
 // Successful connection to AP
 // Когда удачно подключились к роутеру
-void connectOk(const String& SSID, MACAddress bssid, uint8_t channel)
+void connectOk(const String& SSID, MacAddress bssid, uint8_t channel)
 {
 	// debug msg
 	debugf("I'm CONNECTED to WiFi");
@@ -112,14 +112,14 @@ void connectOk(const String& SSID, MACAddress bssid, uint8_t channel)
 	debugf("mac: %s", mac.toString().c_str());
 }
 
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	// Display a message on failed connection
 	// Если подключение к роутеру не удалось, выводим сообщение
 	debugf("I'm NOT CONNECTED!");
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	// Call the sendData function by timer, every 6 minutes
 	// вызываем по таймеру функцию sendData

--- a/samples/TcpClient_NarodMon/app/application.cpp
+++ b/samples/TcpClient_NarodMon/app/application.cpp
@@ -1,6 +1,9 @@
 /* Пример отправки данных на narodmon.ru с помощью TCP-клиента.
+ * An example of sending data to narodmon.ru using a TCP client.
  * By JustACat http://esp8266.ru/forum/members/120/
  * 23.04.2015
+ *
+ * 9/8/2019 mikee47 Revised with English translations
  */
 #include <SmingCore.h>
 
@@ -13,9 +16,20 @@
 #define NARODM_HOST "narodmon.ru"
 #define NARODM_PORT 8283
 
-Timer procTimer; // Таймер для периодического вызова отправки данных
-String mac;		 // Переменная для хранения mac-адреса
-float t1 = -2.5; // Переменная, в которой у нас хранится температура с датчика
+// Time between command packets, in seconds
+const unsigned SENDDATA_INTERVAL = 6 * 60;
+
+// Таймер для периодического вызова отправки данных
+// Timer for a periodic call to send data
+Timer procTimer;
+
+// Переменная для хранения mac-адреса
+// Variable for storing MAC address
+MACAddress mac;
+
+// Переменная, в которой у нас хранится температура с датчика
+// Variable to store temperature from sensor
+float t1 = -2.5;
 
 void nmOnCompleted(TcpClient& client, bool successful)
 {
@@ -32,14 +46,28 @@ void nmOnReadyToSend(TcpClient& client, TcpConnectionEvent sourceEvent)
 
 	// в момент соединения осуществляем отправку
 	if(sourceEvent == eTCE_Connected) {
+		// преобразуем из XXXXXXXXXXXX в XX-XX-XX-XX-XX-XX
+		String command = "#" + mac.toString() + '\n';
 		/* отправляем данные по датчикам (3 штуки)
-		 * T1 = t1 (температура)
-		 * H1 = 8 (влажность)
-		 * P1 = 712.15 (давление)
-		 *
-		 * после отправки сразу закроем соединение: последний параметр = true
+		 * Send data on 3 sensors
 		 */
-		client.sendString("#" + mac + "\n#T1#" + t1 + "\n#H1#8\n#P1#712.15\n##", true);
+		// T1 = t1 (температура Temperature)
+		command += "#T1#" + String(t1) + '\n';
+		// H1 = 8 (влажность Humidity)
+		command += "#H1#8\n";
+		// P1 = 712.15 (давление Pressure)
+		command += "#P1#712.15\n";
+		// Terminate command list
+		command += "##";
+
+		Serial.println(command);
+
+		/*
+		 * после отправки сразу закроем соединение: последний параметр = true
+		 * After sending, close the connection.
+		 */
+		bool forceCloseAfterSent = true;
+		client.sendString(command, forceCloseAfterSent);
 	}
 }
 
@@ -52,67 +80,78 @@ bool nmOnReceive(TcpClient& client, char* buf, int size)
 }
 
 // Создаем объект narodMon класса TcpClient
+// Create the narodMon object
 TcpClient narodMon(nmOnCompleted, nmOnReadyToSend, nmOnReceive);
 
 // эта функция будет вызываться по таймеру
+// This function is called by timer
 void sendData()
 {
+	// Read sensors
 	// считываем показания датчиков
 	// ...
+	// For debugging, increase the value of the variable t1 by 1.39 degrees each time
 	// для отладки просто увеличиваем каждый раз значение переменной t1 на 1.39 градуса
 	t1 += 1.39;
 
+	// Connect to narodmon server
 	// подключаемся к серверу narodmon
 	narodMon.connect(NARODM_HOST, NARODM_PORT);
 }
 
+// Successful connection to AP
 // Когда удачно подключились к роутеру
-void connectOk(const String& SSID, const MACAddress& bssid, uint8_t channel)
+void connectOk(const String& SSID, MACAddress bssid, uint8_t channel)
 {
 	// debug msg
 	debugf("I'm CONNECTED to WiFi");
 
+	// Get the MAC address of our ESP
 	// получаем MAC-адрес нашей ESP и помещаем в переменную mac
-	mac = WifiStation.getMAC();
-	// в верхний регистр
-	mac.toUpperCase();
-	// преобразуем из XXXXXXXXXXXX в XX-XX-XX-XX-XX-XX
-	for(unsigned i = 2; i < mac.length(); i += 2) {
-		mac = mac.substring(0, i) + "-" + mac.substring(i);
-		i++;
-	}
-
-	debugf("mac: %s", mac.c_str());
+	mac = WifiStation.getMacAddress();
+	debugf("mac: %s", mac.toString().c_str());
 }
 
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
+	// Display a message on failed connection
 	// Если подключение к роутеру не удалось, выводим сообщение
 	debugf("I'm NOT CONNECTED!");
 }
 
 void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
 {
+	// Call the sendData function by timer, every 6 minutes
 	// вызываем по таймеру функцию sendData
-	procTimer.initializeMs(6 * 60 * 1000, sendData).start(); // каждые 6 минут
+	procTimer.initializeMs(SENDDATA_INTERVAL * 1000, sendData).start(); // каждые 6 минут
+
+	// Send immediately on startup
 	// ну и заодно сразу после запуска вызываем, чтобы не ждать 6 минут первый раз
 	sendData();
 }
 
 void init()
 {
+	// Configure and enable output in UART for debug
 	// Настраиваем и включаем вывод в UART для дебага
 	Serial.begin(COM_SPEED_SERIAL);
 	Serial.systemDebugOutput(true);
 	Serial.println("Hello friendly world! :)");
 
+	// Disable AP
 	// Отключаем AP
 	WifiAccessPoint.enable(false);
 
+	// Configure and enable Station
 	// Настраиваем и включаем Station
 	WifiStation.config(WIFI_SSID, WIFI_PWD);
 	WifiStation.enable(true);
 
+	/*
+	 * connectOk will be called on connection to the router
+	 * connectFail will be called if it fails to connect
+	 * Timeout is 30 seconds
+	 */
 	/* connectOk будет вызвана, когда (если) подключимся к роутеру
 	 * connectFail будет вызвана, если подключиться не получится
 	 * 30 - таймаут подключения (сек)

--- a/samples/Telnet_TCPServer_TCPClient/app/application.cpp
+++ b/samples/Telnet_TCPServer_TCPClient/app/application.cpp
@@ -100,12 +100,12 @@ void startServers()
 												   "testGroup", applicationCommand));
 }
 
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	startServers();
 }

--- a/samples/Telnet_TCPServer_TCPClient/app/application.cpp
+++ b/samples/Telnet_TCPServer_TCPClient/app/application.cpp
@@ -100,7 +100,7 @@ void startServers()
 												   "testGroup", applicationCommand));
 }
 
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }

--- a/samples/UdpServer_Echo/app/application.cpp
+++ b/samples/UdpServer_Echo/app/application.cpp
@@ -6,13 +6,13 @@
 #define WIFI_PWD "PleaseEnterPass"
 #endif
 
-void onReceive(UdpConnection& connection, char* data, int size, IPAddress remoteIP, uint16_t remotePort); // Declaration
+void onReceive(UdpConnection& connection, char* data, int size, IpAddress remoteIP, uint16_t remotePort); // Declaration
 
 // UDP server
 const uint16_t EchoPort = 1234;
 UdpConnection udp(onReceive);
 
-void onReceive(UdpConnection& connection, char* data, int size, IPAddress remoteIP, uint16_t remotePort)
+void onReceive(UdpConnection& connection, char* data, int size, IpAddress remoteIP, uint16_t remotePort)
 {
 	debugf("UDP Server callback from %s:%d, %d bytes", remoteIP.toString().c_str(), remotePort, size);
 
@@ -25,7 +25,7 @@ void onReceive(UdpConnection& connection, char* data, int size, IPAddress remote
 	udp.sendStringTo(remoteIP, remotePort, text);
 }
 
-void gotIP(IPAddress ip, IPAddress gateway, IPAddress netmask)
+void gotIP(IpAddress ip, IpAddress gateway, IpAddress netmask)
 {
 	udp.listen(EchoPort);
 

--- a/samples/UdpServer_Echo/app/application.cpp
+++ b/samples/UdpServer_Echo/app/application.cpp
@@ -30,7 +30,7 @@ void gotIP(IPAddress ip, IPAddress gateway, IPAddress netmask)
 	udp.listen(EchoPort);
 
 	Serial.println("\r\n=== UDP SERVER STARTED ===");
-	Serial.print(WifiStation.getIP().toString());
+	Serial.print(WifiStation.getIP());
 	Serial.print(":");
 	Serial.println(EchoPort);
 	Serial.println("=============================\r\n");

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -50,12 +50,12 @@ void startWebServer()
 	Serial.println("==============================\r\n");
 }
 
-void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }
 
-void gotIP(IPAddress ip, IPAddress netmask, IPAddress gateway)
+void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
 	if(!fileExist("index.html"))
 		fileSetContent("index.html",

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -50,7 +50,7 @@ void startWebServer()
 	Serial.println("==============================\r\n");
 }
 
-void connectFail(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void connectFail(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	debugf("I'm NOT CONNECTED!");
 }

--- a/samples/Websocket_Client/README.rst
+++ b/samples/Websocket_Client/README.rst
@@ -1,4 +1,10 @@
 Websocket Client
 ================
 
-To be completed.
+This is a simple demo of the WebsocketClient class.
+
+The client tries to connect to *echo.websocket.org*.
+It sents 10 messages then client connection is closed.
+It reconnects and sends 25 messages and continues doing same.
+
+This demo shows connecton, closing and reconnection methods of WebsocketClient.

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -117,7 +117,7 @@ void wsMessageSent()
 #endif
 }
 
-void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway)
+void STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway)
 {
 	Serial.print(_F("GOTIP - IP: "));
 	Serial.print(ip);
@@ -139,7 +139,7 @@ void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway)
 #endif
 }
 
-void STADisconnect(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
+void STADisconnect(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	Serial.print(_F("DISCONNECT - SSID: "));
 	Serial.print(ssid);

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -24,34 +24,41 @@ WebsocketClient wsClient;
 Timer msgTimer;
 Timer restartTimer;
 
-#define RESTART_PERIOD 20
+// Number of messages to send
+const unsigned MESSAGES_TO_SEND = 10;
+
+// Interval (in seconds) between sending of messages
+const unsigned MESSAGE_INTERVAL = 1;
+
+// Time (in seconds) to wait before restarting client and sending another group of messages
+const unsigned RESTART_PERIOD = 20;
 
 int msg_cnt = 0;
 
 #ifdef ENABLE_SSL
-String ws_Url = "wss://echo.websocket.org";
+DEFINE_FSTR_LOCAL(ws_Url, "wss://echo.websocket.org");
 #else
-String ws_Url = "ws://echo.websocket.org";
+DEFINE_FSTR_LOCAL(ws_Url, "ws://echo.websocket.org");
 #endif /* ENABLE_SSL */
 
 void wsMessageSent();
 
 void wsConnected(WebsocketConnection& wsConnection)
 {
-	Serial.printf("Start sending messages every second...");
-	msgTimer.initializeMs(1 * 1000, wsMessageSent);
+	Serial.printf(_F("Start sending messages every %u second(s)...\n"), MESSAGE_INTERVAL);
+	msgTimer.initializeMs(MESSAGE_INTERVAL * 1000, wsMessageSent);
 	msgTimer.start();
 }
 
 void wsMessageReceived(WebsocketConnection& wsConnection, const String& message)
 {
-	Serial.printf("WebSocket message received: %s\n", message.c_str());
-	Serial.printf("Free Heap: %d\n", system_get_free_heap_size());
+	Serial.printf(_F("WebSocket message received: %s\n"), message.c_str());
+	Serial.printf(_F("Free Heap: %d\n"), system_get_free_heap_size());
 }
 
 void wsBinReceived(WebsocketConnection& wsConnection, uint8_t* data, size_t size)
 {
-	Serial.printf("WebSocket BINARY received\n");
+	Serial.println(_F("WebSocket BINARY received"));
 	for(uint8_t i = 0; i < size; i++) {
 		Serial.printf("wsBin[%u] = 0x%02X\n", i, data[i]);
 	}
@@ -61,20 +68,18 @@ void wsBinReceived(WebsocketConnection& wsConnection, uint8_t* data, size_t size
 
 void restart()
 {
+	Serial.println("restart...");
+
 	msg_cnt = 0;
-	wsClient.connect(ws_Url);
+	wsClient.connect(String(ws_Url));
 #ifdef ENABLE_SSL
 	wsClient.getHttpConnection()->addSslOptions(SSL_SERVER_VERIFY_LATER);
 #endif
-
-	msgTimer.setCallback(wsMessageSent);
-	msgTimer.setIntervalMs(1 * 1000);
-	msgTimer.start();
 }
 
 void wsDisconnected(WebsocketConnection& wsConnection)
 {
-	Serial.printf("Restarting websocket client after %d seconds\n", RESTART_PERIOD);
+	Serial.printf(_F("Restarting websocket client after %d seconds\n"), RESTART_PERIOD);
 	msgTimer.setCallback(restart);
 	msgTimer.setIntervalMs(RESTART_PERIOD * 1000);
 	msgTimer.startOnce();
@@ -87,22 +92,23 @@ void wsMessageSent()
 		return;
 	}
 
-	if(msg_cnt > 10) {
-		Serial.println("End Websocket client session");
-		wsClient.close(); // clean disconnect.
+	if(msg_cnt > MESSAGES_TO_SEND) {
+		Serial.println(_F("End Websocket client session"));
 		msgTimer.stop();
+		wsClient.close(); // clean disconnect.
 
 		return;
 	}
 
 #ifndef WS_BINARY
-	String message = "Hello " + String(msg_cnt++);
-	Serial.printf("Sending websocket message: %s\n", message.c_str());
+	String message = F("Hello ") + String(msg_cnt++);
+	Serial.print(_F("Sending websocket message: "));
+	Serial.println(message);
 	wsClient.sendString(message);
 #else
 	uint8_t buf[] = {0xF0, 0x00, 0xF0};
 	buf[1] = msg_cnt++;
-	Serial.printf("Sending websocket binary buffer\n");
+	Serial.println(_F("Sending websocket binary buffer"));
 	for(uint8_t i = 0; i < 3; i++) {
 		Serial.printf("wsBin[%u] = 0x%02X\n", i, buf[i]);
 	}
@@ -113,16 +119,21 @@ void wsMessageSent()
 
 void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway)
 {
-	Serial.printf("GOTIP - IP: %s, MASK: %s, GW: %s\n", ip.toString().c_str(), mask.toString().c_str(),
-				  gateway.toString().c_str());
+	Serial.print(_F("GOTIP - IP: "));
+	Serial.print(ip);
+	Serial.print(_F(", MASK: "));
+	Serial.print(mask);
+	Serial.print(_F(", GW: "));
+	Serial.println(gateway);
 
-	Serial.printf("Connecting to Websocket Server %s\n", ws_Url.c_str());
+	Serial.print(_F("Connecting to Websocket Server "));
+	Serial.println(ws_Url);
 
 	wsClient.setMessageHandler(wsMessageReceived);
 	wsClient.setBinaryHandler(wsBinReceived);
 	wsClient.setDisconnectionHandler(wsDisconnected);
 	wsClient.setConnectionHandler(wsConnected);
-	wsClient.connect(ws_Url);
+	wsClient.connect(String(ws_Url));
 #ifdef ENABLE_SSL
 	wsClient.getHttpConnection()->addSslOptions(SSL_SERVER_VERIFY_LATER);
 #endif
@@ -130,7 +141,10 @@ void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway)
 
 void STADisconnect(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
-	Serial.printf("DISCONNECT - SSID: %s, REASON: %s\n", ssid.c_str(), WifiEvents.getDisconnectReasonDesc(reason));
+	Serial.print(_F("DISCONNECT - SSID: "));
+	Serial.print(ssid);
+	Serial.print(_F(", REASON: "));
+	Serial.println(WifiEvents.getDisconnectReasonDesc(reason));
 }
 
 void init()

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -130,7 +130,7 @@ void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway)
 
 void STADisconnect(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
 {
-	Serial.printf("DISCONNECT - SSID: %s, REASON: %d\n", ssid.c_str(), reason);
+	Serial.printf("DISCONNECT - SSID: %s, REASON: %s\n", ssid.c_str(), WifiEvents.getDisconnectReasonDesc(reason));
 }
 
 void init()

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -128,7 +128,7 @@ void STAGotIP(IPAddress ip, IPAddress mask, IPAddress gateway)
 #endif
 }
 
-void STADisconnect(const String& ssid, const MACAddress& bssid, WifiDisconnectReason reason)
+void STADisconnect(const String& ssid, MACAddress bssid, WifiDisconnectReason reason)
 {
 	Serial.printf("DISCONNECT - SSID: %s, REASON: %s\n", ssid.c_str(), WifiEvents.getDisconnectReasonDesc(reason));
 }

--- a/samples/Websocket_Client/component.mk
+++ b/samples/Websocket_Client/component.mk
@@ -1,7 +1,7 @@
 DISABLE_SPIFFS = 1
 
-# Uncomment the option below if you do not want to have SSL support.
-ENABLE_SSL=1
+# Uncomment the option below if you want SSL support
+#ENABLE_SSL=1
 
 ## size of the flash chip
 SPI_SIZE  ?= 4M


### PR DESCRIPTION
Update WiFi documentation

* Create doxygen `WiFi` group, and add station, ap and events to it.
* Add descriptions for Wifi disconnection reasons

MACAddress class:

* Bugfix: `operator!()` sense inverted
* Enforce array size checks - i.e. cannot instantiate MACAddress with anything other than uint8_t[6]
* Rename `getMacAddr()` -> `getMacAddress()`
* Make printable, so `Serial.print(mac)` works

Change `const MACAddress&` parameters in Delegates to `MACAddress`.

  I investigated the code which is generated for various cases where `MACAddress`, `IPAddress` and `String`
  types are passed by reference (`const MACAddress& mac`) or by value (`MACAddress mac`).

  For both `MACAddress` and `IPAddress` the code is virtually identical, so using the more complex `const&` syntax
  has no benefit. With `String` it *does* make a difference so they need to remain as references.

  Note that this works because the WifiEventsClass methods which invoke the callbacks don't re-use
  the constructed MACAddress or IPAddress objects, so the compiler doesn't have to worry about preserving
  the object and so doesn't care if the callback modifies them.

IPAddress class:

* Simplify IP address printing. IPAddress is printable, so `Serial.print(ip)` can be used instead of `Serial.print(ip.toString())`.
* Add `!=` operators. Notable omission. Also use lwip manipulation macros, will make it easier when/if the class gets updated to support IPv6.


Host implementation:

* Add some network messages to console so we can always see when IP address is allocated, etc.
* Add better check for Host WPS/SmartConfig support.
  Now throws an error compiling application if either is enabled, without breaking dist-clean.
  The previous version also added 'esp-wifi-check' files everywhere...

Review and update a couple of samples:

* Websocket_Client - bug in wsDisconnected, line 92 where msgTimer.stop() is called immediately after close(). This cancelled the 20-second retry timer because the wsDisconnected callback gets handled inside close().
* TcpClient_NarodMon (with translations)
