### PR TITLE
Automatic linker script generation

### DIFF
--- a/Sming/Components/rboot/.patches/rboot.patch
+++ b/Sming/Components/rboot/.patches/rboot.patch
@@ -1,11 +1,14 @@
 diff --git a/Makefile b/Makefile
-index 0b43474..7cb71f4 100644
+index 0b43474..5176f8f 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -58,6 +58,16 @@ endif
+@@ -58,6 +58,19 @@ endif
  ifeq ($(RBOOT_IROM_CHKSUM),1)
  	CFLAGS += -DBOOT_IROM_CHKSUM
  endif
++ifneq ($(RBOOT_ROM0_ADDR),)
++	CFLAGS += -DBOOT_ROM0_ADDR=$(RBOOT_ROM0_ADDR)
++endif
 +ifneq ($(RBOOT_ROM1_ADDR),)
 +	CFLAGS += -DBOOT_ROM1_ADDR=$(RBOOT_ROM1_ADDR)
 +endif
@@ -19,7 +22,7 @@ index 0b43474..7cb71f4 100644
  ifneq ($(RBOOT_EXTRA_INCDIR),)
  	CFLAGS += $(addprefix -I,$(RBOOT_EXTRA_INCDIR))
  endif
-@@ -75,6 +85,10 @@ else ifeq ($(SPI_SIZE), 2Mb)
+@@ -75,6 +88,10 @@ else ifeq ($(SPI_SIZE), 2Mb)
  	E2_OPTS += -2048b
  else ifeq ($(SPI_SIZE), 4M)
  	E2_OPTS += -4096
@@ -30,9 +33,8 @@ index 0b43474..7cb71f4 100644
  endif
  ifeq ($(SPI_MODE), qio)
  	E2_OPTS += -qio
-
 diff --git a/rboot.c b/rboot.c
-index d622f97..00ccaeb 100644
+index d622f97..5e254fa 100644
 --- a/rboot.c
 +++ b/rboot.c
 @@ -13,6 +13,12 @@
@@ -48,10 +50,15 @@ index d622f97..00ccaeb 100644
  static uint32_t check_image(uint32_t readpos) {
  
  	uint8_t buffer[BUFFER_SIZE];
-@@ -258,7 +264,25 @@ static uint8_t calc_chksum(uint8_t *start, uint8_t *end) {
+@@ -257,8 +263,30 @@ static uint8_t calc_chksum(uint8_t *start, uint8_t *end) {
+ // created on first boot or in case of corruption
  static uint8_t default_config(rboot_config *romconf, uint32_t flashsize) {
  	romconf->count = 2;
++#ifdef BOOT_ROM0_ADDR
++    romconf->roms[0] = BOOT_ROM0_ADDR;
++#else
  	romconf->roms[0] = SECTOR_SIZE * (BOOT_CONFIG_SECTOR + 1);
++#endif
 +
 +#ifdef BOOT_ROM1_ADDR
 +	romconf->roms[1] = BOOT_ROM1_ADDR;
@@ -74,7 +81,7 @@ index d622f97..00ccaeb 100644
  #ifdef BOOT_GPIO_ENABLED
  	romconf->mode = MODE_GPIO_ROM;
  #endif
-@@ -306,100 +330,100 @@ uint32_t NOINLINE find_image(void) {
+@@ -306,100 +334,100 @@ uint32_t NOINLINE find_image(void) {
  	ets_delay_us(BOOT_DELAY_MICROS);
  #endif
  
@@ -204,7 +211,7 @@ index d622f97..00ccaeb 100644
  
  	// read boot config
  	SPIRead(BOOT_CONFIG_SECTOR * SECTOR_SIZE, buffer, SECTOR_SIZE);
-@@ -410,7 +434,7 @@ uint32_t NOINLINE find_image(void) {
+@@ -410,7 +438,7 @@ uint32_t NOINLINE find_image(void) {
  #endif
  		) {
  		// create a default config for a standard 2 rom setup
@@ -213,7 +220,7 @@ index d622f97..00ccaeb 100644
  		ets_memset(romconf, 0x00, sizeof(rboot_config));
  		romconf->magic = BOOT_CONFIG_MAGIC;
  		romconf->version = BOOT_CONFIG_VERSION;
-@@ -433,10 +457,10 @@ uint32_t NOINLINE find_image(void) {
+@@ -433,10 +461,10 @@ uint32_t NOINLINE find_image(void) {
  
  		if (rtc.next_mode & MODE_TEMP_ROM) {
  			if (rtc.temp_rom >= romconf->count) {
@@ -226,7 +233,7 @@ index d622f97..00ccaeb 100644
  			temp_boot = 1;
  			romToBoot = rtc.temp_rom;
  		}
-@@ -447,10 +471,10 @@ uint32_t NOINLINE find_image(void) {
+@@ -447,10 +475,10 @@ uint32_t NOINLINE find_image(void) {
  	if (perform_gpio_boot(romconf)) {
  #if defined(BOOT_GPIO_ENABLED)
  		if (romconf->gpio_rom >= romconf->count) {
@@ -239,7 +246,7 @@ index d622f97..00ccaeb 100644
  		romToBoot = romconf->gpio_rom;
  		gpio_boot = 1;
  #elif defined(BOOT_GPIO_SKIP_ENABLED)
-@@ -462,7 +486,7 @@ uint32_t NOINLINE find_image(void) {
+@@ -462,7 +490,7 @@ uint32_t NOINLINE find_image(void) {
  #endif
  		updateConfig = 1;
  		if (romconf->mode & MODE_GPIO_ERASES_SDKCONFIG) {
@@ -248,7 +255,7 @@ index d622f97..00ccaeb 100644
  			for (sec = 1; sec < 5; sec++) {
  				SPIEraseSector((flashsize / SECTOR_SIZE) - sec);
  			}
-@@ -474,7 +498,7 @@ uint32_t NOINLINE find_image(void) {
+@@ -474,7 +502,7 @@ uint32_t NOINLINE find_image(void) {
  	// gpio/temp boots will have already validated this
  	if (romconf->current_rom >= romconf->count) {
  		// if invalid rom selected try rom 0
@@ -257,7 +264,7 @@ index d622f97..00ccaeb 100644
  		romToBoot = 0;
  		romconf->current_rom = 0;
  		updateConfig = 1;
-@@ -486,14 +510,14 @@ uint32_t NOINLINE find_image(void) {
+@@ -486,14 +514,14 @@ uint32_t NOINLINE find_image(void) {
  #ifdef BOOT_GPIO_ENABLED
  	if (gpio_boot && loadAddr == 0) {
  		// don't switch to backup for gpio-selected rom
@@ -274,7 +281,7 @@ index d622f97..00ccaeb 100644
  		// make sure rtc temp boot mode doesn't persist
  		rtc.next_mode = MODE_STANDARD;
  		rtc.chksum = calc_chksum((uint8_t*)&rtc, (uint8_t*)&rtc.chksum);
-@@ -504,7 +528,7 @@ uint32_t NOINLINE find_image(void) {
+@@ -504,7 +532,7 @@ uint32_t NOINLINE find_image(void) {
  
  	// check we have a good rom
  	while (loadAddr == 0) {
@@ -283,7 +290,7 @@ index d622f97..00ccaeb 100644
  		// for normal mode try each previous rom
  		// until we find a good one or run out
  		updateConfig = 1;
-@@ -512,7 +536,7 @@ uint32_t NOINLINE find_image(void) {
+@@ -512,7 +540,7 @@ uint32_t NOINLINE find_image(void) {
  		if (romToBoot < 0) romToBoot = romconf->count - 1;
  		if (romToBoot == romconf->current_rom) {
  			// tried them all and all are bad!
@@ -292,7 +299,7 @@ index d622f97..00ccaeb 100644
  			return 0;
  		}
  		loadAddr = check_image(romconf->roms[romToBoot]);
-@@ -543,7 +567,7 @@ uint32_t NOINLINE find_image(void) {
+@@ -543,7 +571,7 @@ uint32_t NOINLINE find_image(void) {
  	system_rtc_mem(RBOOT_RTC_ADDR, &rtc, sizeof(rboot_rtc_data), RBOOT_RTC_WRITE);
  #endif
  

--- a/Sming/Components/rboot/README.rst
+++ b/Sming/Components/rboot/README.rst
@@ -1,8 +1,108 @@
 rBoot
 =====
 
-Sming uses rBoot exclusively because of its flexibility, reliability and
-ease of use.
+rBoot is a 2nd stage bootloader that allows booting application images from several 
+pre-configured flash memory addresses (called "slots"). Sming supports up to three 
+slots.
+
+Sming uses rBoot exclusively because of its flexibility, reliability and ease of use. 
+
+*Warning note: Make sure that your slots do not extend beyond a 1MB boundary and 
+do not overlap with each other, the file system (if enabled) or the RFcal/system 
+parameters area! Sming currently has no means of detecting a misconfigured memory 
+layout.*
+
+Slot 0 at `RBOOT_ROM0_ADDR`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This is the default slot which is always used. Its start address can be configured
+via `RBOOT_ROM0_ADDR`. The default is 0x2000, which is the third sector, right after 
+rBoot and its configuration data. Except for the use case described in the "Slot 2" 
+section below, you should hardly ever need to change this default.
+
+Slot 1 at `RBOOT_ROM1_ADDR`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This slot is disabled by default. If you don't need it, just leave `RBOOT_ROM1_ADDR` 
+unconfigured (empty).
+
+However, if your application includes any kind of Over-the-Air (OTA) firmware 
+update functionality, you will need a second memory slot to store the received 
+update image while the update routines execute from the first slot. Upon successful 
+completion of the update, the second slot is activated, such that on next reset 
+rBoot boots into the uploaded application. While now running from slot 1, the next 
+update will be stored to slot 0 again, i.e. the roles of slot 0 and slot 1 are 
+flipped with every update.
+
+The start address of slot 1 is configured by `RBOOT_ROM1_ADDR`. For devices with 
+more than 1MB of flash memory, it is advisable to choose an address with the same 
+offset within its 1MB block than `RBOOT_ROM0_ADDR`, e.g. 0x102000 for the default 
+slot 0 address (0x2000). This way, the same application image can be used for both 
+slots (see `RBOOT_TWO_ROMS` below for further details).
+
+
+Slot 2 (GPIO slot) at `RBOOT_ROM2_ADDR`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This slot is also disabled by default.
+
+rBoot supports booting into a third slot upon explicit user request, e.g. by pressing 
+a button during reset/power up. This is especially useful for implementing some sort 
+of recovery mechanism. To enable slot 2, set `RBOOT_GPIO_ENABLED` to 1 and `RBOOT_ROM2_ADDR` 
+to a suitable address. Note that these settings will only configure rBoot. Sming will 
+not create an application image for slot 2. You can, however, use a second Sming 
+project to build a recovery application image as follows:
+
+1. Create a new Sming project for your recovery application. This will be a simple
+   single-slot project. Set `RBOOT_ROM0_ADDR` of the recovery project to the value 
+   of `RBOOT_ROM2_ADDR` of the main project.
+
+2. Build and flash the recovery project as usual by typing `make flash`. This will 
+   install the recovery ROM (into slot 2 of the main project) and a temporary 
+   bootloader, which will be overwritten in the next step.
+
+3. Go back to your main project. Build and flash it with `make flash`. This will 
+   install the main application (into slot 0) and the final bootloader. You are 
+   now all set for booting into the recovery image if the need arises.
+
+Automatically derived settings
+==============================
+
+The following items where configuration variables in earlier versions of Sming and 
+are now derived automatically, i.e. it is no longer necessary nor possible to 
+configured them from your project:
+
+* `RBOOT_BIG_FLASH`
+* `RBOOT_TWO_ROMS`
+
+
+Big Flash Mode (`RBOOT_BIG_FLASH`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ESP8266 can map only 1MB of flash memory into its internal address space at a time. 
+As you might expect, the first megabyte is mapped by default. This is fine if your image(s) 
+reside(s) in this range. Otherwise, rBoot has to inject a piece of code into the 
+application startup routine to set up the flash controller with the correct mapping. 
+The Sming build system automatically enables Big Flash Mode when `RBOOT_ROM0_ADDR` 
+or `RBOOT_ROM1_ADDR` >= `0x100000`.
+
+Single vs. Dual ROMs (`RBOOT_TWO_ROMS`)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Since every 1MB range of flash memory is mapped to an identical internal address range, 
+the same ROM image can be used for slots 0 and 1 **if (and only if!)** both slots have 
+the same address offsets within their 1MB blocks, i.e. `(RBOOT_ROM0_ADDR & 0xFFFFF) == 
+(RBOOT_ROM1_ADDR & 0xFFFFF)`. 
+Consequently, for such configurations, the Sming build system generates only one ROM image.
+
+In all other cases, two distinct application images must be linked with different addresses 
+for the 'irom0_0_seg' memory region. The Sming build system takes care of all the details, 
+including linker script generation from a template (`RBOOT_LD_TEMPLATE`). Just run `make` 
+and find the resulting ROM images in the 'firmware' folder of your project's output directory.
+
+
+Further configuration settings
+==============================
 
 .. envvar:: ESPTOOL2
 

--- a/Sming/Components/rboot/component.mk
+++ b/Sming/Components/rboot/component.mk
@@ -34,6 +34,8 @@ endif
 ### ROM Addresses ###
 # Make sure that your ROM slots and SPIFFS slot(s) do not overlap!
 
+CONFIG_VARS				+= RBOOT_ROM0_ADDR RBOOT_ROM1_ADDR RBOOT_ROM2_ADDR
+
 # Loation of first ROM (default is sector 2 after rboot and rboot config sector)
 RBOOT_ROM0_ADDR			?= 0x002000
 
@@ -62,9 +64,13 @@ else
 RBOOT_TWO_ROMS := 0
 endif
 
+DEBUG_VARS 				+= RBOOT_TWO_ROMS
+
 # BIGFLASH mode is needed if at least one ROM address exceeds the first 1MB of flash
 BIGFLASH_TEST := awk 'BEGIN { big=0; for(i = 1; i < ARGC; ++i) if(strtonum(ARGV[i]) > 0x100000) big=1; print big }'
 RBOOT_BIG_FLASH := $(shell $(BIGFLASH_TEST) $(RBOOT_ROM0_ADDR) $(RBOOT_ROM1_ADDR) $(RBOOT_ROM2_ADDR))
+
+DEBUG_VARS 				+= RBOOT_BIG_FLASH
 
 
 CONFIG_VARS				+= RBOOT_SILENT
@@ -96,7 +102,6 @@ COMPONENT_APPCODE		:= appcode rboot/appcode $(if $(RBOOT_EMULATION),host)
 APP_CFLAGS				+= -DRBOOT_INTEGRATION
 
 # these are exported for use by the rBoot Makefile
-CONFIG_VARS				+= RBOOT_ROM0_ADDR RBOOT_ROM1_ADDR RBOOT_ROM2_ADDR
 export RBOOT_BUILD_BASE	:= $(abspath $(COMPONENT_BUILD_DIR))
 export RBOOT_FW_BASE	:= $(abspath $(FW_BASE))
 export ESPTOOL2

--- a/Sming/Components/rboot/component.mk
+++ b/Sming/Components/rboot/component.mk
@@ -21,37 +21,61 @@ endif
 # => APP
 
 # rBoot options, overwrite them in the projects Makefile-user.mk
-CONFIG_VARS				+= RBOOT_BIG_FLASH RBOOT_TWO_ROMS RBOOT_RTC_ENABLED RBOOT_GPIO_ENABLED RBOOT_GPIO_SKIP_ENABLED
-RBOOT_BIG_FLASH			?= 1
-RBOOT_TWO_ROMS			?= 0
+CONFIG_VARS				+= RBOOT_RTC_ENABLED RBOOT_GPIO_ENABLED RBOOT_GPIO_SKIP_ENABLED
 RBOOT_RTC_ENABLED		?= 0
 RBOOT_GPIO_ENABLED		?= 0
 # RBOOT_GPIO_SKIP_ENABLED and RBOOT_GPIO_ENABLED cannot be used at the same time.
 RBOOT_GPIO_SKIP_ENABLED	?= 0
 
 ifeq ($(RBOOT_GPIO_ENABLED)$(RBOOT_GPIO_SKIP_ENABLED),11)
-$(error "Cannot enable RBOOT_GPIO_ENABLED and RBOOT_GPIO_SKIP_ENABLED at the same time)
+$(error Cannot enable RBOOT_GPIO_ENABLED and RBOOT_GPIO_SKIP_ENABLED at the same time)
 endif
 
 ### ROM Addresses ###
-# The parameter below specifies the location of the second rom.
-# This parameter is used only when RBOOT_BIG_FLASH = 1 
-# BOOT_ROM1_ADDR = 0x200000
+# Make sure that your ROM slots and SPIFFS slot(s) do not overlap!
+
+# Loation of first ROM (default is sector 2 after rboot and rboot config sector)
+RBOOT_ROM0_ADDR			?= 0x002000
+
+# The parameter below specifies the location of the second ROM.
+# You need a second slot for any kind of firmware update mechanism.
+# Leave empty if you don't need a second ROM slot.
+RBOOT_ROM1_ADDR			?=
 
 # The parameter below specifies the location of the GPIO ROM.
-# This parameter is used only when RBOOT_GPIO_ENABLED = 1
-# If you use two SPIFFS make sure that this address is minimum
-# RBOOT_SPIFFS_1 + SPIFF_SIZE 
-# BOOT_ROM2_ADDR = 0x310000
+# It is only used when RBOOT_GPIO_ENABLED = 1
+# Note that setting this parameter will only configure rboot.
+# The Sming build system does not create a ROM for this slot.
+RBOOT_ROM2_ADDR			?=
+
+ifeq ($(RBOOT_GPIO_ENABLED),0)
+ifneq ($(RBOOT_ROM2_ADDR),)
+$(warning RBOOT_GPIO_ENABLED is 0, RBOOT_ROM2_ADDR will be ignored)
+RBOOT_ROM2_ADDR :=
+endif
+endif
+
+# determine number of roms to generate
+ifneq ($(RBOOT_ROM1_ADDR),)
+RBOOT_TWO_ROMS := $(shell awk 'BEGIN { print ($(RBOOT_ROM0_ADDR) % 0x100000) == ($(RBOOT_ROM1_ADDR) % 0x100000) ? 0 : 1 }')
+else
+RBOOT_TWO_ROMS := 0
+endif
+
+# BIGFLASH mode is needed if at least one ROM address exceeds the first 1MB of flash
+BIGFLASH_TEST := awk 'BEGIN { big=0; for(i = 1; i < ARGC; ++i) if(strtonum(ARGV[i]) > 0x100000) big=1; print big }'
+RBOOT_BIG_FLASH := $(shell $(BIGFLASH_TEST) $(RBOOT_ROM0_ADDR) $(RBOOT_ROM1_ADDR) $(RBOOT_ROM2_ADDR))
+
 
 CONFIG_VARS				+= RBOOT_SILENT
 RBOOT_SILENT			?= 0
 
-RELINK_VARS				+= RBOOT_ROM_0 RBOOT_ROM_1 RBOOT_LD_0 RBOOT_LD_1
+RELINK_VARS				+= RBOOT_ROM_0 RBOOT_ROM_1 RBOOT_LD_TEMPLATE
 RBOOT_ROM_0				?= rom0
 RBOOT_ROM_1				?= rom1
-RBOOT_LD_0				?= rboot.rom0.ld
-RBOOT_LD_1				?= rom1.ld
+RBOOT_LD_TEMPLATE		?= $(ARCH_BASE)/Compiler/ld/rboot.rom0.ld
+RBOOT_LD_0				:= $(BUILD_BASE)/$(RBOOT_ROM_0).ld
+RBOOT_LD_1				:= $(BUILD_BASE)/$(RBOOT_ROM_1).ld
 
 #
 CONFIG_VARS				+= RBOOT_SPIFFS_0 RBOOT_SPIFFS_1
@@ -59,9 +83,6 @@ RBOOT_SPIFFS_0			?= 0x100000
 RBOOT_SPIFFS_1			?= 0x300000
 APP_CFLAGS				+= -DRBOOT_SPIFFS_0=$(RBOOT_SPIFFS_0)
 APP_CFLAGS				+= -DRBOOT_SPIFFS_1=$(RBOOT_SPIFFS_1)
-
-# Fixed addresses
-ROM_0_ADDR				:= 0x002000
 
 # filenames and options for generating rBoot rom images with esptool2
 RBOOT_E2_SECTS			?= .text .text1 .data .rodata
@@ -75,7 +96,7 @@ COMPONENT_APPCODE		:= appcode rboot/appcode $(if $(RBOOT_EMULATION),host)
 APP_CFLAGS				+= -DRBOOT_INTEGRATION
 
 # these are exported for use by the rBoot Makefile
-CONFIG_VARS				+= RBOOT_ROM1_ADDR RBOOT_ROM2_ADDR
+CONFIG_VARS				+= RBOOT_ROM0_ADDR RBOOT_ROM1_ADDR RBOOT_ROM2_ADDR
 export RBOOT_BUILD_BASE	:= $(abspath $(COMPONENT_BUILD_DIR))
 export RBOOT_FW_BASE	:= $(abspath $(FW_BASE))
 export ESPTOOL2
@@ -125,10 +146,34 @@ endif # RBOOT_EMULATION
 
 # Define our flash chunks
 FLASH_RBOOT_BOOT_CHUNKS				:= 0x00000=$(RBOOT_BIN)
-FLASH_RBOOT_APP_CHUNKS				:= $(ROM_0_ADDR)=$(RBOOT_ROM_0_BIN)
+FLASH_RBOOT_APP_CHUNKS				:= $(RBOOT_ROM0_ADDR)=$(RBOOT_ROM_0_BIN)
 FLASH_RBOOT_ERASE_CONFIG_CHUNKS		:= 0x01000=$(SDK_BASE)/bin/blank.bin
 
 ifndef RBOOT_EMULATION
+
+# => Automatic linker script generation from template
+# $1 -> application target
+# $2 -> linker script
+# $3 -> ROM address variable (not value!)
+define GenerateLinkerScriptTargets
+# Mark linker script out-of-date if ROM address differs from previous run
+-include $2.config
+ifneq ($$(GEN_$3),$$($3))
+.PHONY: $2
+endif
+# Generate linker script from template
+$2: $(RBOOT_LD_TEMPLATE)
+	$$(info LDGEN $$@)
+	$$(Q) awk 'match($$$$0, /(^.*irom0_0_seg\s*:\s*)\S+/, m) { \
+			printf "%sorg = 0x%08X, len = 1M - 0x%X\n", m[1], 0x40200010 + $$($3) % 0x100000, $$($3) % 0x100000; next \
+		} 1 { print $$$$0 }' $$< > $$@
+	$$(Q) echo GEN_$3 := $($3) > $2.config
+# Make application depend on linker script
+$1: $2
+endef
+
+$(eval $(call GenerateLinkerScriptTargets,$(TARGET_OUT_0),$(RBOOT_LD_0),RBOOT_ROM0_ADDR))
+
 # => Firmware images
 CUSTOM_TARGETS += $(RBOOT_ROM_0_BIN)
 $(RBOOT_ROM_0_BIN): $(TARGET_OUT_0)
@@ -136,9 +181,15 @@ $(RBOOT_ROM_0_BIN): $(TARGET_OUT_0)
 	$(Q) $(ESPTOOL2) $(RBOOT_E2_USER_ARGS) $< $@ $(RBOOT_E2_SECTS)
 	$(Q) $(call WriteFirmwareConfigFile,$@)
 
+ifneq ($(RBOOT_ROM_1_BIN),)
+$(eval $(call GenerateLinkerScriptTargets,$(TARGET_OUT_1),$(RBOOT_LD_1),RBOOT_ROM1_ADDR))
+
 CUSTOM_TARGETS += $(RBOOT_ROM_1_BIN)
 $(RBOOT_ROM_1_BIN): $(TARGET_OUT_1)
 	$(info ESPTOOL2 $@)
 	$(Q) $(ESPTOOL2) $(RBOOT_E2_USER_ARGS) $< $@ $(RBOOT_E2_SECTS)
 	$(Q) $(call WriteFirmwareConfigFile,$@)
+
 endif
+
+endif # RBOOT_EMULATION

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -90,6 +90,11 @@ CMAKE ?= cmake
 DEBUG_VARS	+= CLANG_FORMAT
 CLANG_FORMAT ?= clang-format
 
+# more tools
+DEBUG_VARS += AWK
+# In case 'awk' is an alias for 'gawk' on your system, having 'POSIXLY_CORRECT' in the environment
+# invokes an awk compatibility mode. It has no effect on other awk implementations.
+AWK ?= POSIXLY_CORRECT= awk
 
 
 V ?= $(VERBOSE)

--- a/docs/source/information/rboot-ota.rst
+++ b/docs/source/information/rboot-ota.rst
@@ -49,8 +49,7 @@ in the same 1MB block of flash. Set the following options in your project's
 
 .. code-block:: make
 
-   RBOOT_BIG_FLASH = 0
-   RBOOT_TWO_ROMS  = 1
+   RBOOT_ROM1_ADDR = 0x80000
    SPI_SIZE        = 1M
 
 SPIFFS

--- a/samples/Basic_rBoot/README.rst
+++ b/samples/Basic_rBoot/README.rst
@@ -51,23 +51,15 @@ Important compiler flags used:
 -  SPIFF_SIZE=value - passed through to code for mounting the filesystem.
    Also used in the Makefile to create the SPIFFS.
 
-Disabling big flash
--------------------
+Flash layout considerations
+---------------------------
 
 If you want to use, for example, two 512k roms in the first 1MB block of
-flash (old style) then follow these instructions to produce two
-separately linked roms. If you are flashing a single rom to multiple 1MB
-flash blocks (using big flash) you only need one linked rom that can be
-used on each.
+flash (old style) then Sming will automatically create two separately linked 
+roms. If you are flashing a single rom to multiple 1MB flash blocks, all using
+the same offset inside their 1MB blocks, only a single rom is created.
+See the rBoot readme for further details.
 
-This assumes you understand the concepts explained in the rBoot readme
-about memory mapping and setting linker script address. This is not
-covered here, just how to use this sample without bigflash support.
-
--  Copy rom0.ld to rom1.ld.
--  Adjust the rom offsets and length as appropriate in each ld file.
--  Set *RBOOT_TWO_ROMS = 1* in component.mk (or as an environment variable).
--  Set *RBOOT_BIG_FLASH = 0* in component.mk
 -  If using a very small flash (e.g. 512k) there may be no room for a
    spiffs fileystem, disable it with *DISABLE_SPIFFS = 1*
 -  If you are using spiffs set *RBOOT_SPIFFS_0* & *RBOOT_SPIFFS_1* to

--- a/samples/Basic_rBoot/component.mk
+++ b/samples/Basic_rBoot/component.mk
@@ -3,24 +3,18 @@
 ## use rboot build mode
 RBOOT_ENABLED		?= 1
 
-## enable big flash support (for multiple roms, each in separate 1mb block of flash)
-RBOOT_BIG_FLASH		?= 1
-
-## two rom mode (where two roms sit in the same 1mb block of flash)
-#RBOOT_TWO_ROMS		?= 1
-
 ## size of the flash chip
 SPI_SIZE			?= 4M
+
+## address of ROM slots 0 & 1
+#RBOOT_ROM0_ADDR 	?= 0x002000
+RBOOT_ROM1_ADDR 	?= 0x102000
 
 ## output file for first rom (.bin will be appended)
 #RBOOT_ROM_0 		?= rom0
 
-## input linker file for first rom
-#RBOOT_LD_0			?= rom0.ld
-
 ## these next options only needed when using two rom mode
 #RBOOT_ROM_1		?= rom1
-#RBOOT_LD_1			?= rom1.ld
 
 ## size of the spiffs to create
 SPIFF_SIZE			?= 65536

--- a/samples/HttpServer_FirmwareUpload/README.rst
+++ b/samples/HttpServer_FirmwareUpload/README.rst
@@ -38,19 +38,15 @@ Usage instructions
 1. 'make flash' to build and flash the example via USB cable. You need to do 
    this only once. Subsequent updates can be performed using the web interface.
 
-2. 'make signedrom' to create the signed image in out/firmware/.../rom0.bin.signed
+2. 'make signedrom' to create the signed images in out/firmware/.../rom*.bin.signed
 
 3. Point your browser to your ESP's IP address to open the firmware upgrade page.
 
 4. Select the signed image created in step 2 and hit the "Update" button. 
+   If you have an ROM layout that requires two different images, select the image 
+   for the currently unused slot. 
    After a few seconds, you should see a confirmation that the upgrade was successful.
    The ESP now reboots into the new firmware. 
    
 If the upgrade is not successful, check the serial console for error messages.
 
-
-Limitations
------------
-
-For simplicity, this example assumes RBOOT_BIG_FLASH=1, i. e. the same ROM 
-image can be used for both slots.

--- a/samples/HttpServer_FirmwareUpload/app/SignedRbootOutputStream.cpp
+++ b/samples/HttpServer_FirmwareUpload/app/SignedRbootOutputStream.cpp
@@ -17,55 +17,61 @@ void SignedRbootOutputStream::setError(const char* message)
 
 size_t SignedRbootOutputStream::write(const uint8_t* data, size_t size)
 {
-	size_t available = size;
-	if(!errorFlag) {
-		if(missingHeaderBytes > 0) {
-			const size_t chunkSize = std::min(available, missingHeaderBytes);
-			memcpy(headerPtr, data, chunkSize);
-			headerPtr += chunkSize;
-			missingHeaderBytes -= chunkSize;
-			data += chunkSize;
-			available -= chunkSize;
-			if(missingHeaderBytes == 0) {
-				debug_i("Receive image for load address 0x%08X, slot starts at 0x%08X\n", header.loadAddress,
-						startAddress);
-				const bool unexpectedMagic = (header.magic != HEADER_MAGIC_EXPECTED);
-				const bool unexpectedLoadAddress = ((header.loadAddress & 0x000FFFFF) != (startAddress & 0x000FFFFF));
-				if(unexpectedMagic || unexpectedLoadAddress) {
-					setError(unexpectedLoadAddress ? "Unexpected load address. Try image for other slot."
-												   : "Invalid image received.");
-				} else {
-					init();
-				}
-			}
-		}
+	if(errorFlag) {
+		return 0;
+	}
 
-		if(!errorFlag && (available > 0)) {
-			crypto_sign_update(&verifierState, static_cast<const unsigned char*>(data), available);
-			const size_t written = RbootOutputStream::write(data, available);
-			if(written != available) {
-				setError("Flash write failure");
+	size_t consumed = 0;
+	if(missingHeaderBytes > 0) {
+		const size_t chunkSize = std::min(size, missingHeaderBytes);
+		memcpy(headerPtr, data, chunkSize);
+		headerPtr += chunkSize;
+		missingHeaderBytes -= chunkSize;
+		data += chunkSize;
+		size -= chunkSize;
+		consumed += chunkSize;
+		if(missingHeaderBytes == 0) {
+			debug_i("Receive image for load address 0x%08X, slot starts at 0x%08X\n", header.loadAddress, startAddress);
+			const bool unexpectedMagic = (header.magic != HEADER_MAGIC_EXPECTED);
+			const bool unexpectedLoadAddress = ((header.loadAddress & 0x000FFFFF) != (startAddress & 0x000FFFFF));
+			if(unexpectedMagic || unexpectedLoadAddress) {
+				setError(unexpectedLoadAddress ? "Unexpected load address. Try image for other slot."
+											   : "Invalid image received.");
+			} else {
+				init();
 			}
 		}
 	}
-	return size; // Always pretend to consume everything. Otherwise the connection is closed before we get a chance to report our error message.
+
+	if(!errorFlag && (size > 0)) {
+		crypto_sign_update(&verifierState, static_cast<const unsigned char*>(data), size);
+		const size_t written = RbootOutputStream::write(data, size);
+		consumed += written;
+		if(written != size) {
+			setError("Flash write failure");
+		}
+	}
+
+	return consumed;
 }
 
 bool SignedRbootOutputStream::verifySignature(const uint8_t* verificationKey)
 {
-	if(!errorFlag) {
-		// write final batch of of data
-		if(RbootOutputStream::close()) {
-			const bool signatureMatch =
-				(crypto_sign_final_verify(&verifierState, header.signature, verificationKey) == 0);
-			if(!signatureMatch) {
-				// destroy start sector of updated ROM to avoid accidental booting an unsanctioned firmware
-				flashmem_erase_sector(startAddress / SECTOR_SIZE);
-				setError("Signature mismatch");
-			}
-		} else {
-			setError("Flash write failure");
-		}
+	if(errorFlag) {
+		return false;
 	}
-	return !errorFlag;
+
+	// write final batch of of data
+	if(RbootOutputStream::close()) {
+		if(crypto_sign_final_verify(&verifierState, header.signature, verificationKey) == 0) {
+			return true;
+		}
+		// signature mismatch: destroy start sector of updated ROM to avoid accidental booting an unsanctioned firmware image
+		flashmem_erase_sector(startAddress / SECTOR_SIZE);
+		setError("Signature mismatch");
+	} else {
+		setError("Flash write failure");
+	}
+
+	return false;
 }

--- a/samples/HttpServer_FirmwareUpload/app/application.cpp
+++ b/samples/HttpServer_FirmwareUpload/app/application.cpp
@@ -100,6 +100,21 @@ void fileUploadMapper(HttpFiles& files)
 
 void startWebServer()
 {
+	HttpServerSettings settings;
+	/* 
+	 * If an error is detected early in a request's message body (like an attempt to upload a firmware image for the 
+	 * wrong slot), the default behaviour of Sming's HTTP server is to send the error response as soon as possible and 
+	 * then close the connection.
+	 * However, some HTTP clients (most notably Firefox!) start listening for a response only after having transmitted 
+	 * the whole request. Such clients may miss the error response entirely and instead report to the user that the 
+	 * connection was closed unexpectedly. Disabling 'closeOnContentError' instructs the server to delay the error 
+	 * response until after the whole message body has been received. This allows all clients to receive the response 
+	 * and display the exact error message to the user, leading to an overall improved user experience.
+	 */
+	settings.closeOnContentError = false;
+	settings.keepAliveSeconds = 2; // default from HttpServer::HttpServer()
+	server.configure(settings);
+
 	server.listen(80);
 	server.paths.set("/", onIndex);
 

--- a/samples/HttpServer_FirmwareUpload/component.mk
+++ b/samples/HttpServer_FirmwareUpload/component.mk
@@ -40,10 +40,14 @@ $(VERIFICATION_HEADER): $(SIGNING_KEY)
 # add dependency to trigger automatic generation of verification key header
 $(COMPONENT_PATH)/app/application.cpp: $(VERIFICATION_HEADER)
 
-SIGNED_ROM0 = $(RBOOT_ROM_0_BIN).signed
-$(SIGNED_ROM0): $(RBOOT_ROM_0_BIN) $(SIGNING_KEY)
-	@echo Generating signed firmware update file...
-	$(Q) $(SIGNTOOL) --keyfile=$(SIGNING_KEY) --out "$(SIGNED_ROM0)" --rom "$(ROM_0_ADDR)=$(RBOOT_ROM_0_BIN)"
 
+# make signed image generation a phony target, because the rboot component and its variables have not been loaded yet
 .PHONY: signedrom
-signedrom: $(SIGNED_ROM0) ##Create signed ROM image
+signedrom: $(RBOOT_ROM_0_BIN) $(RBOOT_ROM_1_BIN) ##Create signed ROM image (or images if your setup requires two separate ROM images)
+	$(info Generating signed firmware update file(s)...)
+	$(Q) $(SIGNTOOL) --keyfile=$(SIGNING_KEY) --out "$(RBOOT_ROM_0_BIN).signed" --rom "$(RBOOT_ROM0_ADDR)=$(RBOOT_ROM_0_BIN)"
+	$(Q) if [ -n "$(RBOOT_ROM_1_BIN)" ]; then \
+		$(SIGNTOOL) --keyfile=$(SIGNING_KEY) --out "$(RBOOT_ROM_1_BIN).signed" --rom "$(RBOOT_ROM1_ADDR)=$(RBOOT_ROM_1_BIN)"; \
+	fi
+
+


### PR DESCRIPTION
Currently, for two-rom setups (on <=1MB devices), the second linker script has to be created manually. Although this quite easy, it is an unnecessary manual step when setting up a new project and it is also an additional complication for users new to the framework.

This PR integrates the linker script generation into the build process. 
It also tries to simplify the RBOOT configuration by automatically deriving the values of `RBOOT_TWO_ROMS` and `RBOOT_BIG_FLASH` from the provided ROM addresses, i.e. it now suffices to set `RBOOT_ROM1_ADDR` to the desired value.

Please consider this PR as a proposal. I am very open to suggestions on how to implement things differently, because I most certainly am not aware of all the details of the build system yet and the many thoughts behind it.