### PR TITLE
Fix deprecated list plus minor doc updates

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -15,6 +15,8 @@ If you like **Sming**, give it a star, or fork it and [contribute](#contribute)!
 [![GitHub stars](https://img.shields.io/github/stars/SmingHub/Sming.svg?style=social&label=Star)](https://github.com/SmingHub/Sming/stargazers)
 [![GitHub forks](https://img.shields.io/github/forks/SmingHub/Sming.svg?style=social&label=Fork)](https://github.com/SmingHub/Sming/network)
 
+Please note **develop** branch documentation is at [sming.readthedocs.io](https://sming.readthedocs.io/).
+
 ## Summary
 * Highly effective in performance and memory usage (this is native firmware!)
 * Simple and powerful hardware API wrappers

--- a/Sming/Arch/Host/README.rst
+++ b/Sming/Arch/Host/README.rst
@@ -37,9 +37,7 @@ or later. If it’s older, execute these commands:
 Building
 --------
 
-Build the framework and application as usual, specifying :envvar:`SMING_ARCH` =Host. For example:
-
-::
+Build the framework and application as usual, specifying :envvar:`SMING_ARCH` =Host. For example::
 
    cd $SMING_HOME
    make SMING_ARCH=Host
@@ -92,9 +90,7 @@ Alternatively, you can run the application manually like this:
 
 ``out/firmware/app --pause --uart=0 --uart=1``
 
-Now start a telnet session for each serial port, in separate command windows:
-
-::
+Now start a telnet session for each serial port, in separate command windows::
 
    telnet localhost 10000
    telnet localhost 10001
@@ -106,9 +102,7 @@ output at startup.)
 
 Note: For Windows users, ``putty`` is a good alternative to telnet. It
 has options to for things like carriage-return/linefeed translation
-(“\\n” -> “\\r\\n`”). Run using:
-
-::
+(“\\n” -> “\\r\\n`”). Run using::
 
    putty telnet://localhost:10000
 
@@ -118,7 +112,42 @@ different port numbers, use ``--uartport`` option.
 Digital I/O
 ~~~~~~~~~~~
 
-At present the emulator just writes output to the console. Inputs all return 0.
+By default, the emulator just writes output to the console so you can see when outputs are changed.
+
+Reading from an input returns 0.
+
+All digital functions can be customised by overriding the *DigitalHooks* class, like this:
+
+.. code-block:: c++
+
+   // You'd probably put this in a separate module and conditionally include it
+   #ifdef ARCH_HOST
+   class MyDigitalHooks: public DigitalHooks
+   {
+   public:
+      // Override class methods as required
+      uint8_t digitalRead(uint16_t pin, uint8_t mode) override
+      {
+         if(pin == 0) {
+            return 255;
+         } else {
+            return DigitalHooks::digitalRead(pin, mode);
+         }
+      }
+   };
+   
+   MyDigitalHooks myDigitalHooks;
+   #endif
+
+   void init()
+   {
+      #ifdef ARCH_HOST
+      setDigitalHooks(&myDigitalHooks);
+      #endif
+   }
+
+See :source:`Sming/Arch/Host/Core/DigitalHooks.h` for further details.
+
 
 Network
 ~~~~~~~
@@ -128,9 +157,7 @@ Linux
 
 Support is provided via TAP network interface (a virtual network layer
 operating at the ethernet frame level). A TAP interface must be created
-first, and requires root priviledge:
-
-::
+first, and requires root priviledge::
 
    sudo ip tuntap add dev tap0 mode tap user `whoami`
    sudo ip a a dev tap0 192.168.13.1/24
@@ -142,9 +169,7 @@ select the first ``tap`` interface found. To override this, use the
 using the ``--ipaddr`` option.
 
 If your application needs to access the internet, additional setup is
-required:
-
-::
+required::
 
    sudo sysctl net.ipv4.ip_forward=1
    sudo sysctl net.ipv6.conf.default.forwarding=1
@@ -231,4 +256,3 @@ todo
 * Consider how this mechanism might be used to support emulation of other devices (SPI, I2C, etc).
 * Development platforms with SPI or I2C (e.g. Raspberry Pi) could be supported.
 * Are there any generic device emulators available? For example, to simulate specific types of SPI slave.
-* All code is intended to run on either Windows (MinGW) or Linux as simply as possible, without requiring any additional dependencies.

--- a/Sming/Arch/Host/README.rst
+++ b/Sming/Arch/Host/README.rst
@@ -100,8 +100,8 @@ In the application window, press Enter. This behaviour is enabled by the
 telnet can connect to it. Without ``pause`` you’ll lose any serial
 output at startup.)
 
-Note: For Windows users, ``putty`` is a good alternative to telnet. It
-has options to for things like carriage-return/linefeed translation
+Note: For Windows users, ``putty`` is a good alternative to telnet. It also
+has options for things like carriage-return/linefeed translation
 (“\\n” -> “\\r\\n`”). Run using::
 
    putty telnet://localhost:10000

--- a/Sming/Components/libsodium/.patches/libsodium.patch
+++ b/Sming/Components/libsodium/.patches/libsodium.patch
@@ -1618,3 +1618,7 @@ index 1fbd3a37..2e28e9d6 100644
  sodium_mlock(void *const addr, const size_t len)
  {
 
+diff --git a/README.markdown b/README.md
+similarity index 100%
+rename from README.markdown
+rename to README.md

--- a/Sming/Core/Data/StreamTransformer.h
+++ b/Sming/Core/Data/StreamTransformer.h
@@ -110,7 +110,7 @@ protected:
 	}
 
 	/** @brief Callback function to perform transformation
-	 *  @deprecated Create inherited class and verride transform() method instead
+	 *  @deprecated Create inherited class and override transform() method instead
 	 */
 	StreamTransformerCallback transformCallback = nullptr;
 

--- a/Sming/Core/Network/RbootHttpUpdater.h
+++ b/Sming/Core/Network/RbootHttpUpdater.h
@@ -65,7 +65,7 @@ public:
 	 * - default SSL fingeprints
 	 * - default SSL client certificates
 	 *
-	 * @param HttpRequest *
+	 * @param request
 	 */
 	void setBaseRequest(HttpRequest* request)
 	{

--- a/Sming/Core/Network/rBootHttpUpdate.h
+++ b/Sming/Core/Network/rBootHttpUpdate.h
@@ -1,3 +1,3 @@
-#include "RbootHttpUpdater.h";
+#include "RbootHttpUpdater.h"
 
 #warning "Please include `RbootHttpUpdater.h` instead of `rBootHttpUpdate.h`"

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -49,6 +49,9 @@ TAB_SIZE               = 4
 
 ALIASES                = "license=@par License:\n"
 
+
+EXTRACT_ALL = YES
+
 # If the EXTRACT_STATIC tag is set to YES, all static members of a file will be
 # included in the documentation.
 # The default value is: NO.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -206,8 +206,7 @@ MISSING_README_DIRS		:= $(filter-out $(SOURCE_FILE_DIRS:/=),$(SOURCE_DIRS))
 
 .PHONY: clean
 clean:
-	$(call Sphinx)
-	$(Q) rm -rf $(SOURCE_INCDIR) api
+	$(Q) rm -rf $(SOURCE_INCDIR) api $(BUILDDIR)
 
 SOURCE_INCDIRS			:= $(sort $(call GetIncPath,$(COMPONENT_DIRS) $(SOURCE_FILE_DIRS)))
 # Each Sample, Library or Component README.* is included directly rather than added to the toctree

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -33,7 +33,7 @@ Summary
 
 -  ESP8266 specific features
 
-  -  Integrated boot loader :component-esp8266:`rboot` with support for 1MB ROMs, OTA firmware updating and ROM switching
+  -  Integrated boot loader :component:`rboot` with support for 1MB ROMs, OTA firmware updating and ROM switching
   -  :doc:`Crash handlers <information/debugging>` for analyzing/handling system restarts due to fatal errors or WDT resets.
   -  :component-esp8266:`PWM support <pwm_open>` based on `Stefan Bruens PWM <https://github.com/StefanBruens/ESP8266_new_pwm.git>`__
   -  Optional :component-esp8266:`custom heap allocation <custom_heap>` based on `Umm Malloc <https://github.com/rhempel/umm_malloc.git>`__

--- a/docs/source/information/rboot-ota.rst
+++ b/docs/source/information/rboot-ota.rst
@@ -64,7 +64,7 @@ the third 1MB block of flash. This leaves a whole 1MB spare after each
 ROM in which you can put your SPIFFS.
 
 If you have to a smaller flash the SPIFFS will have to share the 1MB block with the ROM.
- For example, the first part of each 1MB block may contain the ROM, and the second part
+For example, the first part of each 1MB block may contain the ROM, and the second part
 the SPIFFS (but does *not* have to be split equally in half). So for the 4MB example
 you could put the SPIFFS for your first ROM at flash address at 0x100000
 and the SPIFFS for your second ROM at 0x300000; in each case that is the

--- a/docs/source/upgrading/3.8-4.0.rst
+++ b/docs/source/upgrading/3.8-4.0.rst
@@ -1,6 +1,6 @@
-***************************
+*****************
 From v3.8 to v4.0
-***************************
+*****************
 
 Summary
 =======
@@ -9,8 +9,11 @@ With Sming version 4.0 there are some backwards
 incompatible changes. This page is provided to help with migrating your
 applications.
 
-You can find more detailed information in the
-:doc:`/_inc/Sming/building` readme.
+In particular, the build system has changed so the process is now driven from the
+project directory.
+
+See :doc:`/_inc/Sming/building` for detailed information and a list of known issues.
+
 
 Header files
 ============

--- a/samples/Basic_Interrupts/README.rst
+++ b/samples/Basic_Interrupts/README.rst
@@ -1,4 +1,4 @@
 Basic Interrupts
 ================
 
-To be completed.
+Simple example of how interrupts can be used within Sming.

--- a/samples/Basic_rBoot/README.rst
+++ b/samples/Basic_rBoot/README.rst
@@ -6,7 +6,7 @@ Basic rBoot
 Introduction
 ------------
 
-This sample integrates :component-esp8266:`rboot` and Sming, for the many people who have
+This sample integrates :component:`rboot` and Sming, for the many people who have
 been asking for it. It demonstrates dual rom booting, big flash support,
 OTA updates and dual spiffs filesystems. You must enable big flash
 support in rBoot and use on an ESP12 (or similar device with 4MB flash).

--- a/samples/Humidity_DHT22/README.rst
+++ b/samples/Humidity_DHT22/README.rst
@@ -1,7 +1,7 @@
 DHT22 Humidity Sensor
 =====================
 
-Example application demonstrating the use of the :library:`DHTEsp` library with a DHT22 humidity sensor.
+Example application demonstrating the use of the :library:`DHTesp` library with a DHT22 humidity sensor.
 
 .. image:: dht22.jpg
    :height: 192px


### PR DESCRIPTION
Address issues raised in #1816

* Some typedefs don't appear in dOxygen deprecated list unless `EXTRACT_ALL=YES`. Might be a better setting, can't find it.
* Fix docs. `clean` target so it doesn't require sphinx, thus dist-clean works without additional requirements
* Rename libsodium submodule README so doc. system picks it up
* Update Host readme with note on `DigitalHooks`
* Fix rboot reference in docs
