### PR TITLE
Fix Compiler errors

### DIFF
--- a/Sming/Services/CommandProcessing/CommandHandler.cpp
+++ b/Sming/Services/CommandProcessing/CommandHandler.cpp
@@ -82,12 +82,12 @@ void CommandHandler::procesHelpCommand(String commandLine, CommandOutput* comman
 	debugf("HelpCommand entered");
 	commandOutput->println(_F("Commands available are :"));
 	for(unsigned idx = 0; idx < registeredCommands->count(); idx++) {
-		commandOutput->printf("%s", registeredCommands->valueAt(idx).commandName.c_str());
-		commandOutput->printf(" | ");
-		commandOutput->printf("%s", registeredCommands->valueAt(idx).commandGroup.c_str());
-		commandOutput->printf(" | ");
-		commandOutput->printf("%s", registeredCommands->valueAt(idx).commandHelp.c_str());
-		commandOutput->printf("\r\n");
+		commandOutput->print(registeredCommands->valueAt(idx).commandName.c_str());
+		commandOutput->print(" | ");
+		commandOutput->print(registeredCommands->valueAt(idx).commandGroup.c_str());
+		commandOutput->print(" | ");
+		commandOutput->print(registeredCommands->valueAt(idx).commandHelp.c_str());
+		commandOutput->print("\r\n");
 	}
 }
 

--- a/Sming/Services/CommandProcessing/CommandHandler.cpp
+++ b/Sming/Services/CommandProcessing/CommandHandler.cpp
@@ -82,11 +82,11 @@ void CommandHandler::procesHelpCommand(String commandLine, CommandOutput* comman
 	debugf("HelpCommand entered");
 	commandOutput->println(_F("Commands available are :"));
 	for(unsigned idx = 0; idx < registeredCommands->count(); idx++) {
-		commandOutput->printf(registeredCommands->valueAt(idx).commandName.c_str());
+		commandOutput->printf("%s", registeredCommands->valueAt(idx).commandName.c_str());
 		commandOutput->printf(" | ");
-		commandOutput->printf(registeredCommands->valueAt(idx).commandGroup.c_str());
+		commandOutput->printf("%s", registeredCommands->valueAt(idx).commandGroup.c_str());
 		commandOutput->printf(" | ");
-		commandOutput->printf(registeredCommands->valueAt(idx).commandHelp.c_str());
+		commandOutput->printf("%s", registeredCommands->valueAt(idx).commandHelp.c_str());
 		commandOutput->printf("\r\n");
 	}
 }


### PR DESCRIPTION
<pre><b>/tmp/Sming/Sming/Services/CommandProcessing/CommandHandler.cpp:</b> In member function ‘<b>void CommandHandler::procesHelpCommand(String, CommandOutput*)</b>’:
<b>/tmp/Sming/Sming/Services/CommandProcessing/CommandHandler.cpp:85:77:</b> <font color="#CC0000"><b>error: </b></font>format not a string literal and no format arguments [<font color="#CC0000"><b>-Werror=format-security</b></font>]
   commandOutput-&gt;printf(registeredCommands-&gt;valueAt(idx).commandName.c_str()<font color="#CC0000"><b>)</b></font>;
                                                                             <font color="#CC0000"><b>^</b></font>
<b>/tmp/Sming/Sming/Services/CommandProcessing/CommandHandler.cpp:87:78:</b> <font color="#CC0000"><b>error: </b></font>format not a string literal and no format arguments [<font color="#CC0000"><b>-Werror=format-security</b></font>]
   commandOutput-&gt;printf(registeredCommands-&gt;valueAt(idx).commandGroup.c_str()<font color="#CC0000"><b>)</b></font>;
                                                                              <font color="#CC0000"><b>^</b></font>
<b>/tmp/Sming/Sming/Services/CommandProcessing/CommandHandler.cpp:89:77:</b> <font color="#CC0000"><b>error: </b></font>format not a string literal and no format arguments [<font color="#CC0000"><b>-Werror=format-security</b></font>]
   commandOutput-&gt;printf(registeredCommands-&gt;valueAt(idx).commandHelp.c_str()<font color="#CC0000"><b>)</b></font>;
                                                                             <font color="#CC0000"><b>^</b></font>
cc1plus: all warnings being treated as errors
</pre>
