### PR TITLE
Place IRAM and FLASH data in separate segments

### DIFF
--- a/Sming/Arch/Esp8266/Compiler/ld/common.ld
+++ b/Sming/Arch/Esp8266/Compiler/ld/common.ld
@@ -107,7 +107,7 @@ SECTIONS
     *libm.a:(.literal .text .literal.* .text.*)
 
     *(.rodata._ZTV*) /* C++ vtables */
-    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom.text .irom.debug.*)
+    *(.irom0.literal .irom.literal .irom.text.literal .irom0.text .irom0.text.* .irom.text .irom.debug.*)
 
     /* Generated libraries */
     *liblwip2.a:(.literal .text .literal.* .text.*)
@@ -160,7 +160,7 @@ SECTIONS
     *(.init.literal)
     *(.init)
     *(.literal .text .literal.* .text.* .stub .gnu.warning .gnu.linkonce.literal.* .gnu.linkonce.t.*.literal .gnu.linkonce.t.*)
-	  *(.iram.literal .iram.text.literal .iram.text)
+	  *(.iram.literal .iram.text.literal .iram.text .iram.text.*)
     *(.fini.literal)
     *(.fini)
     *(.gnu.version)

--- a/Sming/Arch/Esp8266/Components/esp8266/include/esp_attr.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/esp_attr.h
@@ -1,25 +1,29 @@
 // ESP8266 attribute definitions (previously in c_types.h)
 #pragma once
 
-#define IRAM_ATTR __attribute__((section(".iram.text")))
-#define STORE_TYPEDEF_ATTR __attribute__((aligned(4),packed))
+// http://stackoverflow.com/a/35441900
+#define MACROQUOT(x) #x
+#define MACROQUOTE(x) MACROQUOT(x)
+
+#define STORE_TYPEDEF_ATTR __attribute__((aligned(4), packed))
 #define STORE_ATTR __attribute__((aligned(4)))
 
 #define DMEM_ATTR __attribute__((section(".bss")))
 #define SHMEM_ATTR
 
-#ifdef ICACHE_FLASH
-#define ICACHE_FLASH_ATTR __attribute__((section(".irom0.text")))
-#define ICACHE_RODATA_ATTR __attribute__((section(".irom.text")))
-#else
-#define ICACHE_FLASH_ATTR
-#define ICACHE_RODATA_ATTR
-#endif
+#define ICACHE_FLASH_ATTR \
+	__attribute__((section(".irom0.text." __FILE__ MACROQUOTE(__LINE__) MACROQUOTE(__COUNTER__))))
+#define ICACHE_RAM_ATTR \
+	__attribute__((section(".iram.text." __FILE__ MACROQUOTE(__LINE__) MACROQUOTE(__COUNTER__))))
+#define ICACHE_RODATA_ATTR \
+	__attribute__((section(".irom0.text." __FILE__ MACROQUOTE(__LINE__) MACROQUOTE(__COUNTER__))))
+
+#define IRAM_ATTR ICACHE_RAM_ATTR
 
 #define STORE_ATTR __attribute__((aligned(4)))
 
 #ifdef ENABLE_GDB
-	#define GDB_IRAM_ATTR IRAM_ATTR
+#define GDB_IRAM_ATTR IRAM_ATTR
 #else
-	#define GDB_IRAM_ATTR
+#define GDB_IRAM_ATTR
 #endif


### PR DESCRIPTION
Resolves section conflict issues when attempting to inline header methods, generally more of a problem with GCC 4.8.

Thanks to esp8266/Arduino#5116