### PR TITLE
Avoid using `WiringFrameworkDependencies.h` within framework

### DIFF
--- a/Sming/Arch/Esp8266/Components/axtls-8266/axtls-8266.patch
+++ b/Sming/Arch/Esp8266/Components/axtls-8266/axtls-8266.patch
@@ -31,14 +31,15 @@ diff -Nuar a/replacements/libc.c b/replacements/libc.c
 +    return ets_vprintf(ets_putc, format, arg);
 +}
 diff --git a/replacements/time.c b/replacements/time.c
-index 4972119..1a79aac 100644
+index 4972119..da75839 100644
 --- a/replacements/time.c
 +++ b/replacements/time.c
-@@ -24,20 +24,16 @@ extern uint64_t system_mktime(uint32_t year, uint32_t mon, uint32_t day, uint32_
+@@ -24,21 +24,14 @@ extern uint64_t system_mktime(uint32_t year, uint32_t mon, uint32_t day, uint32_
  
  static int errno_var = 0;
  
 -int* __errno(void) {
++// These functions are implemented in Espressif SDK versions 2 and later (libmain.a) so we weaken them to avoid linker problems
 +#define WEAK_ATTR __attribute__((weak))
 +
 +int* WEAK_ATTR __errno(void) {
@@ -50,17 +51,32 @@ index 4972119..1a79aac 100644
 -{
 -	return system_get_time() / 1000UL;
 -}
-+extern unsigned long millis(void);
- 
+-
 -unsigned long micros(void)
 -{
 -	return system_get_time();
 -}
-+extern unsigned long micros(void);
- 
+-
  #ifndef _TIMEVAL_DEFINED
  #define _TIMEVAL_DEFINED
-@@ -79,7 +75,7 @@ static void setServer(int id, const char* name_or_ip)
+ struct timeval {
+@@ -60,12 +53,12 @@ static time_t s_bootTime = 0;
+ // calculate offset used in gettimeofday
+ static void ensureBootTimeIsSet()
+ {
+-    if (!s_bootTime)
++    if (s_bootTime == 0)
+     {
+         time_t now = sntp_get_current_timestamp();
+-        if (now)
++        if (now != 0)
+         {
+-            s_bootTime =  now - millis() / 1000;
++            s_bootTime =  now - (system_get_time() / 1000000);
+         }
+     }
+ }
+@@ -79,7 +72,7 @@ static void setServer(int id, const char* name_or_ip)
      }
  }
  
@@ -69,16 +85,20 @@ index 4972119..1a79aac 100644
  {
      sntp_stop();
  
-@@ -93,7 +89,7 @@ void configTime(int timezone, int daylightOffset_sec, const char* server1, const
+@@ -93,22 +86,24 @@ void configTime(int timezone, int daylightOffset_sec, const char* server1, const
      sntp_init();
  }
  
 -int clock_gettime(clockid_t unused, struct timespec *tp)
 +int WEAK_ATTR clock_gettime(clockid_t unused, struct timespec *tp)
  {
-     tp->tv_sec  = millis() / 1000;
-     tp->tv_nsec = micros() * 1000;
-@@ -101,14 +97,14 @@ int clock_gettime(clockid_t unused, struct timespec *tp)
+-    tp->tv_sec  = millis() / 1000;
+-    tp->tv_nsec = micros() * 1000;
++    unsigned long us = system_get_time();
++    tp->tv_sec  = us / 1000000UL;
++    us %= 1000000UL;
++    tp->tv_nsec = us * 1000;
+     return 0;
  }
  
  // seconds since 1970
@@ -95,7 +115,7 @@ index 4972119..1a79aac 100644
  {
      time_t seconds = sntp_get_current_timestamp();
      if (t)
-@@ -118,24 +114,24 @@ time_t time(time_t * t)
+@@ -118,30 +113,32 @@ time_t time(time_t * t)
      return seconds;
  }
  
@@ -124,6 +144,16 @@ index 4972119..1a79aac 100644
  {
      if (tp)
      {
+         ensureBootTimeIsSet();
+-        tp->tv_sec  = (s_bootTime + millis()) / 1000;
+-        tp->tv_usec = micros() * 1000;
++        unsigned long us = system_get_time();
++        tp->tv_sec  = s_bootTime + (us / 1000000UL);
++        us %= 1000000UL;
++        tp->tv_usec = us * 1000UL;
+     }
+     return 0;
+ }
 diff --git a/ssl/os_port.h b/ssl/os_port.h
 index e0b9e46..7d85ff1 100644
 --- a/ssl/os_port.h

--- a/Sming/Arch/Esp8266/Components/driver/include/driver/gpio.h
+++ b/Sming/Arch/Esp8266/Components/driver/include/driver/gpio.h
@@ -4,8 +4,20 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * uart.h
+ * gpio.h
  *
  ****/
 
-#include_next <driver/uart.h>
+#pragma once
+
+#include <c_types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <gpio.h>
+
+#ifdef __cplusplus
+}
+#endif

--- a/Sming/Arch/Esp8266/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp8266/Components/driver/uart.cpp
@@ -43,12 +43,11 @@
  * NC = Not Connected to Module Pads --> No Access
  *
  */
-#include "Clock.h"
-#include "Digital.h"
+#include <Digital.h>
+#include <BitManipulations.h>
+#include <WConstants.h>
 
 #include "driver/uart.h"
-#include "espinc/peri.h"
-
 #include "SerialBuffer.h"
 
 /*
@@ -60,7 +59,7 @@
  * For the hardware FIFO, data is processed via interrupt so the headroom can be fairly small.
  * The greater the headroom, the more interrupts will be generated thus reducing efficiency.
  */
-#define RX_FIFO_FULL_THRESHOLD 120 ///< UIFF interrupt when FIFO bytes > threshold
+#define RX_FIFO_FULL_THRESHOLD 120									  ///< UIFF interrupt when FIFO bytes > threshold
 #define RX_FIFO_HEADROOM (UART_RX_FIFO_SIZE - RX_FIFO_FULL_THRESHOLD) ///< Chars between UIFF and UIOF
 /*
  * Using a buffer, data is typically processed via task callback so requires additional time.
@@ -539,13 +538,13 @@ void uart_wait_tx_empty(uart_t* uart)
 
 	if(uart->tx_buffer != nullptr) {
 		while(!uart->tx_buffer->isEmpty()) {
-			delay(0);
+			system_soft_wdt_feed();
 		}
 	}
 
 	if(is_physical(uart)) {
 		while(uart_txfifo_count(uart->uart_nr) != 0)
-			delay(0);
+			system_soft_wdt_feed();
 	}
 }
 

--- a/Sming/Arch/Esp8266/Components/esp8266/include/esp_systemapi.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/esp_systemapi.h
@@ -59,11 +59,6 @@ typedef enum {
 #define REG_CLR_BIT(_r, _b)  (*(volatile uint32_t*)(_r) &= ~(_b))
 
 #undef assert
-#ifdef SMING_RELEASE
-#define debugf(fmt, ...)
-#else
-#define debugf debug_i
-#endif
 #define assert(condition) \
 	do {\
 		if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__); \

--- a/Sming/Arch/Esp8266/Components/esp8266/include/espinc/spi_register.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/espinc/spi_register.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include <c_types.h>
+
 #define REG_SPI_BASE(i)  (0x60000200-i*0x100)
 
 #define SPI_CMD(i)                            (REG_SPI_BASE(i)  + 0x0)

--- a/Sming/Arch/Esp8266/Core/Digital.cpp
+++ b/Sming/Arch/Esp8266/Core/Digital.cpp
@@ -8,9 +8,8 @@
  *
  ****/
 
-#include "Digital.h"
-#include "WiringFrameworkIncludes.h"
-#include "espinc/peri.h"
+#include <Digital.h>
+#include <espinc/peri.h>
 #include "ESP8266EX.h"
 
 const unsigned int A0 = 17; // Single ESP8266EX analog input pin (TOUT) 10 bit, 0..1v

--- a/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
@@ -23,11 +23,10 @@
  *
  */
 
-#include "Clock.h"
-#include "WiringFrameworkIncludes.h"
+#include <Clock.h>
 #include "ESP8266EX.h"
 
-#include "HardwarePWM.h"
+#include <HardwarePWM.h>
 
 #define PERIOD_TO_MAX_DUTY(x) (x * 25)
 

--- a/Sming/Arch/Esp8266/Core/Interrupts.cpp
+++ b/Sming/Arch/Esp8266/Core/Interrupts.cpp
@@ -8,10 +8,10 @@
  *
  ****/
 
-#include "Interrupts.h"
-#include "Digital.h"
-#include "WiringFrameworkIncludes.h"
-#include "Platform/System.h"
+#include <Interrupts.h>
+#include <Digital.h>
+#include <Platform/System.h>
+#include <BitManipulations.h>
 
 static InterruptCallback gpioInterruptsList[16] = {0};
 static InterruptDelegate delegateFunctionList[16];

--- a/Sming/Arch/Esp8266/Platform/RTC.cpp
+++ b/Sming/Arch/Esp8266/Platform/RTC.cpp
@@ -8,7 +8,8 @@
  *
  ****/
 
-#include "Platform/RTC.h"
+#include <Platform/RTC.h>
+#include <esp_systemapi.h>
 
 RtcClass RTC;
 

--- a/Sming/Arch/Host/Components/esp_hal/include/esp_systemapi.h
+++ b/Sming/Arch/Host/Components/esp_hal/include/esp_systemapi.h
@@ -19,7 +19,7 @@ extern "C" {
 #include "c_types.h"
 
 struct ip_addr {
-  uint32_t addr;
+	uint32_t addr;
 };
 
 #include <sming_attr.h>
@@ -44,16 +44,13 @@ struct ip_addr {
 #include <assert.h>
 
 #include "debug_progmem.h"
-#define debugf debug_i
 
 #define SYSTEM_ERROR(fmt, ...) hostmsg("ERROR: " fmt "\r\n", ##__VA_ARGS__)
 
 #define noInterrupts()
 #define interrupts()
 
-
-//#include <string.h>
-//#include <assert.h>
+#define BIT(nr)         (1UL << (nr))
 
 #ifdef __cplusplus
 }

--- a/Sming/Arch/Host/Core/Digital.cpp
+++ b/Sming/Arch/Host/Core/Digital.cpp
@@ -9,7 +9,6 @@
  ****/
 
 #include <Digital.h>
-#include <WiringFrameworkIncludes.h>
 #include "DigitalHooks.h"
 
 // Wemos D1 mini has pin 16

--- a/Sming/Arch/Host/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Host/Core/HardwarePWM.cpp
@@ -23,9 +23,9 @@
  *
  */
 
-#include "HardwarePWM.h"
+#include <HardwarePWM.h>
 
-HardwarePWM::HardwarePWM(uint8* pins, uint8 no_of_pins) : channel_count(no_of_pins)
+HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
 }
 
@@ -33,27 +33,27 @@ HardwarePWM::~HardwarePWM()
 {
 }
 
-uint8 HardwarePWM::getChannel(uint8 pin)
+uint8_t HardwarePWM::getChannel(uint8_t pin)
 {
 	return PWM_BAD_CHANNEL;
 }
 
-uint32 HardwarePWM::getDutyChan(uint8 chan)
+uint32_t HardwarePWM::getDutyChan(uint8_t chan)
 {
 	return 0;
 }
 
-bool HardwarePWM::setDutyChan(uint8 chan, uint32 duty, bool update)
+bool HardwarePWM::setDutyChan(uint8_t chan, uint32_t duty, bool update)
 {
 	return false;
 }
 
-uint32 HardwarePWM::getPeriod()
+uint32_t HardwarePWM::getPeriod()
 {
 	return 0;
 }
 
-void HardwarePWM::setPeriod(uint32 period)
+void HardwarePWM::setPeriod(uint32_t period)
 {
 }
 

--- a/Sming/Arch/Host/Core/Interrupts.cpp
+++ b/Sming/Arch/Host/Core/Interrupts.cpp
@@ -8,10 +8,9 @@
  *
  ****/
 
-#include "Interrupts.h"
-#include "Digital.h"
-#include "WiringFrameworkIncludes.h"
-#include "Platform/System.h"
+#include <Interrupts.h>
+#include <Digital.h>
+#include <Platform/System.h>
 
 void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode)
 {

--- a/Sming/Core/AtClient.h
+++ b/Sming/Core/AtClient.h
@@ -16,7 +16,7 @@
 #pragma once
 
 #include "HardwareSerial.h"
-#include "FILO.h"
+#include "FIFO.h"
 #include "Timer.h"
 
 #define AT_REPLY_OK "OK"

--- a/Sming/Core/Clock.cpp
+++ b/Sming/Core/Clock.cpp
@@ -9,7 +9,7 @@
  ****/
 
 #include "Clock.h"
-#include "WiringFrameworkIncludes.h"
+#include <esp_systemapi.h>
 
 #define MAX_SAFE_DELAY 1000
 

--- a/Sming/Core/Clock.h
+++ b/Sming/Core/Clock.h
@@ -16,7 +16,8 @@
 
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
+#include <stdint.h>
+#include <sming_attr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/Sming/Core/Data/CStringArray.cpp
+++ b/Sming/Core/Data/CStringArray.cpp
@@ -11,6 +11,7 @@
  ****/
 
 #include "CStringArray.h"
+#include <stringutil.h>
 
 bool CStringArray::add(const char* str, unsigned length)
 {

--- a/Sming/Core/Data/HexString.cpp
+++ b/Sming/Core/Data/HexString.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "HexString.h"
+#include <stringutil.h>
 
 String makeHexString(const uint8_t* data, unsigned length, char separator)
 {

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -9,6 +9,7 @@
 
 #include "DateTime.h"
 #include "Data/CStringArray.h"
+#include <stringconversion.h>
 
 #define LEAP_YEAR(year) ((year % 4) == 0)
 

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -17,8 +17,9 @@
 #pragma once
 
 #include <time.h>
-#include "WString.h"
+#include <WString.h>
 #include "SmingLocale.h"
+#include <sming_attr.h>
 
 /*==============================================================================*/
 /* Useful Constants */

--- a/Sming/Core/Digital.h
+++ b/Sming/Core/Digital.h
@@ -16,7 +16,10 @@
 
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
+#include <WConstants.h>
+#include <esp_attr.h>
+#include <pins_arduino.h>
+#include <esp_systemapi.h>
 
 #ifdef ARCH_HOST
 #include <DigitalHooks.h>

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -9,7 +9,8 @@
  ****/
 
 #include "FileSystem.h"
-#include "WString.h"
+#include <WString.h>
+#include <debug_progmem.h>
 
 file_t fileOpen(const String& name, FileOpenFlags flags)
 {

--- a/Sming/Core/HardwarePWM.h
+++ b/Sming/Core/HardwarePWM.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
+#include <stdint.h>
 #include <driver/pwm.h>
 
 #define PWM_BAD_CHANNEL 0xff ///< Invalid PWM channel

--- a/Sming/Core/HardwareSerial.cpp
+++ b/Sming/Core/HardwareSerial.cpp
@@ -16,7 +16,7 @@
 #include "m_printf.h"
 
 #if ENABLE_CMD_EXECUTOR
-#include "../Services/CommandProcessing/CommandExecutor.h"
+#include <Services/CommandProcessing/CommandExecutor.h>
 #endif
 
 HardwareSerial Serial(UART_ID_0);

--- a/Sming/Core/HardwareSerial.h
+++ b/Sming/Core/HardwareSerial.h
@@ -15,9 +15,12 @@
 
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
-#include "Data/Stream/ReadWriteStream.h"
-#include "driver/uart.h"
+#include <stdint.h>
+#include <Delegate.h>
+#include <Data/Stream/ReadWriteStream.h>
+#include <BitManipulations.h>
+#include <driver/uart.h>
+#include <espinc/peri.h>
 
 #define UART_ID_0 0 ///< ID of UART 0
 #define UART_ID_1 1 ///< ID of UART 1

--- a/Sming/Core/Interrupts.h
+++ b/Sming/Core/Interrupts.h
@@ -14,7 +14,9 @@
 */
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
+#include <stdint.h>
+#include <driver/gpio.h>
+#include <Delegate.h>
 
 #define ESP_MAX_INTERRUPTS 16
 

--- a/Sming/Core/NanoTime.cpp
+++ b/Sming/Core/NanoTime.cpp
@@ -13,6 +13,7 @@
 #include "NanoTime.h"
 
 #include <WString.h>
+#include <stringconversion.h>
 
 namespace NanoTime
 {

--- a/Sming/Core/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Core/Network/Http/Websocket/WebsocketConnection.cpp
@@ -9,9 +9,9 @@
  ****/
 
 #include "WebsocketConnection.h"
-
-#include "Network/WebHelpers/aw-sha1.h"
-#include "Network/WebHelpers/base64.h"
+#include <BitManipulations.h>
+#include <Network/WebHelpers/aw-sha1.h>
+#include <Network/WebHelpers/base64.h>
 
 DEFINE_FSTR(WSSTR_CONNECTION, "connection")
 DEFINE_FSTR(WSSTR_UPGRADE, "upgrade")

--- a/Sming/Core/Network/MqttClient.h
+++ b/Sming/Core/Network/MqttClient.h
@@ -12,9 +12,10 @@
 
 #include "TcpClient.h"
 #include "Url.h"
-#include "WString.h"
-#include "WHashMap.h"
-#include "Data/ObjectQueue.h"
+#include <BitManipulations.h>
+#include <WString.h>
+#include <WHashMap.h>
+#include <Data/ObjectQueue.h>
 #include "Mqtt/MqttPayloadParser.h"
 #include "mqtt-codec/src/message.h"
 #include "mqtt-codec/src/serialiser.h"

--- a/Sming/Core/Network/NetUtils.cpp
+++ b/Sming/Core/Network/NetUtils.cpp
@@ -8,10 +8,11 @@
  *
  ****/
 
+#include <user_config.h>
 #include "NetUtils.h"
-#include "Data/CStringArray.h"
+#include <Data/CStringArray.h>
+#include <WString.h>
 
-#include "WString.h"
 #ifdef __ets__
 #include "lwip/tcp_impl.h"
 #else

--- a/Sming/Core/Network/NtpClient.cpp
+++ b/Sming/Core/Network/NtpClient.cpp
@@ -11,6 +11,7 @@
 #include "NtpClient.h"
 #include "Platform/Station.h"
 #include "SystemClock.h"
+#include <algorithm>
 
 NtpClient::NtpClient(const String& reqServer, unsigned reqIntervalSeconds, NtpTimeResultDelegate delegateFunction)
 {
@@ -110,7 +111,7 @@ void NtpClient::setAutoQuery(bool autoQuery)
 
 void NtpClient::setAutoQueryInterval(unsigned seconds)
 {
-	autoQuerySeconds = max(seconds, NTP_MIN_AUTOQUERY_SECONDS);
+	autoQuerySeconds = std::max(seconds, NTP_MIN_AUTOQUERY_SECONDS);
 	if(autoQueryEnabled) {
 		setAutoQuery(true);
 	}

--- a/Sming/Core/Network/SmtpClient.h
+++ b/Sming/Core/Network/SmtpClient.h
@@ -27,13 +27,14 @@
  */
 
 #include "TcpClient.h"
-#include "Data/MailMessage.h"
+#include <Data/MailMessage.h>
 #include "Url.h"
-#include "WString.h"
-#include "WVector.h"
-#include "Data/Stream/DataSourceStream.h"
-#include "WebConstants.h"
-#include "Data/ObjectQueue.h"
+#include <BitManipulations.h>
+#include <WString.h>
+#include <WVector.h>
+#include <Data/Stream/DataSourceStream.h>
+#include <WConstants.h>
+#include <Data/ObjectQueue.h>
 
 /* Maximum waiting emails in the mail queue */
 #define SMTP_QUEUE_SIZE 5

--- a/Sming/Core/Network/Ssl/SslFingerprints.h
+++ b/Sming/Core/Network/Ssl/SslFingerprints.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include "ssl/ssl.h"
+#include <ssl/ssl.h>
 
 /**
  * @brief SSL Certificate fingerprint type

--- a/Sming/Core/Network/Ssl/SslValidator.cpp
+++ b/Sming/Core/Network/Ssl/SslValidator.cpp
@@ -10,9 +10,8 @@
  *
  ****/
 
-#ifdef ENABLE_SSL
-
 #include "SslValidator.h"
+#include <debug_progmem.h>
 
 static bool sslValidateCertificateSha1(SSL* ssl, void* data)
 {
@@ -112,5 +111,3 @@ bool SslValidatorList::add(SslFingerprints& fingerprints)
 
 	return success;
 }
-
-#endif /* ENABLE_SSL */

--- a/Sming/Core/Network/Ssl/SslValidator.h
+++ b/Sming/Core/Network/Ssl/SslValidator.h
@@ -17,10 +17,11 @@
 
 #pragma once
 
-#include "ssl/ssl.h"
-#include "ssl/tls1.h"
+#include <ssl/ssl.h>
+#include <ssl/tls1.h>
 
-#include "WVector.h"
+#include <Delegate.h>
+#include <WVector.h>
 
 #include "SslFingerprints.h"
 

--- a/Sming/Core/Network/TcpConnection.cpp
+++ b/Sming/Core/Network/TcpConnection.cpp
@@ -10,11 +10,10 @@
 
 #include "TcpConnection.h"
 
-#include "Data/Stream/DataSourceStream.h"
-#include "Platform/WDT.h"
+#include <Data/Stream/DataSourceStream.h>
+#include <Platform/WDT.h>
 #include "NetUtils.h"
-#include "WString.h"
-#include "IpAddress.h"
+#include <WString.h>
 
 #ifdef DEBUG_TCP_EXTENDED
 #define debug_tcp(fmt, ...) debug_d(fmt, ##__VA_ARGS__)

--- a/Sming/Core/Network/TcpConnection.h
+++ b/Sming/Core/Network/TcpConnection.h
@@ -16,13 +16,11 @@
 #pragma once
 
 #ifdef ENABLE_SSL
-#include "axtls-8266/compat/lwipr_compat.h"
-#include "Clock.h"
+#include <axtls-8266/compat/lwipr_compat.h>
 #include "Ssl/SslStructs.h"
 #endif
 
-#include "WiringFrameworkDependencies.h"
-#include "IpAddress.h"
+#include <IpAddress.h>
 
 #define NETWORK_DEBUG
 
@@ -42,7 +40,6 @@ enum TcpConnectionEvent {
 struct pbuf;
 class String;
 class IDataSourceStream;
-class IpAddress;
 class TcpConnection;
 
 typedef Delegate<void(TcpConnection&)> TcpConnectionDestroyedDelegate;

--- a/Sming/Core/Network/UdpConnection.h
+++ b/Sming/Core/Network/UdpConnection.h
@@ -16,8 +16,7 @@
 
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
-#include "IpAddress.h"
+#include <IpAddress.h>
 
 class UdpConnection;
 

--- a/Sming/Core/Network/Url.h
+++ b/Sming/Core/Network/Url.h
@@ -24,8 +24,9 @@
 
 #pragma once
 
-#include "WString.h"
+#include <WString.h>
 #include "Http/HttpParams.h"
+#include <sming_attr.h>
 
 /*
  * Common URL schemes (name, scheme, port)

--- a/Sming/Core/Network/WebConstants.cpp
+++ b/Sming/Core/Network/WebConstants.cpp
@@ -9,8 +9,9 @@
  ****/
 
 #include "WebConstants.h"
-#include "FakePgmSpace.h"
+#include <FakePgmSpace.h>
 #include <Data/CStringArray.h>
+#include <stringutil.h>
 
 namespace ContentType
 {

--- a/Sming/Core/Network/WebConstants.h
+++ b/Sming/Core/Network/WebConstants.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "WString.h"
+#include <WString.h>
 
 /** @brief Basic MIME types and file extensions
  *  @note Each MIME type can have only one associated file extension. Where other extensions

--- a/Sming/Core/SystemClock.cpp
+++ b/Sming/Core/SystemClock.cpp
@@ -9,7 +9,8 @@
  ****/
 
 #include "SystemClock.h"
-#include "Platform/RTC.h"
+#include <Platform/RTC.h>
+#include <debug_progmem.h>
 
 SystemClockClass SystemClock;
 

--- a/Sming/Core/twi.h
+++ b/Sming/Core/twi.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
+#include <stdint.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/Sming/Platform/BssInfo.cpp
+++ b/Sming/Platform/BssInfo.cpp
@@ -15,7 +15,6 @@ String BssInfo::getAuthorizationMethodName() const
 	case AUTH_WPA_WPA2_PSK:
 		return F("WPA_WPA2_PSK");
 	default:
-		SYSTEM_ERROR("Unknown auth: %d", authorization);
-		return nullptr;
+		return F("UNKNOWN_") + authorization;
 	}
 }

--- a/Sming/Platform/BssInfo.h
+++ b/Sming/Platform/BssInfo.h
@@ -24,6 +24,7 @@ enum WifiAuthMode {
 	AUTH_MAX,
 };
 #else
+#include <esp_systemapi.h>
 typedef AUTH_MODE WifiAuthMode;
 #endif
 

--- a/Sming/Platform/RTC.h
+++ b/Sming/Platform/RTC.h
@@ -15,7 +15,7 @@
 */
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
+#include <stdint.h>
 
 /** @brief  Real time clock class
  *  @addtogroup rtc

--- a/Sming/Services/CommandProcessing/CommandDelegate.h
+++ b/Sming/Services/CommandProcessing/CommandDelegate.h
@@ -12,7 +12,6 @@
 
 #include "WString.h"
 #include "Network/TcpClient.h"
-#include "WiringFrameworkIncludes.h"
 #include "CommandOutput.h"
 
 /** @brief  Command delegate function

--- a/Sming/Services/CommandProcessing/CommandExecutor.h
+++ b/Sming/Services/CommandProcessing/CommandExecutor.h
@@ -7,8 +7,7 @@
 
 #pragma once
 
-#include "WiringFrameworkIncludes.h"
-#include "Network/TcpClient.h"
+#include <Network/TcpClient.h>
 #include "CommandHandler.h"
 #include "CommandOutput.h"
 #include <Data/Buffer/LineBuffer.h>

--- a/Sming/Services/CommandProcessing/CommandHandler.h
+++ b/Sming/Services/CommandProcessing/CommandHandler.h
@@ -24,12 +24,10 @@
 
 #pragma once
 
-#include "WiringFrameworkIncludes.h"
 #include "CommandDelegate.h"
-#include "WHashMap.h"
-#include "SystemClock.h"
-#include <stdio.h>
-#include "HardwareSerial.h"
+#include <WHashMap.h>
+#include <SystemClock.h>
+#include <HardwareSerial.h>
 
 /** @brief  Verbose mode
 */

--- a/Sming/Services/CommandProcessing/CommandOutput.h
+++ b/Sming/Services/CommandProcessing/CommandOutput.h
@@ -7,11 +7,10 @@
 
 #pragma once
 
-#include "Network/TcpClient.h"
-#include "Stream.h"
-#include "Print.h"
-#include "WiringFrameworkDependencies.h"
-#include "Network/Http/Websocket/WebsocketConnection.h"
+#include <Network/TcpClient.h>
+#include <Stream.h>
+#include <Print.h>
+#include <Network/Http/Websocket/WebsocketConnection.h>
 
 class CommandOutput : public Print
 {

--- a/Sming/System/include/debug_progmem.h
+++ b/Sming/System/include/debug_progmem.h
@@ -130,6 +130,12 @@ extern uint32_t system_get_time();
 
 #endif /*DEBUG_BUILD*/
 
+#ifdef SMING_RELEASE
+#define debugf(fmt, ...)
+#else
+#define debugf debug_i
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/Wiring/Countable.h
+++ b/Sming/Wiring/Countable.h
@@ -16,8 +16,6 @@
 
 #pragma once
 
-#include "WiringFrameworkDependencies.h"
-
 template<typename T>
 class Countable
 {

--- a/Sming/Wiring/Display.h
+++ b/Sming/Wiring/Display.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include "Print.h"
-#include "WiringFrameworkIncludes.h"
 
 class Display : public Print
 {

--- a/Sming/Wiring/FIFO.h
+++ b/Sming/Wiring/FIFO.h
@@ -20,7 +20,6 @@
 #define FIFO_H
 
 #include "Countable.h"
-#include "WiringFrameworkDependencies.h"
 
 template<typename T, int rawSize>
 class FIFO : public Countable<T>

--- a/Sming/Wiring/FILO.h
+++ b/Sming/Wiring/FILO.h
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include "WiringFrameworkIncludes.h"
+#include "Countable.h"
 
 template<typename T, int rawSize>
 class FILO : public Countable<T>

--- a/Sming/Wiring/FakePgmSpace.cpp
+++ b/Sming/Wiring/FakePgmSpace.cpp
@@ -1,5 +1,15 @@
-#include "WiringFrameworkDependencies.h"
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * FakePgmSpace.cpp
+ *
+ ****/
+
 #include "FakePgmSpace.h"
+#include <esp_systemapi.h>
 
 #ifdef ICACHE_FLASH
 

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -4,7 +4,7 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * Support for reading flash memory
+ * FakePgmSpace.h - Support for reading flash memory
  *
  ****/
 

--- a/Sming/Wiring/FlashString.h
+++ b/Sming/Wiring/FlashString.h
@@ -83,6 +83,7 @@
 #pragma once
 
 #include "WString.h"
+#include "FakePgmSpace.h"
 
 /** @brief Define a FlashString
  *  @param _name variable to identify the string

--- a/Sming/Wiring/Print.cpp
+++ b/Sming/Wiring/Print.cpp
@@ -18,6 +18,9 @@
 
 #include "Print.h"
 #include "WString.h"
+#include <stringconversion.h>
+#include <math.h>
+#include <algorithm>
 
 /*
 || @description
@@ -111,8 +114,8 @@ size_t Print::printFloat(double number, uint8_t digits)
 {
   size_t n = 0;
   
-  if (isnan(number)) return print("nan");
-  if (isinf(number)) return print("inf");
+  if (std::isnan(number)) return print("nan");
+  if (std::isinf(number)) return print("inf");
   if (number > 4294967040.0) return print ("ovf");  // constant determined empirically
   if (number <-4294967040.0) return print ("ovf");  // constant determined empirically
   

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -20,7 +20,6 @@
 
 #ifdef __cplusplus
 
-#include "WiringFrameworkDependencies.h"
 #include "Printable.h"
 #include "WString.h"
 

--- a/Sming/Wiring/Printable.h
+++ b/Sming/Wiring/Printable.h
@@ -35,11 +35,13 @@
 
 #pragma once
 
+#include <stddef.h>
+
 class Print;
 
 class Printable
 {
-  public:
+public:
     virtual ~Printable() { }
-    virtual size_t printTo(Print &p) const = 0;
+	virtual size_t printTo(Print& p) const = 0;
 };

--- a/Sming/Wiring/SplitString.h
+++ b/Sming/Wiring/SplitString.h
@@ -13,7 +13,6 @@
 
 #include "WVector.h"
 #include "WString.h"
-#include "WiringFrameworkDependencies.h"
 
 /** @brief split a delimited string list of integers into an array
  *  @param what
@@ -23,7 +22,7 @@
  *  @note leading/trailing whitespace is removed from 'what' before parsing
  *  example: "   1,2,3,4,5" returns [1, 2, 3, 4, 5]
  */
-int splitString(String &what, char delim,  Vector<int> &splits);
+int splitString(String& what, char delim, Vector<int>& splits);
 
 /** @brief split a delimited string list into an array
  *  @param what
@@ -33,4 +32,4 @@ int splitString(String &what, char delim,  Vector<int> &splits);
  *  @note leading/trailing whitespace is removed from 'what' before parsing
  *  example: "   a,b,c,d,e" returns ["a", "b", "c", "d", "e"]
  */
-int splitString(String &what, char delim,  Vector<String> &splits);
+int splitString(String& what, char delim, Vector<String>& splits);

--- a/Sming/Wiring/Stream.cpp
+++ b/Sming/Wiring/Stream.cpp
@@ -20,7 +20,6 @@
 ||
 */
 
-#include "WiringFrameworkIncludes.h"
 #include "Stream.h"
 
 #include "Clock.h"

--- a/Sming/Wiring/Stream.cpp
+++ b/Sming/Wiring/Stream.cpp
@@ -22,7 +22,7 @@
 
 #include "Stream.h"
 
-#include "Clock.h"
+#include <Platform/Timers.h>
 
 #define PARSE_TIMEOUT 1000  // default number of milli-seconds to wait
 #define NO_SKIP_CHAR  1  // a magic char not found in a valid ASCII numeric field
@@ -30,11 +30,11 @@
 // private method to read stream with timeout
 int Stream::timedRead()
 {
-  startMillis = millis();
+  OneShotFastMs timer(receiveTimeout);
   do {
     int c = read();
     if (c >= 0) return c;
-  } while(millis() - startMillis < receiveTimeout);
+  } while(!timer.expired());
   return -1;     // -1 indicates timeout
 }
 
@@ -42,11 +42,11 @@ int Stream::timedRead()
 int Stream::timedPeek()
 {
   int c;
-  startMillis = millis();
+  OneShotFastMs timer(receiveTimeout);
   do {
     c = peek();
     if (c >= 0) return c;
-  } while(millis() - startMillis < receiveTimeout);
+  } while(!timer.expired());
   return -1;     // -1 indicates timeout
 }
 

--- a/Sming/Wiring/Stream.h
+++ b/Sming/Wiring/Stream.h
@@ -24,7 +24,6 @@
 #pragma once
 
 #include "Print.h"
-#include "WiringFrameworkDependencies.h"
 
 class Stream : public Print
 {

--- a/Sming/Wiring/WCharacter.h
+++ b/Sming/Wiring/WCharacter.h
@@ -17,8 +17,6 @@
 
 #pragma once
 
-#include "WiringFrameworkIncludes.h"
-
 // WCharacter.h prototypes
 inline bool isAlphaNumeric(int c) __attribute__((always_inline));
 inline bool isAlpha(int c) __attribute__((always_inline));

--- a/Sming/Wiring/WConstants.h
+++ b/Sming/Wiring/WConstants.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <user_config.h>
+#include <stdint.h>
 
 // Wiring API version for libraries
 // this is passed in at compile-time
@@ -28,7 +28,6 @@
 // passed in at compile-time
 #ifndef F_CPU
 #define F_CPU 80000000L
-#warning "F_CPU was not defined.  Default to 80 MHz."
 #endif
 
 /*************************************************************
@@ -61,11 +60,6 @@
 #define LSBFIRST 0x0
 #define MSBFIRST 0x1
 
-// Defined in ctypes
-//#define true     0x1
-//#define false    0x0
-//#define TRUE     0x1
-//#define FALSE    0x0
 #define null     NULL
 
 #define DEC      10
@@ -101,25 +95,9 @@
  * Useful macros
  *************************************************************/
 
-/*#define int(x)                         ((int)(x))
-#define char(x)                        ((char)(x))
-#define long(x)                        ((long)(x))
-#define byte(x)                        ((uint8_t)(x))
-#define float(x)                       ((float)(x))
-#define boolean(x)                     ((uint8_t)((x)==0?false:true))
-*/
-
 #define word(...) makeWord(__VA_ARGS__)
 
 #define sq(x)                          ((x)*(x))
-//#define abs(x)                         ((x)>0?(x):-(x))
-//#ifndef min
-//#define min(a,b)                       ((a)<(b)?(a):(b))
-//#endif
-//#ifndef max
-//#define max(a,b)                       ((a)>(b)?(a):(b))
-//#endif
-//#define round(x)                       ((x)>=0?(long)((x)+0.5):(long)((x)-0.5))
 #define radians(deg)                   ((deg)*DEG_TO_RAD)
 #define degrees(rad)                   ((rad)*RAD_TO_DEG)
 #define constrain(amt,low,high)        ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))

--- a/Sming/Wiring/WMath.cpp
+++ b/Sming/Wiring/WMath.cpp
@@ -19,8 +19,7 @@
 ||
 */
 
-#include "WiringFrameworkIncludes.h"
-
+#include "WMath.h"
 
 unsigned int static seed;
 

--- a/Sming/Wiring/WMath.h
+++ b/Sming/Wiring/WMath.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "WiringFrameworkIncludes.h"
+#include <stdint.h>
 
 long random(long);
 long random(long, long);

--- a/Sming/Wiring/WShift.cpp
+++ b/Sming/Wiring/WShift.cpp
@@ -15,10 +15,8 @@
 ||
 */
 
-#include "Clock.h"
-#include "Digital.h"
-#include "WiringFrameworkIncludes.h"
-
+#include <Clock.h>
+#include <Digital.h>
 
 uint16_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t count, uint8_t delayTime)
 {

--- a/Sming/Wiring/WShift.h
+++ b/Sming/Wiring/WShift.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include "WiringFrameworkIncludes.h"
+#include <stdint.h>
 
 uint16_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t count = 8, uint8_t delayTime = 1);
 void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint16_t value, uint8_t count = 8, uint8_t delayTime = 1);

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -16,7 +16,10 @@
 ||
 */
 
-#include "WiringFrameworkIncludes.h"
+#include "WString.h"
+#include <string.h>
+#include <stringutil.h>
+#include <stringconversion.h>
 
 const String String::nullstr = nullptr;
 const String String::empty = "";

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -50,8 +50,7 @@
 
 #ifdef __cplusplus
 
-#include "WiringFrameworkDependencies.h"
-#include "WVector.h"
+#include "WConstants.h"
 
 // @deprecated Should not be using String in interrupt context
 #define STRING_IRAM_ATTR // IRAM_ATTR

--- a/Sming/Wiring/WVector.h
+++ b/Sming/Wiring/WVector.h
@@ -20,6 +20,7 @@
 #include "Countable.h"
 #include <stdlib.h>
 #include <string.h>
+#include <algorithm>
 
 template <typename Element> class Vector : public Countable<Element>
 {

--- a/Sming/Wiring/WiringFrameworkDependencies.h
+++ b/Sming/Wiring/WiringFrameworkDependencies.h
@@ -14,8 +14,6 @@
 #include <math.h>
 #include <string.h>
 
-#define F_CPU 80000000L ////?
-
 #include "WConstants.h"
 #include "BitManipulations.h"
 #include "FakePgmSpace.h"


### PR DESCRIPTION
Too many low-level dependencies when using things like `String`, `Vector`, etc.