### PR TITLE
Revise UART driver and HardwareSerial to avoid using `peri.h`

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/include/espinc/uart_register.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/espinc/uart_register.h
@@ -1,131 +1,182 @@
-//Generated at 2012-07-03 18:44:06
-/*
- *  Copyright (c) 2010 - 2011 Espressif System
- *
- */
+// Copyright 2018-2025 Espressif Systems (Shanghai) PTE LTD
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #pragma once
 
-#define REG_UART_BASE( i )  (0x60000000+(i)*0xf00)
+#include <c_types.h>
+
+#define REG_UART_BASE(i)                (0x60000000 + (i)*0xf00)
 //version value:32'h062000
 
-#define UART_FIFO( i )                          (REG_UART_BASE( i ) + 0x0)
-#define UART_RXFIFO_RD_BYTE 0x000000FF
-#define UART_RXFIFO_RD_BYTE_S 0
+#define UART_FIFO(i)                    (REG_UART_BASE(i) + 0x0)
+#define UART_RXFIFO_RD_BYTE                 0x000000FF
+#define UART_RXFIFO_RD_BYTE_S               0
 
-#define UART_INT_RAW( i )                       (REG_UART_BASE( i ) + 0x4)
-#define UART_RXFIFO_TOUT_INT_RAW (BIT(8))
-#define UART_BRK_DET_INT_RAW (BIT(7))
-#define UART_CTS_CHG_INT_RAW (BIT(6))
-#define UART_DSR_CHG_INT_RAW (BIT(5))
-#define UART_RXFIFO_OVF_INT_RAW (BIT(4))
-#define UART_FRM_ERR_INT_RAW (BIT(3))
-#define UART_PARITY_ERR_INT_RAW (BIT(2))
-#define UART_TXFIFO_EMPTY_INT_RAW (BIT(1))
-#define UART_RXFIFO_FULL_INT_RAW (BIT(0))
+#define UART_INT_RAW(i)                 (REG_UART_BASE(i) + 0x4)
+#define UART_RXFIFO_TOUT_INT_RAW            (BIT(8))
+#define UART_BRK_DET_INT_RAW                (BIT(7))
+#define UART_CTS_CHG_INT_RAW                (BIT(6))
+#define UART_DSR_CHG_INT_RAW                (BIT(5))
+#define UART_RXFIFO_OVF_INT_RAW             (BIT(4))
+#define UART_FRM_ERR_INT_RAW                (BIT(3))
+#define UART_PARITY_ERR_INT_RAW             (BIT(2))
+#define UART_TXFIFO_EMPTY_INT_RAW           (BIT(1))
+#define UART_RXFIFO_FULL_INT_RAW            (BIT(0))
 
-#define UART_INT_ST( i )                        (REG_UART_BASE( i ) + 0x8)
-#define UART_RXFIFO_TOUT_INT_ST (BIT(8))
-#define UART_BRK_DET_INT_ST (BIT(7))
-#define UART_CTS_CHG_INT_ST (BIT(6))
-#define UART_DSR_CHG_INT_ST (BIT(5))
-#define UART_RXFIFO_OVF_INT_ST (BIT(4))
-#define UART_FRM_ERR_INT_ST (BIT(3))
-#define UART_PARITY_ERR_INT_ST (BIT(2))
-#define UART_TXFIFO_EMPTY_INT_ST (BIT(1))
-#define UART_RXFIFO_FULL_INT_ST (BIT(0))
+#define UART_INT_ST(i)                  (REG_UART_BASE(i) + 0x8)
+#define UART_RXFIFO_TOUT_INT_ST             (BIT(8))
+#define UART_BRK_DET_INT_ST                 (BIT(7))
+#define UART_CTS_CHG_INT_ST                 (BIT(6))
+#define UART_DSR_CHG_INT_ST                 (BIT(5))
+#define UART_RXFIFO_OVF_INT_ST              (BIT(4))
+#define UART_FRM_ERR_INT_ST                 (BIT(3))
+#define UART_PARITY_ERR_INT_ST              (BIT(2))
+#define UART_TXFIFO_EMPTY_INT_ST            (BIT(1))
+#define UART_RXFIFO_FULL_INT_ST             (BIT(0))
 
-#ifndef GDBSTUB_H
-#define UART_INT_ENA( i )                       (REG_UART_BASE( i ) + 0xC)
-#endif
-#define UART_RXFIFO_TOUT_INT_ENA (BIT(8))
-#define UART_BRK_DET_INT_ENA (BIT(7))
-#define UART_CTS_CHG_INT_ENA (BIT(6))
-#define UART_DSR_CHG_INT_ENA (BIT(5))
-#define UART_RXFIFO_OVF_INT_ENA (BIT(4))
-#define UART_FRM_ERR_INT_ENA (BIT(3))
-#define UART_PARITY_ERR_INT_ENA (BIT(2))
-#define UART_TXFIFO_EMPTY_INT_ENA (BIT(1))
-#define UART_RXFIFO_FULL_INT_ENA (BIT(0))
+#define UART_INT_ENA(i)                 (REG_UART_BASE(i) + 0xC)
+#define UART_RXFIFO_TOUT_INT_ENA            (BIT(8))
+#define UART_BRK_DET_INT_ENA                (BIT(7))
+#define UART_CTS_CHG_INT_ENA                (BIT(6))
+#define UART_DSR_CHG_INT_ENA                (BIT(5))
+#define UART_RXFIFO_OVF_INT_ENA             (BIT(4))
+#define UART_FRM_ERR_INT_ENA                (BIT(3))
+#define UART_PARITY_ERR_INT_ENA             (BIT(2))
+#define UART_TXFIFO_EMPTY_INT_ENA           (BIT(1))
+#define UART_RXFIFO_FULL_INT_ENA            (BIT(0))
 
-#ifndef GDBSTUB_H
-#define UART_INT_CLR( i )                       (REG_UART_BASE( i ) + 0x10)
-#endif
-#define UART_RXFIFO_TOUT_INT_CLR (BIT(8))
-#define UART_BRK_DET_INT_CLR (BIT(7))
-#define UART_CTS_CHG_INT_CLR (BIT(6))
-#define UART_DSR_CHG_INT_CLR (BIT(5))
-#define UART_RXFIFO_OVF_INT_CLR (BIT(4))
-#define UART_FRM_ERR_INT_CLR (BIT(3))
-#define UART_PARITY_ERR_INT_CLR (BIT(2))
-#define UART_TXFIFO_EMPTY_INT_CLR (BIT(1))
-#define UART_RXFIFO_FULL_INT_CLR (BIT(0))
+#define UART_INT_CLR(i)                 (REG_UART_BASE(i) + 0x10)
+#define UART_RXFIFO_TOUT_INT_CLR            (BIT(8))
+#define UART_BRK_DET_INT_CLR                (BIT(7))
+#define UART_CTS_CHG_INT_CLR                (BIT(6))
+#define UART_DSR_CHG_INT_CLR                (BIT(5))
+#define UART_RXFIFO_OVF_INT_CLR             (BIT(4))
+#define UART_FRM_ERR_INT_CLR                (BIT(3))
+#define UART_PARITY_ERR_INT_CLR             (BIT(2))
+#define UART_TXFIFO_EMPTY_INT_CLR           (BIT(1))
+#define UART_RXFIFO_FULL_INT_CLR            (BIT(0))
 
-#define UART_CLKDIV( i )                        (REG_UART_BASE( i ) + 0x14)
-#define UART_CLKDIV_CNT 0x000FFFFF
-#define UART_CLKDIV_S 0
+#define UART_RXFIFO_FULL_INT_ENA            (BIT(0))
+#define UART_RXFIFO_FULL_INT_ENA_M          (BIT(0))
+#define UART_RXFIFO_FULL_INT_ST_M           (BIT(0))
+#define UART_RXFIFO_FULL_INT_CLR_M          (BIT(0))
 
-#define UART_AUTOBAUD( i )                      (REG_UART_BASE( i ) + 0x18)
-#define UART_GLITCH_FILT 0x000000FF
-#define UART_GLITCH_FILT_S 8
-#define UART_AUTOBAUD_EN (BIT(0))
+#define UART_TXFIFO_EMPTY_INT_ENA           (BIT(1))
+#define UART_TXFIFO_EMPTY_INT_ENA_M         (BIT(1))
+#define UART_TXFIFO_EMPTY_INT_ST_M          (BIT(1))
+#define UART_TXFIFO_EMPTY_INT_CLR_M         (BIT(1))
 
-#define UART_STATUS( i )                        (REG_UART_BASE( i ) + 0x1C)
-#define UART_TXD (BIT(31))
-#define UART_RTSN (BIT(30))
-#define UART_DTRN (BIT(29))
-#define UART_TXFIFO_CNT 0x000000FF
-#define UART_TXFIFO_CNT_S 16
-#define UART_RXD (BIT(15))
-#define UART_CTSN (BIT(14))
-#define UART_DSRN (BIT(13))
-#define UART_RXFIFO_CNT 0x000000FF
-#define UART_RXFIFO_CNT_S 0
+#define UART_PARITY_ERR_INT_ENA             (BIT(2))
+#define UART_PARITY_ERR_INT_ENA_M           (BIT(2))
+#define UART_PARITY_ERR_INT_ST_M            (BIT(2))
+#define UART_PARITY_ERR_INT_CLR_M           (BIT(2))
 
-#define UART_CONF0( i )                         (REG_UART_BASE( i ) + 0x20)
-#define UART_TXFIFO_RST (BIT(18))
-#define UART_RXFIFO_RST (BIT(17))
-#define UART_IRDA_EN (BIT(16))
-#define UART_TX_FLOW_EN (BIT(15))
-#define UART_LOOPBACK (BIT(14))
-#define UART_IRDA_RX_INV (BIT(13))
-#define UART_IRDA_TX_INV (BIT(12))
-#define UART_IRDA_WCTL (BIT(11))
-#define UART_IRDA_TX_EN (BIT(10))
-#define UART_IRDA_DPLX (BIT(9))
-#define UART_TXD_BRK (BIT(8))
-#define UART_SW_DTR (BIT(7))
-#define UART_SW_RTS (BIT(6))
-#define UART_STOP_BIT_NUM 0x00000003
-#define UART_STOP_BIT_NUM_S 4
-#define UART_BIT_NUM 0x00000003
-#define UART_BIT_NUM_S 2
-#define UART_PARITY_EN (BIT(1))
-#define UART_PARITY (BIT(0))
+#define UART_FRM_ERR_INT_ENA                (BIT(3))
+#define UART_FRM_ERR_INT_ENA_M              (BIT(3))
+#define UART_FRM_ERR_INT_ST_M               (BIT(3))
+#define UART_FRM_ERR_INT_CLR_M              (BIT(3))
 
-#define UART_CONF1( i )                         (REG_UART_BASE( i ) + 0x24)
-#define UART_RX_TOUT_EN (BIT(31))
-#define UART_RX_TOUT_THRHD 0x0000007F
-#define UART_RX_TOUT_THRHD_S 24
-#define UART_RX_FLOW_EN (BIT(23))
-#define UART_RX_FLOW_THRHD 0x0000007F
-#define UART_RX_FLOW_THRHD_S 16
-#define UART_TXFIFO_EMPTY_THRHD 0x0000007F
-#define UART_TXFIFO_EMPTY_THRHD_S 8
-#define UART_RXFIFO_FULL_THRHD 0x0000007F
-#define UART_RXFIFO_FULL_THRHD_S 0
+#define UART_RXFIFO_OVF_INT_ENA             (BIT(4))
+#define UART_RXFIFO_OVF_INT_ENA_M           (BIT(4))
+#define UART_RXFIFO_OVF_INT_ST_M            (BIT(4))
+#define UART_RXFIFO_OVF_INT_CLR_M           (BIT(4))
 
-#define UART_LOWPULSE( i )                      (REG_UART_BASE( i ) + 0x28)
-#define UART_LOWPULSE_MIN_CNT         0x000FFFFF
-#define UART_LOWPULSE_MIN_CNT_S     0
+#define UART_RXFIFO_TOUT_INT_ENA            (BIT(8))
+#define UART_RXFIFO_TOUT_INT_ENA_M          (BIT(8))
+#define UART_RXFIFO_TOUT_INT_ST_M           (BIT(8))
+#define UART_RXFIFO_TOUT_INT_CLR_M          (BIT(8))
 
-#define UART_HIGHPULSE( i )                     (REG_UART_BASE( i ) + 0x2C)
-#define UART_HIGHPULSE_MIN_CNT         0x000FFFFF
-#define UART_HIGHPULSE_MIN_CNT_S     0
+#define UART_CLKDIV(i)                  (REG_UART_BASE(i) + 0x14)
+#define UART_CLKDIV_CNT                     0x000FFFFF
+#define UART_CLKDIV_S                       0
 
-#define UART_PULSE_NUM( i )                     (REG_UART_BASE( i ) + 0x30)
+#define UART_AUTOBAUD(i)                (REG_UART_BASE(i) + 0x18)
+#define UART_GLITCH_FILT                    0x000000FF
+#define UART_GLITCH_FILT_S                  8
+#define UART_AUTOBAUD_EN                    (BIT(0))
+
+#define UART_STATUS(i)                  (REG_UART_BASE(i) + 0x1C)
+#define UART_TXD                            (BIT(31))
+#define UART_RTSN                           (BIT(30))
+#define UART_DTRN                           (BIT(29))
+#define UART_TXFIFO_CNT                     0x000000FF
+#define UART_TXFIFO_CNT_S                   16
+#define UART_RXD                            (BIT(15))
+#define UART_CTSN                           (BIT(14))
+#define UART_DSRN                           (BIT(13))
+#define UART_RXFIFO_CNT                     0x000000FF
+#define UART_RXFIFO_CNT_S                   0
+
+#define UART_CONF0(i)                   (REG_UART_BASE(i) + 0x20)
+#define UART_DTR_INV                        (BIT(24))
+#define UART_RTS_INV                        (BIT(23))
+#define UART_TXD_INV                        (BIT(22))
+#define UART_DSR_INV                        (BIT(21))
+#define UART_CTS_INV                        (BIT(20))
+#define UART_RXD_INV                        (BIT(19))
+#define UART_TXFIFO_RST                     (BIT(18))
+#define UART_RXFIFO_RST                     (BIT(17))
+#define UART_IRDA_EN                        (BIT(16))
+#define UART_TX_FLOW_EN                     (BIT(15))
+#define UART_LOOPBACK                       (BIT(14))
+#define UART_IRDA_RX_INV                    (BIT(13))
+#define UART_IRDA_TX_INV                    (BIT(12))
+#define UART_IRDA_WCTL                      (BIT(11))
+#define UART_IRDA_TX_EN                     (BIT(10))
+#define UART_IRDA_DPLX                      (BIT(9))
+#define UART_TXD_BRK                        (BIT(8))
+#define UART_SW_DTR                         (BIT(7))
+#define UART_SW_RTS                         (BIT(6))
+#define UART_STOP_BIT_NUM                   0x00000003
+#define UART_STOP_BIT_NUM_S                 4
+#define UART_BIT_NUM                        0x00000003
+#define UART_BIT_NUM_S                      2
+#define UART_PARITY_EN                      (BIT(1))
+#define UART_PARITY_EN_M                    0x00000001
+#define UART_PARITY_EN_S                    1
+#define UART_PARITY                         (BIT(0))
+#define UART_PARITY_M                       0x00000001
+#define UART_PARITY_S                        0
+
+#define UART_CONF1(i)                   (REG_UART_BASE(i) + 0x24)
+#define UART_RX_TOUT_EN                     (BIT(31))
+#define UART_RX_TOUT_THRHD                  0x0000007F
+#define UART_RX_TOUT_THRHD_S                24
+#define UART_RX_FLOW_EN                     (BIT(23))
+#define UART_RX_FLOW_THRHD                  0x0000007F
+#define UART_RX_FLOW_THRHD_S                16
+#define UART_TXFIFO_EMPTY_THRHD             0x0000007F
+#define UART_TXFIFO_EMPTY_THRHD_S           8
+#define UART_RXFIFO_FULL_THRHD              0x0000007F
+#define UART_RXFIFO_FULL_THRHD_S            0
+
+#define UART_LOWPULSE(i)                (REG_UART_BASE(i) + 0x28)
+#define UART_LOWPULSE_MIN_CNT               0x000FFFFF
+#define UART_LOWPULSE_MIN_CNT_S             0
+
+#define UART_HIGHPULSE(i)               (REG_UART_BASE(i) + 0x2C)
+#define UART_HIGHPULSE_MIN_CNT              0x000FFFFF
+#define UART_HIGHPULSE_MIN_CNT_S            0
+
+#define UART_PULSE_NUM(i)               (REG_UART_BASE(i) + 0x30)
 #define UART_PULSE_NUM_CNT                  0x0003FF
-#define UART_PULSE_NUM_CNT_S               0
+#define UART_PULSE_NUM_CNT_S                0
 
-#define UART_DATE( i )                          (REG_UART_BASE( i ) + 0x78)
-#define UART_ID( i )                            (REG_UART_BASE( i ) + 0x7C)
+#define UART_DATE(i)                    (REG_UART_BASE(i) + 0x78)
+#define UART_ID(i)                          (REG_UART_BASE(i) + 0x7C)
+
+#define UART_SWAP_REG                   0x3FF00028
+#define UART_SWAP                           BIT(0) //Swaps UART
+#define UART_SWAP0                          BIT(2) //Swaps UART 0 pins (u0rxd <-> u0cts), (u0txd <-> u0rts)
+#define UART_SWAP1                          BIT(3) //Swaps UART 1 pins (u1rxd <-> u1cts), (u1txd <-> u1rts)

--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbuart.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbuart.cpp
@@ -13,6 +13,7 @@
 #include "gdbuart.h"
 #include "GdbPacket.h"
 #include <driver/uart.h>
+#include <espinc/uart_register.h>
 #include <driver/SerialBuffer.h>
 #include <Platform/System.h>
 #include <HardwareSerial.h>
@@ -34,13 +35,13 @@ static uint8_t break_requests;		  ///< How many times Ctrl+C was received before
 // Get number of characters in receive FIFO
 __forceinline static uint8_t uart_rxfifo_count(uint8_t nr)
 {
-	return (USS(nr) >> USRXC) & 0xff;
+	return (READ_PERI_REG(UART_STATUS(nr)) >> UART_RXFIFO_CNT_S) & UART_RXFIFO_CNT;
 }
 
 // Get number of characters in transmit FIFO
 __forceinline static uint8_t uart_txfifo_count(uint8_t nr)
 {
-	return (USS(nr) >> USTXC) & 0xff;
+	return (READ_PERI_REG(UART_STATUS(nr)) >> UART_TXFIFO_CNT_S) & UART_TXFIFO_CNT;
 }
 
 // Get available free characters in transmit FIFO
@@ -64,7 +65,7 @@ static int ATTR_GDBEXTERNFN gdb_uart_read_char()
 	if(uart_rxfifo_count(GDB_UART) == 0) {
 		c = -1;
 	} else {
-		c = USF(GDB_UART) & 0xff;
+		c = READ_PERI_REG(UART_FIFO(GDB_UART)) & 0xff;
 	}
 	return c;
 }
@@ -82,11 +83,11 @@ static size_t ATTR_GDBEXTERNFN gdb_uart_write(const void* data, size_t length)
 		while(uart_txfifo_full(GDB_UART)) {
 			//
 		}
-		USF(GDB_UART) = static_cast<const uint8_t*>(data)[i];
+		WRITE_PERI_REG(UART_FIFO(GDB_UART), static_cast<const uint8_t*>(data)[i]);
 	}
 
 	// Enable TX FIFO EMPTY interrupt
-	bitSet(USIE(GDB_UART), UIFE);
+	SET_PERI_REG_MASK(UART_INT_ENA(GDB_UART), UART_TXFIFO_EMPTY_INT_ENA);
 
 	return length;
 }
@@ -99,10 +100,10 @@ static size_t ATTR_GDBEXTERNFN gdb_uart_write_char(char c)
 	while(uart_txfifo_full(GDB_UART)) {
 		//
 	}
-	USF(GDB_UART) = c;
+	WRITE_PERI_REG(UART_FIFO(GDB_UART), c);
 
 	// Enable TX FIFO EMPTY interrupt
-	bitSet(USIE(GDB_UART), UIFE);
+	SET_PERI_REG_MASK(UART_INT_ENA(GDB_UART), UART_TXFIFO_EMPTY_INT_ENA);
 
 	return 1;
 }
@@ -276,10 +277,10 @@ static void IRAM_ATTR gdb_uart_callback(uart_t* uart, uint32_t status)
 	user_uart_status = status;
 
 	// TX FIFO empty ?
-	if(bitRead(status, UIFE)) {
+	if(status & UART_TXFIFO_EMPTY_INT_ST) {
 		// Disable TX FIFO EMPTY interrupt to stop it recurring - re-enabled by uart_write()
 		if(uart_txfifo_count(GDB_UART) == 0) {
-			bitClear(USIE(GDB_UART), UIFE);
+			CLEAR_PERI_REG_MASK(UART_INT_ENA(GDB_UART), UART_TXFIFO_EMPTY_INT_ENA);
 		}
 
 		auto txbuf = user_uart == nullptr ? nullptr : user_uart->tx_buffer;
@@ -288,28 +289,28 @@ static void IRAM_ATTR gdb_uart_callback(uart_t* uart, uint32_t status)
 			if(!txbuf->isEmpty()) {
 				// Yes - send it via task callback (because packetising code may not be in IRAM)
 				queueSendUserData();
-				bitClear(user_uart_status, UIFE);
+				user_uart_status &= ~UART_TXFIFO_EMPTY_INT_ST;
 			} else if(userDataSending) {
 				// User data has now all been sent - UIFE will remain set
 				userDataSending = false;
 			} else {
 				// No user data was in transit, so this event doesn't apply to user uart
-				bitClear(user_uart_status, UIFE);
+				user_uart_status &= ~UART_TXFIFO_EMPTY_INT_ST;
 			}
 		}
 	}
 #else
-	bitClear(USIE(GDB_UART), UIFE);
+	CLEAR_PERI_REG_MASK(UART_INT_ENA(GDB_UART), UART_TXFIFO_EMPTY_INT_ENA);
 #endif
 
 	// RX FIFO Full or RX FIFO Timeout ?
-	if(status & (_BV(UIFF) | _BV(UITO))) {
+	if(status & (UART_RXFIFO_FULL_INT_ST | UART_RXFIFO_TOUT_INT_ST)) {
 #if GDBSTUB_ENABLE_UART2
 		auto rxbuf = user_uart == nullptr ? nullptr : user_uart->rx_buffer;
 #endif
 
 		while(uart_rxfifo_count(GDB_UART) != 0) {
-			char c = USF(GDB_UART);
+			char c = READ_PERI_REG(UART_FIFO(GDB_UART));
 #if GDBSTUB_CTRLC_BREAK
 			bool breakCheck = gdb_state.enabled;
 #if GDBSTUB_CTRLC_BREAK == 1
@@ -341,7 +342,7 @@ static void IRAM_ATTR gdb_uart_callback(uart_t* uart, uint32_t status)
 			// When attached, nothing gets routed to UART2
 			if(!gdb_state.attached && rxbuf != nullptr) {
 				if(rxbuf->writeChar(c) == 0) {
-					bitSet(user_uart_status, UIOF); // Overflow
+					user_uart_status |= UART_RXFIFO_OVF_INT_ST; // Overflow
 				}
 			}
 #endif
@@ -351,10 +352,9 @@ static void IRAM_ATTR gdb_uart_callback(uart_t* uart, uint32_t status)
 		if(rxbuf != nullptr) {
 			if(rxbuf->isEmpty()) {
 				// This event doesn't apply to user uart
-				bitClear(user_uart_status, UIFF);
-				bitClear(user_uart_status, UITO);
+				user_uart_status &= ~(UART_RXFIFO_FULL_INT_ST | UART_RXFIFO_TOUT_INT_ST);
 			} else if(rxbuf->getFreeSpace() > size_t(UART_RX_FIFO_SIZE) + user_uart->rx_headroom) {
-				bitClear(user_uart_status, UIFF);
+				user_uart_status &= ~UART_RXFIFO_FULL_INT_ST;
 			}
 		}
 #endif

--- a/Sming/Arch/Host/Components/driver/uart_server.cpp
+++ b/Sming/Arch/Host/Components/driver/uart_server.cpp
@@ -18,8 +18,7 @@
  ****/
 
 #include "uart_server.h"
-
-#include <espinc/peri.h>
+#include <espinc/uart_register.h>
 #include <SerialBuffer.h>
 #include <BitManipulations.h>
 
@@ -145,9 +144,9 @@ int CUartServer::serviceRead()
 			}
 			space -= read;
 			if(space == 0) {
-				bitSet(uart->status, UIFF);
+				uart->status |= UART_RXFIFO_FULL_INT_ST;
 			} else {
-				bitSet(uart->status, UITO);
+				uart->status |= UART_RXFIFO_TOUT_INT_ST;
 			}
 		}
 	}
@@ -185,7 +184,7 @@ int CUartServer::serviceWrite()
 	} while((avail = txbuf->getReadData(data)) != 0);
 
 	if(txbuf->isEmpty()) {
-		bitSet(uart->status, UIFE);
+		uart->status |= UART_TXFIFO_EMPTY_INT_ST;
 	} else {
 		txsem.post();
 	}

--- a/Sming/Core/Data/Stream/ReadWriteStream.cpp
+++ b/Sming/Core/Data/Stream/ReadWriteStream.cpp
@@ -23,9 +23,12 @@ size_t ReadWriteStream::copyFrom(IDataSourceStream* source, size_t size)
 	size_t total = 0;
 	size_t count;
 	while((count = source->readMemoryBlock(buffer, sizeof(buffer))) != 0) {
-		write(reinterpret_cast<uint8_t*>(buffer), count);
-		source->seek(count);
+		auto written = write(reinterpret_cast<uint8_t*>(buffer), count);
+		source->seek(written);
 		total += count;
+		if(written != count) {
+			break;
+		}
 	}
 
 	return total;

--- a/Sming/Core/HardwareSerial.h
+++ b/Sming/Core/HardwareSerial.h
@@ -20,7 +20,6 @@
 #include <Data/Stream/ReadWriteStream.h>
 #include <BitManipulations.h>
 #include <driver/uart.h>
-#include <espinc/peri.h>
 
 #define UART_ID_0 0 ///< ID of UART 0
 #define UART_ID_1 1 ///< ID of UART 1
@@ -91,10 +90,10 @@ enum SerialMode { SERIAL_FULL = UART_FULL, SERIAL_RX_ONLY = UART_RX_ONLY, SERIAL
 
 /** @brief Notification and error status bits */
 enum SerialStatus {
-	eSERS_BreakDetected = UIBD, ///< Break condition detected on receive line
-	eSERS_Overflow = UIOF,		///< Receive buffer overflowed
-	eSERS_FramingError = UIFR,  ///< Receive framing error
-	eSERS_ParityError = UIPE,   ///< Parity check failed on received data
+	eSERS_BreakDetected, ///< Break condition detected on receive line
+	eSERS_Overflow,		 ///< Receive buffer overflowed
+	eSERS_FramingError,  ///< Receive framing error
+	eSERS_ParityError,   ///< Parity check failed on received data
 };
 
 /// Hardware serial class
@@ -441,10 +440,7 @@ public:
 	 * @retval unsigned Status flags, combination of SerialStatus bits
 	 * @see SerialStatus
 	 */
-	unsigned getStatus()
-	{
-		return uart_get_status(uart);
-	}
+	unsigned getStatus();
 
 private:
 	int uartNr = -1;

--- a/samples/Basic_Serial/app/application.cpp
+++ b/samples/Basic_Serial/app/application.cpp
@@ -236,7 +236,7 @@ void init()
 	 * to refill the buffer when it becomes empty. This demo shows how that can be done for outputting a file.
 	 */
 	Serial.setTxBufferSize(2048);
-	// Serial.setTxWait(false);
+	Serial.setTxWait(false);
 
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 
@@ -285,6 +285,8 @@ void init()
 
 	// Initialise and prepare the second (debug) serial port
 	Serial1.begin(SERIAL_BAUD_RATE);
+	Serial1.setTxBufferSize(1024);
+	Serial1.setTxWait(false);
 
 	/*
 	 * The line below redirect debug output to UART1

--- a/samples/Basic_Serial/app/application.cpp
+++ b/samples/Basic_Serial/app/application.cpp
@@ -175,10 +175,10 @@ void testPrintf()
 	Serial.printf("Display -99:%d, \t\t-3.0104:%f, \t'abc'=%s, \t\t0.75:%f, \t\t0.888888889:%f\r\n", -99, -3.01040,
 				  "abc", 3.0 / 4, 8.0 / 9);
 
-	Serial.printf("Display '   -99':%6d, \t-3.010:%.3f, \t\t'abc'=%5s, \t\t0.75000:%-+.5f, \t0.888888889:%#*f\r\n", -99,
+	Serial.printf("Display '   -99':%6d, \t-3.010:%.3f, \t\t'abc'=%5s, \t\t0.75000:%-+.5f, \t0.888888889:%f\r\n", -99,
 				  -3.01040, "abc", 3.0 / 4, 8.0 / 9);
 
-	Serial.printf("Display -99:%3d, \t\t-3.010:%.3f, \t\t'abc'=%#s, \t\t' 0.75':%5f, \t\t0.889:%.3f\r\n", -99, -3.01040,
+	Serial.printf("Display -99:%3d, \t\t-3.010:%.3f, \t\t'abc'=%s, \t\t' 0.75':%5f, \t\t0.889:%.3f\r\n", -99, -3.01040,
 				  "abc", 3.0 / 4, 8.0 / 9);
 
 	Serial.printf("Display -99:%.3d, \t\t-3.0104000:%.7f, \t'abc'=%s, \t\t0.750:%.3f, \t\t' 0.889':%6.3f\r\n", -99,


### PR DESCRIPTION
Definitions in peri.h are too succinct and hard to read. Instead, use the `uart_register.h` definitions from the RTOS SDK.

Goal here is to migrate all driver-level code onto RTOS SDK definitions as they are the most current, logical and clearly laid out.

Tested asynchronous operation with Basic_Serial sample, fixes to `ReadWriteStream::copyFrom`  required.
