### PR TITLE
Fix issue with undefined millis() / micros()

### DIFF
--- a/Sming/Components/rboot/component.mk
+++ b/Sming/Components/rboot/component.mk
@@ -119,6 +119,7 @@ COMPONENT_LDFLAGS		:= -u Cache_Read_Enable_New
 $(LIBMAIN_RBOOT_DST): $(LIBMAIN_SRC)
 	@echo "OC $@"
 	$(Q) $(OBJCOPY) -W Cache_Read_Enable_New $^ $@
+	$(Q) $(AR) d $@ time.o
 
 ifeq ($(RBOOT_BIG_FLASH),1)
 LIBMAIN					:= $(LIBMAIN_RBOOT)

--- a/Sming/Core/Clock.h
+++ b/Sming/Core/Clock.h
@@ -29,7 +29,7 @@ extern "C" {
  *  @note   This function uses ESP8266 _system time_ clock which pauses during sleep. Function is provided for compatibility with Arduino. For date and time functionality, use SystemClock
  *  @see    SystemClockClass
  */
-unsigned long millis(void) WEAK_ATTR;
+unsigned long millis(void);
 
 /** @brief  Get the time from clock in microseconds
  *  @retval "unsigned long" Quantity of microseconds elapsed since clock epoch
@@ -37,7 +37,7 @@ unsigned long millis(void) WEAK_ATTR;
  *  @note   This function uses ESP8266 _system time_ clock which pauses during sleep. Function is provided for compatibility with Arduino. For date and time functionality, use SystemClock
  *  @see    SystemClockClass
  */
-unsigned long micros(void) WEAK_ATTR;
+unsigned long micros(void);
 
 /** @brief  Pause execution
  *  @param  milliseconds Duration of delay


### PR DESCRIPTION
Don't weaken millis() or micros(), and remove conflicting `time.o` functions from libmain.

Fixes #1837.