### PR TITLE
Add `seekFrom` virtual method to `IDataSourceStream`

### DIFF
--- a/Sming/Core/Data/Stream/DataSourceStream.h
+++ b/Sming/Core/Data/Stream/DataSourceStream.h
@@ -13,6 +13,7 @@
 #include <user_config.h>
 #include "Stream.h"
 #include "WString.h"
+#include <unistd.h>
 
 /** @brief  Data stream type
  *  @ingroup constants
@@ -76,11 +77,26 @@ public:
 	 */
 	int peek() override;
 
+	/** @brief Change position in stream
+	 *  @param offset
+	 *  @param origin SEEK_SET, SEEK_CUR, SEEK_END
+	 *  @retval New position, < 0 on error
+	 *  @note This method is implemented by streams which support random seeking,
+	 *  such as files and memory streams.
+	 */
+	virtual int seekFrom(int offset, unsigned origin)
+	{
+		return -1;
+	}
+
 	/** @brief  Move read cursor
 	 *  @param  len Relative cursor adjustment
 	 *  @retval bool True on success.
 	 */
-	virtual bool seek(int len) = 0;
+	virtual bool seek(int len)
+	{
+		return seekFrom(len, SEEK_CUR) >= 0;
+	}
 
 	/** @brief  Check if all data has been read
      *  @retval bool True on success.

--- a/Sming/Core/Data/Stream/FileStream.cpp
+++ b/Sming/Core/Data/Stream/FileStream.cpp
@@ -95,10 +95,10 @@ size_t FileStream::write(const uint8_t* buffer, size_t size)
 	return written > 0 ? written : 0;
 }
 
-int FileStream::seekFrom(int offset, SeekOriginFlags origin)
+int FileStream::seekFrom(int offset, unsigned origin)
 {
 	// Cannot rely on return value from fileSeek - failure does not mean position hasn't changed
-	fileSeek(handle, offset, origin);
+	fileSeek(handle, offset, SeekOriginFlags(origin));
 	int newpos = fileTell(handle);
 	if(check(newpos)) {
 		pos = size_t(newpos);

--- a/Sming/Core/Data/Stream/FileStream.h
+++ b/Sming/Core/Data/Stream/FileStream.h
@@ -65,7 +65,6 @@ public:
 	 */
 	void close();
 
-	//Use base class documentation
 	StreamType getStreamType() const override
 	{
 		return eSST_File;
@@ -73,23 +72,10 @@ public:
 
 	size_t write(const uint8_t* buffer, size_t size) override;
 
-	//Use base class documentation
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	/** @brief Change position in file stream
-	 *  @param offset
-	 *  @param origin
-	 *  @retval New position, < 0 on error
-	 */
-	int seekFrom(int offset, SeekOriginFlags origin);
+	int seekFrom(int offset, unsigned origin) override;
 
-	//Use base class documentation
-	bool seek(int offset) override
-	{
-		return seekFrom(offset, eSO_CurrentPos) >= 0;
-	}
-
-	//Use base class documentation
 	bool isFinished() override
 	{
 		return fileIsEOF(handle);

--- a/Sming/Core/Data/Stream/FlashMemoryStream.cpp
+++ b/Sming/Core/Data/Stream/FlashMemoryStream.cpp
@@ -20,13 +20,27 @@ uint16_t FlashMemoryStream::readMemoryBlock(char* data, int bufSize)
 	return count;
 }
 
-bool FlashMemoryStream::seek(int len)
+int FlashMemoryStream::seekFrom(int offset, unsigned origin)
 {
-	size_t newPos = static_cast<size_t>(readPos + len);
-	if(newPos <= flashString.length()) {
-		readPos = newPos;
-		return true;
-	} else {
-		return false;
+	size_t newPos;
+	switch(origin) {
+	case SEEK_SET:
+		newPos = offset;
+		break;
+	case SEEK_CUR:
+		newPos = readPos + offset;
+		break;
+	case SEEK_END:
+		newPos = flashString.length() + offset;
+		break;
+	default:
+		return -1;
 	}
+
+	if(newPos > flashString.length()) {
+		return -1;
+	}
+
+	readPos = newPos;
+	return readPos;
 }

--- a/Sming/Core/Data/Stream/FlashMemoryStream.h
+++ b/Sming/Core/Data/Stream/FlashMemoryStream.h
@@ -47,7 +47,7 @@ public:
 
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	bool seek(int len) override;
+	int seekFrom(int offset, unsigned origin) override;
 
 	bool isFinished() override
 	{

--- a/Sming/Core/Data/Stream/GdbFileStream.cpp
+++ b/Sming/Core/Data/Stream/GdbFileStream.cpp
@@ -106,19 +106,17 @@ size_t GdbFileStream::write(const uint8_t* buffer, size_t size)
 	return written;
 }
 
-bool GdbFileStream::seek(int len)
+int GdbFileStream::seekFrom(int offset, unsigned origin)
 {
-	int newpos = gdb_syscall_lseek(handle, len, SEEK_CUR);
-	if(!check(newpos)) {
-		return false;
+	int newpos = gdb_syscall_lseek(handle, offset, origin);
+	if(check(newpos)) {
+		pos = size_t(newpos);
+		if(pos > size) {
+			size = pos;
+		}
 	}
 
-	pos = size_t(newpos);
-	if(pos > size) {
-		size = pos;
-	}
-
-	return true;
+	return newpos;
 }
 
 String GdbFileStream::id() const

--- a/Sming/Core/Data/Stream/GdbFileStream.h
+++ b/Sming/Core/Data/Stream/GdbFileStream.h
@@ -52,13 +52,10 @@ public:
 
 	size_t write(const uint8_t* buffer, size_t size) override;
 
-	//Use base class documentation
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	//Use base class documentation
-	bool seek(int len) override;
+	int seekFrom(int offset, unsigned origin) override;
 
-	//Use base class documentation
 	bool isFinished() override
 	{
 		return pos == size;

--- a/Sming/Core/Data/Stream/MemoryDataStream.cpp
+++ b/Sming/Core/Data/Stream/MemoryDataStream.cpp
@@ -60,12 +60,27 @@ uint16_t MemoryDataStream::readMemoryBlock(char* data, int bufSize)
 	return available;
 }
 
-bool MemoryDataStream::seek(int len)
+int MemoryDataStream::seekFrom(int offset, unsigned origin)
 {
-	int newpos = readPos + len;
-	if(newpos < 0 || newpos > (int)size) {
-		return false;
+	size_t newPos;
+	switch(origin) {
+	case SEEK_SET:
+		newPos = offset;
+		break;
+	case SEEK_CUR:
+		newPos = readPos + offset;
+		break;
+	case SEEK_END:
+		newPos = size + offset;
+		break;
+	default:
+		return -1;
 	}
-	readPos = size_t(newpos);
-	return true;
+
+	if(newPos > size) {
+		return -1;
+	}
+
+	readPos = newPos;
+	return readPos;
 }

--- a/Sming/Core/Data/Stream/MemoryDataStream.h
+++ b/Sming/Core/Data/Stream/MemoryDataStream.h
@@ -66,7 +66,7 @@ public:
 
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	bool seek(int len) override;
+	int seekFrom(int offset, unsigned origin) override;
 
 	bool isFinished() override
 	{


### PR DESCRIPTION
Method already implemented for FileStream, but `SeekOriginFlags` is filesystem-specific.
It seems safer therefore to switch to standard SEEK_SET, SEEK_CUR and SEEK_END
values which are consistent.

Implement `seekFrom` for FlashMemoryStream, MemoryDataStream and GdbFileStream.