### PR TITLE
Update interrupt functions

### DIFF
--- a/Sming/Arch/Host/Core/Interrupts.cpp
+++ b/Sming/Arch/Host/Core/Interrupts.cpp
@@ -12,23 +12,15 @@
 #include <Digital.h>
 #include <Platform/System.h>
 
-void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode)
+void attachInterrupt(uint8_t pin, InterruptCallback callback, GPIO_INT_TYPE type)
 {
 }
 
-void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, uint8_t mode)
+void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, GPIO_INT_TYPE type)
 {
 }
 
-void attachInterrupt(uint8_t pin, InterruptCallback callback, GPIO_INT_TYPE mode)
-{
-}
-
-void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, GPIO_INT_TYPE mode)
-{
-}
-
-void attachInterruptHandler(uint8_t pin, GPIO_INT_TYPE mode)
+void attachInterruptHandler(uint8_t pin, GPIO_INT_TYPE type)
 {
 }
 
@@ -36,28 +28,6 @@ void detachInterrupt(uint8_t pin)
 {
 }
 
-void interruptMode(uint8_t pin, uint8_t mode)
-{
-}
-
 void interruptMode(uint8_t pin, GPIO_INT_TYPE type)
 {
-}
-
-GPIO_INT_TYPE ConvertArduinoInterruptMode(uint8_t mode)
-{
-	switch(mode) {
-	case LOW: // to trigger the interrupt whenever the pin is low,
-		return GPIO_PIN_INTR_LOLEVEL;
-	case CHANGE:				 // to trigger the interrupt whenever the pin changes value
-		return (GPIO_INT_TYPE)3; // GPIO_PIN_INTR_ANYEDGE
-	case RISING:				 // to trigger when the pin goes from low to high,
-		return GPIO_PIN_INTR_POSEDGE;
-	case FALLING: // for when the pin goes from high to low.
-		return GPIO_PIN_INTR_NEGEDGE;
-	case HIGH: // to trigger the interrupt whenever the pin is high.
-		return GPIO_PIN_INTR_HILEVEL;
-	default:
-		return GPIO_PIN_INTR_DISABLE;
-	}
 }

--- a/Sming/Core/Interrupts.h
+++ b/Sming/Core/Interrupts.h
@@ -35,7 +35,7 @@ void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode);
 /** @brief  Attach a function to a GPIO interrupt
  *  @param  pin GPIO to configure
  *  @param  delegateFunction Function to call when interrupt occurs on GPIO
- *  @param  mode Arduino type interrupt mode
+ *  @param  mode Arduino type interrupt mode (LOW, HIGH, CHANGE, RISING, FALLING)
  *  @note   Delegate function method, can be a regular function, method, etc.
  *  The delegate function is called via the system task queue so does not need any special consideration.
  *  Note that this type of interrupt handler is not suitable for timing-sensitive applications.

--- a/Sming/Core/Interrupts.h
+++ b/Sming/Core/Interrupts.h
@@ -17,11 +17,43 @@
 #include <stdint.h>
 #include <driver/gpio.h>
 #include <Delegate.h>
+#include <WConstants.h>
+#include <sming_attr.h>
 
-#define ESP_MAX_INTERRUPTS 16
+constexpr unsigned ESP_MAX_INTERRUPTS = 16;
 
 typedef void (*InterruptCallback)();
 typedef Delegate<void()> InterruptDelegate;
+
+/** @brief  Convert Arduino interrupt mode to Sming mode
+ *  @param  mode Arduino mode type
+ *  @retval GPIO_INT_TYPE Sming interrupt type
+ */
+__forceinline GPIO_INT_TYPE ConvertArduinoInterruptMode(uint8_t mode)
+{
+	switch(mode) {
+	case LOW: // to trigger the interrupt whenever the pin is low,
+		return GPIO_PIN_INTR_LOLEVEL;
+	case CHANGE:				 // to trigger the interrupt whenever the pin changes value
+		return (GPIO_INT_TYPE)3; // GPIO_PIN_INTR_ANYEDGE
+	case RISING:				 // to trigger when the pin goes from low to high,
+		return GPIO_PIN_INTR_POSEDGE;
+	case FALLING: // for when the pin goes from high to low.
+		return GPIO_PIN_INTR_NEGEDGE;
+	case HIGH: // to trigger the interrupt whenever the pin is high.
+		return GPIO_PIN_INTR_HILEVEL;
+	default:
+		return GPIO_PIN_INTR_DISABLE;
+	}
+}
+
+/** @brief  Attach a function to a GPIO interrupt
+ *  @param  pin GPIO to configure
+ *  @param  callback Function to call when interrupt occurs on GPIO
+ *  @param  type Interrupt type
+ *  @note   Traditional c-type callback function method
+ */
+void attachInterrupt(uint8_t pin, InterruptCallback callback, GPIO_INT_TYPE type);
 
 /** @brief  Attach a function to a GPIO interrupt
  *  @param  pin GPIO to configure
@@ -30,7 +62,19 @@ typedef Delegate<void()> InterruptDelegate;
  *  @note   Traditional c-type callback function method, MUST use IRAM_ATTR
  *  Use this type of interrupt handler for timing-sensitive applications.
  */
-void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode);
+__forceinline void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode)
+{
+	GPIO_INT_TYPE type = ConvertArduinoInterruptMode(mode);
+	attachInterrupt(pin, callback, type);
+}
+
+/** @brief  Attach a function to a GPIO interrupt
+ *  @param  pin GPIO to configure
+ *  @param  delegateFunction Function to call when interrupt occurs on GPIO
+ *  @param  type Interrupt type
+ *  @note   Delegate function method
+ */
+void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, GPIO_INT_TYPE type);
 
 /** @brief  Attach a function to a GPIO interrupt
  *  @param  pin GPIO to configure
@@ -40,31 +84,18 @@ void attachInterrupt(uint8_t pin, InterruptCallback callback, uint8_t mode);
  *  The delegate function is called via the system task queue so does not need any special consideration.
  *  Note that this type of interrupt handler is not suitable for timing-sensitive applications.
  */
-void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, uint8_t mode);
-
-/** @brief  Attach a function to a GPIO interrupt
- *  @param  pin GPIO to configure
- *  @param  callback Function to call when interrupt occurs on GPIO
- *  @param  mode Interrupt mode
- *  @note   Traditional c-type callback function method
- *  @todo   Add GPIO_INT_TYPE documentation - is this in SDK?
- */
-void attachInterrupt(uint8_t pin, InterruptCallback callback, GPIO_INT_TYPE mode); // ESP compatible version
-
-/** @brief  Attach a function to a GPIO interrupt
- *  @param  pin GPIO to configure
- *  @param  delegateFunction Function to call when interrupt occurs on GPIO
- *  @param  mode Interrupt mode
- *  @note   Delegate function method
- */
-void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, GPIO_INT_TYPE mode); // ESP compatible version
+__forceinline void attachInterrupt(uint8_t pin, InterruptDelegate delegateFunction, uint8_t mode)
+{
+	GPIO_INT_TYPE type = ConvertArduinoInterruptMode(mode);
+	attachInterrupt(pin, delegateFunction, type);
+}
 
 /** @brief  Enable interrupts on GPIO pin
  *  @param  pin GPIO to enable interrupts for
- *  @param  mode Interrupt mode
- *  @note   Configure interrupt handler with attachInterrupt(pin, callback, mode)
+ *  @param  type Interrupt type
+ *  @note   Configure interrupt handler with attachInterrupt(pin, callback, type)
  */
-void attachInterruptHandler(uint8_t pin, GPIO_INT_TYPE mode);
+void attachInterruptHandler(uint8_t pin, GPIO_INT_TYPE type);
 
 /** @brief  Disable interrupts on GPIO pin
  *  @param  pin GPIO to disable interrupts for
@@ -73,23 +104,21 @@ void detachInterrupt(uint8_t pin);
 
 /** @brief  Set interrupt mode
  *  @param  pin GPIO to configure
- *  @param  mode Interrupt mode
- *  @note   Use ConvertArduinoInterruptMode to get Sming interrupt type from an Arduino interrupt type
- */
-void interruptMode(uint8_t pin, uint8_t mode);
-
-/** @brief  Set interrupt mode
- *  @param  pin GPIO to configure
  *  @param  type Interrupt type
  *  @note   Use ConvertArduinoInterruptMode to get Sming interrupt type from an Arduino interrupt type
  */
 void interruptMode(uint8_t pin, GPIO_INT_TYPE type);
 
-/** @brief  Convert Arduino interrupt mode to Sming mode
- *  @param  mode Arduino mode type
- *  @retval GPIO_INT_TYPE Sming interrupt mode type
+/** @brief  Set interrupt mode
+ *  @param  pin GPIO to configure
+ *  @param  mode Interrupt mode
+ *  @note   Use ConvertArduinoInterruptMode to get Sming interrupt type from an Arduino interrupt type
  */
-GPIO_INT_TYPE ConvertArduinoInterruptMode(uint8_t mode);
+__forceinline void interruptMode(uint8_t pin, uint8_t mode)
+{
+	GPIO_INT_TYPE type = ConvertArduinoInterruptMode(mode);
+	interruptMode(pin, type);
+}
 
 #define digitalPinToInterrupt(pin) ((pin) < ESP_MAX_INTERRUPTS ? (pin) : -1)
 

--- a/samples/Basic_Interrupts/app/application.cpp
+++ b/samples/Basic_Interrupts/app/application.cpp
@@ -10,6 +10,21 @@
 #define say(a) (Serial.print(a))
 #define newline() (Serial.println())
 
+static unsigned interruptToggleCount;
+
+void showInterruptToggleCount(uint32_t toggleCount)
+{
+	say("Toggle count hit ");
+	say(toggleCount);
+	say(", current value is ");
+	say(interruptToggleCount);
+	say("!");
+	newline();
+	say("Max tasks queued: ");
+	say(System.getMaxTaskCount());
+	newline();
+}
+
 /** @brief Low-level interrupt handler
  *  @note An interrupt handling callback must have the IRAM_ATTR attribute.
  *  Interrupt processing code should be as short as possible.
@@ -26,29 +41,29 @@ void IRAM_ATTR interruptHandler()
 
 	// Example of how you can queue a callback from inside a regular interrupt handler
 	const unsigned MAX_TOGGLE_COUNTS = 10;
-	static unsigned toggleCount;
-	++toggleCount;
-	if(toggleCount > MAX_TOGGLE_COUNTS) {
+	++interruptToggleCount;
+	if(interruptToggleCount > MAX_TOGGLE_COUNTS) {
+		System.queueCallback(showInterruptToggleCount, interruptToggleCount);
 		/*
-		 * Using a 'lambda function' we can easily include any code to be executed by the callback
-		 * without having to define a function elsewhere.
-		 * You could also pass a function pointer to queueCallback().
+		 * Note that `queueCallback` also supports std::function arguments, so we can use lambdas,
+		 * class methods, etc.
+		 *
+		 * For example, we could use a lambda to capture to capture the instantaneous value of 'toggleCount':
+		 *
+		 * 	```
+		 * 	System.queueCallback([toggleCount]() {
+		 * 		showInterruptToggleCount(toggleCount);
+		 * 	};
+		 * 	```
+		 *
+		 * IMPORTANT: the lambda inherits this function's context, so will be stored in IRAM which
+		 * is a very limited resource. The lambda is therefore best suited to simple 'glue' code.
+		 *
+		 * IMPORTANT: Avoid using std::bind from interrupt handlers because it may attempt to allocate
+		 * storage on the heap; this will likely crash the system.
+		 *
 		 */
-		System.queueCallback(
-			[](uint32_t interruptToggleCount) {
-				say("Toggle count hit ");
-				say(interruptToggleCount);
-				say(", current value is ");
-				say(toggleCount);
-				say("!");
-				newline();
-				say("Max tasks queued: ");
-				say(System.getMaxTaskCount());
-				newline();
-			},
-			toggleCount);
-
-		toggleCount = 0;
+		interruptToggleCount = 0;
 	}
 }
 


### PR DESCRIPTION
Updates to Interrupts module
    
* Use InterruptDelegate type
* Put delegate callback into separate function to save IRAM
* Use `ESP_MAX_INTERRUPTS` consistently

Refactor attachInterrupt code using inlines.
Be clear with distinction between ESP *GPIO_INT_TYPE* and Arduino interrupt *mode*.

Update `Basic_Interrupts` sample. Use function instead of lambda and explain reason in comments.
