### PR TITLE
Remove `swap` macros and make std::swap available

### DIFF
--- a/Sming/Libraries/Adafruit_GFX/Adafruit_GFX.h
+++ b/Sming/Libraries/Adafruit_GFX/Adafruit_GFX.h
@@ -8,8 +8,6 @@
  #include "WProgram.h"
 #endif
 
-#define swap(a, b) { int16_t t = a; a = b; b = t; }
-
 class Adafruit_GFX : public Print {
 
  public:

--- a/Sming/Libraries/ArduCAM/ArduCAM.h
+++ b/Sming/Libraries/ArduCAM/ArduCAM.h
@@ -101,8 +101,6 @@
 #define cport(port, data) port &= data
 #define sport(port, data) port |= data
 
-#define swap(type, i, j) {type t = i; i = j; j = t;}
-
 #define fontbyte(x) pgm_read_byte(&cfont.font[x])  
 
 #define regtype volatile uint8_t
@@ -119,8 +117,6 @@
 
 #define cport(port, data) port &= data
 #define sport(port, data) port |= data
-
-#define swap(type, i, j) {type t = i; i = j; j = t;}
 
 #define fontbyte(x) cfont.font[x]  
 
@@ -156,8 +152,6 @@
 
 #define cport(port, data) port &= data
 #define sport(port, data) port |= data
-
-#define swap(type, i, j) {type t = i; i = j; j = t;}
 
 #define fontbyte(x) cfont.font[x]
 

--- a/Sming/Wiring/WiringFrameworkDependencies.h
+++ b/Sming/Wiring/WiringFrameworkDependencies.h
@@ -26,3 +26,4 @@ using std::isinf;
 using std::isnan;
 using std::max;
 using std::min;
+using std::swap;


### PR DESCRIPTION
Swap macros not necessary.
Fixes #1841, supersedes #1855.