### PR TITLE
Bugfix: `CallbackTimer::start()` doesn't remember `repeating` state

### DIFF
--- a/Sming/Core/CallbackTimer.h
+++ b/Sming/Core/CallbackTimer.h
@@ -396,7 +396,7 @@ private:
 		TimerApi::setInterval(ticks);
 		intervalSet = true;
 		if(started) {
-			restart();
+			TimerApi::arm(repeating);
 		}
 	}
 
@@ -416,6 +416,7 @@ template <typename TimerApi> IRAM_ATTR bool CallbackTimer<TimerApi>::start(bool 
 
 	TimerApi::arm(repeating);
 	started = true;
+	this->repeating = repeating;
 	return true;
 }
 


### PR DESCRIPTION
Calling `setInterval()` on a repeating timer whilst timer is running does not work as expected.
