### PR TITLE
Simplify and refactor APA102 sample

### DIFF
--- a/Sming/Libraries/APA102/apa102.cpp
+++ b/Sming/Libraries/APA102/apa102.cpp
@@ -9,9 +9,8 @@
 #include "apa102.h"
 #include <SPI.h>
 
-static constexpr uint8_t LED_PREAMBLE = 0xE0;	// LED frame preamble
-static constexpr uint8_t LED_BR_MAX = 31; // Maximum LED brightness value
-
+static constexpr uint8_t LED_PREAMBLE = 0xE0; // LED frame preamble
+static constexpr uint8_t LED_BR_MAX = 31;	 // Maximum LED brightness value
 
 /* APA102 class for hardware & software SPI */
 
@@ -29,102 +28,114 @@ APA102::APA102(uint16_t n, SPIBase& spiRef)
 	}
 }
 
-void APA102::begin(void) {
-    pSPI.begin();
+void APA102::begin(void)
+{
+	pSPI.begin();
 }
 
-void APA102::begin(SPISettings & mySettings) {
-    pSPI.begin();
-    SPI_APA_Settings = mySettings;
+void APA102::begin(SPISettings& mySettings)
+{
+	pSPI.begin();
+	SPI_APA_Settings = mySettings;
 }
 
-void APA102::end() {
-    pSPI.end();
+void APA102::end()
+{
+	pSPI.end();
 }
 
-
-
-void APA102::show(void) {
-    pSPI.beginTransaction(SPI_APA_Settings);
-    sendStart();
-    for (unsigned i = 0; i < numLEDs; i++) {
-        auto col = LEDbuffer[i];
-        pSPI.transfer(reinterpret_cast<uint8_t*>(&col), sizeof(col));
-    }
-    sendStop();
-    pSPI.endTransaction();
+void APA102::show(void)
+{
+	pSPI.beginTransaction(SPI_APA_Settings);
+	sendStart();
+	for(unsigned i = 0; i < numLEDs; i++) {
+		auto col = LEDbuffer[i];
+		pSPI.transfer(reinterpret_cast<uint8_t*>(&col), sizeof(col));
+	}
+	sendStop();
+	pSPI.endTransaction();
 }
 
-void APA102::show(uint16_t startPos) {
-    pSPI.beginTransaction(SPI_APA_Settings);
-    unsigned sp = numLEDs - (startPos % numLEDs);
-    sendStart();
-    for (unsigned i = 0; i < numLEDs; i++) {
-        auto col = LEDbuffer[(i + sp) % numLEDs];
-        pSPI.transfer(reinterpret_cast<uint8_t*>(&col), sizeof(col));
-    }
-    sendStop();
-    pSPI.endTransaction();
+void APA102::show(uint16_t startPos)
+{
+	pSPI.beginTransaction(SPI_APA_Settings);
+	unsigned sp = numLEDs - (startPos % numLEDs);
+	sendStart();
+	for(unsigned i = 0; i < numLEDs; i++) {
+		auto col = LEDbuffer[(i + sp) % numLEDs];
+		pSPI.transfer(reinterpret_cast<uint8_t*>(&col), sizeof(col));
+	}
+	sendStop();
+	pSPI.endTransaction();
 }
 
-void APA102::clear(void) {
-    for (unsigned i = 0; i < numLEDs; i++) {
-        LEDbuffer[i] = {LED_PREAMBLE, 0, 0, 0};
-    }
+void APA102::clear(void)
+{
+	for(unsigned i = 0; i < numLEDs; i++) {
+		LEDbuffer[i] = {LED_PREAMBLE, 0, 0, 0};
+	}
 }
 
-void APA102::setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b) {
+void APA102::setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b)
+{
 	col_t col = {brightness, r, g, b};
 	setPixel(n, &col);
 }
 
-void APA102::setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t br) {
+void APA102::setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t br)
+{
 	col_t col = {br, r, g, b};
 	setPixel(n, &col);
 }
 
-void APA102::setPixel(uint16_t n, const col_t& col) {
-    if (n < numLEDs) {
-    	auto c = col;
-    	c.br = std::min(c.br, LED_BR_MAX) | LED_PREAMBLE;
-        LEDbuffer[n] = c;
-    }
+void APA102::setPixel(uint16_t n, const col_t& col)
+{
+	if(n < numLEDs) {
+		auto c = col;
+		c.br = std::min(c.br, LED_BR_MAX) | LED_PREAMBLE;
+		LEDbuffer[n] = c;
+	}
 }
 
-void APA102::setAllPixel(uint8_t r, uint8_t g, uint8_t b) {
+void APA102::setAllPixel(uint8_t r, uint8_t g, uint8_t b)
+{
 	col_t col = {brightness, r, g, b};
 	setAllPixel(col);
 }
 
-void APA102::setAllPixel(const col_t& col) {
+void APA102::setAllPixel(const col_t& col)
+{
 	auto c = col;
 	c.br = std::min(c.br, LED_BR_MAX) | LED_PREAMBLE;
-    for (unsigned i = 0; i < numLEDs; i++) {
-        LEDbuffer[i] = c;
-    }
+	for(unsigned i = 0; i < numLEDs; i++) {
+		LEDbuffer[i] = c;
+	}
 }
 
-void APA102::setBrightness(uint8_t br) {
-    brightness = std::min(br, LED_BR_MAX);
+void APA102::setBrightness(uint8_t br)
+{
+	brightness = std::min(br, LED_BR_MAX);
 }
-
 
 /* direct write functions */
 
-inline void APA102::sendStart(void) {
-    uint8_t startFrame[] = {0x00, 0x00, 0x00, 0x00};
-    pSPI.transfer(startFrame, sizeof(startFrame));
+inline void APA102::sendStart(void)
+{
+	uint8_t startFrame[] = {0x00, 0x00, 0x00, 0x00};
+	pSPI.transfer(startFrame, sizeof(startFrame));
 }
 
-inline void APA102::sendStop(void) {
-    uint8_t stopFrame[] = {0xff, 0xff, 0xff, 0xff};
-    pSPI.transfer(stopFrame, sizeof(stopFrame));
+inline void APA102::sendStop(void)
+{
+	uint8_t stopFrame[] = {0xff, 0xff, 0xff, 0xff};
+	pSPI.transfer(stopFrame, sizeof(stopFrame));
 }
 
-void APA102::directWrite(uint8_t r, uint8_t g, uint8_t b, uint8_t br) {
-    br = std::min(br, LED_BR_MAX);
-	col_t col = {uint8_t(LED_PREAMBLE | br), r, g, b };
+void APA102::directWrite(uint8_t r, uint8_t g, uint8_t b, uint8_t br)
+{
+	br = std::min(br, LED_BR_MAX);
+	col_t col = {uint8_t(LED_PREAMBLE | br), r, g, b};
 
 	pSPI.beginTransaction(SPI_APA_Settings);
-    pSPI.transfer(reinterpret_cast<uint8_t*>(&col), sizeof(col));
+	pSPI.transfer(reinterpret_cast<uint8_t*>(&col), sizeof(col));
 }

--- a/Sming/Libraries/APA102/apa102.cpp
+++ b/Sming/Libraries/APA102/apa102.cpp
@@ -5,40 +5,29 @@
  * All files of the Sming Core are provided under the LGPL v3 license.
  * APA102 library by HappyCodingRobot@github.com
  ****/
-#include <SmingCore.h>
-// APA102 LED class
-#include <SPI.h>
-#include <SPISoft.h>
+
 #include "apa102.h"
+#include <SPI.h>
 
-
-#define LED_PREAMBLE     (uint8_t)0xE0          // LED frame preamble
-#define LED_PREAMBLELONG (uint32_t)0xE0000000   // LED frame preamble
-#define brOfs 0
-#define bOfs  1
-#define gOfs  2
-#define rOfs  3
-
+static constexpr uint8_t LED_PREAMBLE = 0xE0;	// LED frame preamble
+static constexpr uint8_t LED_BR_MAX = 31; // Maximum LED brightness value
 
 
 /* APA102 class for hardware & software SPI */
 
-APA102::APA102(uint16_t n) : numLEDs(n), brightness(0), LEDbuffer(NULL), pSPI(SPI) {
-    if (LEDbuffer = (uint8_t *) malloc(numLEDs * 4)) {
-        clear();
-    }
+APA102::APA102(uint16_t n) : APA102(n, SPI)
+{
 }
 
-APA102::APA102(uint16_t n, SPIBase & spiRef) : numLEDs(n), brightness(0), LEDbuffer(NULL), pSPI(spiRef) {
-    if (LEDbuffer = (uint8_t *) malloc(numLEDs * 4)) {
-        clear();
-    }
+APA102::APA102(uint16_t n, SPIBase& spiRef)
+	: numLEDs(n), LEDbuffer(new col_t[numLEDs]), SPI_APA_Settings(4000000, MSBFIRST, SPI_MODE3), pSPI(spiRef)
+{
+	if(LEDbuffer == nullptr) {
+		numLEDs = 0;
+	} else {
+		clear();
+	}
 }
-
-APA102::~APA102() {
-    if (LEDbuffer) free(LEDbuffer);
-}
-
 
 void APA102::begin(void) {
     pSPI.begin();
@@ -56,113 +45,86 @@ void APA102::end() {
 
 
 void APA102::show(void) {
-    uint32_t *buf = (uint32_t*) LEDbuffer;
-    uint32_t elem;
     pSPI.beginTransaction(SPI_APA_Settings);
     sendStart();
-    for (uint16_t i = 0; i < numLEDs; i++) {
-        elem = buf[i];
-        pSPI.transfer((uint8_t*)&elem, 4);
+    for (unsigned i = 0; i < numLEDs; i++) {
+        auto col = LEDbuffer[i];
+        pSPI.transfer(reinterpret_cast<uint8_t*>(&col), sizeof(col));
     }
     sendStop();
     pSPI.endTransaction();
 }
 
-void APA102::show(int16_t SPos) {
-    uint32_t *buf = (uint32_t*) LEDbuffer;
-    uint32_t elem;
+void APA102::show(uint16_t startPos) {
     pSPI.beginTransaction(SPI_APA_Settings);
-    int sp = numLEDs - (SPos % numLEDs);
+    unsigned sp = numLEDs - (startPos % numLEDs);
     sendStart();
-    for (int i = 0; i < numLEDs; i++) {
-        elem = buf[(i + sp) % numLEDs];
-        pSPI.transfer((uint8_t*)&elem, 4);
+    for (unsigned i = 0; i < numLEDs; i++) {
+        auto col = LEDbuffer[(i + sp) % numLEDs];
+        pSPI.transfer(reinterpret_cast<uint8_t*>(&col), sizeof(col));
     }
     sendStop();
     pSPI.endTransaction();
 }
 
 void APA102::clear(void) {
-    for (uint16_t i = 0; i < numLEDs; i++) {
-        LEDbuffer[i * 4] = LED_PREAMBLE;
-        LEDbuffer[i * 4 + bOfs] = 0;
-        LEDbuffer[i * 4 + gOfs] = 0;
-        LEDbuffer[i * 4 + rOfs] = 0;
+    for (unsigned i = 0; i < numLEDs; i++) {
+        LEDbuffer[i] = {LED_PREAMBLE, 0, 0, 0};
     }
 }
 
 void APA102::setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b) {
-    if (n < numLEDs) {
-        LEDbuffer[n * 4] = LED_PREAMBLE | brightness;
-        LEDbuffer[n * 4 + bOfs] = b;
-        LEDbuffer[n * 4 + gOfs] = g;
-        LEDbuffer[n * 4 + rOfs] = r;
-    }
+	col_t col = {brightness, r, g, b};
+	setPixel(n, &col);
 }
 
 void APA102::setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t br) {
-    if (n < numLEDs) {
-        LEDbuffer[n * 4] = LED_PREAMBLE | (br < 32 ? br : 31);
-        LEDbuffer[n * 4 + bOfs] = b;
-        LEDbuffer[n * 4 + gOfs] = g;
-        LEDbuffer[n * 4 + rOfs] = r;
-    }
+	col_t col = {br, r, g, b};
+	setPixel(n, &col);
 }
 
-void APA102::setPixel(uint16_t n, col_t* p) {
+void APA102::setPixel(uint16_t n, const col_t& col) {
     if (n < numLEDs) {
-        LEDbuffer[n * 4] = LED_PREAMBLE | brightness;
-        LEDbuffer[n * 4 + bOfs] = p->b;
-        LEDbuffer[n * 4 + gOfs] = p->g;
-        LEDbuffer[n * 4 + rOfs] = p->r;
+    	auto c = col;
+    	c.br = std::min(c.br, LED_BR_MAX) | LED_PREAMBLE;
+        LEDbuffer[n] = c;
     }
 }
 
 void APA102::setAllPixel(uint8_t r, uint8_t g, uint8_t b) {
-    for (uint16_t i = 0; i < numLEDs; i++) {
-        LEDbuffer[i * 4] = LED_PREAMBLE | brightness;
-        LEDbuffer[i * 4 + bOfs] = b;
-        LEDbuffer[i * 4 + gOfs] = g;
-        LEDbuffer[i * 4 + rOfs] = r;
-    }
+	col_t col = {brightness, r, g, b};
+	setAllPixel(col);
 }
 
-void APA102::setAllPixel(col_t* p) {
-    for (uint16_t i = 0; i < numLEDs; i++) {
-        LEDbuffer[i * 4] = LED_PREAMBLE | brightness;
-        LEDbuffer[i * 4 + bOfs] = p->b;
-        LEDbuffer[i * 4 + gOfs] = p->g;
-        LEDbuffer[i * 4 + rOfs] = p->r;
+void APA102::setAllPixel(const col_t& col) {
+	auto c = col;
+	c.br = std::min(c.br, LED_BR_MAX) | LED_PREAMBLE;
+    for (unsigned i = 0; i < numLEDs; i++) {
+        LEDbuffer[i] = c;
     }
 }
 
 void APA102::setBrightness(uint8_t br) {
-    brightness = (br < 32 ? br : 31);
+    brightness = std::min(br, LED_BR_MAX);
 }
 
-uint8_t APA102::getBrightness(void) {
-    return brightness;
-}
 
 /* direct write functions */
 
 inline void APA102::sendStart(void) {
     uint8_t startFrame[] = {0x00, 0x00, 0x00, 0x00};
-    pSPI.transfer(startFrame, sizeof (startFrame));
+    pSPI.transfer(startFrame, sizeof(startFrame));
 }
 
 inline void APA102::sendStop(void) {
     uint8_t stopFrame[] = {0xff, 0xff, 0xff, 0xff};
-    pSPI.transfer(stopFrame, sizeof (stopFrame));
+    pSPI.transfer(stopFrame, sizeof(stopFrame));
 }
 
 void APA102::directWrite(uint8_t r, uint8_t g, uint8_t b, uint8_t br) {
-    uint8_t pix[4];
-    pSPI.beginTransaction(SPI_APA_Settings);
-    pix[0] = 0xE0 | (br < 32 ? br : 31);
-    pix[bOfs] = b;
-    pix[gOfs] = g;
-    pix[rOfs] = r;
-    pSPI.transfer(pix, sizeof (pix));
-}
+    br = std::min(br, LED_BR_MAX);
+	col_t col = {uint8_t(LED_PREAMBLE | br), r, g, b };
 
+	pSPI.beginTransaction(SPI_APA_Settings);
+    pSPI.transfer(reinterpret_cast<uint8_t*>(&col), sizeof(col));
+}

--- a/Sming/Libraries/APA102/apa102.cpp
+++ b/Sming/Libraries/APA102/apa102.cpp
@@ -10,7 +10,6 @@
 #include <SPI.h>
 
 static constexpr uint8_t LED_PREAMBLE = 0xE0; // LED frame preamble
-static constexpr uint8_t LED_BR_MAX = 31;	 // Maximum LED brightness value
 
 /* APA102 class for hardware & software SPI */
 
@@ -26,22 +25,6 @@ APA102::APA102(uint16_t n, SPIBase& spiRef)
 	} else {
 		clear();
 	}
-}
-
-void APA102::begin(void)
-{
-	pSPI.begin();
-}
-
-void APA102::begin(SPISettings& mySettings)
-{
-	pSPI.begin();
-	SPI_APA_Settings = mySettings;
-}
-
-void APA102::end()
-{
-	pSPI.end();
 }
 
 void APA102::show(void)
@@ -76,18 +59,6 @@ void APA102::clear(void)
 	}
 }
 
-void APA102::setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b)
-{
-	col_t col = {brightness, r, g, b};
-	setPixel(n, &col);
-}
-
-void APA102::setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t br)
-{
-	col_t col = {br, r, g, b};
-	setPixel(n, &col);
-}
-
 void APA102::setPixel(uint16_t n, const col_t& col)
 {
 	if(n < numLEDs) {
@@ -97,12 +68,6 @@ void APA102::setPixel(uint16_t n, const col_t& col)
 	}
 }
 
-void APA102::setAllPixel(uint8_t r, uint8_t g, uint8_t b)
-{
-	col_t col = {brightness, r, g, b};
-	setAllPixel(col);
-}
-
 void APA102::setAllPixel(const col_t& col)
 {
 	auto c = col;
@@ -110,11 +75,6 @@ void APA102::setAllPixel(const col_t& col)
 	for(unsigned i = 0; i < numLEDs; i++) {
 		LEDbuffer[i] = c;
 	}
-}
-
-void APA102::setBrightness(uint8_t br)
-{
-	brightness = std::min(br, LED_BR_MAX);
 }
 
 /* direct write functions */

--- a/Sming/Libraries/APA102/apa102.h
+++ b/Sming/Libraries/APA102/apa102.h
@@ -21,6 +21,8 @@ struct col_t {
 class APA102
 {
 public:
+	APA102(const APA102&) = delete;
+
 	/**
 	 * @brief Initialise for given number of LEDs on standard SPI
 	 */

--- a/Sming/Libraries/APA102/apa102.h
+++ b/Sming/Libraries/APA102/apa102.h
@@ -12,81 +12,81 @@
 #include <SPISettings.h>
 
 struct col_t {
-    uint8_t br;
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
+	uint8_t br;
+	uint8_t r;
+	uint8_t g;
+	uint8_t b;
 };
 
-
-class APA102 {
+class APA102
+{
 public:
-    APA102(uint16_t n);
-    APA102(uint16_t n, SPIBase& spiRef);
+	APA102(uint16_t n);
+	APA102(uint16_t n, SPIBase& spiRef);
 
-    ~APA102()
-    {
-    	delete LEDbuffer;
-    }
+	~APA102()
+	{
+		delete LEDbuffer;
+	}
 
-    void begin();
-    void begin(SPISettings& mySettings);
-    void end();
+	void begin();
+	void begin(SPISettings& mySettings);
+	void end();
 
-    /* send data buffer to LEDs, including start & stop sequences */
-    void show();
-    void show(uint16_t startPos);
+	/* send data buffer to LEDs, including start & stop sequences */
+	void show();
+	void show(uint16_t startPos);
 
-    /* clear data buffer */
-    void clear();
+	/* clear data buffer */
+	void clear();
 
-    /* set pixel color */
-    void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
-    void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t br);
+	/* set pixel color */
+	void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
+	void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t br);
 
-    void setPixel(uint16_t n, const col_t& col);
+	void setPixel(uint16_t n, const col_t& col);
 
-    void setPixel(uint16_t n, const col_t* col)
-    {
-    	if(col != nullptr) {
-    		setPixel(n, *col);
-    	}
-    }
+	void setPixel(uint16_t n, const col_t* col)
+	{
+		if(col != nullptr) {
+			setPixel(n, *col);
+		}
+	}
 
-    void setAllPixel(uint8_t r, uint8_t g, uint8_t b);
+	void setAllPixel(uint8_t r, uint8_t g, uint8_t b);
 
-    void setAllPixel(const col_t& col);
+	void setAllPixel(const col_t& col);
 
-    void setAllPixel(const col_t* col) {
-    	if(col != nullptr) {
-    		setAllPixel(*col);
-    	}
-    }
+	void setAllPixel(const col_t* col)
+	{
+		if(col != nullptr) {
+			setAllPixel(*col);
+		}
+	}
 
-    /* set global LED brightness level */
-    void setBrightness(uint8_t br);
+	/* set global LED brightness level */
+	void setBrightness(uint8_t br);
 
-    /* get global LED brightness level */
-    uint8_t getBrightness() const
-    {
-    	return brightness;
-    }
+	/* get global LED brightness level */
+	uint8_t getBrightness() const
+	{
+		return brightness;
+	}
 
-
-    /* send start sequence */
-    void sendStart();
-    /* send stop sequence */
-    void sendStop();
-    /* direct write single LED data */
-    void directWrite(uint8_t r, uint8_t g, uint8_t b, uint8_t br);
+	/* send start sequence */
+	void sendStart();
+	/* send stop sequence */
+	void sendStop();
+	/* direct write single LED data */
+	void directWrite(uint8_t r, uint8_t g, uint8_t b, uint8_t br);
 
 protected:
-    uint16_t numLEDs = 0;
-    uint8_t brightness = 0;                 // global brightness 0..31 -> 0..100%
-    col_t *LEDbuffer = nullptr;
+	uint16_t numLEDs = 0;
+	uint8_t brightness = 0; // global brightness 0..31 -> 0..100%
+	col_t* LEDbuffer = nullptr;
 
-    SPISettings SPI_APA_Settings;
-    SPIBase& pSPI;
+	SPISettings SPI_APA_Settings;
+	SPIBase& pSPI;
 
 private:
 };

--- a/Sming/Libraries/APA102/apa102.h
+++ b/Sming/Libraries/APA102/apa102.h
@@ -21,28 +21,62 @@ struct col_t {
 class APA102
 {
 public:
+	/**
+	 * @brief Initialise for given number of LEDs on standard SPI
+	 */
 	APA102(uint16_t n);
+
+	/**
+	 * @brief Iniitialise for given number of LEDs on specific SPI device
+	 */
 	APA102(uint16_t n, SPIBase& spiRef);
 
 	~APA102()
 	{
-		delete LEDbuffer;
+		delete[] LEDbuffer;
 	}
 
-	void begin();
-	void begin(SPISettings& mySettings);
-	void end();
+	void begin()
+	{
+		pSPI.begin();
+	}
 
-	/* send data buffer to LEDs, including start & stop sequences */
+	void begin(SPISettings& mySettings)
+	{
+		pSPI.begin();
+		SPI_APA_Settings = mySettings;
+	}
+
+	void end()
+	{
+		pSPI.end();
+	}
+
+	/**
+	 *  @brief Send buffered data to LEDs, including start & stop sequences
+	 */
 	void show();
+
+	/**
+	 * @brief Send buffered data to LEDs from specified position
+	 */
 	void show(uint16_t startPos);
 
 	/* clear data buffer */
 	void clear();
 
 	/* set pixel color */
-	void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
-	void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t br);
+	void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b)
+	{
+		col_t col = {brightness, r, g, b};
+		setPixel(n, col);
+	}
+
+	void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t br)
+	{
+		col_t col = {br, r, g, b};
+		setPixel(n, col);
+	}
 
 	void setPixel(uint16_t n, const col_t& col);
 
@@ -53,7 +87,11 @@ public:
 		}
 	}
 
-	void setAllPixel(uint8_t r, uint8_t g, uint8_t b);
+	void setAllPixel(uint8_t r, uint8_t g, uint8_t b)
+	{
+		col_t col = {brightness, r, g, b};
+		setAllPixel(col);
+	}
 
 	void setAllPixel(const col_t& col);
 
@@ -65,7 +103,10 @@ public:
 	}
 
 	/* set global LED brightness level */
-	void setBrightness(uint8_t br);
+	void setBrightness(uint8_t br)
+	{
+		brightness = std::min(br, LED_BR_MAX);
+	}
 
 	/* get global LED brightness level */
 	uint8_t getBrightness() const
@@ -75,8 +116,10 @@ public:
 
 	/* send start sequence */
 	void sendStart();
+
 	/* send stop sequence */
 	void sendStop();
+
 	/* direct write single LED data */
 	void directWrite(uint8_t r, uint8_t g, uint8_t b, uint8_t br);
 
@@ -89,4 +132,5 @@ protected:
 	SPIBase& pSPI;
 
 private:
+	static constexpr uint8_t LED_BR_MAX = 31; // Maximum LED brightness value
 };

--- a/Sming/Libraries/APA102/apa102.h
+++ b/Sming/Libraries/APA102/apa102.h
@@ -6,67 +6,87 @@
  * APA102 library by HappyCodingRobot@github.com
  ****/
 
-#ifndef _APA102_H_
-#define _APA102_H_
+#pragma once
 
 #include <SPIBase.h>
 #include <SPISettings.h>
 
-typedef struct {
-    //uint8_t br;
+struct col_t {
+    uint8_t br;
     uint8_t r;
     uint8_t g;
     uint8_t b;
-} col_t;
+};
 
 
 class APA102 {
 public:
     APA102(uint16_t n);
-    APA102(uint16_t n, SPIBase & spiRef);
-    ~APA102(void);
+    APA102(uint16_t n, SPIBase& spiRef);
 
-    void begin(void);
-    void begin(SPISettings & mySettings);
-    void end(void);
-    
+    ~APA102()
+    {
+    	delete LEDbuffer;
+    }
+
+    void begin();
+    void begin(SPISettings& mySettings);
+    void end();
+
     /* send data buffer to LEDs, including start & stop sequences */
-    void show(void);
-    void show(int16_t SPos);
-    
+    void show();
+    void show(uint16_t startPos);
+
     /* clear data buffer */
-    void clear(void);
-    
+    void clear();
+
     /* set pixel color */
     void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b);
     void setPixel(uint16_t n, uint8_t r, uint8_t g, uint8_t b, uint8_t br);
-    void setPixel(uint16_t n, col_t* p);
+
+    void setPixel(uint16_t n, const col_t& col);
+
+    void setPixel(uint16_t n, const col_t* col)
+    {
+    	if(col != nullptr) {
+    		setPixel(n, *col);
+    	}
+    }
+
     void setAllPixel(uint8_t r, uint8_t g, uint8_t b);
-    //void LEDsetAllPixel(uint8_t r, uint8_t g, uint8_t b, uint8_t br);
-    void setAllPixel(col_t*);
-    
+
+    void setAllPixel(const col_t& col);
+
+    void setAllPixel(const col_t* col) {
+    	if(col != nullptr) {
+    		setAllPixel(*col);
+    	}
+    }
+
     /* set global LED brightness level */
-    void setBrightness(uint8_t);
+    void setBrightness(uint8_t br);
+
     /* get global LED brightness level */
-    uint8_t getBrightness(void);
-    
-    
+    uint8_t getBrightness() const
+    {
+    	return brightness;
+    }
+
+
     /* send start sequence */
-    void sendStart(void);
+    void sendStart();
     /* send stop sequence */
-    void sendStop(void);
+    void sendStop();
     /* direct write single LED data */
     void directWrite(uint8_t r, uint8_t g, uint8_t b, uint8_t br);
 
 protected:
-    uint16_t numLEDs;
-    uint8_t brightness;                 // global brightness 0..31 -> 0..100%
-    uint8_t *LEDbuffer;
-    
-    SPISettings SPI_APA_Settings = SPISettings(4000000, MSBFIRST, SPI_MODE3);
-    SPIBase & pSPI;
+    uint16_t numLEDs = 0;
+    uint8_t brightness = 0;                 // global brightness 0..31 -> 0..100%
+    col_t *LEDbuffer = nullptr;
+
+    SPISettings SPI_APA_Settings;
+    SPIBase& pSPI;
 
 private:
 };
-
-#endif /* _APA102_H_ */


### PR DESCRIPTION
Use the `col_t` structure instead of byte arrays, eliminate code duplication.
Sample refactored using state machine instead of long delays, WDT reset removed.

Untested on APA102 hardware but compiles and runs fine.
