### PR TITLE
Bugfix: hexchar() should return regular `char`, not `signed char`.

### DIFF
--- a/Sming/System/include/stringutil.h
+++ b/Sming/System/include/stringutil.h
@@ -45,7 +45,7 @@ int strcasecmp(const char* s1, const char* s2);
 void* memmem(const void* haystack, size_t haystacklen, const void* needle, size_t needlelen);
 #endif
 
-static inline signed char hexchar(unsigned char c)
+static inline char hexchar(unsigned char c)
 {
 	if(c < 10)
 		return '0' + c;


### PR DESCRIPTION
Attempting to do things like this produce strange results:

```
String s;
s += hexchar(0);
s += hexchar(1);
```

This produces the result "4849" instead of "01".