### PR TITLE
Handle case where WIFI_PWD is empty (open networks)

### DIFF
--- a/Sming/component.mk
+++ b/Sming/component.mk
@@ -64,7 +64,7 @@ CONFIG_VARS				+= WIFI_SSID WIFI_PWD
 ifdef WIFI_SSID
 	APP_CFLAGS			+= -DWIFI_SSID=\"$(WIFI_SSID)\"
 endif
-ifdef WIFI_PWD
+ifneq ($(origin WIFI_PWD),undefined)
 	APP_CFLAGS			+= -DWIFI_PWD=\"$(WIFI_PWD)\"
 endif
 


### PR DESCRIPTION
ifdef ignores empty values, must check if it's undefined.

Fixes #1891