### PR TITLE
Use library `assert()` instead of redefined macro

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/include/esp_systemapi.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/esp_systemapi.h
@@ -23,6 +23,7 @@ extern "C" {
 #define __CORRECT_ISO_CPP_STDLIB_H_PROTO
 #include <limits.h>
 #include "c_types.h"
+#include <assert.h>
 
 // Remove buggy espconn
 #define _NO_ESPCON_
@@ -75,12 +76,6 @@ typedef enum {
 
 #endif // ETS_SLC_INUM
 
-
-#undef assert
-#define assert(condition) \
-	do {\
-		if (!(condition)) SYSTEM_ERROR("ASSERT: %s %d", __FUNCTION__, __LINE__); \
-	} while(0)
 #define SYSTEM_ERROR(fmt, ...) debug_e("ERROR: " fmt "\r\n", ##__VA_ARGS__)
 
 extern void ets_wdt_enable(void);

--- a/Sming/Arch/Esp8266/Components/esp8266/libc.c
+++ b/Sming/Arch/Esp8266/Components/esp8266/libc.c
@@ -8,8 +8,20 @@
  *
  */
 
+#include <debug_progmem.h>
+#include <gdb/gdb_hooks.h>
+
 int* __errno(void)
 {
 	static int errno_s = 0;
 	return &errno_s;
+}
+
+void __assert_func(const char* file, int line, const char* func, const char* what)
+{
+	SYSTEM_ERROR("ASSERT: %s %d", func, line);
+	gdb_do_break();
+	while(1) {
+		//
+	}
 }


### PR DESCRIPTION
See also #751