### PR TITLE
Add `BasicHttpHeaders` class for in-place parsing

### DIFF
--- a/Sming/Core/Network/Http/BasicHttpHeaders.cpp
+++ b/Sming/Core/Network/Http/BasicHttpHeaders.cpp
@@ -1,0 +1,124 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * BasicHttpHeaders.cpp
+ *
+ * @author: 2019 - Mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#include "BasicHttpHeaders.h"
+#include <FakePgmSpace.h>
+#include <stringutil.h>
+#include <debug_progmem.h>
+
+#define GET_HEADERS()                                                                                                  \
+	auto headers = static_cast<BasicHttpHeaders*>(parser->data);                                                       \
+	if(headers == nullptr) {                                                                                           \
+		return -1;                                                                                                     \
+	}
+
+const http_parser_settings BasicHttpHeaders::parserSettings PROGMEM = {
+	.on_message_begin = nullptr,
+	.on_url = nullptr,
+	.on_status = nullptr,
+	.on_header_field = staticOnField,
+	.on_header_value = staticOnValue,
+	.on_headers_complete = nullptr,
+	.on_body = nullptr,
+	.on_message_complete = nullptr,
+	.on_chunk_header = nullptr,
+	.on_chunk_complete = nullptr,
+};
+
+void BasicHttpHeaders::clear()
+{
+	http_parser_init(&parser, HTTP_BOTH);
+	parser.data = this;
+	count_ = 0;
+}
+
+http_errno BasicHttpHeaders::parse(char* data, size_t len, http_parser_type type)
+{
+	http_parser_init(&parser, type);
+	http_parser_execute(&parser, &parserSettings, data, len);
+	return http_errno(parser.http_errno);
+}
+
+int BasicHttpHeaders::staticOnField(http_parser* parser, const char* at, size_t length)
+{
+	GET_HEADERS();
+	return headers->onField(at, length);
+}
+
+int BasicHttpHeaders::onField(const char* at, size_t length)
+{
+	if(count_ >= ARRAY_SIZE(headers)) {
+		return -1;
+	}
+	const_cast<char*>(at)[length] = '\0';
+	headers[count_].name = at;
+	return 0;
+}
+
+int BasicHttpHeaders::staticOnValue(http_parser* parser, const char* at, size_t length)
+{
+	GET_HEADERS();
+	return headers->onValue(at, length);
+}
+
+int BasicHttpHeaders::onValue(const char* at, size_t length)
+{
+	if(count_ >= ARRAY_SIZE(headers)) {
+		return -1;
+	}
+	const_cast<char*>(at)[length] = '\0';
+	headers[count_].value = at;
+	++count_;
+	return 0;
+}
+
+const char* BasicHttpHeaders::operator[](const char* name) const
+{
+	if(name == nullptr) {
+		return nullptr;
+	}
+
+	for(unsigned i = 0; i < count_; ++i) {
+		auto& hdr = headers[i];
+		if(strcasecmp(hdr.name, name) == 0) {
+			return hdr.value;
+		}
+	}
+
+	return nullptr;
+}
+
+const char*& BasicHttpHeaders::operator[](const char* name)
+{
+	if(name == nullptr) {
+		nullValue = nullptr;
+		return nullValue;
+	}
+
+	for(unsigned i = 0; i < count_; ++i) {
+		auto& hdr = headers[i];
+		if(strcasecmp(hdr.name, name) == 0) {
+			return hdr.value;
+		}
+	}
+
+	if(count_ >= ARRAY_SIZE(headers)) {
+		nullValue = nullptr;
+		return nullValue;
+	}
+
+	auto& hdr = headers[count_];
+	hdr.name = name;
+	hdr.value = nullptr;
+	++count_;
+	return hdr.value;
+}

--- a/Sming/Core/Network/Http/BasicHttpHeaders.h
+++ b/Sming/Core/Network/Http/BasicHttpHeaders.h
@@ -1,0 +1,162 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * BasicHttpHeaders.h - in-place HTTP header parsing
+ *
+ * @author: 2019 - Mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#pragma once
+
+#include "HttpCommon.h"
+
+/**
+ * @brief Parse array of name/value pairs as references to original data
+ * @note When parsing a fixed block of text we don't need to make copies of the content,
+ * just nul-terminate the elements and build a list of references.
+ */
+class BasicHttpHeaders
+{
+public:
+	struct Header {
+		const char* name;
+		const char* value;
+
+		/**
+		 * @brief Return a String in the form "name: value\r\n"
+		 */
+		String toString() const
+		{
+			String s;
+			s += name;
+			s += ": ";
+			s += value;
+			s += "\r\n";
+			return s;
+		}
+
+		operator String() const
+		{
+			return toString();
+		}
+	};
+
+	BasicHttpHeaders()
+	{
+		clear();
+	}
+
+	/**
+	 * @brief Reset to default state
+	 */
+	void clear();
+
+	/**
+	 * @brief Parse header data into name/value pairs
+	 * @param data
+	 * @param len
+	 * @param type Type of headers to parse. The default (HTTP_BOTH) detects this automatically,
+	 * use `type()` to determine which. Specifying HTTP_REQUEST or HTTP_RESPONSE will only accept
+	 * the given type and fail on mismatch.
+	 * @retval http_errno Result of parsing, HPE_OK on success.
+	 * Can use with `httpGetErrorName()` or `httpGetErrorDescription()`.
+	 * @note Content of provided data is modified to insert NUL terminators on string values
+	 * Use type() method to determine whether it's a request or response
+	 */
+	http_errno parse(char* data, size_t len, http_parser_type type = HTTP_BOTH);
+
+	const Header& operator[](unsigned i) const
+	{
+		return headers[i];
+	}
+
+	String toString(unsigned i) const
+	{
+		return operator[](i).toString();
+	}
+
+	const char*& operator[](const char* name);
+
+	/**
+	 * @brief Get number of parsed headers
+	 */
+	unsigned count() const
+	{
+		return count_;
+	}
+
+	/**
+	 * @brief Find a header by name
+	 * @param name Case-insensitive
+	 * @retval const char* If found, the value, otherwise nullptr
+	 */
+	const char* operator[](const char* name) const;
+
+	/**
+	 * @brief Get the type of message parsed
+	 * @retval http_parser_type either HTTP_REQUEST or HTTP_RESPONSE
+	 */
+	http_parser_type type() const
+	{
+		return http_parser_type(parser.type);
+	}
+
+	/**
+	 * @brief Obtain request method
+	 */
+	http_method method() const
+	{
+		return http_method(parser.method);
+	}
+
+	void setMethod(http_method method)
+	{
+		parser.method = unsigned(method);
+	}
+
+	/**
+	 * @brief Obtain text for request method
+	 */
+	const char* methodStr() const
+	{
+		return http_method_str(method());
+	}
+
+	/**
+	 * @brief Obtain response status
+	 */
+	http_status status() const
+	{
+		return http_status(parser.status_code);
+	}
+
+	String statusStr() const
+	{
+		return httpGetStatusText(status());
+	}
+
+	/**
+	 * @brief Obtain content length field value
+	 */
+	unsigned contentLength() const
+	{
+		return parser.content_length;
+	}
+
+private:
+	static int staticOnField(http_parser* parser, const char* at, size_t length);
+	static int staticOnValue(http_parser* parser, const char* at, size_t length);
+	int onField(const char* at, size_t length);
+	int onValue(const char* at, size_t length);
+
+private:
+	http_parser parser;
+	static const http_parser_settings parserSettings;
+	Header headers[16];
+	unsigned count_ = 0;
+	const char* nullValue = nullptr;
+};


### PR DESCRIPTION
Used for fast processing of SSDP packets, for example.