### PR TITLE
Provide better handling for undefined WIFI_SSID

### DIFF
--- a/Sming/component.mk
+++ b/Sming/component.mk
@@ -64,9 +64,7 @@ CONFIG_VARS				+= WIFI_SSID WIFI_PWD
 ifdef WIFI_SSID
 	APP_CFLAGS			+= -DWIFI_SSID=\"$(WIFI_SSID)\"
 endif
-ifneq ($(origin WIFI_PWD),undefined)
-	APP_CFLAGS			+= -DWIFI_PWD=\"$(WIFI_PWD)\"
-endif
+APP_CFLAGS				+= -DWIFI_PWD=\"$(WIFI_PWD)\"
 
 # => WPS
 COMPONENT_VARS			+= ENABLE_WPS

--- a/samples/HttpClient/app/application.cpp
+++ b/samples/HttpClient/app/application.cpp
@@ -4,8 +4,8 @@
 
 // If you want, you can define WiFi settings globally in Eclipse Environment Variables
 #ifndef WIFI_SSID
-#define WIFI_SSID "PleaseEnterSSID" // Put your SSID and Password here
-#define WIFI_PWD "PleaseEnterPass"
+static_assert(false, "Please define WIFI_SSID and, if required, WIFI_PWD.");
+#define WIFI_SSID "PleaseEnterSSID"
 #endif
 
 HttpClient httpClient;


### PR DESCRIPTION
Following from #1891, and addressing #1901, this PR aims to improve the handling of undefined WIFI_SSID in sample applications.

The following use cases are accounted for:

Undefined WIFI_SSID: Display a suitable error message (WIFI_PWD
Open network: WIFI_SSID defined, WIFI_PWD undefined
Secure network: Both WIFI_SSID and WIFI_PWD defined

Note that in all cases "" are not required when defining these values.