### PR TITLE
Fix incorrect HTTP header date format

### DIFF
--- a/Sming/Core/Network/Http/HttpServerConnection.cpp
+++ b/Sming/Core/Network/Http/HttpServerConnection.cpp
@@ -264,7 +264,7 @@ void HttpServerConnection::sendResponseHeaders(HttpResponse* response)
 #endif
 
 	if(SystemClock.isSet()) {
-		response->headers[HTTP_HEADER_DATE] = SystemClock.getSystemTimeString();
+		response->headers[HTTP_HEADER_DATE] = DateTime(SystemClock.now(eTZ_UTC)).toHTTPDate();
 	}
 
 	for(unsigned i = 0; i < response->headers.count(); i++) {

--- a/Sming/Core/Network/NtpClient.cpp
+++ b/Sming/Core/Network/NtpClient.cpp
@@ -15,8 +15,6 @@
 
 NtpClient::NtpClient(const String& reqServer, unsigned reqIntervalSeconds, NtpTimeResultDelegate delegateFunction)
 {
-	debug_d("NtpClient(\"%s\", %u)", reqServer.c_str(), reqIntervalSeconds);
-
 	// Setup timer, but don't start it
 	timer.setCallback(TimerDelegate(&NtpClient::requestTime, this));
 
@@ -25,6 +23,8 @@ NtpClient::NtpClient(const String& reqServer, unsigned reqIntervalSeconds, NtpTi
 	if(!delegateFunction) {
 		autoUpdateSystemClock = true;
 	}
+
+	debug_d("NtpClient(\"%s\", %u)", reqServer.c_str(), reqIntervalSeconds);
 
 	if(reqIntervalSeconds) {
 		setAutoQueryInterval(reqIntervalSeconds);


### PR DESCRIPTION
Needs to use HTTP date format to comply with [RFC 2822](https://www.ietf.org/rfc/rfc2822.txt) 3.3

Ref. https://www.w3.org/Protocols/rfc2616/rfc2616-sec3.html#sec3.3.1