### PR TITLE
GCC 8.2 throws range warning attempting to copy out of FlashString.

### DIFF
--- a/samples/Basic_ProgMem/app/TestProgmem.cpp
+++ b/samples/Basic_ProgMem/app/TestProgmem.cpp
@@ -112,14 +112,19 @@ void testFSTR(Print& out)
 
 	// Example of array or custom data usage
 	out.print("> demoArray1 : {");
-	static struct {
-		FlashString fstr;
+	static const struct {
+		size_t length;
 		char data[5];
-	} demoArray1 = {{5}, {1, 2, 3, 4, 5}};
-	String arr(demoArray1.fstr);
+	} demoArray1 PROGMEM = {5, {1, 2, 3, 4, 5}};
+	// This defines fstrArray as a `const FlashString&`
+	static DEFINE_FSTR_REF(fstrArray, demoArray1);
+	// fstrArray can be now be used in calls to functions, etc.
+	String arr(fstrArray);
 	for(unsigned i = 0; i < arr.length(); ++i) {
+		if(i > 0) {
+			out.print(", ");
+		}
 		out.print(arr[i], DEC);
-		out.print(", ");
 	}
 	out.println("}");
 


### PR DESCRIPTION
To fix this requires re-defining the FlashString structure with a maximum-length array.
I've also added a private constructor to guard against inadvertently trying to instantiate this.

This change breaks the sample application which shows how to cast custom structures into a FlashString,
so a couple of new macros have been added to provide a cleaner way of doing this:
FSTR_STRUCT_PTR
DEFINE_FSTR_REF

The specific error reported is:

```
IMPORT_FSTR(fstr_master_key, PROJECT_DIR "/master.key");

memcpy_P(&master_key, fstr_master_key.data(), fstr_master_key.length());
^^
```

> r:/sming-ifs/Sming/Wiring/FakePgmSpace.h:157:40: error: 'void* memcpy(void*, const void*, size_t)' forming offset [5, 20] is out of the bounds [0, 4] of object 'fstr_master_key' with type 'const FlashString' [-Werror=array-bounds]