### PR TITLE
Keep assert out of RELEASE builds, and strings out of RAM

### DIFF
--- a/Sming/Arch/Esp8266/System/include/assert.h
+++ b/Sming/Arch/Esp8266/System/include/assert.h
@@ -1,0 +1,6 @@
+#include_next <assert.h>
+
+#ifndef NDEBUG
+#undef assert
+#define assert(__e) ((__e) ? (void)0 : __assert_func(__FILE__, __LINE__, __ASSERT_FUNC, _F(#__e)))
+#endif

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -124,7 +124,8 @@ endif
 ifeq ($(SMING_RELEASE),1)
 	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
 	#      for full list of optimization options
-	CFLAGS		+= -Os -DSMING_RELEASE=1
+	# Note: ANSI requires NDEBUG to be defined for correct assert behaviour
+	CFLAGS		+= -Os -DSMING_RELEASE=1 -DNDEBUG
 else ifeq ($(ENABLE_GDB), 1)
 	CFLAGS		+= -Og
 else


### PR DESCRIPTION
Ensure `NDEBUG` is defined for release builds, and provide modified macro so strings aren't in RAM.

http://www.cplusplus.com/reference/cassert/assert/

Without this, asserts (and their strings) remain.