### PR TITLE
assert replacement requires _F() macro

### DIFF
--- a/Sming/Arch/Esp8266/System/include/assert.h
+++ b/Sming/Arch/Esp8266/System/include/assert.h
@@ -3,4 +3,7 @@
 #ifndef NDEBUG
 #undef assert
 #define assert(__e) ((__e) ? (void)0 : __assert_func(__FILE__, __LINE__, __ASSERT_FUNC, _F(#__e)))
+
+#include <FakePgmSpace.h>
+
 #endif


### PR DESCRIPTION
Travis logs full of warnings!