### PR TITLE
Bugfix: `flashmem_get_info()` only works if running from slot #0.

### DIFF
--- a/Sming/Arch/Esp8266/Components/spi_flash/flashmem.c
+++ b/Sming/Arch/Esp8266/Components/spi_flash/flashmem.c
@@ -180,8 +180,10 @@ bool flashmem_erase_sector(uint32_t sector_id)
 
 SPIFlashInfo flashmem_get_info()
 {
-    volatile SPIFlashInfo spi_flash_info STORE_ATTR;
-    spi_flash_info = *((SPIFlashInfo *)(INTERNAL_FLASH_START_ADDRESS));
+    SPIFlashInfo spi_flash_info STORE_ATTR;
+    if(flashmem_read_internal(&spi_flash_info, 0x00000000, sizeof(spi_flash_info)) == 0) {
+    	memset(&spi_flash_info, 0, sizeof(spi_flash_info));
+    }
     return spi_flash_info;
 }
 


### PR DESCRIPTION
Fixes #1922 