### PR TITLE
Allow HTTP connections to ignore rejected body content (#1875)

### DIFF
--- a/Sming/Core/Network/Http/HttpServerConnection.h
+++ b/Sming/Core/Network/Http/HttpServerConnection.h
@@ -76,6 +76,11 @@ public:
 		return &request;
 	}
 
+	void setCloseOnContentError(bool close = true)
+	{
+		closeOnContentError = close;
+	}
+
 protected:
 	// HTTP parser methods
 
@@ -120,6 +125,8 @@ private:
 
 	const BodyParsers* bodyParsers = nullptr;	///< const reference ensures we cannot modify map, only look stuff up
 	HttpBodyParserDelegate bodyParser = nullptr; ///< Active body parser for this message, if any
+	bool closeOnContentError = false;
+	bool hasContentError = false;
 };
 
 /** @} */

--- a/Sming/Core/Network/HttpServer.cpp
+++ b/Sming/Core/Network/HttpServer.cpp
@@ -43,6 +43,7 @@ TcpConnection* HttpServer::createClient(tcp_pcb* clientTcp)
 	HttpServerConnection* con = new HttpServerConnection(clientTcp);
 	con->setResourceTree(&paths);
 	con->setBodyParsers(&bodyParsers);
+	con->setCloseOnContentError(settings.closeOnContentError);
 
 	return con;
 }

--- a/Sming/Core/Network/HttpServer.h
+++ b/Sming/Core/Network/HttpServer.h
@@ -29,6 +29,8 @@ typedef struct {
 	int keepAliveSeconds = 0;	  ///< default seconds to keep the connection alive before closing it
 	int minHeapSize = -1;		   ///< min heap size that is required to accept connection, -1 means use server default
 	bool useDefaultBodyParsers = 1; ///< if the default body parsers,  as form-url-encoded, should be used
+	bool closeOnContentError =
+		true; ///< close the connection if a body parser or resource fails to parse the body content.
 #ifdef ENABLE_SSL
 	int sslSessionCacheSize =
 		10; ///< number of SSL session ids to cache. Setting this to 0 will disable SSL session resumption.


### PR DESCRIPTION
This PR allows the HTTP server to ignore invalid body content, i.e. content rejected by the body parser or the `HttpResource::onBody` callback, without closing the connection immediately (see #1875).
The old behaviour can be restored either for the whole server (`HttpServerSettings::closeOnBadBodyContent = true`) or per connection (`HttpServerConnection::setCloseOnBadBodyContent(true)`).
