### PR TITLE
Make clang-format binary configurable.

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -125,7 +125,7 @@ CS_FILES	= $(call rwildcard,$(CS_DIRS:=/*),%.cpp %.h %.c)
 cs: ##Apply coding style to all core files
 	$(if $(V),$(info Applying coding style to $(words $(CS_FILES)) files ...))
 	@for FILE in $(CS_FILES); do \
-		clang-format -i -style=file $$FILE; \
+		$(CLANG_FORMAT) -i -style=file $$FILE; \
 	done
 
 

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -79,10 +79,17 @@ TOOLS_BASE		= $(SMING_HOME)/$(OUT_BASE)/tools
 USER_LIBDIR		= $(SMING_HOME)/$(OUT_BASE)/lib
 
 # Git command
+DEBUG_VARS	+= GIT
 GIT ?= git
 
 # CMake command
+DEBUG_VARS	+= CMAKE
 CMAKE ?= cmake
+
+# clang-format command
+DEBUG_VARS	+= CLANG_FORMAT
+CLANG_FORMAT ?= clang-format
+
 
 
 V ?= $(VERBOSE)


### PR DESCRIPTION
Allow overriding clang-format binary like `make CLANGFORMAT=path/to/my/clang-format cs`