### PR TITLE
Fix `pure virtual method called` error when running CI tests

### DIFF
--- a/.travis/build.sh
+++ b/.travis/build.sh
@@ -68,7 +68,7 @@ if [ "$TRAVIS_BUILD_STAGE_NAME" == "Test" ]; then
 
 	# Build and run tests
 	export SMING_TARGET_OPTIONS='--flashfile=$(FLASH_BIN) --flashsize=$(SPI_SIZE)'
-	$MAKE_PARALLEL tests || true
+	$MAKE_PARALLEL tests
 
 	# Build the documentation
 	mv $SMING_PROJECTS_DIR/samples ..

--- a/Sming/Arch/Host/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Host/Components/driver/hw_timer.cpp
@@ -34,10 +34,11 @@ public:
 		execute();
 	}
 
-	~CTimerThread()
+	void terminate()
 	{
 		state = terminating;
 		sem.post();
+		join();
 	}
 
 	void attach_interrupt(hw_timer_source_type_t source_type, hw_timer_callback_t callback, void* arg)
@@ -138,8 +139,6 @@ private:
 	bool auto_load = false;
 };
 
-static CTimerThread timer1("Timer1");
-
 void* CTimerThread::thread_routine()
 {
 #ifdef __WIN32
@@ -206,6 +205,13 @@ void* CTimerThread::thread_routine()
 	thread_state = terminating;
 
 	return nullptr;
+}
+
+static CTimerThread timer1("Timer1");
+
+void hw_timer_cleanup()
+{
+	timer1.terminate();
 }
 
 void hw_timer1_attach_interrupt(hw_timer_source_type_t source_type, hw_timer_callback_t callback, void* arg)

--- a/Sming/Arch/Host/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Host/Components/driver/include/driver/hw_timer.h
@@ -83,6 +83,8 @@ inline void hw_timer_init(void)
 {
 }
 
+void hw_timer_cleanup();
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/Arch/Host/Components/driver/uart_server.cpp
+++ b/Sming/Arch/Host/Components/driver/uart_server.cpp
@@ -51,6 +51,12 @@ private:
 
 void* KeyboardThread::thread_routine()
 {
+	// Small applications can complete before we even get here!
+	msleep(50);
+	if(done) {
+		return nullptr;
+	}
+
 	keyb_raw();
 	while(!done) {
 		int c = getkey();

--- a/Sming/Arch/Host/Components/driver/uart_server.cpp
+++ b/Sming/Arch/Host/Components/driver/uart_server.cpp
@@ -36,9 +36,10 @@ public:
 	{
 	}
 
-	~KeyboardThread()
+	void terminate()
 	{
 		done = true;
+		join();
 	}
 
 protected:
@@ -84,6 +85,17 @@ void* KeyboardThread::thread_routine()
 
 static KeyboardThread* keyboardThread;
 
+static void destroyKeyboardThread()
+{
+	if(keyboardThread == nullptr) {
+		return;
+	}
+
+	keyboardThread->terminate();
+	delete keyboardThread;
+	keyboardThread = nullptr;
+}
+
 static void onUart0Notify(uart_t* uart, uart_notify_code_t code)
 {
 	switch(code) {
@@ -105,12 +117,9 @@ static void onUart0Notify(uart_t* uart, uart_notify_code_t code)
 		}
 		break;
 
-	case UART_NOTIFY_BEFORE_CLOSE: {
-		auto thread = keyboardThread;
-		keyboardThread = nullptr;
-		delete thread;
+	case UART_NOTIFY_BEFORE_CLOSE:
+		destroyKeyboardThread();
 		break;
-	}
 
 	default:; // ignore
 	}
@@ -150,16 +159,24 @@ void CUartServer::startup(const UartServerConfig& config)
 
 void CUartServer::shutdown()
 {
+	destroyKeyboardThread();
+
 	for(unsigned i = 0; i < UART_COUNT; ++i) {
 		auto& server = uartServers[i];
+		if(server == nullptr) {
+			continue;
+		}
+
+		server->terminate();
 		delete server;
 		server = nullptr;
 	}
 }
 
-CUartServer::~CUartServer()
+void CUartServer::terminate()
 {
 	close();
+	join();
 	hostmsg("UART%u server destroyed", uart_nr);
 }
 

--- a/Sming/Arch/Host/Components/driver/uart_server.h
+++ b/Sming/Arch/Host/Components/driver/uart_server.h
@@ -56,7 +56,7 @@ public:
 	{
 	}
 
-	~CUartServer();
+	void terminate();
 
 protected:
 	void onNotify(uart_t* uart, uart_notify_code_t code);

--- a/Sming/Arch/Host/Components/hostlib/keyb.cpp
+++ b/Sming/Arch/Host/Components/hostlib/keyb.cpp
@@ -246,7 +246,6 @@ void keyb_raw()
 		// make stdin non-blocking
 		g_orig_flags = fcntl(0, F_GETFL);
 		tcgetattr(STDIN_FILENO, &g_orig_attr);
-		atexit(keyb_restore);
 	}
 
 	// make stdin non-blocking

--- a/Sming/Arch/Host/Components/hostlib/startup.cpp
+++ b/Sming/Arch/Host/Components/hostlib/startup.cpp
@@ -44,6 +44,7 @@ extern void host_init_bootloader();
 
 static void cleanup()
 {
+	hw_timer_cleanup();
 	host_flashmem_cleanup();
 	CUartServer::shutdown();
 	sockets_finalise();

--- a/Sming/Arch/Host/Components/hostlib/threads.h
+++ b/Sming/Arch/Host/Components/hostlib/threads.h
@@ -20,8 +20,15 @@
 #pragma once
 
 #include "hostlib.h"
+#include "hostmsg.h"
 #include <pthread.h>
 #include <semaphore.h>
+
+#if defined(DEBUG_VERBOSE_LEVEL) && (DEBUG_VERBOSE_LEVEL == 3)
+#define HOST_THREAD_DEBUG(fmt, ...) host_printf(fmt "\n", ##__VA_ARGS__)
+#else
+#define HOST_THREAD_DEBUG(fmt, ...)
+#endif
 
 class CMutex;
 
@@ -39,6 +46,7 @@ public:
 
 	virtual ~CThread()
 	{
+		HOST_THREAD_DEBUG("Thread '%s' destroyed", name);
 	}
 
 	bool execute()
@@ -59,6 +67,7 @@ public:
 	void join()
 	{
 		pthread_join(m_thread, nullptr);
+		HOST_THREAD_DEBUG("Thread '%s' complete", name);
 	}
 
 	/*
@@ -91,6 +100,7 @@ private:
 	static void* thread_start(void* param)
 	{
 		auto thread = static_cast<CThread*>(param);
+		HOST_THREAD_DEBUG("Thread '%s' running", thread->name);
 		return thread->thread_routine();
 	}
 

--- a/Sming/Arch/Host/Components/hostlib/threads.h
+++ b/Sming/Arch/Host/Components/hostlib/threads.h
@@ -39,7 +39,6 @@ public:
 
 	virtual ~CThread()
 	{
-		join();
 	}
 
 	bool execute()


### PR DESCRIPTION
See #1905 for discussion.

Unsafe to call methods from virtual CThread destructor, so add `terminate()` method to all derived classes and call explicitly _before_ destroying the object.

Fix keyboard thread race condition.

Closes #1905 