### PR TITLE
Add support for 'Expect: 100-continue' in HTTP server.

### DIFF
--- a/Sming/Core/Network/Http/HttpHeaders.h
+++ b/Sming/Core/Network/Http/HttpHeaders.h
@@ -48,6 +48,7 @@
 	XX(CONTENT_TRANSFER_ENCODING, "Content-Transfer-Encoding", "Coding method used in a MIME message body part")       \
 	XX(CACHE_CONTROL, "Cache-Control", "Directives for caches along the request/response chain")                       \
 	XX(DATE, "Date", "Message originating date/time")                                                                  \
+	XX(EXPECT, "Expect", "Behaviours to be supported by the server in order to properly handle this request.")         \
 	XX(ETAG, "ETag",                                                                                                   \
 	   "Validates resource, such as a file, so recipient can confirm whether it has changed - generally more "         \
 	   "reliable than Date")                                                                                           \

--- a/Sming/Core/Network/Http/HttpServerConnection.cpp
+++ b/Sming/Core/Network/Http/HttpServerConnection.cpp
@@ -101,16 +101,19 @@ int HttpServerConnection::onHeadersComplete(const HttpHeaders& headers)
 
 	if(resource != nullptr && resource->onHeadersComplete) {
 		error = resource->onHeadersComplete(*this, request, response);
+		if(error != 0) {
+			return error;
+		}
 	}
 
-	if(!error && request.method == HTTP_HEAD) {
-		error = 1;
+	if(request.method == HTTP_HEAD) {
+		return 1;
 	}
 
 	if(bodyParsers != nullptr && request.headers.contains(HTTP_HEADER_CONTENT_TYPE)) {
 		String contentType = request.headers[HTTP_HEADER_CONTENT_TYPE];
 		int endPos = contentType.indexOf(';');
-		if(endPos != -1) {
+		if(endPos >= 0) {
 			contentType = contentType.substring(0, endPos);
 		}
 
@@ -131,6 +134,15 @@ int HttpServerConnection::onHeadersComplete(const HttpHeaders& headers)
 			bodyParser = bodyParsers->valueAt(i);
 			assert(bodyParser != nullptr);
 			bodyParser(request, nullptr, PARSE_DATASTART);
+		}
+	}
+
+	// respond to 'Expect: 100-continue' according to RFC 7231 5.1.1
+	if(request.headers.contains(HTTP_HEADER_EXPECT)) {
+		if(request.headers[HTTP_HEADER_EXPECT] == F("100-continue")) {
+			sendString(F("HTTP/1.1 100 Continue\r\n\r\n"));
+		} else {
+			debug_i("HttpServerConnection: Ignoring unknown header '%s'", request.headers[HTTP_HEADER_EXPECT].c_str());
 		}
 	}
 


### PR DESCRIPTION
When uploading files as multipart/form-data, browsers (and other HTTP clients like curl) may generate an [`Expect: 100-continue`](https://tools.ietf.org/html/rfc7231#section-5.1.1) header (depending on file size) and subsequently wait for a [`100 Continue`](https://tools.ietf.org/html/rfc7231#section-6.2.1) response from the server before continuing to send the body data. 

Although most clients will continue to send the body data anyway after a short timeout, this PR avoids  the timeout.