### PR TITLE
Fix strncpy + flash.bin bug

### DIFF
--- a/Sming/Arch/Host/Components/hostlib/hostlib.c
+++ b/Sming/Arch/Host/Components/hostlib/hostlib.c
@@ -29,10 +29,10 @@ int msleep(unsigned ms)
 	return nanosleep(&req, &rem);
 }
 
-void getHostAppDir(char* path, size_t bufSize)
+size_t getHostAppDir(char* path, size_t bufSize)
 {
 	if(path == NULL ||bufSize == 0) {
-		return;
+		return 0;
 	}
 
 	size_t len;
@@ -46,7 +46,9 @@ void getHostAppDir(char* path, size_t bufSize)
 #endif
 	path[len] = '\0';
 	char* p = strrchr(path, sep);
-	if(p) {
+	if(p != NULL) {
 		p[1] = '\0';
+		len = 1 + p - path;
 	}
+	return len;
 }

--- a/Sming/Arch/Host/Components/hostlib/hostlib.c
+++ b/Sming/Arch/Host/Components/hostlib/hostlib.c
@@ -38,7 +38,7 @@ void getHostAppDir(char* path, size_t bufSize)
 	size_t len;
 	char sep;
 #ifdef __WIN32
-	len = GetModuleFileName(NULL, path, bufSize - 1);
+	len = GetModuleFileName(NULL, path, bufSize);
 	sep = '\\';
 #else
 	len = readlink("/proc/self/exe", path, bufSize - 1);

--- a/Sming/Arch/Host/Components/hostlib/hostlib.h
+++ b/Sming/Arch/Host/Components/hostlib/hostlib.h
@@ -55,8 +55,13 @@ extern "C" {
 
 int msleep(unsigned ms);
 
-// Include trailing path separator
-void getHostAppDir(char* path, size_t bufSize);
+/**
+ * @brief Get directory where application is executing from
+ * @param path Receives directory path, including trailing path separator
+ * @param bufSize
+ * @retval size_t Number of characters written, excluding NUL
+ */
+size_t getHostAppDir(char* path, size_t bufSize);
 
 #ifdef __cplusplus
 }

--- a/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
@@ -24,7 +24,7 @@
 static int flashFile = -1;
 static size_t flashFileSize = 0x400000U;
 static char flashFileName[256];
-static const char* defaultFlashFileName = "flash.bin";
+static const char defaultFlashFileName[] = "flash.bin";
 
 #define SPI_FLASH_SEC_SIZE 4096
 
@@ -42,8 +42,11 @@ bool host_flashmem_init(FlashmemConfig& config)
 		strncpy(flashFileName, config.filename, sizeof(flashFileName));
 		flashFileName[sizeof(flashFileName) - 1] = '\0';
 	} else {
-		getHostAppDir(flashFileName, sizeof(flashFileName));
-		strcpy(flashFileName, defaultFlashFileName);
+		size_t len = getHostAppDir(flashFileName, sizeof(flashFileName));
+		if(len + sizeof(defaultFlashFileName) > sizeof(flashFileName)) {
+			return false;
+		}
+		memcpy(&flashFileName[len], defaultFlashFileName, sizeof(defaultFlashFileName));
 		config.filename = flashFileName;
 	}
 

--- a/Sming/Components/spiffs/spiffs.patch
+++ b/Sming/Components/spiffs/spiffs.patch
@@ -70,3 +70,23 @@ index 235aaaa..4df4b4e 100644
    (void)fh;
    spiffs_page_object_ix_header objix_hdr;
 
+diff --git a/src/spiffs_nucleus.c b/src/spiffs_nucleus.c
+index f811d93..ff9db29 100644
+--- a/src/spiffs_nucleus.c
++++ b/src/spiffs_nucleus.c
+@@ -945,6 +945,7 @@ s32_t spiffs_object_create(
+   oix_hdr.type = type;
+   oix_hdr.size = SPIFFS_UNDEFINED_LEN; // keep ones so we can update later without wasting this page
+   strncpy((char*)oix_hdr.name, (const char*)name, SPIFFS_OBJ_NAME_LEN);
++  oix_hdr.name[SPIFFS_OBJ_NAME_LEN - 1] = '\0';
+ #if SPIFFS_OBJ_META_LEN
+   if (meta) {
+     _SPIFFS_MEMCPY(oix_hdr.meta, meta, SPIFFS_OBJ_META_LEN);
+@@ -1008,6 +1009,7 @@ s32_t spiffs_object_update_index_hdr(
+   // change name
+   if (name) {
+     strncpy((char*)objix_hdr->name, (const char*)name, SPIFFS_OBJ_NAME_LEN);
++    objix_hdr->name[SPIFFS_OBJ_NAME_LEN - 1] = '\0';
+   }
+ #if SPIFFS_OBJ_META_LEN
+   if (meta) {


### PR DESCRIPTION
Addresses #1932. Also fixes bug introduced in #1913 which affects default location of flash.bin if not specified on command line.