### PR TITLE
[WIP] Ensure request callback is invoked on client connection error

### DIFF
--- a/Sming/Components/Network/src/Network/Http/HttpClientConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/HttpClientConnection.cpp
@@ -61,6 +61,20 @@ void HttpClientConnection::reset()
 	HttpConnection::reset();
 }
 
+void HttpClientConnection::onError(err_t err)
+{
+	HttpConnection::onError(err);
+
+	auto request = waitingQueue.peek();
+
+	if(request != nullptr) {
+		auto callback = request->requestCompletedDelegate;
+		if(callback) {
+			callback(*this, false);
+		}
+	}
+}
+
 int HttpClientConnection::onMessageBegin(http_parser* parser)
 {
 	incomingRequest = executionQueue.peek();

--- a/Sming/Components/Network/src/Network/Http/HttpClientConnection.h
+++ b/Sming/Components/Network/src/Network/Http/HttpClientConnection.h
@@ -68,6 +68,7 @@ protected:
 
 	// TCP methods
 	void onReadyToSendData(TcpConnectionEvent sourceEvent) override;
+	void onError(err_t err) override;
 
 	void onClosed() override;
 

--- a/Sming/Components/Network/src/Network/Http/HttpRequest.h
+++ b/Sming/Components/Network/src/Network/Http/HttpRequest.h
@@ -155,7 +155,7 @@ public:
 	 */
 	String getQueryParameter(const String& name, const String& defaultValue = nullptr) const
 	{
-		return static_cast<const HttpParams&>(uri.Query)[name] ?: defaultValue;
+		return uri.getQueryParam(name, defaultValue);
 	}
 
 	/**

--- a/Sming/Components/Network/src/Network/Url.cpp
+++ b/Sming/Components/Network/src/Network/Url.cpp
@@ -51,6 +51,16 @@ Url& Url::operator=(String urlString)
 	return *this;
 }
 
+String Url::getScheme() const
+{
+	if(!Scheme) {
+		return URI_SCHEME_DEFAULT;
+	}
+	String s = Scheme;
+	s.toLowerCase();
+	return s;
+}
+
 int Url::getDefaultPort(const String& scheme)
 {
 #define XX(name, str, port)                                                                                            \

--- a/Sming/Components/Network/src/Network/Url.h
+++ b/Sming/Components/Network/src/Network/Url.h
@@ -166,6 +166,14 @@ public:
 	 */
 	void debugPrintTo(Print& p) const;
 
+	/**
+	 * @brief Get a query parameter without risk of modification
+	 */
+	const String& getQueryParam(const String& name, const String& defaultValue = nullptr) const
+	{
+		return Query[name] ?: defaultValue;
+	}
+
 public:
 	String Scheme; ///< without ":" and "//"
 	String User;

--- a/Sming/Components/Network/src/Network/Url.h
+++ b/Sming/Components/Network/src/Network/Url.h
@@ -121,6 +121,12 @@ public:
 		return toString();
 	}
 
+	/**
+	 * @brief Get the applicable scheme, using the default if not specified
+	 * The returned string is always lowercase.
+	 */
+	String getScheme() const;
+
 	/** @brief Obtain the default port for a given scheme
 	 *  @retval int 0 if scheme is not recognised or has no standard port defined
 	 */
@@ -132,7 +138,7 @@ public:
 	 */
 	int getPort() const
 	{
-		return Port ?: getDefaultPort(Scheme);
+		return Port ?: getDefaultPort(getScheme());
 	}
 
 	/** @brief Get hostname+port part of URL string

--- a/Sming/Components/Network/src/Network/WebsocketClient.cpp
+++ b/Sming/Components/Network/src/Network/WebsocketClient.cpp
@@ -74,6 +74,12 @@ bool WebsocketClient::connect(const Url& url)
 	request->headers[HTTP_HEADER_SEC_WEBSOCKET_PROTOCOL] = F("chat");
 	request->headers[HTTP_HEADER_SEC_WEBSOCKET_VERSION] = String(WEBSOCKET_VERSION);
 	request->onHeadersComplete(RequestHeadersCompletedDelegate(&WebsocketClient::verifyKey, this));
+	request->onRequestComplete([this](HttpConnection& client, bool successful) -> int {
+		if(state != eWSCS_Open && wsDisconnect) {
+			wsDisconnect(*this);
+		}
+		return 0;
+	});
 
 	if(!httpConnection->send(request)) {
 		return false;

--- a/Sming/Components/Network/src/Network/WebsocketClient.cpp
+++ b/Sming/Components/Network/src/Network/WebsocketClient.cpp
@@ -87,6 +87,7 @@ bool WebsocketClient::connect(const Url& url)
 int WebsocketClient::verifyKey(HttpConnection& connection, HttpResponse& response)
 {
 	if(!response.headers.contains(HTTP_HEADER_SEC_WEBSOCKET_ACCEPT)) {
+		debug_e("[WS] Websocket Accept missing from headers");
 		state = eWSCS_Closed;
 		return -2; // we don't have response.
 	}

--- a/tests/HostTests/modules/Network/Url.cpp
+++ b/tests/HostTests/modules/Network/Url.cpp
@@ -119,7 +119,10 @@ public:
 			uri.Query["key"] = "7XXUJWCWYTMXKN3L";
 			int sensorValue = 347;
 			uri.Query["field1"] = String(sensorValue);
-			REQUIRE(uri.toString() == FS_url);
+			REQUIRE_EQ(uri.toString(), FS_url);
+			REQUIRE(!uri.Scheme);
+			REQUIRE_EQ(uri.Port, 0);
+			REQUIRE_EQ(uri.getPort(), 80);
 		}
 	}
 


### PR DESCRIPTION
This PR addresses the apparent lack of response when HTTP connections fail, such as with invalid URLs (issue #1937).

When a HTTP request is issued a `completed` delgate is supplied, which receives a boolean `successful` parameter. This parameter is false if HTTP parsing fails or the remote connection returns an HTTP error code.

If, when sending the request, a failure occurs in the connection process then the callback is never invoked. This can happen if:

- The server address specified cannot be resolved (DNS failure)
- A TCP connection cannot be made to the server (no service on the specified port)

And probabaly others. These failures are permanent and if notifed the application can act on them promptly. The alternative is implementing a separate timeout mechanism and just giving up.

So this PR catches a TCP error condition and invokes the request `completed` delegate with a failure code.
The request remains on the waiting queue though, so the request will continue to be retried.