### PR TITLE
Enforce optional TCP connection limit

### DIFF
--- a/Sming/Core/Network/HttpServer.cpp
+++ b/Sming/Core/Network/HttpServer.cpp
@@ -30,6 +30,13 @@ void HttpServer::configure(const HttpServerSettings& settings)
 
 TcpConnection* HttpServer::createClient(tcp_pcb* clientTcp)
 {
+	if(connections.count() >= settings.maxActiveConnections) {
+		debug_w("HttpServer refusing connection, already have %u", connections.count());
+		return nullptr;
+	}
+
+	debug_i("HttpServer::createClient(), connections = %u", connections.count());
+
 	HttpServerConnection* con = new HttpServerConnection(clientTcp);
 	con->setResourceTree(&paths);
 	con->setBodyParsers(&bodyParsers);

--- a/Sming/Core/Network/HttpServer.cpp
+++ b/Sming/Core/Network/HttpServer.cpp
@@ -20,6 +20,7 @@ void HttpServer::configure(const HttpServerSettings& settings)
 	if(settings.minHeapSize > -1) {
 		minHeapSize = settings.minHeapSize;
 	}
+	maxConnections = settings.maxActiveConnections;
 
 	if(settings.useDefaultBodyParsers) {
 		setBodyParser(MIME_FORM_URL_ENCODED, formUrlParser);
@@ -30,13 +31,6 @@ void HttpServer::configure(const HttpServerSettings& settings)
 
 TcpConnection* HttpServer::createClient(tcp_pcb* clientTcp)
 {
-	if(connections.count() >= settings.maxActiveConnections) {
-		debug_w("HttpServer refusing connection, already have %u", connections.count());
-		return nullptr;
-	}
-
-	debug_i("HttpServer::createClient(), connections = %u", connections.count());
-
 	HttpServerConnection* con = new HttpServerConnection(clientTcp);
 	con->setResourceTree(&paths);
 	con->setBodyParsers(&bodyParsers);

--- a/Sming/Core/Network/HttpServer.h
+++ b/Sming/Core/Network/HttpServer.h
@@ -25,9 +25,9 @@
 #include "Http/HttpBodyParser.h"
 
 typedef struct {
-	int maxActiveConnections = 10; ///< maximum number of concurrent requests..
-	int keepAliveSeconds = 0;	  ///< default seconds to keep the connection alive before closing it
-	int minHeapSize = -1;		   ///< min heap size that is required to accept connection, -1 means use server default
+	unsigned maxActiveConnections = 10; ///< maximum number of concurrent requests..
+	unsigned keepAliveSeconds = 0;		///< default seconds to keep the connection alive before closing it
+	int minHeapSize = -1; ///< min heap size that is required to accept connection, -1 means use server default
 	bool useDefaultBodyParsers = 1; ///< if the default body parsers,  as form-url-encoded, should be used
 	bool closeOnContentError =
 		true; ///< close the connection if a body parser or resource fails to parse the body content.

--- a/Sming/Core/Network/HttpServer.h
+++ b/Sming/Core/Network/HttpServer.h
@@ -25,8 +25,8 @@
 #include "Http/HttpBodyParser.h"
 
 typedef struct {
-	unsigned maxActiveConnections = 10; ///< maximum number of concurrent requests..
-	unsigned keepAliveSeconds = 0;		///< default seconds to keep the connection alive before closing it
+	uint16_t maxActiveConnections = 10; ///< maximum number of concurrent requests..
+	uint16_t keepAliveSeconds = 0;		///< default seconds to keep the connection alive before closing it
 	int minHeapSize = -1; ///< min heap size that is required to accept connection, -1 means use server default
 	bool useDefaultBodyParsers = 1; ///< if the default body parsers,  as form-url-encoded, should be used
 	bool closeOnContentError =

--- a/Sming/Core/Network/TcpServer.cpp
+++ b/Sming/Core/Network/TcpServer.cpp
@@ -28,7 +28,7 @@ TcpConnection* TcpServer::createClient(tcp_pcb* clientTcp)
 //Timer stateTimer;
 void list_mem()
 {
-	debug_d("Free heap size=%u", system_get_free_heap_size());
+	debug_d("Free heap size=%u, K=%u", system_get_free_heap_size(), TcpServer::totalConnections);
 }
 
 void TcpServer::setKeepAlive(uint16_t seconds)
@@ -63,6 +63,12 @@ err_t TcpServer::onAccept(tcp_pcb* clientTcp, err_t err)
 	if(system_get_free_heap_size() < minHeapSize) {
 		debug_w("\r\n\r\nCONNECTION DROPPED\r\n\t(free heap: %u)\r\n\r\n", system_get_free_heap_size());
 		return ERR_MEM;
+	}
+
+	// Obey any requested connection limit
+	if(maxConnections != 0 && connections.count() >= maxConnections) {
+		debug_w("\r\n\r\nCONNECTION DROPPED\r\n\t(Existing connections: %u)\r\n\r\n", connections.count());
+		return ERR_ABRT;
 	}
 
 #ifdef NETWORK_DEBUG

--- a/Sming/Core/Network/TcpServer.cpp
+++ b/Sming/Core/Network/TcpServer.cpp
@@ -10,8 +10,6 @@
 
 #include "TcpServer.h"
 
-uint16_t TcpServer::totalConnections = 0;
-
 TcpConnection* TcpServer::createClient(tcp_pcb* clientTcp)
 {
 	debug_d("TCP Server createClient %sNULL\r\n", clientTcp ? "not" : "");
@@ -30,7 +28,7 @@ TcpConnection* TcpServer::createClient(tcp_pcb* clientTcp)
 //Timer stateTimer;
 void list_mem()
 {
-	debug_d("Free heap size=%u, K=%u", system_get_free_heap_size(), TcpServer::totalConnections);
+	debug_d("Free heap size=%u", system_get_free_heap_size());
 }
 
 void TcpServer::setKeepAlive(uint16_t seconds)

--- a/Sming/Core/Network/TcpServer.h
+++ b/Sming/Core/Network/TcpServer.h
@@ -65,6 +65,11 @@ public:
 
 	void shutdown();
 
+	const Vector<TcpConnection*>& getConnections() const
+	{
+		return connections;
+	}
+
 protected:
 	// Overload this method in your derived class!
 	virtual TcpConnection* createClient(tcp_pcb* clientTcp);
@@ -79,7 +84,6 @@ private:
 	static err_t staticAccept(void* arg, tcp_pcb* new_tcp, err_t err);
 
 public:
-	static uint16_t totalConnections; ///< @deprecated not updated by framework
 	uint16_t activeClients = 0;
 
 protected:

--- a/Sming/Core/Network/TcpServer.h
+++ b/Sming/Core/Network/TcpServer.h
@@ -88,6 +88,7 @@ public:
 
 protected:
 	size_t minHeapSize = 16384;
+	uint16_t maxConnections = 0; ///< By default, don't limit connection count
 
 	bool active = true;
 	Vector<TcpConnection*> connections;


### PR DESCRIPTION
As per https://github.com/SmingHub/Sming/pull/1942#issuecomment-553451304, this PR includes a connection count check before accepting a TCP connection. If a connection limit has been specified and accepting the new connection would exceed this value, then the connection is aborted.

Discussion #1940