### PR TITLE
bugfix: HttpConnection freed twice (#1938)

### DIFF
--- a/Sming/SmingCore/Network/HttpClient.cpp
+++ b/Sming/SmingCore/Network/HttpClient.cpp
@@ -28,9 +28,8 @@ bool HttpClient::send(HttpRequest* request)
 		if(connection->getConnectionState() > eTCS_Connecting && !connection->isActive()) {
 			debug_d("Removing stale connection: State: %d, Active: %d", connection->getConnectionState(),
 					connection->isActive());
-			delete connection;
-			connection = nullptr;
 			httpConnectionPool.removeAt(i);
+			connection = nullptr;
 		}
 	}
 


### PR DESCRIPTION
Connection is owned by map so gets freed automatically when removed.