### PR TITLE
Scheme missing from URL in `HttpClient_ThingSpeak` sample

### DIFF
--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -41,6 +41,7 @@ void sendData()
 	     "http://api.thingspeak.com/update?key=7XXUJWCWYTMXKN3L&field1=" + String(sensorValue)
 	 */
 	Url url;
+	url.Scheme = URI_SCHEME_HTTP;
 	url.Host = "api.thingspeak.com";
 	url.Path = "/update";
 	url.Query["key"] = "7XXUJWCWYTMXKN3L";


### PR DESCRIPTION
Without this port doesn't get set, attempts to connect to port 0 which fails with ERR_ABORT.