### PR TITLE
Fix `OneWire does not name a type` error (#1949)

### DIFF
--- a/Sming/Libraries/DS18S20/ds18s20.h
+++ b/Sming/Libraries/DS18S20/ds18s20.h
@@ -15,7 +15,7 @@
  *  @ingroup    libraries
  *  @{
 */
-#include <Wire.h>
+#include <Libraries/OneWire/OneWire.h>
 
 #define MAX_SENSORS 4         ///< Maximum quantity of sensors to read
 

--- a/Sming/Libraries/DS18S20/ds18s20.h
+++ b/Sming/Libraries/DS18S20/ds18s20.h
@@ -15,7 +15,7 @@
  *  @ingroup    libraries
  *  @{
 */
-#include <Libraries/OneWire/OneWire.h>
+#include <Wire.h>
 
 #define MAX_SENSORS 4         ///< Maximum quantity of sensors to read
 
@@ -35,6 +35,8 @@
     @note   Example: void onMeasurment() { ... };
 */
 typedef Delegate<void()> DS18S20CompletedDelegate;
+
+class OneWire;
 
 /** @brief  This class implements access to the DS18x20 range of temperature sensors
 */

--- a/samples/Temperature_DS1820/app/application.cpp
+++ b/samples/Temperature_DS1820/app/application.cpp
@@ -1,6 +1,4 @@
 #include <SmingCore.h>
-#include <Libraries/OneWire/OneWire.h>
-
 #include <Libraries/DS18S20/ds18s20.h>
 
 DS18S20 ReadTemp;


### PR DESCRIPTION
See #1949 for details