### PR TITLE
Implement Small String Optimisation (SSO)

### DIFF
--- a/Sming/Arch/Host/Components/libc/memrchr.c
+++ b/Sming/Arch/Host/Components/libc/memrchr.c
@@ -1,0 +1,197 @@
+/* memrchr -- find the last occurrence of a byte in a memory block
+   Copyright (C) 1991-2019 Free Software Foundation, Inc.
+   This file is part of the GNU C Library.
+   Based on strlen implementation by Torbjorn Granlund (tege@sics.se),
+   with help from Dan Sahlin (dan@sics.se) and
+   commentary by Jim Blandy (jimb@ai.mit.edu);
+   adaptation to memchr suggested by Dick Karpinski (dick@cca.ucsf.edu),
+   and implemented by Roland McGrath (roland@ai.mit.edu).
+
+   The GNU C Library is free software; you can redistribute it and/or
+   modify it under the terms of the GNU Lesser General Public
+   License as published by the Free Software Foundation; either
+   version 2.1 of the License, or (at your option) any later version.
+
+   The GNU C Library is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+   Lesser General Public License for more details.
+
+   You should have received a copy of the GNU Lesser General Public
+   License along with the GNU C Library; if not, see
+   <https://www.gnu.org/licenses/>.  */
+
+#include <stdlib.h>
+
+#ifdef HAVE_CONFIG_H
+# include <config.h>
+#endif
+
+#if defined _LIBC
+# include <string.h>
+# include <memcopy.h>
+#endif
+
+#if defined HAVE_LIMITS_H || defined _LIBC
+# include <limits.h>
+#endif
+
+#define LONG_MAX_32_BITS 2147483647
+
+#ifndef LONG_MAX
+# define LONG_MAX LONG_MAX_32_BITS
+#endif
+
+#include <sys/types.h>
+
+#undef __memrchr
+#undef memrchr
+
+#ifndef weak_alias
+# define __memrchr memrchr
+#endif
+
+/* Search no more than N bytes of S for C.  */
+void *
+#ifndef MEMRCHR
+__memrchr
+#else
+MEMRCHR
+#endif
+     (const void *s, int c_in, size_t n)
+{
+  const unsigned char *char_ptr;
+  const unsigned long int *longword_ptr;
+  unsigned long int longword, magic_bits, charmask;
+  unsigned char c;
+
+  c = (unsigned char) c_in;
+
+  /* Handle the last few characters by reading one character at a time.
+     Do this until CHAR_PTR is aligned on a longword boundary.  */
+  for (char_ptr = (const unsigned char *) s + n;
+       n > 0 && ((unsigned long int) char_ptr
+		 & (sizeof (longword) - 1)) != 0;
+       --n)
+    if (*--char_ptr == c)
+      return (void *) char_ptr;
+
+  /* All these elucidatory comments refer to 4-byte longwords,
+     but the theory applies equally well to 8-byte longwords.  */
+
+  longword_ptr = (const unsigned long int *) char_ptr;
+
+  /* Bits 31, 24, 16, and 8 of this number are zero.  Call these bits
+     the "holes."  Note that there is a hole just to the left of
+     each byte, with an extra at the end:
+
+     bits:  01111110 11111110 11111110 11111111
+     bytes: AAAAAAAA BBBBBBBB CCCCCCCC DDDDDDDD
+
+     The 1-bits make sure that carries propagate to the next 0-bit.
+     The 0-bits provide holes for carries to fall into.  */
+  magic_bits = -1;
+  magic_bits = magic_bits / 0xff * 0xfe << 1 >> 1 | 1;
+
+  /* Set up a longword, each of whose bytes is C.  */
+  charmask = c | (c << 8);
+  charmask |= charmask << 16;
+#if LONG_MAX > LONG_MAX_32_BITS
+  charmask |= charmask << 32;
+#endif
+
+  /* Instead of the traditional loop which tests each character,
+     we will test a longword at a time.  The tricky part is testing
+     if *any of the four* bytes in the longword in question are zero.  */
+  while (n >= sizeof (longword))
+    {
+      /* We tentatively exit the loop if adding MAGIC_BITS to
+	 LONGWORD fails to change any of the hole bits of LONGWORD.
+
+	 1) Is this safe?  Will it catch all the zero bytes?
+	 Suppose there is a byte with all zeros.  Any carry bits
+	 propagating from its left will fall into the hole at its
+	 least significant bit and stop.  Since there will be no
+	 carry from its most significant bit, the LSB of the
+	 byte to the left will be unchanged, and the zero will be
+	 detected.
+
+	 2) Is this worthwhile?  Will it ignore everything except
+	 zero bytes?  Suppose every byte of LONGWORD has a bit set
+	 somewhere.  There will be a carry into bit 8.  If bit 8
+	 is set, this will carry into bit 16.  If bit 8 is clear,
+	 one of bits 9-15 must be set, so there will be a carry
+	 into bit 16.  Similarly, there will be a carry into bit
+	 24.  If one of bits 24-30 is set, there will be a carry
+	 into bit 31, so all of the hole bits will be changed.
+
+	 The one misfire occurs when bits 24-30 are clear and bit
+	 31 is set; in this case, the hole at bit 31 is not
+	 changed.  If we had access to the processor carry flag,
+	 we could close this loophole by putting the fourth hole
+	 at bit 32!
+
+	 So it ignores everything except 128's, when they're aligned
+	 properly.
+
+	 3) But wait!  Aren't we looking for C, not zero?
+	 Good point.  So what we do is XOR LONGWORD with a longword,
+	 each of whose bytes is C.  This turns each byte that is C
+	 into a zero.  */
+
+      longword = *--longword_ptr ^ charmask;
+
+      /* Add MAGIC_BITS to LONGWORD.  */
+      if ((((longword + magic_bits)
+
+	    /* Set those bits that were unchanged by the addition.  */
+	    ^ ~longword)
+
+	   /* Look at only the hole bits.  If any of the hole bits
+	      are unchanged, most likely one of the bytes was a
+	      zero.  */
+	   & ~magic_bits) != 0)
+	{
+	  /* Which of the bytes was C?  If none of them were, it was
+	     a misfire; continue the search.  */
+
+	  const unsigned char *cp = (const unsigned char *) longword_ptr;
+
+#if LONG_MAX > 2147483647
+	  if (cp[7] == c)
+	    return (void *) &cp[7];
+	  if (cp[6] == c)
+	    return (void *) &cp[6];
+	  if (cp[5] == c)
+	    return (void *) &cp[5];
+	  if (cp[4] == c)
+	    return (void *) &cp[4];
+#endif
+	  if (cp[3] == c)
+	    return (void *) &cp[3];
+	  if (cp[2] == c)
+	    return (void *) &cp[2];
+	  if (cp[1] == c)
+	    return (void *) &cp[1];
+	  if (cp[0] == c)
+	    return (void *) cp;
+	}
+
+      n -= sizeof (longword);
+    }
+
+  char_ptr = (const unsigned char *) longword_ptr;
+
+  while (n-- > 0)
+    {
+      if (*--char_ptr == c)
+	return (void *) char_ptr;
+    }
+
+  return 0;
+}
+#ifndef MEMRCHR
+# ifdef weak_alias
+weak_alias (__memrchr, memrchr)
+# endif
+#endif

--- a/Sming/Core/Data/CStringArray.cpp
+++ b/Sming/Core/Data/CStringArray.cpp
@@ -58,9 +58,10 @@ int CStringArray::indexOf(const char* str, bool ignoreCase) const
 		return -1;
 	}
 
+	auto buf = begin();
 	unsigned index = 0;
-	for(unsigned offset = 0; offset < len; ++index) {
-		const char* s = buffer + offset;
+	for(unsigned offset = 0; offset < buflen; ++index) {
+		const char* s = buf + offset;
 		if(ignoreCase) {
 			if(strcasecmp(str, s) == 0) {
 				return index;

--- a/Sming/System/include/stringutil.h
+++ b/Sming/System/include/stringutil.h
@@ -43,6 +43,9 @@ int strcasecmp(const char* s1, const char* s2);
  *  @note non-ANSI GNU C library extension
 */
 void* memmem(const void* haystack, size_t haystacklen, const void* needle, size_t needlelen);
+
+void *memrchr(const void *s, int c, size_t n);
+
 #endif
 
 int memicmp(const void* buf1, const void* buf2, size_t len);

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -267,6 +267,11 @@ String &String::copy(flash_string_t pstr, size_t length)
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
 void String::move(String &rhs)
 {
+	if(rhs.isNull()) {
+		invalidate();
+		return;
+	}
+
 	auto rhs_len = rhs.length();
 	if(rhs.sso.set) {
 		// Switch to SSO if required

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -547,17 +547,14 @@ bool String::equalsIgnoreCase(const FlashString& fstr) const
   return memicmp(buf, cbuffer(), len) == 0;
 }
 
-bool String::startsWith(const String &prefix) const
-{
-  if (length() < prefix.length()) return false;
-  return startsWith(prefix, 0);
-}
-
 bool String::startsWith(const String &prefix, size_t offset) const
 {
-  auto prefix_buffer = prefix.cbuffer();
   auto prefix_len = prefix.length();
-  if (offset + prefix_len > length() || !prefix_buffer) return false;
+  auto len = length();
+  if(prefix_len == 0 || prefix_len > len || offset > len - prefix_len) {
+	  return false;
+  }
+  auto prefix_buffer = prefix.cbuffer();
   return memcmp(&cbuffer()[offset], prefix_buffer, prefix_len) == 0;
 }
 
@@ -566,7 +563,7 @@ bool String::endsWith(const String &suffix) const
   auto len = length();
   auto suffix_buffer = suffix.cbuffer();
   auto suffix_len = suffix.length();
-  if (len < suffix_len || !suffix_buffer) return false;
+  if (len < suffix_len || suffix_len == 0) return false;
   return memcmp(&cbuffer()[len - suffix_len], suffix_buffer, suffix_len) == 0;
 }
 

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -703,34 +703,44 @@ int String::indexOf(const String &s2, size_t fromIndex) const
 
 int String::lastIndexOf(char theChar) const
 {
-  return lastIndexOf(theChar, len - 1);
+	auto len = length();
+	if(len == 0) {
+		return -1;
+	}
+	auto buf = cbuffer();
+	auto found = memrchr(buf, theChar, len);
+	return found ? (static_cast<const char*>(found) - buf) : -1;
 }
 
 int String::lastIndexOf(char ch, size_t fromIndex) const
 {
-  auto len = length();
-  if (fromIndex >= len) return -1;
-  auto buf = buffer();
-  char tempchar = buf[fromIndex + 1];
-  buf[fromIndex + 1] = '\0';
-  char* temp = strrchr(buf, ch);
-  buf[fromIndex + 1] = tempchar;
-  if (temp == nullptr) return -1;
-  return temp - buf;
+	auto len = length();
+	if(len == 0) {
+		return -1;
+	}
+	if(fromIndex < len) {
+		len = fromIndex + 1;
+	}
+	auto buf = cbuffer();
+	auto found = memrchr(buf, ch, len);
+	return found ? (static_cast<const char*>(found) - buf) : -1;
 }
 
 int String::lastIndexOf(const String &s2) const
 {
-  return lastIndexOf(s2, length() - s2.length());
+  return lastIndexOf(s2.cbuffer(), length() - s2.length(), s2.length());
 }
 
 int String::lastIndexOf(const String &s2, size_t fromIndex) const
 {
+	return lastIndexOf(s2.cbuffer(), fromIndex, s2.length());
+}
+
+int String::lastIndexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const
+{
   auto len = length();
-  auto s2_len = s2.length();
   if (s2_len == 0 || len == 0 || s2_len > len) return -1;
   auto buf = cbuffer();
-  auto s2_buf = s2.cbuffer();
   if (fromIndex >= len) fromIndex = len - 1;
   int found = -1;
   for (auto p = buf; p <= buf + fromIndex; p++)

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -851,18 +851,12 @@ void String::replace(const String& find, const String& replace)
   }
 }
 
-void String::remove(size_t index)
-{
-	auto len = length();
-	if(index < len) remove(index, len - index);
-}
-
 void String::remove(size_t index, size_t count)
 {
 	if (count == 0) { return; }
 	auto len = length();
 	if (index >= len) { return; }
-	if (index + count > len) { count = len - index; }
+	if (count > len - index) { count = len - index; }
 	char *writeTo = buffer() + index;
 	len -= count;
 	memcpy(writeTo, writeTo + count, len - index);

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -626,12 +626,12 @@ int String::indexOf(char ch, size_t fromIndex) const
   return static_cast<const char*>(temp) - buf;
 }
 
-int String::indexOf(const String &s2, size_t fromIndex) const
+int String::indexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const
 {
   auto len = length();
   if (fromIndex >= len) return -1;
   auto buf = cbuffer();
-  auto found = memmem(buf + fromIndex, len - fromIndex, s2.cbuffer(), s2.length());
+  auto found = memmem(buf + fromIndex, len - fromIndex, s2_buf, s2_len);
   if (found == nullptr) return -1;
   return static_cast<const char*>(found) - buf;
 }

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -34,31 +34,12 @@ String::String(const char *cstr)
   if (cstr) copy(cstr, strlen(cstr));
 }
 
-String::String(const char *cstr, size_t length)
-{
-  if (cstr) copy(cstr, length);
-}
-
-String::String(const String &value)
-{
-  *this = value;
-}
-
-String::String(flash_string_t pstr, int length)
-{
-  setString(pstr, length);
-}
-
 String::String(const FlashString& fstr)
 {
   setString(fstr.data(), fstr.length());
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String::String(String &&rval)
-{
-  move(rval);
-}
 String::String(StringSumHelper &&rval)
 {
   move(rval);
@@ -130,11 +111,6 @@ String::String(double value, unsigned char decimalPlaces)
 {
 	char buf[33];
 	*this = dtostrf(value, 0, decimalPlaces, buf);
-}
-
-String::~String()
-{
-	invalidate();
 }
 
 void String::setString(const char *cstr, int length /* = -1 */)
@@ -314,12 +290,6 @@ String & String::operator = (const String &rhs)
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String & String::operator = (String && rval)
-{
-  if (this != &rval) move(rval);
-  return *this;
-}
-
 String & String::operator = (StringSumHelper && rval)
 {
   if (this != &rval) move(rval);
@@ -338,11 +308,6 @@ String & String::operator = (const char *cstr)
 /*********************************************/
 /*  concat                                   */
 /*********************************************/
-
-bool String::concat(const String &s)
-{
-  return concat(s.cbuffer(), s.length());
-}
 
 bool String::concat(const char *cstr, size_t length)
 {
@@ -559,26 +524,6 @@ bool String::equals(const FlashString& fstr) const
 	return memcmp(buf, cbuffer(), len) == 0;
 }
 
-bool String::operator<(const String &rhs) const
-{
-  return compareTo(rhs) < 0;
-}
-
-bool String::operator>(const String &rhs) const
-{
-  return compareTo(rhs) > 0;
-}
-
-bool String::operator<=(const String &rhs) const
-{
-  return compareTo(rhs) <= 0;
-}
-
-bool String::operator>=(const String &rhs) const
-{
-  return compareTo(rhs) >= 0;
-}
-
 bool String::equalsIgnoreCase(const char* cstr) const
 {
   auto buf = cbuffer();
@@ -629,11 +574,6 @@ bool String::endsWith(const String &suffix) const
 /*  Character Access                         */
 /*********************************************/
 
-char String::charAt(size_t index) const
-{
-  return operator[](index);
-}
-
 void String::setCharAt(size_t index, char c)
 {
   if (index < length()) buffer()[index] = c;
@@ -676,11 +616,6 @@ size_t String::getBytes(unsigned char *buf, size_t bufsize, size_t index) const
 /*  Search                                   */
 /*********************************************/
 
-int String::indexOf(char c) const
-{
-  return indexOf(c, 0);
-}
-
 int String::indexOf(char ch, size_t fromIndex) const
 {
   auto len = length();
@@ -689,11 +624,6 @@ int String::indexOf(char ch, size_t fromIndex) const
   auto temp = memchr(buf + fromIndex, ch, len - fromIndex);
   if (temp == nullptr) return -1;
   return static_cast<const char*>(temp) - buf;
-}
-
-int String::indexOf(const String &s2) const
-{
-  return indexOf(s2, 0);
 }
 
 int String::indexOf(const String &s2, size_t fromIndex) const

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -709,24 +709,24 @@ String String::substring(size_t left, size_t right) const
 
 void String::replace(char find, char replace)
 {
-  if (isNull()) return;
-  auto len = length();
-  auto buf = buffer();
-  for (unsigned i = 0; i < len; ++i)
-  {
-    if (buf[i] == find) buf[i] = replace;
-  }
+	auto buf = buffer();
+	for(unsigned len = length(); len > 0; --len, ++buf) {
+		if(*buf == find) {
+			*buf = replace;
+		}
+	}
 }
 
-void String::replace(const String& find, const String& replace)
+bool String::replace(const String& find, const String& replace)
+{
+	return this->replace(find.cbuffer(), find.length(), replace.cbuffer(), replace.length());
+}
+
+bool String::replace(const char* find_buf, size_t find_len, const char* replace_buf, size_t replace_len)
 {
   auto len = length();
-  auto find_len = find.length();
-  auto replace_len = replace.length();
   auto buf = buffer();
-  auto find_buf = find.cbuffer();
-  auto replace_buf = replace.cbuffer();
-  if (len == 0 || find_len == 0) return;
+  if (len == 0 || find_len == 0) return true;
   int diff = replace_len - find_len;
   char *readFrom = buf;
   const char* end = buf + len;
@@ -763,13 +763,13 @@ void String::replace(const String& find, const String& replace)
       readFrom = foundAt + find_len;
       size += diff;
     }
-    if (size == len) return;
+    if (size == len) return true;
     if(!reserve(size)) {
-    	return;
+    	return false;
     }
     buf = buffer();
     int index = len - 1;
-    while ((index = lastIndexOf(find, index)) >= 0)
+    while ((index = lastIndexOf(find_buf, index, find_len)) >= 0)
     {
       readFrom = buf + index + find_len;
       memmove(readFrom + diff, readFrom, len - (readFrom - buf));
@@ -779,6 +779,7 @@ void String::replace(const String& find, const String& replace)
     }
     setlen(len);
   }
+  return true;
 }
 
 void String::remove(size_t index, size_t count)

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -752,16 +752,10 @@ String String::substring(size_t left, size_t right) const
     right = left;
     left = temp;
   }
-  String out;
   auto len = length();
-  if (left > len) return out;
+  if (left >= len) return nullptr;
   if (right > len) right = len;
-  auto buf = buffer();
-  char temp = buf[right];  // save the replaced character
-  buf[right] = '\0';
-  out = buf + left;  // pointer arithmetic
-  buf[right] = temp;  //restore character
-  return out;
+  return String(cbuffer() + left, right - left);
 }
 
 /*********************************************/

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -34,7 +34,7 @@ String::String(const char *cstr)
   if (cstr) copy(cstr, strlen(cstr));
 }
 
-String::String(const char *cstr, unsigned int length)
+String::String(const char *cstr, size_t length)
 {
   if (cstr) copy(cstr, length);
 }
@@ -175,7 +175,7 @@ void String::invalidate(void)
   capacity = len = 0;
 }
 
-bool String::reserve(unsigned int size)
+bool String::reserve(size_t size)
 {
   if (buffer && capacity >= size) return true;
   if (changeBuffer(size))
@@ -186,7 +186,7 @@ bool String::reserve(unsigned int size)
   return false;
 }
 
-bool String::setLength(unsigned int size)
+bool String::setLength(size_t size)
 {
 	if(!reserve(size))
 		return false;
@@ -198,7 +198,7 @@ bool String::setLength(unsigned int size)
 	return true;
 }
 
-bool String::changeBuffer(unsigned int maxStrLen)
+bool String::changeBuffer(size_t maxStrLen)
 {
   char *newbuffer = (char *)realloc(buffer, maxStrLen + 1);
   if (newbuffer)
@@ -214,7 +214,7 @@ bool String::changeBuffer(unsigned int maxStrLen)
 /*  Copy and Move                            */
 /*********************************************/
 
-String & String::copy(const char *cstr, unsigned int length)
+String & String::copy(const char *cstr, size_t length)
 {
   if (!reserve(length))
   {
@@ -227,10 +227,10 @@ String & String::copy(const char *cstr, unsigned int length)
   return *this;
 }
 
-String &String::copy(flash_string_t pstr, unsigned int length)
+String &String::copy(flash_string_t pstr, size_t length)
 {
 	// If necessary, allocate additional space so copy can be aligned
-	unsigned int length_aligned = ALIGNUP(length);
+	size_t length_aligned = ALIGNUP(length);
 	if(!reserve(length_aligned))
 	{
 		invalidate();
@@ -299,9 +299,9 @@ bool String::concat(const String &s)
   return concat(s.buffer, s.len);
 }
 
-bool String::concat(const char *cstr, unsigned int length)
+bool String::concat(const char *cstr, size_t length)
 {
-  unsigned int newlen = len + length;
+  size_t newlen = len + length;
   if (length == 0) return true; // Nothing to add
   if (!cstr) return false; // Bad argument (length is non-zero)
   if (!reserve(newlen)) return false;
@@ -466,7 +466,7 @@ StringSumHelper & operator + (const StringSumHelper &lhs, double num)
 /*  Comparison                               */
 /*********************************************/
 
-int String::compareTo(const char* cstr, unsigned int length) const
+int String::compareTo(const char* cstr, size_t length) const
 {
   auto len = this->length();
   if (len == 0 || length == 0) {
@@ -492,7 +492,7 @@ bool String::equals(const char *cstr) const
   return memcmp(buffer, cstr, len) == 0;
 }
 
-bool String::equals(const char *cstr, unsigned int length) const
+bool String::equals(const char *cstr, size_t length) const
 {
   auto len = this->length();
   if (len != length) return false;
@@ -533,7 +533,7 @@ bool String::equalsIgnoreCase(const char* cstr) const
   return strcasecmp(cstr, buffer) == 0;
 }
 
-bool String::equalsIgnoreCase(const char* cstr, unsigned int length) const
+bool String::equalsIgnoreCase(const char* cstr, size_t length) const
 {
   auto len = this->length();
   if (len != length) return false;
@@ -554,7 +554,7 @@ bool String::startsWith(const String &prefix) const
   return startsWith(prefix, 0);
 }
 
-bool String::startsWith(const String &prefix, unsigned int offset) const
+bool String::startsWith(const String &prefix, size_t offset) const
 {
   if (offset + prefix.len > len || !buffer || !prefix.buffer) return false;
   return memcmp(&buffer[offset], prefix.buffer, prefix.len) == 0;
@@ -570,17 +570,17 @@ bool String::endsWith(const String &suffix) const
 /*  Character Access                         */
 /*********************************************/
 
-char String::charAt(unsigned int index) const
+char String::charAt(size_t index) const
 {
   return operator[](index);
 }
 
-void String::setCharAt(unsigned int index, char c)
+void String::setCharAt(size_t index, char c)
 {
   if (index < len) buffer[index] = c;
 }
 
-char & String::operator[](unsigned int index)
+char & String::operator[](size_t index)
 {
   if (index >= len || !buffer)
   {
@@ -591,13 +591,13 @@ char & String::operator[](unsigned int index)
   return buffer[index];
 }
 
-char String::operator[](unsigned int index) const
+char String::operator[](size_t index) const
 {
   if (index >= len || !buffer) return '\0';
   return buffer[index];
 }
 
-unsigned int String::getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index) const
+size_t String::getBytes(unsigned char *buf, size_t bufsize, size_t index) const
 {
   if (!bufsize || !buf) return 0;
   if (index >= len)
@@ -605,7 +605,7 @@ unsigned int String::getBytes(unsigned char *buf, unsigned int bufsize, unsigned
     buf[0] = '\0';
     return 0;
   }
-  unsigned int n = bufsize - 1;
+  size_t n = bufsize - 1;
   if (n > len - index) n = len - index;
   memmove(buf, buffer + index, n);
   buf[n] = '\0';
@@ -621,7 +621,7 @@ int String::indexOf(char c) const
   return indexOf(c, 0);
 }
 
-int String::indexOf(char ch, unsigned int fromIndex) const
+int String::indexOf(char ch, size_t fromIndex) const
 {
   if (fromIndex >= len) return -1;
   auto temp = (const char*)memchr(buffer + fromIndex, ch, len - fromIndex);
@@ -634,7 +634,7 @@ int String::indexOf(const String &s2) const
   return indexOf(s2, 0);
 }
 
-int String::indexOf(const String &s2, unsigned int fromIndex) const
+int String::indexOf(const String &s2, size_t fromIndex) const
 {
   if (fromIndex >= len) return -1;
   auto found = (const char*)memmem(buffer + fromIndex, len - fromIndex, s2.buffer, s2.len);
@@ -647,7 +647,7 @@ int String::lastIndexOf(char theChar) const
   return lastIndexOf(theChar, len - 1);
 }
 
-int String::lastIndexOf(char ch, unsigned int fromIndex) const
+int String::lastIndexOf(char ch, size_t fromIndex) const
 {
   if (fromIndex >= len) return -1;
   char tempchar = buffer[fromIndex + 1];
@@ -663,7 +663,7 @@ int String::lastIndexOf(const String &s2) const
   return lastIndexOf(s2, len - s2.len);
 }
 
-int String::lastIndexOf(const String &s2, unsigned int fromIndex) const
+int String::lastIndexOf(const String &s2, size_t fromIndex) const
 {
   if (s2.len == 0 || len == 0 || s2.len > len) return -1;
   if (fromIndex >= len) fromIndex = len - 1;
@@ -677,13 +677,13 @@ int String::lastIndexOf(const String &s2, unsigned int fromIndex) const
   return found;
 }
 
-String String::substring(unsigned int left, unsigned int right) const
+String String::substring(size_t left, size_t right) const
 {
   if (!buffer) return nullptr;
 
   if (left > right)
   {
-    unsigned int temp = right;
+    size_t temp = right;
     right = left;
     left = temp;
   }
@@ -730,7 +730,7 @@ void String::replace(const String& find, const String& replace)
     char *writeTo = buffer;
     while ((foundAt = (char*)memmem(readFrom, end - readFrom, find.buffer, find.len)) != nullptr)
     {
-      unsigned int n = foundAt - readFrom;
+      size_t n = foundAt - readFrom;
       memcpy(writeTo, readFrom, n);
       writeTo += n;
       memcpy(writeTo, replace.buffer, replace.len);
@@ -743,7 +743,7 @@ void String::replace(const String& find, const String& replace)
   }
   else
   {
-    unsigned int size = len; // compute size needed for result
+    size_t size = len; // compute size needed for result
     while ((foundAt = (char*)memmem(readFrom, end - readFrom, find.buffer, find.len)) != nullptr)
     {
       readFrom = foundAt + find.len;
@@ -764,12 +764,12 @@ void String::replace(const String& find, const String& replace)
   }
 }
 
-void String::remove(unsigned int index)
+void String::remove(size_t index)
 {
 	if(index < len) remove(index, len - index);
 }
 
-void String::remove(unsigned int index, unsigned int count)
+void String::remove(size_t index, size_t count)
 {
 	if (index >= len) { return; }
 	if (count == 0) { return; }

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -60,9 +60,6 @@
 #include <stddef.h>
 #include <sming_attr.h>
 
-// @deprecated Should not be using String in interrupt context
-#define STRING_IRAM_ATTR // IRAM_ATTR
-
 #ifndef __GXX_EXPERIMENTAL_CXX0X__
 #define __GXX_EXPERIMENTAL_CXX0X__
 #endif
@@ -113,7 +110,7 @@ class String
     // complications of an operator bool(). for more information, see:
     // http://www.artima.com/cppsource/safebool.html
     typedef void (String::*StringIfHelperType)() const;
-    void STRING_IRAM_ATTR StringIfHelper() const {}
+    void StringIfHelper() const {}
 
   public:
     // Use these for const references, e.g. in function return values
@@ -126,15 +123,15 @@ class String
        if the initial value is null or invalid, or if memory allocation
        fails, the string will be marked as invalid (i.e. "if (s)" will be false).
     */
-    STRING_IRAM_ATTR String(const char *cstr = nullptr);
-    STRING_IRAM_ATTR String(const char *cstr, size_t length);
-    STRING_IRAM_ATTR String(const String &str);
+    String(const char *cstr = nullptr);
+    String(const char *cstr, size_t length);
+    String(const String &str);
     explicit String(flash_string_t pstr, int length = -1);
     String(const FlashString& fstr);
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    STRING_IRAM_ATTR String(String && rval);
-    STRING_IRAM_ATTR String(StringSumHelper && rval);
+    String(String && rval);
+    String(StringSumHelper && rval);
 #endif
     explicit String(char c);
     explicit String(unsigned char, unsigned char base = 10);
@@ -172,8 +169,8 @@ class String
     // creates a copy of the assigned value.  if the value is null or
     // invalid, or if the memory allocation fails, the string will be
     // marked as invalid ("if (s)" will be false).
-    String & STRING_IRAM_ATTR operator = (const String &rhs);
-    String & STRING_IRAM_ATTR operator = (const char *cstr);
+    String & operator = (const String &rhs);
+    String & operator = (const char *cstr);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
     String & operator = (String && rval);
     String & operator = (StringSumHelper && rval);
@@ -186,7 +183,7 @@ class String
     // concatenation is considered unsucessful.
     bool concat(const String &str);
     bool concat(const char *cstr);
-    bool STRING_IRAM_ATTR concat(const char *cstr, size_t length);
+    bool concat(const char *cstr, size_t length);
     bool concat(char c)
     {
       return concat(&c, 1);
@@ -286,31 +283,31 @@ class String
     {
    	  return compareTo(s.cbuffer(), s.length());
     }
-    bool STRING_IRAM_ATTR equals(const String &s) const
+    bool equals(const String &s) const
     {
     	return equals(s.cbuffer(), s.length());
     }
-    bool STRING_IRAM_ATTR equals(const char *cstr) const;
+    bool equals(const char *cstr) const;
     bool equals(const char *cstr, size_t length) const;
     bool equals(const FlashString& fstr) const;
 
-    bool STRING_IRAM_ATTR operator == (const String &rhs) const
+    bool operator == (const String &rhs) const
     {
       return equals(rhs);
     }
-    bool STRING_IRAM_ATTR operator == (const char *cstr) const
+    bool operator == (const char *cstr) const
     {
       return equals(cstr);
     }
-    bool STRING_IRAM_ATTR operator==(const FlashString& fstr) const
+    bool operator==(const FlashString& fstr) const
     {
       return equals(fstr);
     }
-    bool STRING_IRAM_ATTR operator != (const String &rhs) const
+    bool operator != (const String &rhs) const
     {
       return !equals(rhs);
     }
-    bool STRING_IRAM_ATTR operator != (const char *cstr) const
+    bool operator != (const char *cstr) const
     {
       return !equals(cstr);
     }
@@ -330,10 +327,10 @@ class String
     bool endsWith(const String &suffix) const;
 
     // character acccess
-    char STRING_IRAM_ATTR charAt(size_t index) const;
-    void STRING_IRAM_ATTR setCharAt(size_t index, char c);
-    char STRING_IRAM_ATTR operator [](size_t index) const;
-    char& STRING_IRAM_ATTR operator [](size_t index);
+    char charAt(size_t index) const;
+    void setCharAt(size_t index, char c);
+    char operator [](size_t index) const;
+    char& operator [](size_t index);
 
     /** @brief read contents of string into a buffer
      *  @param buf buffer to write data
@@ -356,9 +353,9 @@ class String
     const char* end() const { return c_str() + length(); }
   
     // search
-    int STRING_IRAM_ATTR indexOf(char ch) const;
+    int indexOf(char ch) const;
     int indexOf(char ch, size_t fromIndex) const;
-    int STRING_IRAM_ATTR indexOf(const String &str) const;
+    int indexOf(const String &str) const;
     int indexOf(const String &s2, size_t fromIndex) const;
     int lastIndexOf(char ch) const;
     int lastIndexOf(char ch, size_t fromIndex) const;
@@ -411,7 +408,7 @@ protected:
 
 protected:
 	// Free any heap memory and set to non-SSO mode; isNull() will return true
-	void STRING_IRAM_ATTR invalidate(void);
+	void invalidate(void);
 
     // String is Null (invalid) by default, i.e. non-SSO and null buffer
     __forceinline bool isNull() const

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -371,7 +371,10 @@ class String
     // modification
     void replace(char find, char replace);
     void replace(const String& find, const String& replace);
-    void remove(size_t index);
+    void remove(size_t index)
+    {
+    	remove(index, SIZE_MAX);
+    }
     void remove(size_t index, size_t count);
     void toLowerCase(void);
     void toUpperCase(void);

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -364,6 +364,7 @@ class String
     int lastIndexOf(char ch, size_t fromIndex) const;
     int lastIndexOf(const String &s2) const;
     int lastIndexOf(const String &s2, size_t fromIndex) const;
+    int lastIndexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const;
     String substring(size_t beginIndex) const { return substring(beginIndex, length()); }
     String substring(size_t beginIndex, size_t endIndex) const;
 

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -406,7 +406,8 @@ class String
 
     // modification
     void replace(char find, char replace);
-    void replace(const String& find, const String& replace);
+    bool replace(const String& find, const String& replace);
+    bool replace(const char* find_buf, size_t find_len, const char* replace_buf, size_t replace_len);
     void remove(size_t index)
     {
     	remove(index, SIZE_MAX);

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -187,7 +187,10 @@ class String
     bool concat(const String &str);
     bool concat(const char *cstr);
     bool STRING_IRAM_ATTR concat(const char *cstr, size_t length);
-    bool concat(char c);
+    bool concat(char c)
+    {
+      return concat(&c, 1);
+    }
     bool concat(unsigned char num);
     bool concat(int num);
     bool concat(unsigned int num);

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -119,7 +119,7 @@ class String
        fails, the string will be marked as invalid (i.e. "if (s)" will be false).
     */
     STRING_IRAM_ATTR String(const char *cstr = nullptr);
-    STRING_IRAM_ATTR String(const char *cstr, unsigned int length);
+    STRING_IRAM_ATTR String(const char *cstr, size_t length);
     STRING_IRAM_ATTR String(const String &str);
     explicit String(flash_string_t pstr, int length = -1);
     String(const FlashString& fstr);
@@ -147,16 +147,16 @@ class String
     // return true on success, false on failure (in which case, the string
     // is left unchanged).  reserve(0), if successful, will validate an
     // invalid string (i.e., "if (s)" will be true afterwards)
-    bool reserve(unsigned int size);
+    bool reserve(size_t size);
 
     /** @brief set the string length accordingly, expanding if necessary
      *  @param length required for string (nul terminator additional)
      *  @retval true on success, false on failure
      *  @note extra characters are undefined
      */
-    bool setLength(unsigned int length);
+    bool setLength(size_t length);
 
-    inline unsigned int length(void) const
+    inline size_t length(void) const
     {
       return len;
     }
@@ -178,9 +178,9 @@ class String
     // concatenation is considered unsucessful.
     bool concat(const String &str);
     bool concat(const char *cstr);
-    bool STRING_IRAM_ATTR concat(const char *cstr, unsigned int length);
+    bool STRING_IRAM_ATTR concat(const char *cstr, size_t length);
     bool concat(char c);
-    bool concat(unsigned char c);
+    bool concat(unsigned char num);
     bool concat(int num);
     bool concat(unsigned int num);
     bool concat(long num);
@@ -315,14 +315,14 @@ class String
     }
     bool equalsIgnoreCase(const FlashString& fstr) const;
     bool startsWith(const String &prefix) const;
-    bool startsWith(const String &prefix, unsigned int offset) const;
+    bool startsWith(const String &prefix, size_t offset) const;
     bool endsWith(const String &suffix) const;
 
     // character acccess
-    char STRING_IRAM_ATTR charAt(unsigned int index) const;
-    void STRING_IRAM_ATTR setCharAt(unsigned int index, char c);
-    char STRING_IRAM_ATTR operator [](unsigned int index) const;
-    char& STRING_IRAM_ATTR operator [](unsigned int index);
+    char STRING_IRAM_ATTR charAt(size_t index) const;
+    void STRING_IRAM_ATTR setCharAt(size_t index, char c);
+    char STRING_IRAM_ATTR operator [](size_t index) const;
+    char& STRING_IRAM_ATTR operator [](size_t index);
 
     /** @brief read contents of string into a buffer
      *  @param buf buffer to write data
@@ -332,9 +332,9 @@ class String
      *  @note Returned data always nul terminated so buffer size needs to take this
      *  into account
      */
-    unsigned int getBytes(unsigned char *buf, unsigned int bufsize, unsigned int index = 0) const;
+    size_t getBytes(unsigned char *buf, size_t bufsize, size_t index = 0) const;
 
-    void toCharArray(char *buf, unsigned int bufsize, unsigned int index = 0) const
+    void toCharArray(char *buf, size_t bufsize, size_t index = 0) const
     {
       getBytes((unsigned char *)buf, bufsize, index);
     }
@@ -346,21 +346,21 @@ class String
   
     // search
     int STRING_IRAM_ATTR indexOf(char ch) const;
-    int indexOf(char ch, unsigned int fromIndex) const;
+    int indexOf(char ch, size_t fromIndex) const;
     int STRING_IRAM_ATTR indexOf(const String &str) const;
-    int indexOf(const String &s2, unsigned int fromIndex) const;
+    int indexOf(const String &s2, size_t fromIndex) const;
     int lastIndexOf(char ch) const;
-    int lastIndexOf(char ch, unsigned int fromIndex) const;
+    int lastIndexOf(char ch, size_t fromIndex) const;
     int lastIndexOf(const String &s2) const;
-    int lastIndexOf(const String &s2, unsigned int fromIndex) const;
-    String substring(unsigned int beginIndex) const { return substring(beginIndex, len); }
-    String substring(unsigned int beginIndex, unsigned int endIndex) const;
+    int lastIndexOf(const String &s2, size_t fromIndex) const;
+    String substring(size_t beginIndex) const { return substring(beginIndex, len); }
+    String substring(size_t beginIndex, size_t endIndex) const;
 
     // modification
     void replace(char find, char replace);
     void replace(const String& find, const String& replace);
-    void remove(unsigned int index);
-    void remove(unsigned int index, unsigned int count);
+    void remove(size_t index);
+    void remove(size_t index, size_t count);
     void toLowerCase(void);
     void toUpperCase(void);
     void trim(void);
@@ -381,11 +381,11 @@ class String
 
   protected:
     void STRING_IRAM_ATTR invalidate(void);
-    bool STRING_IRAM_ATTR changeBuffer(unsigned int maxStrLen);
+    bool STRING_IRAM_ATTR changeBuffer(size_t maxStrLen);
 
     // copy and move
-    String & copy(const char *cstr, unsigned int length);
-    String& copy(flash_string_t pstr, unsigned int length);
+    String & copy(const char *cstr, size_t length);
+    String& copy(flash_string_t pstr, size_t length);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
     void move(String &rhs);
 #endif

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -390,16 +390,12 @@ class String
     const char* end() const { return c_str() + length(); }
   
     // search
-    int indexOf(char ch) const
+    int indexOf(char ch, size_t fromIndex = 0) const;
+    int indexOf(const char* s2_buf, size_t fromIndex = 0, size_t s2_len = 0) const;
+    int indexOf(const String &s2, size_t fromIndex = 0) const
     {
-      return indexOf(ch, 0);
+    	return indexOf(s2.cbuffer(), fromIndex, s2.length());
     }
-    int indexOf(char ch, size_t fromIndex) const;
-    int indexOf(const String &str) const
-    {
-      return indexOf(str, 0);
-    }
-    int indexOf(const String &s2, size_t fromIndex) const;
     int lastIndexOf(char ch) const;
     int lastIndexOf(char ch, size_t fromIndex) const;
     int lastIndexOf(const String &s2) const;

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -124,13 +124,25 @@ class String
        fails, the string will be marked as invalid (i.e. "if (s)" will be false).
     */
     String(const char *cstr = nullptr);
-    String(const char *cstr, size_t length);
-    String(const String &str);
-    explicit String(flash_string_t pstr, int length = -1);
+    String(const char *cstr, size_t length)
+    {
+      if (cstr) copy(cstr, length);
+    }
+    String(const String &str)
+    {
+      *this = str;
+    }
+    explicit String(flash_string_t pstr, int length = -1)
+    {
+      setString(pstr, length);
+    }
     String(const FlashString& fstr);
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    String(String && rval);
+    String(String && rval)
+    {
+   	  move(rval);
+    }
     String(StringSumHelper && rval);
 #endif
     explicit String(char c);
@@ -143,7 +155,10 @@ class String
     explicit String(unsigned long long, unsigned char base = 10);
     explicit String(float, unsigned char decimalPlaces=2);
     explicit String(double, unsigned char decimalPlaces=2);
-    ~String(void);
+    ~String(void)
+    {
+    	invalidate();
+    }
 
     void setString(const char *cstr, int length = -1);
     void setString(flash_string_t pstr, int length = -1);
@@ -172,7 +187,11 @@ class String
     String & operator = (const String &rhs);
     String & operator = (const char *cstr);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    String & operator = (String && rval);
+    String & operator = (String && rval)
+    {
+      if (this != &rval) move(rval);
+      return *this;
+    }
     String & operator = (StringSumHelper && rval);
 #endif
 
@@ -181,7 +200,10 @@ class String
     // returns true on success, false on failure (in which case, the string
     // is left unchanged).  if the argument is null or invalid, the
     // concatenation is considered unsucessful.
-    bool concat(const String &str);
+    bool concat(const String &str)
+    {
+      return concat(str.cbuffer(), str.length());
+    }
     bool concat(const char *cstr);
     bool concat(const char *cstr, size_t length);
     bool concat(char c)
@@ -311,10 +333,22 @@ class String
     {
       return !equals(cstr);
     }
-    bool operator < (const String &rhs) const;
-    bool operator > (const String &rhs) const;
-    bool operator <= (const String &rhs) const;
-    bool operator >= (const String &rhs) const;
+    bool operator < (const String &rhs) const
+    {
+      return compareTo(rhs) < 0;
+    }
+    bool operator > (const String &rhs) const
+    {
+      return compareTo(rhs) > 0;
+    }
+    bool operator <= (const String &rhs) const
+	{
+	  return compareTo(rhs) <= 0;
+	}
+    bool operator >= (const String &rhs) const
+    {
+      return compareTo(rhs) >= 0;
+    }
     bool equalsIgnoreCase(const char* cstr) const;
     bool equalsIgnoreCase(const char* cstr, size_t length) const;
     bool equalsIgnoreCase(const String &s2) const
@@ -327,7 +361,10 @@ class String
     bool endsWith(const String &suffix) const;
 
     // character acccess
-    char charAt(size_t index) const;
+    char charAt(size_t index) const
+    {
+      return operator[](index);
+    }
     void setCharAt(size_t index, char c);
     char operator [](size_t index) const;
     char& operator [](size_t index);
@@ -353,9 +390,15 @@ class String
     const char* end() const { return c_str() + length(); }
   
     // search
-    int indexOf(char ch) const;
+    int indexOf(char ch) const
+    {
+      return indexOf(ch, 0);
+    }
     int indexOf(char ch, size_t fromIndex) const;
-    int indexOf(const String &str) const;
+    int indexOf(const String &str) const
+    {
+      return indexOf(str, 0);
+    }
     int indexOf(const String &s2, size_t fromIndex) const;
     int lastIndexOf(char ch) const;
     int lastIndexOf(char ch, size_t fromIndex) const;

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -356,7 +356,10 @@ class String
     	return equalsIgnoreCase(s2.cbuffer(), s2.length());
     }
     bool equalsIgnoreCase(const FlashString& fstr) const;
-    bool startsWith(const String &prefix) const;
+    bool startsWith(const String &prefix) const
+    {
+    	return startsWith(prefix, 0);
+    }
     bool startsWith(const String &prefix, size_t offset) const;
     bool endsWith(const String &suffix) const;
 

--- a/tests/HostTests/app/arduino-test-string.cpp
+++ b/tests/HostTests/app/arduino-test-string.cpp
@@ -283,7 +283,6 @@ public:
 			REQUIRE(!strcmp(s17.c_str(), "1234567890123456_"));
 		}
 
-		/*
 		TEST_CASE("String SSO works", "[core][String]")
 		{
 			// This test assumes that SSO_SIZE==8, if that changes the test must as well
@@ -384,7 +383,6 @@ public:
 			REQUIRE(s == "abcde");
 			REQUIRE(s.length() == 5);
 		}
-		*/
 
 		auto repl = [](const String& key, const String& val, String& s, boolean useURLencode) { s.replace(key, val); };
 


### PR DESCRIPTION
Based on the Arduino ESP8266 core implentation.

- An empty String object now consumes 12 bytes (from 8) but provides an SSO capacity of 10 characters (plus NUL).
  The heap will therefore not be used until capacity exceeds this figure.
- Capacity and length types changed to size_t, thus String is no longer restricted to 64K.
  (Handy for writing test applications running on the Host Emulator.)

If anyone has superclassed String for their own needs then this PR may affect them.
However, it should be possible to rewrite using only public String methods; this has been done
with CStringArray.

**Binary string support**

The following methods have been updated to work with Strings containing NULs and other non-ASCII characters:

- toLowerCase()
- toUpperCase()
- lastIndexOf()
- substring()

The behaviour of lastIndexOf() has changed. Previously, if `fromIndex` exceeded the String length the
method failed. It now just starts the search from the end of the string.
This is more useful/logical/friendly and consistent with ArduinoCore-avr code.

The following methods have been added:

- int compareTo(const char* cstr, size_t length)
- bool equals(const char *cstr, size_t length)
- bool equalsIgnoreCase(const char* cstr, size_t length)
- int indexOf(const char* cstr, size_t cstrlen, size_t fromIndex)
- int lastIndexOf(const char* cstr, size_t cstrlen, size_t fromIndex)
- bool replace(const char* find_buf, size_t find_len, const char* replace_buf, size_t replace_len)

These allow operations which previously required construction of a separate String object,
so are used internally anyway.

**Other fixes/changes**

- Add return `bool` from `replace(String, String)` method as allocation could fail
- Fix `concat(const char*, size_t)` to handle self-append, e.g. `s.concat(s.c_str(), 10)`, `s += s`, etc.
- Fix `substring()` and `lastIndexOf()` so they don't self-modify
- In `substring()`, fix an 'off-by-one' bug which produces an incorrect result if `left` == `right` == `length()`.
- In `move()`, invalidate the String if rhs is null.
- Remove STRING_IRAM_ATTR and commented-out code (references to Print)

A number of trivial methods and operators have been moved into the header, reducing
code size and eliminating un-necessary function calls.
