### PR TITLE
bugfix: malloc_count not fully tracking allocations on Esp8266

### DIFF
--- a/Sming/Components/malloc_count/component.mk
+++ b/Sming/Components/malloc_count/component.mk
@@ -1,12 +1,12 @@
 # Hook all the memory allocation functions we need to monitor heap activity
-ifeq ($(SMING_ARCH),Host)
 EXTRA_LDFLAGS := \
 	-Wl,-wrap,malloc \
 	-Wl,-wrap,calloc \
 	-Wl,-wrap,realloc \
 	-Wl,-wrap,free
-else
-EXTRA_LDFLAGS := \
+
+ifeq ($(SMING_ARCH),Esp8266)
+EXTRA_LDFLAGS += \
 	-Wl,-wrap,pvPortMalloc \
 	-Wl,-wrap,pvPortCalloc \
 	-Wl,-wrap,pvPortRealloc \

--- a/Sming/Components/malloc_count/malloc_count.cpp
+++ b/Sming/Components/malloc_count/malloc_count.cpp
@@ -34,10 +34,6 @@
  * 	This has been changed to use function wrappers, so init heap no longer required and
  * 	code can be simplified.
  *
- *	Added user functions:
- *
- *		malloc_enable_logging
- *		malloc_set_log_threshold
  *
  */
 
@@ -45,6 +41,7 @@
 #include <debug_progmem.h>
 #include <esp_attr.h>
 
+// Names for the actual implementations
 #ifdef ARCH_HOST
 #define F_MALLOC malloc
 #define F_CALLOC calloc
@@ -189,11 +186,10 @@ void setCallback(MallocCountCallback callback)
 }
 
 /****************************************************/
-/* exported symbols that overlay the libc functions */
+/* malloc_count function implementations             */
 /****************************************************/
 
-/* exported malloc symbol that overrides loading from libc */
-extern "C" void* WRAP(F_MALLOC)(size_t size)
+extern "C" void* mc_malloc(size_t size)
 {
 	if(size == 0) {
 		return nullptr;
@@ -220,22 +216,16 @@ extern "C" void* WRAP(F_MALLOC)(size_t size)
 	return ret;
 }
 
-#ifndef ARCH_HOST
-extern "C" void* WRAP(pvPortZalloc)(size_t size)
+extern "C" void* mc_zalloc(size_t size)
 {
-	auto ptr = WRAP(F_MALLOC)(size);
+	auto ptr = mc_malloc(size);
 	if(ptr != nullptr) {
 		memset(ptr, 0, size);
 	}
 	return ptr;
 }
 
-extern "C" void* WRAP(pvPortZallocIram)(size_t size, const char* file, int line)
-	__attribute__((alias("__wrap_pvPortZalloc")));
-#endif // ARCH_HOST
-
-/* exported free symbol that overrides loading from libc */
-extern "C" void WRAP(F_FREE)(void* ptr)
+extern "C" void mc_free(void* ptr)
 {
 	// free(nullptr) is no operation
 	if(ptr == nullptr) {
@@ -261,33 +251,22 @@ extern "C" void WRAP(F_FREE)(void* ptr)
 	REAL(F_FREE)(ptr);
 }
 
-/* exported calloc() symbol that overrides loading from libc, implemented using our malloc */
-extern "C" void* WRAP(F_CALLOC)(size_t nmemb, size_t size)
+extern "C" void* mc_calloc(size_t nmemb, size_t size)
 {
-	size *= nmemb;
-	if(size == 0) {
-		return nullptr;
-	}
-
-	void* ret = WRAP(F_MALLOC)(size);
-	if(ret != nullptr) {
-		memset(ret, 0, size);
-	}
-	return ret;
+	return mc_zalloc(nmemb * size);
 }
 
-/* exported realloc() symbol that overrides loading from libc */
-extern "C" void* WRAP(F_REALLOC)(void* ptr, size_t size)
+extern "C" void* mc_realloc(void* ptr, size_t size)
 {
 	// special case size == 0 -> free()
 	if(size == 0) {
-		WRAP(F_FREE)(ptr);
+		mc_free(ptr);
 		return nullptr;
 	}
 
 	// special case ptr == 0 -> malloc()
 	if(ptr == nullptr) {
-		return WRAP(F_MALLOC)(size);
+		return mc_malloc(size);
 	}
 
 	if(*GET_SENTINEL(ptr) != sentinel) {
@@ -331,26 +310,46 @@ static __attribute__((destructor)) void finish()
 
 }; // namespace MallocCount
 
+/****************************************************/
+/* exported symbols that overlay the libc functions */
+/****************************************************/
+
+extern "C" void* WRAP(malloc)(size_t) __attribute__((alias("mc_malloc")));
+extern "C" void* WRAP(calloc)(size_t, size_t) __attribute__((alias("mc_calloc")));
+extern "C" void* WRAP(realloc)(void*, size_t) __attribute__((alias("mc_realloc")));
+extern "C" void WRAP(free)(void*) __attribute__((alias("mc_free")));
+
 #ifdef ARCH_HOST
+
+using namespace MallocCount;
 
 void* operator new(size_t size)
 {
-	return MallocCount::WRAP(F_MALLOC)(size);
+	return mc_malloc(size);
 }
 
 void* operator new[](size_t size)
 {
-	return MallocCount::WRAP(F_MALLOC)(size);
+	return mc_malloc(size);
 }
 
 void operator delete(void* ptr)
 {
-	MallocCount::WRAP(F_FREE)(ptr);
+	mc_free(ptr);
 }
 
 void operator delete[](void* ptr)
 {
-	MallocCount::WRAP(F_FREE)(ptr);
+	mc_free(ptr);
 }
+
+#else
+
+extern "C" void* WRAP(pvPortMalloc)(size_t) __attribute__((alias("mc_malloc")));
+extern "C" void* WRAP(pvPortCalloc)(size_t) __attribute__((alias("mc_calloc")));
+extern "C" void* WRAP(pvPortRealloc)(void*, size_t) __attribute__((alias("mc_realloc")));
+extern "C" void* WRAP(pvPortZalloc)(size_t) __attribute__((alias("mc_zalloc")));
+extern "C" void* WRAP(pvPortZallocIram)(size_t, const char*, int) __attribute__((alias("mc_zalloc")));
+extern "C" void* WRAP(vPortFree)(void*) __attribute__((alias("mc_free")));
 
 #endif


### PR DESCRIPTION
Need to hook regular malloc, etc. in addition to pvPortMalloc, etc.

Discovered whilst testing #1951