### PR TITLE
Fail `String::substring` if right > left

### DIFF
--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -686,16 +686,11 @@ int String::lastIndexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) con
 
 String String::substring(size_t left, size_t right) const
 {
-  if (isNull()) return nullptr;
-
-  if (left > right)
-  {
-    size_t temp = right;
-    right = left;
-    left = temp;
-  }
   auto len = length();
-  if (left >= len) return nullptr;
+  if (left > right || left >= len) {
+	  return nullptr;
+  }
+
   if (right > len) right = len;
   return String(cbuffer() + left, right - left);
 }

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -405,7 +405,13 @@ class String
     int lastIndexOf(const String &s2, size_t fromIndex) const;
     int lastIndexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const;
     String substring(size_t beginIndex) const { return substring(beginIndex, length()); }
-    String substring(size_t beginIndex, size_t endIndex) const;
+
+    /**
+     * @brief Get a substring of a String
+     * @param from Index of first character to retrieve
+     * @param to (optional) One-past the ending character to retrieve
+     */
+    String substring(size_t from, size_t to) const;
 
     // modification
     void replace(char find, char replace);


### PR DESCRIPTION
Document method from https://www.arduino.cc/reference/en/language/variables/data-types/string/functions/substring/

See https://github.com/SmingHub/Sming/pull/1951#discussion_r343516423