### PR TITLE
Fix String initialization in GCC 4.8.5

### DIFF
--- a/Sming/Core/NanoTime.h
+++ b/Sming/Core/NanoTime.h
@@ -244,12 +244,11 @@ template <typename ClockDef, uint32_t frequency_, typename TickType_, TickType_ 
  *
  * 	uint32_t micros = convert<50, Milliseconds, Microseconds>();
  */
-template <uint64_t time, Unit unitsFrom, Unit unitsTo> constexpr uint64_t convert()
+template <uint64_t time, Unit unitsFrom, Unit unitsTo,
+		  typename R = std::ratio_divide<UnitTickRatio<unitsTo>, UnitTickRatio<unitsFrom>>>
+constexpr uint64_t convert()
 {
-	return ({
-		using R = std::ratio_divide<UnitTickRatio<unitsTo>, UnitTickRatio<unitsFrom>>;
-		round(double(time) * R::num / R::den);
-	});
+	return ({ round(double(time) * R::num / R::den); });
 }
 
 /**

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -29,85 +29,85 @@ const String String::empty = "";
 /*  Constructors                             */
 /*********************************************/
 
-String::String(const char *cstr)
+String::String(const char *cstr) : String()
 {
   if (cstr) copy(cstr, strlen(cstr));
 }
 
-String::String(const FlashString& fstr)
+String::String(const FlashString& fstr) : String()
 {
   setString(fstr.data(), fstr.length());
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String::String(StringSumHelper &&rval)
+String::String(StringSumHelper &&rval) : String()
 {
   move(rval);
 }
 #endif
 
-String::String(char c)
+String::String(char c) : String()
 {
   if (setLength(1))
 	  buffer()[0] = c;
 }
 
-String::String(unsigned char value, unsigned char base)
+String::String(unsigned char value, unsigned char base) : String()
 {
   char buf[8 + 8 * sizeof(value)];
   ultoa(value, buf, base);
   *this = buf;
 }
 
-String::String(int value, unsigned char base)
+String::String(int value, unsigned char base) : String()
 {
   char buf[8 + 8 * sizeof(value)];
   itoa(value, buf, base);
   *this = buf;
 }
 
-String::String(unsigned int value, unsigned char base)
+String::String(unsigned int value, unsigned char base) : String()
 {
   char buf[8 + 8 * sizeof(value)];
   ultoa(value, buf, base);
   *this = buf;
 }
 
-String::String(long value, unsigned char base)
+String::String(long value, unsigned char base) : String()
 {
   char buf[8 + 8 * sizeof(value)];
   ltoa(value, buf, base);
   *this = buf;
 }
 
-String::String(long long value, unsigned char base)
+String::String(long long value, unsigned char base) : String()
 {
   char buf[8 + 8 * sizeof(value)];
   lltoa(value, buf, base);
   *this = buf;
 }
 
-String::String(unsigned long value, unsigned char base)
+String::String(unsigned long value, unsigned char base) : String()
 {
   char buf[8 + 8 * sizeof(value)];
   ultoa(value, buf, base);
   *this = buf;
 }
 
-String::String(unsigned long long value, unsigned char base)
+String::String(unsigned long long value, unsigned char base) : String()
 {
   char buf[8 + 8 * sizeof(value)];
   ulltoa(value, buf, base);
   *this = buf;
 }
 
-String::String(float value, unsigned char decimalPlaces)
+String::String(float value, unsigned char decimalPlaces) : String()
 {
 	char buf[33];
 	*this = dtostrf(value, 0, decimalPlaces, buf);
 }
 
-String::String(double value, unsigned char decimalPlaces)
+String::String(double value, unsigned char decimalPlaces) : String()
 {
 	char buf[33];
 	*this = dtostrf(value, 0, decimalPlaces, buf);

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -58,6 +58,7 @@
 
 #include "WConstants.h"
 #include <stddef.h>
+#include <string.h>
 #include <sming_attr.h>
 
 #ifndef __GXX_EXPERIMENTAL_CXX0X__
@@ -397,7 +398,11 @@ class String
   
     // search
     int indexOf(char ch, size_t fromIndex = 0) const;
-    int indexOf(const char* s2_buf, size_t fromIndex = 0, size_t s2_len = 0) const;
+    int indexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const;
+    int indexOf(const char* s2_buf, size_t fromIndex = 0) const
+    {
+    	return indexOf(s2_buf, fromIndex, strlen(s2_buf));
+    }
     int indexOf(const String &s2, size_t fromIndex = 0) const
     {
     	return indexOf(s2.cbuffer(), fromIndex, s2.length());

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -123,23 +123,26 @@ class String
        if the initial value is null or invalid, or if memory allocation
        fails, the string will be marked as invalid (i.e. "if (s)" will be false).
     */
-    String(const char *cstr = nullptr);
-    String(const char *cstr, size_t length)
+    String() : ptr{nullptr, 0, 0}
+	{
+	}
+    String(const char *cstr);
+    String(const char *cstr, size_t length) : String()
     {
       if (cstr) copy(cstr, length);
     }
-    String(const String &str)
+    String(const String &str) : String()
     {
       *this = str;
     }
-    explicit String(flash_string_t pstr, int length = -1)
+    explicit String(flash_string_t pstr, int length = -1) : String()
     {
       setString(pstr, length);
     }
     String(const FlashString& fstr);
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    String(String && rval)
+    String(String && rval) : String()
     {
    	  move(rval);
     }
@@ -438,7 +441,7 @@ protected:
 	struct PtrBuf {
 		char* buffer;		  // the actual char array
 		size_t len;			  // the String length (not counting the '\0')
-		size_t capacity : 31; // the array length minus one (for the '\0')
+		size_t capacity;	  // the array length minus one (for the '\0')
 	};
 	// For small strings we can store data directly without requiring the heap
 	struct SsoBuf {
@@ -447,9 +450,6 @@ protected:
 		unsigned char set : 1; ///< true for SSO mode
 	};
 	union {
-		struct {
-			size_t u32[STRING_OBJECT_SIZE / 4] = {0};
-		};
 		PtrBuf ptr;
 		SsoBuf sso;
 	};


### PR DESCRIPTION
This PR fixes the instablity problems related to the `String` class since #1951. The problem is present only in Linux with GCC 4.8.5, which silently ignores the union intializer and member variables are left un-initialised at construction time.

This is the initializer which causes the problem:

```
	union {
		struct {
			size_t u32[STRING_OBJECT_SIZE / 4] = {0};
		};
		PtrBuf ptr;
		SsoBuf sso;
	};
```

Simplifying it has no effect:

```
	union {
		PtrBuf ptr = { nullptr, 0, 0 };
		SsoBuf sso;
	};
```

So it seems something to be avoided generally.

The solution, therefore, is to add a default constructor which does the initialisation and ensure it's used by all the other constructors.

This has been tested using `HostTests` build and flashed in a Linux VM.

Note that this PR also addresses another GCC 4.8.5 annoyance in its limited ability to handle constexpr functions. This means the HostTests can be built in Linux.
