### PR TITLE
Add dependency to allow `flashinit` to work without building framework

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/component.mk
+++ b/Sming/Arch/Esp8266/Components/esp8266/component.mk
@@ -10,6 +10,7 @@ SDK_TOOLS				?= $(SDK_BASE)/tools
 endif
 
 SDK_BASE				:= $(call FixPath,$(SDK_BASE))
+FLASH_INIT_DATA			= $(SDK_BASE)/bin/esp_init_data_default.bin
 
 # => 'Internal' SDK - for SDK Version 3+ as submodule in Sming repository
 # SDK_BASE just needs to point into our repo as it's overridden with the correct submodule path
@@ -20,9 +21,8 @@ GLOBAL_CFLAGS			+= -DSDK_INTERNAL=1
 SDK_INTERNAL			:= 1
 COMPONENT_SUBMODULES	:= ESP8266_NONOS_SDK
 SDK_BASE				:= $(COMPONENT_PATH)/ESP8266_NONOS_SDK
-COMPONENT_TARGETS		:= $(SDK_BASE)/bin/esp_init_data_default.bin
 
-$(COMPONENT_RULE)$(SDK_BASE)/bin/esp_init_data_default.bin:
+$(FLASH_INIT_DATA): $(SDK_BASE)/.submodule
 	$(Q) cp -f $(@D)/esp_init_data_default_v08.bin $@
 else
 SDK_INTERNAL			:= 0

--- a/Sming/Arch/Esp8266/Components/esptool/component.mk
+++ b/Sming/Arch/Esp8266/Components/esptool/component.mk
@@ -38,7 +38,7 @@ FLASH_SIZE			:= $(subst K,*1024,$(FLASH_SIZE))
 FlashOffset			= $$(($(FLASH_SIZE)-$1))
 FLASH_INIT_CHUNKS += \
 	$(call FlashOffset,0x5000)=$(SDK_BASE)/bin/blank.bin \
-	$(call FlashOffset,0x4000)=$(SDK_BASE)/bin/esp_init_data_default.bin \
+	$(call FlashOffset,0x4000)=$(FLASH_INIT_DATA) \
 	$(call FlashOffset,0x2000)=$(SDK_BASE)/bin/blank.bin
 
 # Default COM port and speed used for flashing
@@ -49,6 +49,9 @@ COM_SPEED_ESPTOOL		?= $(COM_SPEED)
 COMPONENT_SUBMODULES	+= esptool
 DEBUG_VARS				+= ESPTOOL
 ESPTOOL					:= $(COMPONENT_PATH)/esptool/esptool.py
+ESPTOOL_SUBMODULE		:= $(COMPONENT_PATH)/esptool
+
+$(ESPTOOL): $(ESPTOOL_SUBMODULE)/.submodule
 
 ESPTOOL_CMDLINE			:= $(ESPTOOL) -p $(COM_PORT_ESPTOOL) -b $(COM_SPEED_ESPTOOL)
 

--- a/Sming/Arch/Esp8266/app.mk
+++ b/Sming/Arch/Esp8266/app.mk
@@ -118,7 +118,7 @@ else
 endif
 
 .PHONY: flashinit
-flashinit: ##Erase your device's flash memory and reset system configuration area to defaults
+flashinit: $(ESPTOOL) $(FLASH_INIT_DATA) ##Erase your device's flash memory and reset system configuration area to defaults
 	$(info Flash init data default and blank data)
 	$(info DISABLE_SPIFFS = $(DISABLE_SPIFFS))
 	$(EraseFlash)


### PR DESCRIPTION
As suggested in #1966 provides consistency with other targets