### PR TITLE
Update ArduinoJson to 6.13.0

### DIFF
--- a/Sming/Libraries/ArduinoJson6/include/ArduinoJson.h
+++ b/Sming/Libraries/ArduinoJson6/include/ArduinoJson.h
@@ -37,6 +37,7 @@
 
 #include "../ArduinoJson/src/ArduinoJson.h"
 #include "FlashStringRefAdapter.hpp"
+#include "FlashStringReader.hpp"
 #include <Data/Stream/FileStream.h>
 
 #ifndef JSON_ENABLE_COMPACT

--- a/Sming/Libraries/ArduinoJson6/include/FlashStringReader.hpp
+++ b/Sming/Libraries/ArduinoJson6/include/FlashStringReader.hpp
@@ -1,0 +1,38 @@
+// ArduinoJson - arduinojson.org
+// Copyright Benoit Blanchon 2014-2019
+// MIT License
+//
+// Sming FlashString reader mikee47 Nov 2019 <mike@sillyhouse.net>
+
+#pragma once
+
+namespace ARDUINOJSON_NAMESPACE
+{
+template <> struct Reader<FlashString, void> {
+	explicit Reader(const FlashString& str) : str(str)
+	{
+	}
+
+	int read()
+	{
+		if(index >= str.length()) {
+			return -1;
+		}
+		unsigned char c = str[index];
+		++index;
+		return c;
+	}
+
+	size_t readBytes(char* buffer, size_t length)
+	{
+		auto count = str.read(index, buffer, length);
+		index += count;
+		return count;
+	}
+
+private:
+	const FlashString& str;
+	unsigned index = 0;
+};
+
+} // namespace ARDUINOJSON_NAMESPACE

--- a/Sming/Libraries/ArduinoJson6/include/FlashStringRefAdapter.hpp
+++ b/Sming/Libraries/ArduinoJson6/include/FlashStringRefAdapter.hpp
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <ArduinoJson/Strings/IsWriteableString.hpp>
+
 namespace ARDUINOJSON_NAMESPACE
 {
 class FlashStringRefAdapter
@@ -62,6 +64,9 @@ inline FlashStringRefAdapter adaptString(const FlashString& str)
 }
 
 template <> struct IsString<FlashString> : true_type {
+};
+
+template <> struct IsWriteableString<FlashString> : false_type {
 };
 
 } // namespace ARDUINOJSON_NAMESPACE


### PR DESCRIPTION
Fixes a dangling pointer bug present in 6.12.
Add Flash String reader for more efficient de-serialization.