### PR TITLE
Change SPI flash defaults

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/startup.cpp
+++ b/Sming/Arch/Esp8266/Components/esp8266/startup.cpp
@@ -133,6 +133,7 @@ extern "C" void ICACHE_FLASH_ATTR WEAK_ATTR user_pre_init(void)
 			auto& part = partitions[i];
 			os_printf("partition[%u]: %u, 0x%08x, 0x%08x\n", i, part.type, part.addr, part.size);
 		}
+		os_printf("** Note: SDK 3.0.1 requires SPI_SIZE >= 1M\n");
 		while(1) {
 			// Cannot proceed
 		};

--- a/Sming/Arch/Esp8266/Components/esptool/component.mk
+++ b/Sming/Arch/Esp8266/Components/esptool/component.mk
@@ -7,9 +7,9 @@ CONFIG_VARS				+= SPI_SPEED SPI_MODE SPI_SIZE
 # SPI_SPEED = 40, 26, 20, 80
 SPI_SPEED				?= 40
 # SPI_MODE: qio, qout, dio, dout
-SPI_MODE				?= qio
+SPI_MODE				?= dio
 # SPI_SIZE: 512K, 256K, 1M, 2M, 4M
-SPI_SIZE				?= 512K
+SPI_SIZE				?= 1M
 
 ifeq ($(SPI_SPEED), 26)
 	flashimageoptions	:= -ff 26m


### PR DESCRIPTION
A common problem is mis-configured flash (e.g. #1982). The defaults aren't very helpful,
and neither is the reported error message from SDK 3.

SDK 3.0.1 produces partition error for SPI_SIZE < 1M so add note.
Change defaults for SPI_SIZE=1M (from 512K) and SPI_MODE=dio (from qio)

I've assumed that if flash chip supports QIO mode then it would also support DIO.