### PR TITLE
bugfix: Hangs at startup when custom heap enabled

### DIFF
--- a/Sming/Arch/Esp8266/Components/heap/README.rst
+++ b/Sming/Arch/Esp8266/Components/heap/README.rst
@@ -17,3 +17,14 @@ Configuration variables
 
 .. warning::
    Do not enable custom heap allocation and -mforce-l32 compiler flag at the same time.
+
+
+.. envvar:: UMM_FUNC_IRAM
+
+   Default: 1 (enabled)
+
+   Custom heap functions are stored in IRAM by default for performance reasons.
+
+   If you need the IRAM (about 1.5K bytes) then disable this option::
+   
+      make ENABLE_CUSTOM_HEAP=1 UMM_FUNC_IRAM=0

--- a/Sming/Arch/Esp8266/Components/heap/component.mk
+++ b/Sming/Arch/Esp8266/Components/heap/component.mk
@@ -10,9 +10,16 @@ COMPONENT_SUBMODULES	:= umm_malloc
 COMPONENT_SRCFILES		+= custom_heap.c umm_malloc/src/umm_malloc.c
 COMPONENT_INCDIRS		+= umm_malloc/src umm_malloc/includes/c-helper-macros
 
+#
 COMPONENT_VARS			+= UMM_POISON_CHECK
 ifeq ($(UMM_POISON_CHECK),1)
 GLOBAL_CFLAGS			+= -DUMM_POISON_CHECK
+endif
+
+COMPONENT_VARS			+= UMM_FUNC_IRAM
+UMM_FUNC_IRAM			?= 1
+ifeq ($(UMM_FUNC_IRAM),1)
+COMPONENT_CFLAGS		+= -DUMM_FUNC_IRAM=1
 endif
 
 COMPONENT_CFLAGS		+= -Wno-array-bounds

--- a/Sming/Arch/Esp8266/Components/heap/custom_heap.c
+++ b/Sming/Arch/Esp8266/Components/heap/custom_heap.c
@@ -27,8 +27,6 @@ void IRAM_ATTR vPortFree(void *ptr, const char* file, int line)
 	UMM_FUNC(free)(ptr);
 }
 
-#ifdef __NEWLIB__
-
 void* IRAM_ATTR malloc(size_t size)
 {
 	return UMM_FUNC(malloc)(size);
@@ -48,8 +46,6 @@ void IRAM_ATTR free(void *ptr)
 {
 	UMM_FUNC(free)(ptr);
 }
-
-#endif
 
 void* IRAM_ATTR pvPortCalloc(size_t count, size_t size, const char* file, int line)
 {

--- a/Sming/Arch/Esp8266/Components/heap/umm_malloc.patch
+++ b/Sming/Arch/Esp8266/Components/heap/umm_malloc.patch
@@ -8,6 +8,106 @@ index 6868c00..6e25ae3 100644
 +    umm_init();
 +  }
  
+diff --git a/src/umm_malloc.c b/src/umm_malloc.c
+index 9faec2a..1166260 100644
+--- a/src/umm_malloc.c
++++ b/src/umm_malloc.c
+@@ -29,6 +29,13 @@
+ 
+ #include <stdio.h>
+ #include <string.h>
++#include <esp_attr.h>
++
++#ifdef UMM_FUNC_IRAM
++#define UMM_FUNC_ATTR IRAM_ATTR
++#else
++#define UMM_FUNC_ATTR
++#endif
+ 
+ #include "umm_malloc.h"
+ 
+@@ -92,7 +99,7 @@ unsigned short int umm_numblocks = 0;
+ 
+ /* ------------------------------------------------------------------------ */
+ 
+-static unsigned short int umm_blocks( size_t size ) {
++static unsigned short int UMM_FUNC_ATTR umm_blocks( size_t size ) {
+ 
+   /*
+    * The calculation of the block size is not too difficult, but there are
+@@ -125,7 +132,7 @@ static unsigned short int umm_blocks( size_t size ) {
+  *
+  * Note that free pointers are NOT modified by this function.
+  */
+-static void umm_split_block( unsigned short int c,
++static void UMM_FUNC_ATTR umm_split_block( unsigned short int c,
+     unsigned short int blocks,
+     unsigned short int new_freemask ) {
+ 
+@@ -138,7 +145,7 @@ static void umm_split_block( unsigned short int c,
+ 
+ /* ------------------------------------------------------------------------ */
+ 
+-static void umm_disconnect_from_free_list( unsigned short int c ) {
++static void UMM_FUNC_ATTR umm_disconnect_from_free_list( unsigned short int c ) {
+   /* Disconnect this block from the FREE list */
+ 
+   UMM_NFREE(UMM_PFREE(c)) = UMM_NFREE(c);
+@@ -154,7 +161,7 @@ static void umm_disconnect_from_free_list( unsigned short int c ) {
+  * have the UMM_FREELIST_MASK bit set!
+  */
+ 
+-static void umm_assimilate_up( unsigned short int c ) {
++static void UMM_FUNC_ATTR umm_assimilate_up( unsigned short int c ) {
+ 
+   if( UMM_NBLOCK(UMM_NBLOCK(c)) & UMM_FREELIST_MASK ) {
+     /*
+@@ -180,7 +187,7 @@ static void umm_assimilate_up( unsigned short int c ) {
+  * have the UMM_FREELIST_MASK bit set!
+  */
+ 
+-static unsigned short int umm_assimilate_down( unsigned short int c, unsigned short int freemask ) {
++static unsigned short int UMM_FUNC_ATTR umm_assimilate_down( unsigned short int c, unsigned short int freemask ) {
+ 
+   UMM_NBLOCK(UMM_PBLOCK(c)) = UMM_NBLOCK(c) | freemask;
+   UMM_PBLOCK(UMM_NBLOCK(c)) = UMM_PBLOCK(c);
+@@ -248,7 +255,7 @@ void umm_init( void ) {
+ 
+ /* ------------------------------------------------------------------------ */
+ 
+-void umm_free( void *ptr ) {
++void UMM_FUNC_ATTR umm_free( void *ptr ) {
+ 
+   unsigned short int c;
+ 
+@@ -311,7 +318,7 @@ void umm_free( void *ptr ) {
+ 
+ /* ------------------------------------------------------------------------ */
+ 
+-void *umm_malloc( size_t size ) {
++void * UMM_FUNC_ATTR umm_malloc( size_t size ) {
+   unsigned short int blocks;
+   unsigned short int blockSize = 0;
+ 
+@@ -441,7 +448,7 @@ void *umm_malloc( size_t size ) {
+ 
+ /* ------------------------------------------------------------------------ */
+ 
+-void *umm_realloc( void *ptr, size_t size ) {
++void * UMM_FUNC_ATTR umm_realloc( void *ptr, size_t size ) {
+ 
+   unsigned short int blocks;
+   unsigned short int blockSize;
+@@ -606,7 +613,7 @@ void *umm_realloc( void *ptr, size_t size ) {
+ 
+ /* ------------------------------------------------------------------------ */
+ 
+-void *umm_calloc( size_t num, size_t item_size ) {
++void * UMM_FUNC_ATTR umm_calloc( size_t num, size_t item_size ) {
+   void *ret;
+ 
+   ret = umm_malloc((size_t)(item_size * num));
+
 diff --git a/src/umm_malloc_cfg.h b/src/umm_malloc_cfg.h
 index 6a5a7fc..a74e0a3 100644
 --- a/src/umm_malloc_cfg.h

--- a/Sming/Arch/Esp8266/Components/heap/umm_malloc.patch
+++ b/Sming/Arch/Esp8266/Components/heap/umm_malloc.patch
@@ -1,3 +1,13 @@
+diff --git a/src/umm_info.c b/src/umm_info.c
+index 6868c00..6e25ae3 100644
+--- a/src/umm_info.c
++++ b/src/umm_info.c
+@@ -20,2 +20,5 @@ UMM_HEAP_INFO ummHeapInfo;
+ void *umm_info( void *ptr, int force ) {
++  if(umm_heap == NULL) {
++    umm_init();
++  }
+ 
 diff --git a/src/umm_malloc_cfg.h b/src/umm_malloc_cfg.h
 index 6a5a7fc..a74e0a3 100644
 --- a/src/umm_malloc_cfg.h

--- a/tests/HostTests/app/test-libc.cpp
+++ b/tests/HostTests/app/test-libc.cpp
@@ -55,7 +55,6 @@ public:
 			REQUIRE(isRomPtr(strcmp));
 			REQUIRE(isRomPtr(strncmp));
 			REQUIRE(isRomPtr(strstr));
-			REQUIRE(isRomPtr(bzero));
 		}
 #endif
 	}


### PR DESCRIPTION
Crashes at startup if `umm_info` is called before heap initialised.
Fixes #1994.