### PR TITLE
Fix `make help` on Windows

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/component.mk
+++ b/Sming/Arch/Esp8266/Components/esp8266/component.mk
@@ -3,12 +3,6 @@ COMPONENT_VARS			:= SDK_BASE
 
 SDK_BASE ?= $(COMPONENT_PATH)/ESP8266_NONOS_SDK
 
-ifeq ($(UNAME),Windows)
-SDK_TOOLS				?= $(ESP_HOME)/utils
-else
-SDK_TOOLS				?= $(SDK_BASE)/tools
-endif
-
 SDK_BASE				:= $(call FixPath,$(SDK_BASE))
 FLASH_INIT_DATA			= $(SDK_BASE)/bin/esp_init_data_default.bin
 

--- a/Sming/Components/terminal/component.mk
+++ b/Sming/Components/terminal/component.mk
@@ -19,10 +19,6 @@ COM_OPTS		?= --raw --encoding ascii
 KILL_TERM		?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
 TERMINAL		?= python -m serial.tools.miniterm $(COM_OPTS) $(COM_PORT) $(COM_SPEED_SERIAL)
 
-# Alternative for Windows
-#KILL_TERM		?= taskkill.exe -f -im Terminal.exe || exit 0
-#TERMINAL		?= $(SDK_TOOLS)/Terminal.exe $(COM_PORT) $(COM_SPEED_SERIAL) $(COM_OPTS)
-
 
 ##@Tools
 

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -239,7 +239,7 @@ define PrintHelp
 							printf "  \033[1;36m%-20s\033[0m %s\n", sep[1], targets[t] \
 					} \
 				} \
-			} ' $(MAKEFILE_LIST)
+			} ' $(foreach f,$(MAKEFILE_LIST),"$(f)")
 	@echo
 endef
 


### PR DESCRIPTION
If there are dashes in the path `make help` doesn't work. e.g.

```
S:\sandboxes\sming-dev\samples\Basic_Blink>set SMING_HOME=s:\sandboxes\sming-dev\Sming

S:\sandboxes\sming-dev\samples\Basic_Blink>make help

Basic_Blink: Invoking 'help' for Esp8266 (debug) architecture

Welcome to the Sming build system!
Usage:
  make <target>
awk: (FILENAME=Makefile FNR=9) fatal: cannot open file `s:sandboxessming-devSming/project.mk' for reading (No such file or directory)
make: *** [help] Error 2
```

This PR just wraps each entry in MAKEFILE_LIST in double quotes.
Also remove `SDK_TOOLS` which is no longer required by the build system.