### PR TITLE
Fix pgmspace.h flies

### DIFF
--- a/Sming/Arch/Esp8266/Components/libc/include/sys/pgmspace.h
+++ b/Sming/Arch/Esp8266/Components/libc/include/sys/pgmspace.h
@@ -11,8 +11,8 @@
 #pragma once
 
 #include <sys/features.h>
-#include <c_types.h>
-#include <esp_attr.h>
+#include "../c_types.h"
+#include "../esp_attr.h"
 
 /**
  * @ingroup pgmspace

--- a/Sming/Arch/Host/Components/libc/include/sys/pgmspace.h
+++ b/Sming/Arch/Host/Components/libc/include/sys/pgmspace.h
@@ -10,6 +10,8 @@
 
 #pragma once
 
+#include "../esp_attr.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/Sming/Core/pgmspace.h
+++ b/Sming/Core/pgmspace.h
@@ -8,5 +8,8 @@
  *
  ****/
 
+#ifdef __cplusplus
 #include "SmingCore.h"
+#endif
+
 #include "FakePgmSpace.h"


### PR DESCRIPTION
Add __cplusplus guard to Core/pgmspace.h so it can be #included from C source
Add missing #includes to sys/pgmspace.h