### PR TITLE
Fix issues reported by valgrind

### DIFF
--- a/Sming/Arch/Host/Components/hostlib/startup.cpp
+++ b/Sming/Arch/Host/Components/hostlib/startup.cpp
@@ -255,5 +255,8 @@ int main(int argc, char* argv[])
 
 	pause(config.exitpause);
 
+	// Avoid issues with debug statements whilst running exit handlers
+	m_setPuts(nullptr);
+
 	return exitCode;
 }

--- a/Sming/Core/Network/TcpConnection.cpp
+++ b/Sming/Core/Network/TcpConnection.cpp
@@ -499,12 +499,11 @@ err_t TcpConnection::staticOnPoll(void* arg, tcp_pcb* tcp)
 
 err_t TcpConnection::internalOnPoll()
 {
-	//if (tcp->state != ESTABLISHED)
-	//	return ERR_OK;
-
 	sleep++;
 	err_t res = onPoll();
-	checkSelfFree();
+	if(res == ERR_OK) {
+		checkSelfFree();
+	}
 	debug_tcp_ext("<poll");
 	return res;
 }


### PR DESCRIPTION
Fix issues with debug statements whilst running exit handlers

Fix issue with `TcpConnection::checkSelfFree()` being called twice.
Reported in https://github.com/SmingHub/Sming/pull/2007#discussion_r363032722 and #2016.
