### PR TITLE
Make 'python' command configurable.

### DIFF
--- a/Sming/Arch/Esp8266/Components/esptool/component.mk
+++ b/Sming/Arch/Esp8266/Components/esptool/component.mk
@@ -48,7 +48,7 @@ COM_SPEED_ESPTOOL		?= $(COM_SPEED)
 
 COMPONENT_SUBMODULES	+= esptool
 DEBUG_VARS				+= ESPTOOL
-ESPTOOL					:= $(COMPONENT_PATH)/esptool/esptool.py
+ESPTOOL					:= $(PYTHON) $(COMPONENT_PATH)/esptool/esptool.py
 ESPTOOL_SUBMODULE		:= $(COMPONENT_PATH)/esptool
 
 $(ESPTOOL): $(ESPTOOL_SUBMODULE)/.submodule

--- a/Sming/Arch/Esp8266/build.mk
+++ b/Sming/Arch/Esp8266/build.mk
@@ -59,4 +59,4 @@ endif
 USE_NEWLIB			= $(if $(filter 9%,$(GCC_VERSION)),1,0)
 
 # => Tools
-MEMANALYZER = python $(ARCH_TOOLS)/memanalyzer.py $(OBJDUMP)$(TOOL_EXT)
+MEMANALYZER = $(PYTHON) $(ARCH_TOOLS)/memanalyzer.py $(OBJDUMP)$(TOOL_EXT)

--- a/Sming/Components/terminal/component.mk
+++ b/Sming/Components/terminal/component.mk
@@ -17,7 +17,7 @@ endif
 CACHE_VARS		+= COM_OPTS KILL_TERM TERMINAL
 COM_OPTS		?= --raw --encoding ascii
 KILL_TERM		?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
-TERMINAL		?= python -m serial.tools.miniterm $(COM_OPTS) $(COM_PORT) $(COM_SPEED_SERIAL)
+TERMINAL		?= $(PYTHON) -m serial.tools.miniterm $(COM_OPTS) $(COM_PORT) $(COM_SPEED_SERIAL)
 
 
 ##@Tools

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -95,6 +95,9 @@ DEBUG_VARS += AWK
 # invokes an awk compatibility mode. It has no effect on other awk implementations.
 AWK ?= POSIXLY_CORRECT= awk
 
+# Python command
+DEBUG_VARS += PYTHON
+PYTHON ?= python
 
 V ?= $(VERBOSE)
 ifeq ("$(V)","1")

--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -426,7 +426,7 @@ decode-stacktrace: ##Open the stack trace decoder ready to paste dump text. Alte
 	$(Q) if [ -z "$(TRACE)" ]; then \
 		echo "Decode stack trace: Paste stack trace here"; \
 	fi
-	$(Q) python $(ARCH_TOOLS)/decode-stacktrace.py $(TARGET_OUT_0) $(TRACE)
+	$(Q) $(PYTHON) $(ARCH_TOOLS)/decode-stacktrace.py $(TARGET_OUT_0) $(TRACE)
 
 
 ##@Testing
@@ -437,7 +437,7 @@ SERVER_OTA_PORT		?= 9999
 .PHONY: otaserver
 otaserver: all ##Launch a simple python HTTP server for testing OTA updates
 	$(info Starting OTA server for TESTING)
-	$(Q) cd $(FW_BASE) && python -m SimpleHTTPServer $(SERVER_OTA_PORT)
+	$(Q) cd $(FW_BASE) && $(PYTHON) -m SimpleHTTPServer $(SERVER_OTA_PORT)
 
 ##@Help
 

--- a/samples/HttpServer_FirmwareUpload/component.mk
+++ b/samples/HttpServer_FirmwareUpload/component.mk
@@ -11,9 +11,9 @@ web-upload: web-pack spiffs-image-update
 
 .PHONY: python-requirements
 python-requirements:
-	python -m pip install --user -r requirements.txt
+	$(PYTHON) -m pip install --user -r requirements.txt
 
-SIGNTOOL := python $(COMPONENT_PATH)/signtool.py
+SIGNTOOL := $(PYTHON) $(COMPONENT_PATH)/signtool.py
 SIGNING_KEY := $(COMPONENT_PATH)/signing.key
 VERIFICATION_HEADER := $(COMPONENT_PATH)/app/FirmwareVerificationKey.h
 


### PR DESCRIPTION
Allow overriding the python interpreter used by the build system, e.g.
```
make PYTHON=python3 <target>
```
Maybe not too useful, as one can always use virtualenvs, but since we already have `GIT`, `CMAKE`, `CLANG_FORMAT`, etc., it seemed kind of sensible to provide a python override, too.

Like the other overrides, the `PYTHON` variable is not cached.