### PR TITLE
General fixes

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/startup.cpp
+++ b/Sming/Arch/Esp8266/Components/esp8266/startup.cpp
@@ -133,7 +133,9 @@ extern "C" void ICACHE_FLASH_ATTR WEAK_ATTR user_pre_init(void)
 			auto& part = partitions[i];
 			os_printf("partition[%u]: %u, 0x%08x, 0x%08x\n", i, part.type, part.addr, part.size);
 		}
-		os_printf("** Note: SDK 3.0.1 requires SPI_SIZE >= 1M\n");
+		if(sizeMap < FLASH_SIZE_8M_MAP_512_512) {
+			os_printf("** Note: SDK 3.0.1 requires SPI_SIZE >= 1M\n");
+		}
 		while(1) {
 			// Cannot proceed
 		};

--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbhostio.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbhostio.cpp
@@ -58,7 +58,7 @@ void ATTR_GDBEXTERNFN gdbHandleHostIo(char* commandBuffer, unsigned cmdLen)
 		++data; // skip ,
 		unsigned flags = GdbPacket::readHexValue(data);
 		++data;						   // Skip ,
-		GdbPacket::readHexValue(data); // Skip mode (not used)
+		unsigned mode = GdbPacket::readHexValue(data); // Skip mode (not used)
 
 		FileOpenFlags openFlags;
 		if((flags & 0xff) == O_RDWR) {

--- a/Sming/Arch/Host/Components/driver/gpio.rst
+++ b/Sming/Arch/Host/Components/driver/gpio.rst
@@ -2,4 +2,10 @@ Host GPIO
 =========
 
 The emulator does not provide any low-level GPIO support, this is handled at a higher level
-using :cpp:class:`digitalHooks`.
+using :cpp:class:`DigitalHooks`.
+
+
+API Documentation
+-----------------
+
+.. doxygenclass:: DigitalHooks

--- a/Sming/Arch/Host/Core/DigitalHooks.h
+++ b/Sming/Arch/Host/Core/DigitalHooks.h
@@ -15,7 +15,7 @@
 /** @brief Class to customise behaviour for digital functions
  *  @note By default, actions get output to console but this can get very busy.
  *  The easiest way to change the behaviour is by sub-classing DigitalHooks
- *  and passing the new class instance to `setDigitalHooks`.
+ *  and passing the new class instance to `setDigitalHooks()`.
  */
 class DigitalHooks
 {

--- a/Sming/Arch/Host/Core/DigitalHooks.h
+++ b/Sming/Arch/Host/Core/DigitalHooks.h
@@ -10,7 +10,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 /** @brief Class to customise behaviour for digital functions
  *  @note By default, actions get output to console but this can get very busy.

--- a/Sming/Components/ssl/BearSsl/Asn1Parser.h
+++ b/Sming/Components/ssl/BearSsl/Asn1Parser.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 enum ASN1 {
 	ASN1_BOOLEAN = 0x01,

--- a/Sming/Core/Clock.h
+++ b/Sming/Core/Clock.h
@@ -16,7 +16,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <sming_attr.h>
 
 #ifdef __cplusplus

--- a/Sming/Core/HardwarePWM.h
+++ b/Sming/Core/HardwarePWM.h
@@ -27,7 +27,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <driver/pwm.h>
 
 #define PWM_BAD_CHANNEL 0xff ///< Invalid PWM channel

--- a/Sming/Core/HardwareSerial.h
+++ b/Sming/Core/HardwareSerial.h
@@ -15,7 +15,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <Delegate.h>
 #include <Data/Stream/ReadWriteStream.h>
 #include <BitManipulations.h>

--- a/Sming/Core/Interrupts.h
+++ b/Sming/Core/Interrupts.h
@@ -14,7 +14,7 @@
 */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <driver/gpio.h>
 #include <Delegate.h>
 #include <WConstants.h>

--- a/Sming/Core/NanoTime.h
+++ b/Sming/Core/NanoTime.h
@@ -19,10 +19,10 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <esp_attr.h>
 #include <sming_attr.h>
-#include <math.h>
+#include <cmath>
 #include "Rational.h"
 #include <WString.h>
 

--- a/Sming/Core/Network/WebHelpers/escape.cpp
+++ b/Sming/Core/Network/WebHelpers/escape.cpp
@@ -4,7 +4,6 @@
 #include <stdlib.h>
 #include <c_types.h>
 #include <ctype.h>
-#include <math.h>
 
 // Append str to dest with checks
 static unsigned safe_append(char* dest, size_t len, const char* str)

--- a/Sming/Core/PolledTimer.h
+++ b/Sming/Core/PolledTimer.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <esp_attr.h>
 #include <sming_attr.h>
 #include <Platform/Clocks.h>

--- a/Sming/Core/Rational.h
+++ b/Sming/Core/Rational.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 #include <ratio>
 #include <algorithm>
 #include <muldiv.h>

--- a/Sming/Libraries/RingTone/RingTone.cpp
+++ b/Sming/Libraries/RingTone/RingTone.cpp
@@ -11,7 +11,6 @@
  ****/
 
 #include <FakePgmSpace.h>
-#include <math.h>
 #include "include/RingTone.h"
 
 namespace RingTone

--- a/Sming/Libraries/RingTone/include/RingTone.h
+++ b/Sming/Libraries/RingTone/include/RingTone.h
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include <stdint.h>
-#include <math.h>
+#include <cstdint>
+#include <cmath>
 
 namespace RingTone
 {

--- a/Sming/Libraries/Servo/ServoChannel.h
+++ b/Sming/Libraries/Servo/ServoChannel.h
@@ -11,7 +11,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 /**
  * @brief Manages a single servo channel

--- a/Sming/Libraries/SignalGenerator/StatisticFunction.h
+++ b/Sming/Libraries/SignalGenerator/StatisticFunction.h
@@ -1,5 +1,5 @@
 
-#include <math.h>
+#include <cmath>
 
 class StatisticFunction
 {

--- a/Sming/Libraries/SolarCalculator/SolarCalculator.cpp
+++ b/Sming/Libraries/SolarCalculator/SolarCalculator.cpp
@@ -18,7 +18,7 @@
 
 #include "include/SolarCalculator.h"
 #include <algorithm>
-#include <math.h>
+#include <cmath>
 #include <WConstants.h>
 
 #ifndef M_PI

--- a/Sming/Libraries/ToneGenerator/DeltaSigma.h
+++ b/Sming/Libraries/ToneGenerator/DeltaSigma.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 class DeltaSigma
 {

--- a/Sming/Libraries/ToneGenerator/ToneBuffer.h
+++ b/Sming/Libraries/ToneGenerator/ToneBuffer.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 class ToneBufferQueue;
 

--- a/Sming/Libraries/ToneGenerator/ToneGenerator.cpp
+++ b/Sming/Libraries/ToneGenerator/ToneGenerator.cpp
@@ -19,7 +19,7 @@
 /*
  * Lookup table for quarter sine wave
 
-	#include <math.h>
+	#include <cmath>
 	#include <WConstants.h>
 
 	Serial.println();

--- a/Sming/Platform/RTC.h
+++ b/Sming/Platform/RTC.h
@@ -15,7 +15,7 @@
 */
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 /** @brief  Real time clock class
  *  @addtogroup rtc

--- a/Sming/System/include/m_printf.h
+++ b/Sming/System/include/m_printf.h
@@ -84,6 +84,11 @@ template <typename... Args> int printf(const char* fmt, Args... args)
  *  @param bytesPerLine If non-zero, data will be output in block separated by carriage return
  *  @note intended for debugging
  */
-void m_printHex(const char* tag, const void* data, size_t len, int addr = -1, size_t bytesPerLine = 16);
+extern "C" void m_printHex(const char* tag, const void* data, size_t len, int addr = -1, size_t bytesPerLine = 16);
 }
+
+#else
+
+void m_printHex(const char* tag, const void* data, size_t len, int addr, size_t bytesPerLine);
+
 #endif

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -31,7 +31,7 @@ extern "C"
 /**
  * @brief Simple check to determine if a pointer refers to flash memory
  */
-#define isFlashPtr(ptr) (uint32_t(ptr) >= 0x40200000)
+#define isFlashPtr(ptr) ((uint32_t)ptr >= 0x40200000)
 
 /**
  * @brief determines if the given value is aligned to a word (4-byte) boundary

--- a/Sming/Wiring/MacAddress.h
+++ b/Sming/Wiring/MacAddress.h
@@ -26,7 +26,7 @@
 
 #include "WString.h"
 #include "Print.h"
-#include <stdint.h>
+#include <cstdint>
 
 /**
  * @brief A network hardware (MAC) address.

--- a/Sming/Wiring/Print.cpp
+++ b/Sming/Wiring/Print.cpp
@@ -19,7 +19,7 @@
 #include "Print.h"
 #include "WString.h"
 #include <stringconversion.h>
-#include <math.h>
+#include <cmath>
 #include <algorithm>
 
 /*

--- a/Sming/Wiring/Printable.h
+++ b/Sming/Wiring/Printable.h
@@ -35,7 +35,7 @@
 
 #pragma once
 
-#include <stddef.h>
+#include <cstddef>
 
 class Print;
 

--- a/Sming/Wiring/WConstants.h
+++ b/Sming/Wiring/WConstants.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 // Wiring API version for libraries
 // this is passed in at compile-time

--- a/Sming/Wiring/WHashMap.h
+++ b/Sming/Wiring/WHashMap.h
@@ -28,7 +28,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 /**
  * @brief HashMap class template

--- a/Sming/Wiring/WMath.h
+++ b/Sming/Wiring/WMath.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 long random(long);
 long random(long, long);

--- a/Sming/Wiring/WShift.h
+++ b/Sming/Wiring/WShift.h
@@ -17,7 +17,7 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstdint>
 
 uint16_t shiftIn(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint8_t count = 8, uint8_t delayTime = 1);
 void shiftOut(uint8_t dataPin, uint8_t clockPin, uint8_t bitOrder, uint16_t value, uint8_t count = 8, uint8_t delayTime = 1);

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -57,7 +57,7 @@
 #ifdef __cplusplus
 
 #include "WConstants.h"
-#include <stddef.h>
+#include <cstddef>
 #include <string.h>
 #include <sming_attr.h>
 

--- a/Sming/Wiring/WiringFrameworkDependencies.h
+++ b/Sming/Wiring/WiringFrameworkDependencies.h
@@ -10,9 +10,9 @@
 #include <user_config.h>
 
 #include <c_types.h>
-#include <ctype.h>
-#include <math.h>
-#include <string.h>
+#include <cctype>
+#include <cmath>
+#include <cstring>
 
 #include "WConstants.h"
 #include "BitManipulations.h"

--- a/Sming/component.mk
+++ b/Sming/component.mk
@@ -38,7 +38,7 @@ COMPONENT_DOXYGEN_PREDEFINED := \
 
 COMPONENT_DOXYGEN_INPUT := \
 	Core \
-	$(wildcard Arch/*/Core) \
+	$(patsubst $(SMING_HOME)/%,%,$(wildcard $(SMING_HOME)/Arch/*/Core)) \
 	Platform \
 	Services \
 	Wiring \

--- a/docs/source/arch/esp8266/getting-started/windows-manual.rst
+++ b/docs/source/arch/esp8266/getting-started/windows-manual.rst
@@ -97,6 +97,12 @@ Install ESP8266 Toolchain
    You'll need to do this from an administrative command prompt.
 
 
+Install Python
+--------------
+
+Get the current version from https://www.python.org/.
+
+
 Install GIT
 -----------
 
@@ -117,8 +123,8 @@ Download Sming
 1. You can put Sming anywhere convenient, provided there are **no spaces** in the path!
    For example, *C:\\tools\\sming*::
 
-      mkdir C:\tools\sming
-      cd /d C:\tools\sming
+      mkdir C:\tools
+      cd /d C:\tools
 
 2. To obtain the latest develop code with all the latest features and fixes::
 
@@ -130,7 +136,7 @@ Download Sming
 
 3. Set :envvar:`SMING_HOME` environment variable::
 
-      SETX SMING_HOME C:\tools\sming\Sming
+      SETX SMING_HOME C:\tools\Sming\Sming
 
    Note: there is NO trailing slash on the path!
    

--- a/docs/source/contribute/coding-style.rst
+++ b/docs/source/contribute/coding-style.rst
@@ -2,6 +2,8 @@
 Coding Style Rules
 ******************
 
+.. highlight:: bash
+
 The benefits of coding standards are readability, maintainability and
 compatibility. Any member of the development team in Sming should be
 able to read the code of another developer. The developer who maintains
@@ -32,9 +34,7 @@ Clang-Format and Clang-Tidy
 In order to automatically check and apply our coding standards you need
 to install ``clang-format`` and optionally ``clang-tidy``.
 
-In Ubuntu you should be able to install them using the following command
-
-::
+In Ubuntu you should be able to install them using the following command::
 
    sudo apt-get install clang-format clang-tidy
 
@@ -87,30 +87,34 @@ Single File
 ^^^^^^^^^^^
 
 If you want to directly apply the coding standards from the command line
-you can run the following command
-
-::
+you can run the following command::
 
    cd $SMING_HOME
-   clang-format -style=file -i SmingCore/<modified-file>
+   clang-format -style=file -i Core/<modified-file>
 
-Where ``SmingCore/<modified-file>`` should be replaced with the path to
+Where ``Core/<modified-file>`` should be replaced with the path to
 the file that you have modified.
 
 All files
 ~~~~~~~~~
 
 The following command will run again the coding standards formatter over
-all C,C++ and header files inside the ``Sming/SmingCore`` and
-``samples`` directory.
-
-::
+all C, C++ and header files inside the ``Sming/Core``, ``samples`` and 
+other key directories::
 
    cd $SMING_HOME
    make cs
 
 The command needs time to finish. So be patient. It will go over all
 files and will try to fix any coding style issues.
+
+If you wish to apply coding style to your own project, add an empty ``.cs`` marker file
+to any directory containing source code or header files. All source/header files
+in that directory and any sub-directories will be formatted when you run::
+
+   make cs
+
+from your project directory.
 
 Eclipse
 ~~~~~~~
@@ -124,6 +128,8 @@ C,C++ or header file or a selection in it and run the ``Format`` command
 Style Guide
 ===========
 
+.. highlight:: c++
+
 You don’t have to know by heart the coding style but it is worth having
 an idea about our rules. Below are described some of them. Those rules
 will be can be automatically applied as mentioned in the previous
@@ -133,9 +139,7 @@ Indentation
 -----------
 
 We use tabs for indentation. Configure your editor to display a tab as
-long as 4 spaces. Below are the corresponding settings in clang-format.
-
-::
+long as 4 spaces. The corresponding settings in clang-format are::
 
    TabWidth:        4
    UseTab:          Always
@@ -186,14 +190,12 @@ Naming
 .. |constants| replace:: Constants must be written in uppercase characters separated by underscores.
    Constant names may contain digits if appropriate, but not as the first character.
 
+.. highlight:: text
 
 C++ Standard
 ------------
 
-For the moment we recommend the use of C++11. The corresponding settings
-in clang-format are:
-
-::
+For the moment we recommend the use of C++11. The corresponding settings in clang-format are::
 
    Standard:        Cpp11
    Cpp11BracedListStyle: true
@@ -203,9 +205,7 @@ Starting and ending spaces
 
 We don’t recommend the use of a starting or ending space in angles,
 container literals, c-style cast parentheses, parentheses and square
-brackets. Our settings are
-
-::
+brackets. Our settings are::
 
    SpaceAfterCStyleCast: false
    SpaceBeforeParens: Never
@@ -225,9 +225,7 @@ Line length
 
 We are living in the 21st century so most of the monitors should be
 capable of displaying 120 characters per line. If a line is longer than
-those characters it will be split whenever possible.
-
-::
+those characters it will be split whenever possible::
 
    ColumnLimit:     120
 
@@ -235,9 +233,7 @@ Empty Lines
 -----------
 
 Two or more empty lines will be compacted to one. Also we delete empty
-lines at the start of a block.
-
-::
+lines at the start of a block::
 
    KeepEmptyLinesAtTheStartOfBlocks: false
    MaxEmptyLinesToKeep: 1
@@ -245,7 +241,8 @@ lines at the start of a block.
 Braces
 ------
 
-::
+See the meaning of these keys and their selected values in the
+`ClangFormatStyleOptions document <http://releases.llvm.org/5.0.0/tools/clang/docs/ClangFormatStyleOptions.html>`__::
 
    BraceWrapping:
        AfterClass:      false
@@ -258,15 +255,11 @@ Braces
        IndentBraces:    false
    BreakBeforeBraces: Linux
 
-See the meaning of those keys and their selected values in the
-`ClangFormatStyleOptions document <http://releases.llvm.org/5.0.0/tools/clang/docs/ClangFormatStyleOptions.html>`__.
 
 Pointer Alignment
 -----------------
 
-Always on the left.
-
-::
+Always on the left::
 
    PointerAlignment: Left
 
@@ -274,9 +267,7 @@ Includes
 --------
 
 We don’t re-sort includes although it is highly recommended to order the
-headers alphabetically whenever possible.
-
-::
+headers alphabetically whenever possible::
 
    SortIncludes:    false
 
@@ -284,9 +275,7 @@ Comments
 --------
 
 We try not to split comment lines into smaller ones and also we add one
-space between code and trailing comment.
-
-::
+space between code and trailing comment::
 
    ReflowComments: false
    SpacesBeforeTrailingComments: 1
@@ -294,21 +283,19 @@ space between code and trailing comment.
 Spaces
 ------
 
-For readability put always spaces before assignment operators.
-
-::
+For readability put always spaces before assignment operators::
 
    SpaceBeforeAssignmentOperators: true
 
 Other Elements
 ==============
 
+.. highlight:: c++
+
 Standard file headers
 ---------------------
 
-Please use the standard Sming header with copyright notice:
-
-::
+Please use the standard Sming header with copyright notice::
 
    /****
     * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
@@ -332,21 +319,19 @@ Deprecating code
 ----------------
 
 Where a change in the Sming API may break existing users’ code, then the
-existing method/function/variable must be maintained for a time to allow
+existing type/method/function/variable must be maintained for a time to allow
 time for migration to the new technique. Such changes should only be
 made if there is a good reason, for example improved reliability,
 performance, ease of use.
 
 Deprecation requires two steps:
 
-Step 1: Add a @deprecated tag to the method header comment so the change
+Step 1: Add a ``@deprecated`` tag to the method header comment so the change
 is flagged in the auto-generated API documentation. Include a brief
 explanation of the new method or technique to be adopted. See also
 `Documenting the API <https://github.com/SmingHub/Sming/wiki/Documenting-the-API>`__.
 
-Example:
-
-::
+Example::
 
    /** @deprecated Use `anotherMethod()` instead */
 
@@ -363,15 +348,15 @@ Sming makes extensive use of virtual classes. If you are modifying or
 adding virtual methods then please follow these guidelines:
 
 **Rule**: The base class must have a virtual destructor, even if it
-doesn’t do anything.
+doesn’t do anything. Example::
 
-Example: ``virtual ~Stream() {}``
+   virtual ~Stream() {}
 
 
 **Rule**: Inherited classes must not prepend ``virtual`` or append
-``override`` to any destructor.
+``override`` to any destructor. Example::
 
-Example: ``~IDataSourceStream();``
+   ~IDataSourceStream();
 
 Rationale: virtual destructors do not behave like regular virtual
 methods - they are ‘chained’ rather than overridden - therefore
@@ -379,9 +364,9 @@ methods - they are ‘chained’ rather than overridden - therefore
 and unhelpful
 
 
-**Rule**: Use the ``override`` directive on inherited virtual methods
+**Rule**: Use the ``override`` directive on inherited virtual methods::
 
-Example: ``int read() override;``
+   int read() override;
 
 Rationale: The compiler will ensure there is actually a base method to
 inherit from and generate a warning if one is not found, or if
@@ -397,9 +382,7 @@ Rationale: They’re not necessary
 Common issues
 -------------
 
-Some notes on commonly occurring issues.
-
-::
+Some notes on commonly occurring issues::
 
 
    /**

--- a/samples/Basic_WebSkeletonApp_LTS/component.mk
+++ b/samples/Basic_WebSkeletonApp_LTS/component.mk
@@ -11,10 +11,10 @@
 
 ## SMING_HOME sets the path where Sming framework is located.
 ## Windows:
-# SMING_HOME = c:/tools/sming/Sming 
+# SMING_HOME = c:/tools/Sming/Sming 
 
 # MacOS / Linux
-# SMING_HOME = /opt/sming/Sming
+# SMING_HOME = /opt/Sming/Sming
 
 ## COM port parameter is reqruied to flash firmware correctly.
 ## Windows: 


### PR DESCRIPTION
Various commits culled from #2004, #2014

**Fixes**

* Fix `isFlashPtr` macro - not 'C' compatible

**Warnings**

* gdbstub missing `mode` variable

**Improvements**

* Show partition size warning only if applicable
* Add `m_printHex` declaration for use by C code (no default parameters)
* Update `malloc_count` Component to handle allocation failures

**Documentation**

* Add note on .cs files to coding style guide
* Fix picking up Arch/Core directories, gpio, digitalhooks
* Update windows manual installation guide
    
**Build system**

* Revise project.mk to allow mutually-dependent components

**Coding standard**

* Use C++ headers, e.g. `cmath` instead of `math.h`.
