### PR TITLE
SPIFFS change mounting checking and format

### DIFF
--- a/Sming/Components/rboot/appcode/rboot-overrides.c
+++ b/Sming/Components/rboot/appcode/rboot-overrides.c
@@ -37,10 +37,7 @@ spiffs_config spiffs_get_storage_config()
       debug_w("The requested SPIFFS size is too big.");
       requested_sector = max_allowed_sector;
   }
-  cfg.phys_size = ((requested_sector + 1) * INTERNAL_FLASH_SECTOR_SIZE) -  ( ( u32_t )cfg.phys_addr); // get the max size until the sector end.
-
-  cfg.phys_erase_block = INTERNAL_FLASH_SECTOR_SIZE; // according to datasheet
-  cfg.log_block_size = INTERNAL_FLASH_SECTOR_SIZE * 2; // Important to make large
-  cfg.log_page_size = LOG_PAGE_SIZE; // as we said
+  // get the max size until the sector end
+  cfg.phys_size = ((requested_sector + 1) * INTERNAL_FLASH_SECTOR_SIZE) - cfg.phys_addr;
   return cfg;
 }

--- a/Sming/Components/spiffs/spiffs_sming.c
+++ b/Sming/Components/spiffs/spiffs_sming.c
@@ -127,12 +127,13 @@ static void spiffs_mount_internal(spiffs_config *cfg)
   cfg->hal_write_f = api_spiffs_write;
   cfg->hal_erase_f = api_spiffs_erase;
   
-  uint32_t dat;
+  spiffs_obj_id dat;
   bool writeFirst = false;
-  flashmem_read(&dat, cfg->phys_addr, 4);
+  //get the erase count record
+  flashmem_read(&dat, cfg->phys_addr + cfg->log_page_size - sizeof(spiffs_obj_id), sizeof(spiffs_obj_id));
   //debugf("%X", dat);
 
-  if (dat == UINT32_MAX)
+  if (dat == (spiffs_obj_id) UINT32_MAX)  //not spiffs formatted most likely raw formatted
   {
 	  debugf("First init file system");
 	  spiffs_format_internal(cfg);

--- a/Sming/Components/spiffs/spiffs_sming.cpp
+++ b/Sming/Components/spiffs/spiffs_sming.cpp
@@ -149,6 +149,9 @@ bool spiffs_format_manual(u32_t phys_addr, u32_t phys_size)
 	spiffs_config cfg = {0};
 	cfg.phys_addr = phys_addr;
 	cfg.phys_size = phys_size;
+	cfg.phys_erase_block = INTERNAL_FLASH_SECTOR_SIZE;   // according to datasheet
+	cfg.log_block_size = INTERNAL_FLASH_SECTOR_SIZE * 2; // Important to make large
+	cfg.log_page_size = LOG_PAGE_SIZE;					 // as we said
 	spiffs_format_internal(&cfg);
 	return spiffs_mount_manual(phys_addr, phys_size);
 }

--- a/Sming/Components/spiffs/spiffs_sming.cpp
+++ b/Sming/Components/spiffs/spiffs_sming.cpp
@@ -20,26 +20,26 @@ spiffs _filesystemStorageHandle;
 #define SPIFF_FILEDESC_COUNT 7
 #endif
 
-static u8_t spiffs_work_buf[LOG_PAGE_SIZE * 2];
-static u8_t spiffs_fds[sizeof(spiffs_fd) * SPIFF_FILEDESC_COUNT];
-static u8_t spiffs_cache_buf[(LOG_PAGE_SIZE + 32) * 4];
+static uint8_t spiffs_work_buf[LOG_PAGE_SIZE * 2];
+static uint8_t spiffs_fds[sizeof(spiffs_fd) * SPIFF_FILEDESC_COUNT];
+static uint8_t spiffs_cache_buf[(LOG_PAGE_SIZE + 32) * 4];
 
-static s32_t api_spiffs_read(u32_t addr, u32_t size, u8_t* dst)
+static int32_t api_spiffs_read(uint32_t addr, uint32_t size, uint8_t* dst)
 {
 	return (flashmem_read(dst, addr, size) == size) ? SPIFFS_OK : SPIFFS_ERR_INTERNAL;
 }
 
-static s32_t api_spiffs_write(u32_t addr, u32_t size, u8_t* src)
+static int32_t api_spiffs_write(uint32_t addr, uint32_t size, uint8_t* src)
 {
 	//debugf("api_spiffs_write");
 	return (flashmem_write(src, addr, size) == size) ? SPIFFS_OK : SPIFFS_ERR_INTERNAL;
 }
 
-static s32_t api_spiffs_erase(u32_t addr, u32_t size)
+static int32_t api_spiffs_erase(uint32_t addr, uint32_t size)
 {
 	debugf("api_spiffs_erase");
-	u32_t sect_first = flashmem_get_sector_of_address(addr);
-	u32_t sect_last = sect_first;
+	uint32_t sect_first = flashmem_get_sector_of_address(addr);
+	uint32_t sect_last = sect_first;
 	while(sect_first <= sect_last) {
 		if(!flashmem_erase_sector(sect_first++)) {
 			return SPIFFS_ERR_INTERNAL;
@@ -104,7 +104,7 @@ static bool spiffs_mount_internal(spiffs_config* cfg)
 	if(!isFormatted) {
 		spiffs_file fd = SPIFFS_open(&_filesystemStorageHandle, "initialize_fs_header.dat",
 									 SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
-		SPIFFS_write(&_filesystemStorageHandle, fd, (u8_t*)"1", 1);
+		SPIFFS_write(&_filesystemStorageHandle, fd, (uint8_t*)"1", 1);
 		SPIFFS_fremove(&_filesystemStorageHandle, fd);
 		SPIFFS_close(&_filesystemStorageHandle, fd);
 	}
@@ -118,7 +118,7 @@ bool spiffs_mount()
 	return spiffs_mount_internal(&cfg);
 }
 
-bool spiffs_mount_manual(u32_t phys_addr, u32_t phys_size)
+bool spiffs_mount_manual(uint32_t phys_addr, uint32_t phys_size)
 {
 	spiffs_config cfg = {0};
 	cfg.phys_addr = phys_addr;
@@ -143,7 +143,7 @@ bool spiffs_format()
 	return spiffs_mount();
 }
 
-bool spiffs_format_manual(u32_t phys_addr, u32_t phys_size)
+bool spiffs_format_manual(uint32_t phys_addr, uint32_t phys_size)
 {
 	spiffs_unmount();
 	spiffs_config cfg = {0};

--- a/Sming/Components/spiffs/spiffs_sming.cpp
+++ b/Sming/Components/spiffs/spiffs_sming.cpp
@@ -26,18 +26,18 @@ uint8_t spiffs_work_buf[LOG_PAGE_SIZE * 2];
 uint8_t spiffs_fds[sizeof(spiffs_fd) * SPIFF_FILEDESC_COUNT];
 uint8_t spiffs_cache_buf[(LOG_PAGE_SIZE + 32) * 4];
 
-int32_t api_spiffs_read(uint32_t addr, uint32_t size, uint8_t* dst)
+s32_t api_spiffs_read(u32_t addr, u32_t size, u8_t* dst)
 {
 	return (flashmem_read(dst, addr, size) == size) ? SPIFFS_OK : SPIFFS_ERR_INTERNAL;
 }
 
-int32_t api_spiffs_write(uint32_t addr, uint32_t size, uint8_t* src)
+s32_t api_spiffs_write(u32_t addr, u32_t size, u8_t* src)
 {
 	//debugf("api_spiffs_write");
 	return (flashmem_write(src, addr, size) == size) ? SPIFFS_OK : SPIFFS_ERR_INTERNAL;
 }
 
-int32_t api_spiffs_erase(uint32_t addr, uint32_t size)
+s32_t api_spiffs_erase(u32_t addr, u32_t size)
 {
 	debugf("api_spiffs_erase");
 	uint32_t sect_first = flashmem_get_sector_of_address(addr);

--- a/Sming/Components/spiffs/spiffs_sming.cpp
+++ b/Sming/Components/spiffs/spiffs_sming.cpp
@@ -26,15 +26,13 @@ static u8_t spiffs_cache_buf[(LOG_PAGE_SIZE + 32) * 4];
 
 static s32_t api_spiffs_read(u32_t addr, u32_t size, u8_t* dst)
 {
-	flashmem_read(dst, addr, size);
-	return SPIFFS_OK;
+	return (flashmem_read(dst, addr, size) == size) ? SPIFFS_OK : SPIFFS_ERR_INTERNAL;
 }
 
 static s32_t api_spiffs_write(u32_t addr, u32_t size, u8_t* src)
 {
 	//debugf("api_spiffs_write");
-	flashmem_write(src, addr, size);
-	return SPIFFS_OK;
+	return (flashmem_write(src, addr, size) == size) ? SPIFFS_OK : SPIFFS_ERR_INTERNAL;
 }
 
 static s32_t api_spiffs_erase(u32_t addr, u32_t size)
@@ -67,8 +65,9 @@ bool spiffs_format_internal(spiffs_config* cfg)
 	}
 
 	spiffs_unmount();
-	tryMount(cfg);
-	spiffs_unmount();
+	if(tryMount(cfg)) {
+		spiffs_unmount();
+	}
 
 	int res = SPIFFS_format(&_filesystemStorageHandle);
 	return res >= 0;

--- a/Sming/Components/spiffs/spiffs_sming.cpp
+++ b/Sming/Components/spiffs/spiffs_sming.cpp
@@ -20,33 +20,35 @@ spiffs _filesystemStorageHandle;
 #define SPIFF_FILEDESC_COUNT 7
 #endif
 
-static u8_t spiffs_work_buf[LOG_PAGE_SIZE*2];
+static u8_t spiffs_work_buf[LOG_PAGE_SIZE * 2];
 static u8_t spiffs_fds[sizeof(spiffs_fd) * SPIFF_FILEDESC_COUNT];
-static u8_t spiffs_cache_buf[(LOG_PAGE_SIZE+32)*4];
+static u8_t spiffs_cache_buf[(LOG_PAGE_SIZE + 32) * 4];
 
-static s32_t api_spiffs_read(u32_t addr, u32_t size, u8_t *dst)
+static s32_t api_spiffs_read(u32_t addr, u32_t size, u8_t* dst)
 {
-  flashmem_read(dst, addr, size);
-  return SPIFFS_OK;
+	flashmem_read(dst, addr, size);
+	return SPIFFS_OK;
 }
 
-static s32_t api_spiffs_write(u32_t addr, u32_t size, u8_t *src)
+static s32_t api_spiffs_write(u32_t addr, u32_t size, u8_t* src)
 {
-  //debugf("api_spiffs_write");
-  flashmem_write(src, addr, size);
-  return SPIFFS_OK;
+	//debugf("api_spiffs_write");
+	flashmem_write(src, addr, size);
+	return SPIFFS_OK;
 }
 
 static s32_t api_spiffs_erase(u32_t addr, u32_t size)
 {
-  debugf("api_spiffs_erase");
-  u32_t sect_first = flashmem_get_sector_of_address(addr);
-  u32_t sect_last = sect_first;
-  while( sect_first <= sect_last )
-    if( !flashmem_erase_sector( sect_first ++ ) )
-      return SPIFFS_ERR_INTERNAL;
-  return SPIFFS_OK;
-} 
+	debugf("api_spiffs_erase");
+	u32_t sect_first = flashmem_get_sector_of_address(addr);
+	u32_t sect_last = sect_first;
+	while(sect_first <= sect_last) {
+		if(!flashmem_erase_sector(sect_first++)) {
+			return SPIFFS_ERR_INTERNAL;
+		}
+	}
+	return SPIFFS_OK;
+}
 
 /*******************
 The W25Q32BV array is organized into 16,384 programmable pages of 256-bytes each. Up to 256 bytes can be programmed at a time.
@@ -55,131 +57,115 @@ the entire chip (chip erase). The W25Q32BV has 1,024 erasable sectors and 64 era
 The small 4KB sectors allow for greater flexibility in applications that require data and parameter storage.
 ********************/
 
-bool spiffs_format_internal(spiffs_config *cfg)
+bool spiffs_format_internal(spiffs_config* cfg)
 {
-  if (cfg->phys_addr == 0)
-  {
-	SYSTEM_ERROR("Can't format file system, wrong address given.");
-	return false;
-  }
+	if(cfg->phys_addr == 0) {
+		SYSTEM_ERROR("Can't format file system, wrong address given.");
+		return false;
+	}
 
-  if (cfg->phys_size == 0)
-  {
-	SYSTEM_ERROR("Can't format file system, wrong size given.");
-	return false;
-  }
+	if(cfg->phys_size == 0) {
+		SYSTEM_ERROR("Can't format file system, wrong size given.");
+		return false;
+	}
 
-  uint32_t log_block_count = cfg->phys_size / cfg->log_block_size;
-  uint32_t log_block_erased = 0;
+	uint32_t log_block_count = cfg->phys_size / cfg->log_block_size;
+	uint32_t log_block_erased = 0;
 
-  debugf("sect_first: %x, sect_last: %x\n", 
-    flashmem_get_sector_of_address(cfg->phys_addr), 
-    flashmem_get_sector_of_address(cfg->phys_addr + cfg->phys_size - 1)
-  );
-  ETS_INTR_LOCK();
+	debugf("sect_first: %x, sect_last: %x\n", flashmem_get_sector_of_address(cfg->phys_addr),
+		   flashmem_get_sector_of_address(cfg->phys_addr + cfg->phys_size - 1));
+	ETS_INTR_LOCK();
 
-  while(log_block_erased < log_block_count)
-  {
-    uint32_t sector_per_block = cfg->log_block_size / INTERNAL_FLASH_SECTOR_SIZE;
-    uint32_t sector_erased = 0;
-    while(sector_erased < sector_per_block)
-    {
-      uint32_t target_sector = flashmem_get_sector_of_address(
-        cfg->phys_addr + (log_block_erased * cfg->log_block_size) +
-        (sector_erased * INTERNAL_FLASH_SECTOR_SIZE)
-      );
+	while(log_block_erased < log_block_count) {
+		uint32_t sector_per_block = cfg->log_block_size / INTERNAL_FLASH_SECTOR_SIZE;
+		uint32_t sector_erased = 0;
+		while(sector_erased < sector_per_block) {
+			uint32_t target_sector =
+				flashmem_get_sector_of_address(cfg->phys_addr + (log_block_erased * cfg->log_block_size) +
+											   (sector_erased * INTERNAL_FLASH_SECTOR_SIZE));
 
+			if(!flashmem_erase_sector(target_sector)) {
+				ETS_INTR_UNLOCK();
+				return false;
+			}
 
-      if(!flashmem_erase_sector(target_sector))
-      {
-        ETS_INTR_UNLOCK();
-        return false;
-      }
-      
-      sector_erased++;
-    }
+			sector_erased++;
+		}
 
-    //write erase count to first sector of every logical block
-    uint32_t erase_count_addr = cfg->phys_addr + (log_block_erased * cfg->log_block_size);
-    erase_count_addr += cfg->log_page_size;
-    erase_count_addr -= sizeof(spiffs_obj_id);
+		//write erase count to first sector of every logical block
+		uint32_t erase_count_addr = cfg->phys_addr + (log_block_erased * cfg->log_block_size);
+		erase_count_addr += cfg->log_page_size;
+		erase_count_addr -= sizeof(spiffs_obj_id);
 
-    spiffs_obj_id block_erase_count = 0;
-    flashmem_write(&block_erase_count, erase_count_addr, sizeof(spiffs_obj_id));
+		spiffs_obj_id block_erase_count = 0;
+		flashmem_write(&block_erase_count, erase_count_addr, sizeof(spiffs_obj_id));
 
-    log_block_erased++;
-  }
-  debugf("formatted");
-  ETS_INTR_UNLOCK();
+		log_block_erased++;
+	}
+	debugf("formatted");
+	ETS_INTR_UNLOCK();
 
-  return true;
+	return true;
 }
 
-static void spiffs_mount_internal(spiffs_config *cfg)
+static void spiffs_mount_internal(spiffs_config* cfg)
 {
-  if (cfg->phys_addr == 0)
-  {
-	  SYSTEM_ERROR("Can't start file system, wrong address");
-	  return;
-  }
+	if(cfg->phys_addr == 0) {
+		SYSTEM_ERROR("Can't start file system, wrong address");
+		return;
+	}
 
-  debugf("fs.start: size:%d Kb, offset:0x%X\n", cfg->phys_size / 1024, cfg->phys_addr);
+	debugf("fs.start: size:%d Kb, offset:0x%X\n", cfg->phys_size / 1024, cfg->phys_addr);
 
-  cfg->hal_read_f = api_spiffs_read;
-  cfg->hal_write_f = api_spiffs_write;
-  cfg->hal_erase_f = api_spiffs_erase;
-  
-  spiffs_obj_id dat;
-  bool writeFirst = false;
-  //get the erase count record
-  flashmem_read(&dat, cfg->phys_addr + cfg->log_page_size - sizeof(spiffs_obj_id), sizeof(spiffs_obj_id));
-  //debugf("%X", dat);
+	cfg->hal_read_f = api_spiffs_read;
+	cfg->hal_write_f = api_spiffs_write;
+	cfg->hal_erase_f = api_spiffs_erase;
 
-  if (dat == (spiffs_obj_id) UINT32_MAX)  //not spiffs formatted most likely raw formatted
-  {
-	  debugf("First init file system");
-	  spiffs_format_internal(cfg);
-	  writeFirst = true;
-  }
+	spiffs_obj_id dat;
+	bool writeFirst = false;
+	//get the erase count record
+	flashmem_read(&dat, cfg->phys_addr + cfg->log_page_size - sizeof(spiffs_obj_id), sizeof(spiffs_obj_id));
+	//debugf("%X", dat);
 
-  int res = SPIFFS_mount(&_filesystemStorageHandle,
-    cfg,
-    spiffs_work_buf,
-    spiffs_fds,
-    sizeof(spiffs_fds),
-    spiffs_cache_buf,
-    sizeof(spiffs_cache_buf),
-    NULL);
-  debugf("mount res: %d\n", res);
+	if(dat == (spiffs_obj_id)UINT32_MAX) //not spiffs formatted most likely raw formatted
+	{
+		debugf("First init file system");
+		spiffs_format_internal(cfg);
+		writeFirst = true;
+	}
 
-  if (writeFirst)
-  {
-	  spiffs_file fd = SPIFFS_open(&_filesystemStorageHandle, "initialize_fs_header.dat", SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
-	  SPIFFS_write(&_filesystemStorageHandle, fd, (u8_t *)"1", 1);
-	  SPIFFS_fremove(&_filesystemStorageHandle, fd);
-	  SPIFFS_close(&_filesystemStorageHandle, fd);
-  }
+	int res = SPIFFS_mount(&_filesystemStorageHandle, cfg, spiffs_work_buf, spiffs_fds, sizeof(spiffs_fds),
+						   spiffs_cache_buf, sizeof(spiffs_cache_buf), NULL);
+	debugf("mount res: %d\n", res);
 
-  //dat=0;
-  //flashmem_read(&dat, cfg.phys_addr, 4);
-  //debugf("%X", dat);
+	if(writeFirst) {
+		spiffs_file fd = SPIFFS_open(&_filesystemStorageHandle, "initialize_fs_header.dat",
+									 SPIFFS_CREAT | SPIFFS_TRUNC | SPIFFS_RDWR, 0);
+		SPIFFS_write(&_filesystemStorageHandle, fd, (u8_t*)"1", 1);
+		SPIFFS_fremove(&_filesystemStorageHandle, fd);
+		SPIFFS_close(&_filesystemStorageHandle, fd);
+	}
+
+	//dat=0;
+	//flashmem_read(&dat, cfg.phys_addr, 4);
+	//debugf("%X", dat);
 }
 
 void spiffs_mount()
 {
-  spiffs_config cfg = spiffs_get_storage_config();
-  spiffs_mount_internal(&cfg);
+	spiffs_config cfg = spiffs_get_storage_config();
+	spiffs_mount_internal(&cfg);
 }
 
 void spiffs_mount_manual(u32_t phys_addr, u32_t phys_size)
 {
-  spiffs_config cfg = {0};
-  cfg.phys_addr = phys_addr;
-  cfg.phys_size = phys_size;
-  cfg.phys_erase_block = INTERNAL_FLASH_SECTOR_SIZE; // according to datasheet
-  cfg.log_block_size = INTERNAL_FLASH_SECTOR_SIZE * 2; // Important to make large
-  cfg.log_page_size = LOG_PAGE_SIZE; // as we said
-  spiffs_mount_internal(&cfg);
+	spiffs_config cfg = {0};
+	cfg.phys_addr = phys_addr;
+	cfg.phys_size = phys_size;
+	cfg.phys_erase_block = INTERNAL_FLASH_SECTOR_SIZE;   // according to datasheet
+	cfg.log_block_size = INTERNAL_FLASH_SECTOR_SIZE * 2; // Important to make large
+	cfg.log_page_size = LOG_PAGE_SIZE;					 // as we said
+	spiffs_mount_internal(&cfg);
 }
 
 void spiffs_unmount()
@@ -190,21 +176,20 @@ void spiffs_unmount()
 // FS formatting function
 bool spiffs_format()
 {
-  spiffs_unmount();
-  spiffs_config cfg = spiffs_get_storage_config();
-  spiffs_format_internal(&cfg);
-  spiffs_mount();
-  return true;
+	spiffs_unmount();
+	spiffs_config cfg = spiffs_get_storage_config();
+	spiffs_format_internal(&cfg);
+	spiffs_mount();
+	return true;
 }
 
 bool spiffs_format_manual(u32_t phys_addr, u32_t phys_size)
 {
-
-  spiffs_unmount();
-  spiffs_config cfg = {0};
-  cfg.phys_addr = phys_addr;
-  cfg.phys_size = phys_size;
-  spiffs_format_internal(&cfg);
-  spiffs_mount_manual(phys_addr, phys_size);
-  return true;
+	spiffs_unmount();
+	spiffs_config cfg = {0};
+	cfg.phys_addr = phys_addr;
+	cfg.phys_size = phys_size;
+	spiffs_format_internal(&cfg);
+	spiffs_mount_manual(phys_addr, phys_size);
+	return true;
 }

--- a/Sming/Components/spiffs/spiffs_sming.cpp
+++ b/Sming/Components/spiffs/spiffs_sming.cpp
@@ -4,7 +4,7 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * spiffs_sming.c
+ * spiffs_sming.cpp
  *
  ****/
 
@@ -20,22 +20,24 @@ spiffs _filesystemStorageHandle;
 #define SPIFF_FILEDESC_COUNT 7
 #endif
 
-static uint8_t spiffs_work_buf[LOG_PAGE_SIZE * 2];
-static uint8_t spiffs_fds[sizeof(spiffs_fd) * SPIFF_FILEDESC_COUNT];
-static uint8_t spiffs_cache_buf[(LOG_PAGE_SIZE + 32) * 4];
+namespace
+{
+uint8_t spiffs_work_buf[LOG_PAGE_SIZE * 2];
+uint8_t spiffs_fds[sizeof(spiffs_fd) * SPIFF_FILEDESC_COUNT];
+uint8_t spiffs_cache_buf[(LOG_PAGE_SIZE + 32) * 4];
 
-static int32_t api_spiffs_read(uint32_t addr, uint32_t size, uint8_t* dst)
+int32_t api_spiffs_read(uint32_t addr, uint32_t size, uint8_t* dst)
 {
 	return (flashmem_read(dst, addr, size) == size) ? SPIFFS_OK : SPIFFS_ERR_INTERNAL;
 }
 
-static int32_t api_spiffs_write(uint32_t addr, uint32_t size, uint8_t* src)
+int32_t api_spiffs_write(uint32_t addr, uint32_t size, uint8_t* src)
 {
 	//debugf("api_spiffs_write");
 	return (flashmem_write(src, addr, size) == size) ? SPIFFS_OK : SPIFFS_ERR_INTERNAL;
 }
 
-static int32_t api_spiffs_erase(uint32_t addr, uint32_t size)
+int32_t api_spiffs_erase(uint32_t addr, uint32_t size)
 {
 	debugf("api_spiffs_erase");
 	uint32_t sect_first = flashmem_get_sector_of_address(addr);
@@ -48,7 +50,7 @@ static int32_t api_spiffs_erase(uint32_t addr, uint32_t size)
 	return SPIFFS_OK;
 }
 
-static bool tryMount(spiffs_config* cfg)
+bool tryMount(spiffs_config* cfg)
 {
 	int res = SPIFFS_mount(&_filesystemStorageHandle, cfg, spiffs_work_buf, spiffs_fds, sizeof(spiffs_fds),
 						   spiffs_cache_buf, sizeof(spiffs_cache_buf), nullptr);
@@ -73,7 +75,7 @@ bool spiffs_format_internal(spiffs_config* cfg)
 	return res >= 0;
 }
 
-static bool spiffs_mount_internal(spiffs_config* cfg)
+bool spiffs_mount_internal(spiffs_config* cfg)
 {
 	if(cfg->phys_addr == 0) {
 		SYSTEM_ERROR("Can't start file system, wrong address");
@@ -111,6 +113,8 @@ static bool spiffs_mount_internal(spiffs_config* cfg)
 
 	return true;
 }
+
+} // namespace
 
 bool spiffs_mount()
 {

--- a/Sming/Components/spiffs/spiffs_sming.cpp
+++ b/Sming/Components/spiffs/spiffs_sming.cpp
@@ -10,7 +10,9 @@
 
 #include "spiffs_sming.h"
 #include <esp_spi_flash.h>
+extern "C" {
 #include "spiffs/src/spiffs_nucleus.h"
+}
 
 spiffs _filesystemStorageHandle;
 

--- a/Sming/Components/spiffs/spiffs_sming.h
+++ b/Sming/Components/spiffs/spiffs_sming.h
@@ -18,8 +18,8 @@ extern "C" {
 
 #define LOG_PAGE_SIZE       256
 
-void spiffs_mount();
-void spiffs_mount_manual(u32_t phys_addr, u32_t phys_size);
+bool spiffs_mount();
+bool spiffs_mount_manual(u32_t phys_addr, u32_t phys_size);
 void spiffs_unmount();
 bool spiffs_format();
 bool spiffs_format_internal(spiffs_config *cfg);

--- a/Sming/Components/spiffs/spiffs_sming.h
+++ b/Sming/Components/spiffs/spiffs_sming.h
@@ -16,14 +16,14 @@ extern "C" {
 #include "spiffs.h"
 #include <stdbool.h>
 
-#define LOG_PAGE_SIZE       256
+#define LOG_PAGE_SIZE 256
 
 bool spiffs_mount();
-bool spiffs_mount_manual(u32_t phys_addr, u32_t phys_size);
+bool spiffs_mount_manual(uint32_t phys_addr, uint32_t phys_size);
 void spiffs_unmount();
 bool spiffs_format();
-bool spiffs_format_internal(spiffs_config *cfg);
-bool spiffs_format_manual(u32_t phys_addr, u32_t phys_size);
+bool spiffs_format_internal(spiffs_config* cfg);
+bool spiffs_format_manual(uint32_t phys_addr, uint32_t phys_size);
 spiffs_config spiffs_get_storage_config();
 
 extern spiffs _filesystemStorageHandle;

--- a/Sming/Components/spiffs/spiffs_sming.h
+++ b/Sming/Components/spiffs/spiffs_sming.h
@@ -22,7 +22,6 @@ bool spiffs_mount();
 bool spiffs_mount_manual(uint32_t phys_addr, uint32_t phys_size);
 void spiffs_unmount();
 bool spiffs_format();
-bool spiffs_format_internal(spiffs_config* cfg);
 bool spiffs_format_manual(uint32_t phys_addr, uint32_t phys_size);
 spiffs_config spiffs_get_storage_config();
 

--- a/Sming/Components/spiffs/spiffs_sming.h
+++ b/Sming/Components/spiffs/spiffs_sming.h
@@ -18,13 +18,53 @@ extern "C" {
 
 #define LOG_PAGE_SIZE 256
 
+/**
+ * @brief Mount the SPIFFS volume using default configuration
+ * @retval bool true on success
+ *
+ * Configuration is obtained `spiffs_get_storage_config()`.
+ */
 bool spiffs_mount();
+
+/**
+ * @brief Mount a SPIFFS volume using custom location and size
+ * @param phys_addr The flash memory address (offset) for the volume
+ * @param phys_size The volume size, in bytes
+ * @retval bool true on success, false on failure
+ * @note If the given flash memory range appears to be empty then it is
+ * formatted, erasing any existing content.
+ */
 bool spiffs_mount_manual(uint32_t phys_addr, uint32_t phys_size);
+
+/**
+ * @brief Unmount a previously mounted volume
+ */
 void spiffs_unmount();
+
+/**
+ * @brief Format and mount a SPIFFS volume using default configuration
+ * @retval bool true on success
+ */
 bool spiffs_format();
+
+/**
+ * @brief Format and mount a SPIFFS volume using custom location and size
+ * @param phys_addr The flash memory address (offset) for the volume
+ * @param phys_size The volume size, in bytes
+ * @retval bool true on success
+ */
 bool spiffs_format_manual(uint32_t phys_addr, uint32_t phys_size);
+
+/**
+ * @brief Obtain the default SPIFFS configuration information
+ * @retval spiffs_config
+ * @note Only `phys_addr` and `phys_size` are used, all other parameters are overridden.
+ */
 spiffs_config spiffs_get_storage_config();
 
+/**
+ * @brief Global SPIFFS instance used by FileSystem API
+ */
 extern spiffs _filesystemStorageHandle;
 
 #if defined(__cplusplus)

--- a/Sming/Core/Data/CStringArray.h
+++ b/Sming/Core/Data/CStringArray.h
@@ -236,6 +236,16 @@ public:
 			return s == rhs || strcasecmp(str(), rhs) == 0;
 		}
 
+		bool operator==(const Iterator& rhs) const
+		{
+			return array_ == rhs.array_ && offset_ == rhs.offset_;
+		}
+
+		bool operator!=(const Iterator& rhs) const
+		{
+			return !operator==(rhs);
+		}
+
 		bool operator==(const char* rhs) const
 		{
 			return equals(rhs);
@@ -310,6 +320,8 @@ public:
 				++index_;
 			}
 		}
+
+		using const_iterator = Iterator;
 
 	private:
 		const CStringArray* array_ = nullptr;

--- a/tests/HostTests/app/test-cstringarray.cpp
+++ b/tests/HostTests/app/test-cstringarray.cpp
@@ -170,6 +170,12 @@ public:
 
 				it2 = it1;
 				REQUIRE(it1 == it2);
+
+				it2++;
+				REQUIRE(it1 != it2);
+
+				// Just make sure this compiles OK
+				std::swap(it1, it2);
 			}
 		}
 	}


### PR DESCRIPTION
I've encountered the same issue as described by #1660 and I'm not sure about PR #1663 and understand that PR #1667 is just skip the checking part in the mounting process. My solution is a middle ground between those two PR's. Basically I'm just doing two things:

1. I adding an erase count marker at the `spiffs_sming` formatting process. After looking at the inner working of spiffs, for each block, there should be an `erase count` marker at the end of the first page. The current formatting process just wipes clean the FS area. This condition is consistent with output from spiffy, which uses spiffs own format function to create the spiffs image (I just check the address 0x00FE, 0x20FE, 0x40FE and so on to confirm the spiffs.bin output). So there should be no compatibility issue for those who upload `spiffs.bin` to the device.

2. Changing the checking part, from checking if first ID (at 0x0000 offset) to checking erase count (at 0x00FE offset). This should work better since current approach didn't follow any SPIFFS implementation / design choice, and this have risk to losing entire FS once the first block recycled (eg. formatted). I've experience it myself and losing several month worth of data on many device.

There's also a risk if this solution applied, any device that use SPIFFS but don't upload the spiffs.bin most likely will be formatted, because like I described above, the current format function don't add the `erase count` marker.

Also if you need more proof, I can provide binary sample of FS that guarenteed will be wiped by existing code.

So it's up to the maintainer to choose from different alternative, but if the checking part on mounting process is not needed the solution #1667 didn't have compatibility issue.

Thank You