### PR TITLE
Fix FlashString::Map issue with Basic_WebSkeletonApp sample.

### DIFF
--- a/samples/Basic_WebSkeletonApp/app/webserver.cpp
+++ b/samples/Basic_WebSkeletonApp/app/webserver.cpp
@@ -23,7 +23,7 @@ FILE_LIST(XX)
 #undef XX
 
 // Import content for each file
-#define XX(name, file) IMPORT_FSTR(CONTENT_##name, PROJECT_DIR "/files/" file);
+#define XX(name, file) IMPORT_FSTR_LOCAL(CONTENT_##name, PROJECT_DIR "/files/" file);
 FILE_LIST(XX)
 #undef XX
 


### PR DESCRIPTION
In #2013 omitted to update `IMPORT_FSTR` to `IMPORT_FSTR_LOCAL`.