### PR TITLE
Fix MB_RESPONSE_TIMEOUT variable

### DIFF
--- a/Sming/Libraries/ModbusMaster/ModbusMaster.patch
+++ b/Sming/Libraries/ModbusMaster/ModbusMaster.patch
@@ -12,15 +12,16 @@ index cdcc534..f6f93d4 100644
        u8MBStatus = ku8MBResponseTimedOut;
      }
 diff --git a/src/ModbusMaster.h b/src/ModbusMaster.h
-index 8ab0d52..c335790 100644
+index 8ab0d52..b568a2c 100644
 --- a/src/ModbusMaster.h
 +++ b/src/ModbusMaster.h
-@@ -255,7 +255,7 @@ class ModbusMaster
+@@ -254,9 +254,6 @@ class ModbusMaster
+     static const uint8_t ku8MBMaskWriteRegister          = 0x16; ///< Modbus function 0x16 Mask Write Register
      static const uint8_t ku8MBReadWriteMultipleRegisters = 0x17; ///< Modbus function 0x17 Read Write Multiple Registers
      
-     // Modbus timeout [milliseconds]
+-    // Modbus timeout [milliseconds]
 -    static const uint16_t ku16MBResponseTimeout          = 2000; ///< Modbus timeout [milliseconds]
-+    //static const uint16_t ku16MBResponseTimeout          = 2000; ///< Modbus timeout [milliseconds]
-     
+-    
      // master function that conducts Modbus transactions
      uint8_t ModbusMasterTransaction(uint8_t u8MBFunction);
+     

--- a/Sming/Libraries/ModbusMaster/ModbusMaster.patch
+++ b/Sming/Libraries/ModbusMaster/ModbusMaster.patch
@@ -1,5 +1,18 @@
+diff --git a/src/ModbusMaster.cpp b/src/ModbusMaster.cpp
+index cdcc534..f6f93d4 100644
+--- a/src/ModbusMaster.cpp
++++ b/src/ModbusMaster.cpp
+@@ -860,7 +860,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
+           break;
+       }
+     }
+-    if ((millis() - u32StartTime) > ku16MBResponseTimeout)
++    if ((millis() - u32StartTime) > MB_RESPONSE_TIMEOUT)
+     {
+       u8MBStatus = ku8MBResponseTimedOut;
+     }
 diff --git a/src/ModbusMaster.h b/src/ModbusMaster.h
-index 8ab0d52..f3b1a50 100644
+index 8ab0d52..c335790 100644
 --- a/src/ModbusMaster.h
 +++ b/src/ModbusMaster.h
 @@ -255,7 +255,7 @@ class ModbusMaster
@@ -7,7 +20,7 @@ index 8ab0d52..f3b1a50 100644
      
      // Modbus timeout [milliseconds]
 -    static const uint16_t ku16MBResponseTimeout          = 2000; ///< Modbus timeout [milliseconds]
-+    static const uint16_t ku16MBResponseTimeout          = MB_RESPONSE_TIMEOUT; ///< Modbus timeout [milliseconds]
++    //static const uint16_t ku16MBResponseTimeout          = 2000; ///< Modbus timeout [milliseconds]
      
      // master function that conducts Modbus transactions
      uint8_t ModbusMasterTransaction(uint8_t u8MBFunction);

--- a/Sming/Libraries/ModbusMaster/README.rst
+++ b/Sming/Libraries/ModbusMaster/README.rst
@@ -5,7 +5,7 @@ This library handles Modbus master RTU communication. The library supports callb
 
 .. envvar:: MB_RESPONSE_TIMEOUT
 
-   The patch provides changeable response timeout using :envvar:`MB_RESPONSE_TIMEOUT` (in milliseconds). It is compile-time macro that sets ku16MBResponseTimeout in ModbusMaster.h
+   The patch provides changeable response timeout using :envvar:`MB_RESPONSE_TIMEOUT` (in milliseconds).
 
 The original author of the library is 4-20ma:
 https://github.com/4-20ma/ModbusMaster/


### PR DESCRIPTION
This PR makes direct use of MB_RESPONSE TIMEOUT in ModbusMaster.cpp instead of assigning the value of MB_RESPONSE_TIMEOUT to ku16MBResponseTimeout in ModbusMaster.h

This prevents error when compiling  ModbusMaster/samples/generic