### PR TITLE
Fix lockup with spaces in paths

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -126,9 +126,7 @@ CS_SEARCH_DIRS	?= $(call ListAllSubDirs,$(CS_ROOT_DIRS))
 # Resultant set of directories whose contents to apply coding style to
 CS_DIRS			?= $(patsubst %/.cs,%,$(wildcard $(foreach d,$(CS_SEARCH_DIRS),$d/.cs)))
 # Files to apply coding style to
-ifneq (,$(CS_DIRS))
-CS_FILES		= $(call rwildcard,$(CS_DIRS:=/*),%.cpp %.hpp %.h %.c)
-endif
+CS_FILES		= $(if $(CS_DIRS),$(call rwildcard,$(CS_DIRS:=/*),%.cpp %.hpp %.h %.c),)
 
 .PHONY: cs
 cs: ##Apply coding style to all core files

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -208,11 +208,20 @@ define ListSubDirs
 $(foreach d,$(dir $(wildcard $1/*/.)),$(d:/=))
 endef
 
+# Check that $2 is a valid sub-directory of $1. Return empty string if not.
+# $1 -> Parent directory
+# $2 -> Sub-directory
+# During wildcard searches, paths with spaces cause recursion.
+define IsSubDir
+$(if $(subst $(1:/=),,$(2:/=)),$(findstring $(1:/=),$2),)
+endef
+
 # List sub-directories recursively for a list of root directories
 # Results are sorted and without trailing path separator
+# Sub-directories with spaces are skipped
 # $1 -> Root paths
 define ListAllSubDirs
-$(foreach d,$(dir $(wildcard $1/*/.)),$(d:/=) $(call ListAllSubDirs,$(d:/=)))
+$(foreach d,$(dir $(wildcard $1/*/.)),$(if $(call IsSubDir,$1,$d),$(d:/=) $(call ListAllSubDirs,$(d:/=))))
 endef
 
 # Display variable and list values, e.g. $(call PrintVariable,LIBS)


### PR DESCRIPTION
Whilst source directories must not contain spaces, there could be other directories with spaces in their names.
These must be detected to prevent infinite recusion with `make cs` and `make cs-dev`.

This PR detects and ignores such directories.

Also fix logic so that `CS_DIRS` is only expanded when used. This caused the same lockup to occur when
_any_ target in Makefile is invoked (e.g. dist-clean).

The fault can be confirmed as follows. This hangs indefinitely:

```
cd $SMING_HOME
mkdir "hello there"
make help
```
