### PR TITLE
ModbusMaster fixes

### DIFF
--- a/Sming/Libraries/ModbusMaster/ModbusMaster.patch
+++ b/Sming/Libraries/ModbusMaster/ModbusMaster.patch
@@ -1,8 +1,8 @@
 diff --git a/src/ModbusMaster.cpp b/src/ModbusMaster.cpp
-index cdcc534..ecb03a5 100644
+index cdcc534..b08a335 100644
 --- a/src/ModbusMaster.cpp
 +++ b/src/ModbusMaster.cpp
-@@ -756,15 +756,13 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
+@@ -756,15 +756,12 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
    // flush receive buffer before transmitting request
    while (_serial->read() != -1);
  
@@ -15,13 +15,12 @@ index cdcc534..ecb03a5 100644
 -  {
 -    _serial->write(u8ModbusADU[i]);
 -  }
-+  constexpr uint8_t NUL{0};
 +  _serial->write(u8ModbusADU, u16ModbusADUSize);
-+  _serial->write(NUL);
++  _serial->write((uint8_t)0);
    
    u16ModbusADUSize = 0;
    _serial->flush();    // flush transmit buffer
-@@ -860,7 +858,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
+@@ -860,7 +857,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
            break;
        }
      }

--- a/Sming/Libraries/ModbusMaster/ModbusMaster.patch
+++ b/Sming/Libraries/ModbusMaster/ModbusMaster.patch
@@ -1,8 +1,27 @@
 diff --git a/src/ModbusMaster.cpp b/src/ModbusMaster.cpp
-index cdcc534..f6f93d4 100644
+index cdcc534..ecb03a5 100644
 --- a/src/ModbusMaster.cpp
 +++ b/src/ModbusMaster.cpp
-@@ -860,7 +860,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
+@@ -756,15 +756,13 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
+   // flush receive buffer before transmitting request
+   while (_serial->read() != -1);
+ 
+-  // transmit request
+   if (_preTransmission)
+   {
+     _preTransmission();
+   }
+-  for (i = 0; i < u16ModbusADUSize; i++)
+-  {
+-    _serial->write(u8ModbusADU[i]);
+-  }
++  constexpr uint8_t NUL{0};
++  _serial->write(u8ModbusADU, u16ModbusADUSize);
++  _serial->write(NUL);
+   
+   u16ModbusADUSize = 0;
+   _serial->flush();    // flush transmit buffer
+@@ -860,7 +858,7 @@ uint8_t ModbusMaster::ModbusMasterTransaction(uint8_t u8MBFunction)
            break;
        }
      }

--- a/Sming/Libraries/ModbusMaster/samples/generic/app/application.cpp
+++ b/Sming/Libraries/ModbusMaster/samples/generic/app/application.cpp
@@ -46,12 +46,12 @@ void mbLoop()
 void preTransmission()
 {
 	digitalWrite(RS485_RE_PIN, HIGH);
-	delayMilliseconds(2);
+	//delayMilliseconds(1);
 }
 
 void postTransmission()
 {
-	delayMicroseconds(500);
+	//delayMicroseconds(500);
 	digitalWrite(RS485_RE_PIN, LOW);
 }
 

--- a/Sming/Libraries/ModbusMaster/samples/generic/app/application.cpp
+++ b/Sming/Libraries/ModbusMaster/samples/generic/app/application.cpp
@@ -88,13 +88,14 @@ void mbLogReceive(const uint8_t* adu, size_t aduSize, uint8_t status)
 			break;
 		}
 		debugf("ADU Size: %d, status: %d ", aduSize, status);
+		debug_hex(INFO, "RX ADU", adu, aduSize);
 	}
 	debugf("\r\n");
 }
 
 void mbLogTransmit(const uint8_t* adu, size_t aduSize)
 {
-	debug_hex(INFO, "ADU", adu, aduSize);
+	debug_hex(INFO, "TX ADU", adu, aduSize);
 }
 
 void init()

--- a/Sming/Libraries/ModbusMaster/samples/generic/app/application.cpp
+++ b/Sming/Libraries/ModbusMaster/samples/generic/app/application.cpp
@@ -46,12 +46,10 @@ void mbLoop()
 void preTransmission()
 {
 	digitalWrite(RS485_RE_PIN, HIGH);
-	//delayMilliseconds(1);
 }
 
 void postTransmission()
 {
-	//delayMicroseconds(500);
 	digitalWrite(RS485_RE_PIN, LOW);
 }
 

--- a/Sming/Libraries/ModbusMaster/samples/generic/app/application.cpp
+++ b/Sming/Libraries/ModbusMaster/samples/generic/app/application.cpp
@@ -27,7 +27,6 @@ void mbLoop()
 
 	uint8_t nrOfRegistersToRead = 1;
 	uint8_t mbResult = mbMaster.readHoldingRegisters(SLAVE_REG_ADDR, nrOfRegistersToRead); //see also readInputRegisters
-	uint16_t result = 0;
 
 	if(mbResult == mbMaster.ku8MBSuccess) {
 		/*
@@ -38,7 +37,7 @@ void mbLoop()
 		*/
 		debugf("Data from slave: %d", mbMaster.getResponseBuffer(0));
 	} else {
-		debugf("Res err: %d", result);
+		debugf("Res err: %d", mbResult);
 	}
 
 	mbMaster.clearResponseBuffer();


### PR DESCRIPTION
This PR introduces the following fixes to ModbusMaster:
0. ModbusMaster is patched to use single ```_serial->write()``` to send the whole message instead of 'for loop'.
1. ModbusMaster is now patched so as to send single NUL character after the message in order to ensure TX line release after the whole message is sent.
2. Delays in the generic sample are commented out, but left for reference (the example works well without the delays).
3. In ```mbLoop()``` the variable ```result``` was used instead of ```mbResult``` when reporting the error code. ```result``` is removed and the proper ```mbResult``` is used.
4. In ```mbLogReceive()```  debug message of the RX ADU is added.
5. In ```mbLogTransmit``` ADU is changed to "TX ADU" to clarify the message.