### PR TITLE
Added support for Arduino's TensorFlow Lite.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -142,3 +142,6 @@
 	path = Sming/Libraries/Adafruit_VL53L0X
 	url = https://github.com/adafruit/Adafruit_VL53L0X.git
 	ignore = dirty
+[submodule "Libraries.Arduino_TensorFlowLite"]
+	path = Sming/Libraries/Arduino_TensorFlowLite
+	url = https://github.com/slaff/Arduino_TensorFlowLite.git


### PR DESCRIPTION
Now you can run TensorFlow models directly on your ESP8266 microcontroller with Sming's help.
And do a lot of interesting things. 
See https://www.tensorflow.org/lite/microcontrollers/get_started for details.