### PR TITLE
Build.mk changes to allow the use of CPPFLAGS, CFLAGS and CXXFLAGS.

### DIFF
--- a/Sming/Arch/Esp8266/build.mk
+++ b/Sming/Arch/Esp8266/build.mk
@@ -5,7 +5,6 @@
 ##############
 
 CPPFLAGS			+= -DARCH_ESP8266
-CFLAGS 				+= -std=c11
 CXXFLAGS			+= -fno-rtti -fno-exceptions -fno-threadsafe-statics
 
 # Required to access peripheral registers using structs

--- a/Sming/Arch/Esp8266/build.mk
+++ b/Sming/Arch/Esp8266/build.mk
@@ -4,7 +4,8 @@
 #
 ##############
 
-CFLAGS				+= -DARCH_ESP8266
+CPPFLAGS			+= -DARCH_ESP8266
+CFLAGS 				+= -std=c11
 CXXFLAGS			+= -fno-rtti -fno-exceptions -fno-threadsafe-statics
 
 # Required to access peripheral registers using structs
@@ -31,21 +32,21 @@ TOOLSPEC			:= $(XTENSA_TOOLS_ROOT)/$(CONFIG_TOOLPREFIX)
 
 # select which tools to use as assembler, compiler, librarian and linker
 DEBUG_VARS			+= GDB
-AS					:= $(TOOLSPEC)gcc
-CC					:= $(TOOLSPEC)gcc
-CXX					:= $(TOOLSPEC)g++
-AR					:= $(TOOLSPEC)ar
-LD					:= $(TOOLSPEC)gcc
+AS				:= $(TOOLSPEC)gcc
+CC				:= $(TOOLSPEC)gcc
+CXX				:= $(TOOLSPEC)g++
+AR				:= $(TOOLSPEC)ar
+LD				:= $(TOOLSPEC)gcc
 OBJCOPY			 	:= $(TOOLSPEC)objcopy
 OBJDUMP			 	:= $(TOOLSPEC)objdump
-GDB					:= $(TOOLSPEC)gdb
+GDB				:= $(TOOLSPEC)gdb
 
-CFLAGS_COMMON += \
+CPPFLAGS += \
 	-nostdlib \
 	-mlongcalls \
 	-mtext-section-literals
 
-CFLAGS += \
+CPPFLAGS += \
 	-D__ets__ \
 	-DICACHE_FLASH \
 	-DUSE_OPTIMIZE_PRINTF \

--- a/Sming/Arch/Host/build.mk
+++ b/Sming/Arch/Host/build.mk
@@ -5,7 +5,6 @@
 ##############
 
 CPPFLAGS	+= -DARCH_HOST
-CFLAGS 		+= -std=c11
 
 TOOLSPEC 	:=
 

--- a/Sming/Arch/Host/build.mk
+++ b/Sming/Arch/Host/build.mk
@@ -5,6 +5,7 @@
 ##############
 
 CPPFLAGS	+= -DARCH_HOST
+CFLAGS 		+= -std=c11
 
 TOOLSPEC 	:=
 
@@ -20,8 +21,6 @@ GDB		:= $(TOOLSPEC)gdb
 CPPFLAGS += \
 	-m32 \
 	-Wno-deprecated-declarations
-	
-CFLAGS += -std=c11
 
 # => Tools
 MEMANALYZER = size

--- a/Sming/Arch/Host/build.mk
+++ b/Sming/Arch/Host/build.mk
@@ -4,22 +4,24 @@
 #
 ##############
 
-CFLAGS		+= -DARCH_HOST
+CPPFLAGS	+= -DARCH_HOST
 
 TOOLSPEC 	:=
 
-AS			:= $(TOOLSPEC)gcc
-CC			:= $(TOOLSPEC)gcc
-CXX			:= $(TOOLSPEC)g++
-AR			:= $(TOOLSPEC)ar
-LD			:= $(TOOLSPEC)g++
+AS		:= $(TOOLSPEC)gcc
+CC		:= $(TOOLSPEC)gcc
+CXX		:= $(TOOLSPEC)g++
+AR		:= $(TOOLSPEC)ar
+LD		:= $(TOOLSPEC)g++
 OBJCOPY		:= $(TOOLSPEC)objcopy
 OBJDUMP		:= $(TOOLSPEC)objdump
-GDB			:= $(TOOLSPEC)gdb
+GDB		:= $(TOOLSPEC)gdb
 
-CFLAGS += \
+CPPFLAGS += \
 	-m32 \
 	-Wno-deprecated-declarations
+	
+CFLAGS += -std=c11
 
 # => Tools
 MEMANALYZER = size

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -116,7 +116,7 @@ CFLAGS_COMMON = \
 	-ffunction-sections
 
 # compiler flags using during compilation of source files. Add '-pg' for debugging
-CFLAGS = \
+CPPFLAGS = \
 	-Wall \
 	-Wundef \
 	-Wpointer-arith \
@@ -126,7 +126,7 @@ CFLAGS = \
 
 # If STRICT is enabled, show all warnings but don't treat as errors
 ifneq ($(STRICT),1)
-CFLAGS += \
+CPPFLAGS += \
 	-Werror \
 	-Wno-sign-compare \
 	-Wno-parentheses \
@@ -139,18 +139,18 @@ ifeq ($(SMING_RELEASE),1)
 	# See: https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html
 	#      for full list of optimization options
 	# Note: ANSI requires NDEBUG to be defined for correct assert behaviour
-	CFLAGS		+= -Os -DSMING_RELEASE=1 -DNDEBUG
+	CPPFLAGS	+= -Os -DSMING_RELEASE=1 -DNDEBUG
 else ifeq ($(ENABLE_GDB), 1)
 	ifeq ($(SMING_ARCH),Host)
-		CFLAGS		+= -O0
+		CPPFLAGS	+= -O0
 	else
-		CFLAGS		+= -Og
+		CPPFLAGS	+= -Og
 	endif
 else
-	CFLAGS		+= -Os -g
+	CPPFLAGS	+= -Os -g
 endif
 
-CXXFLAGS = $(CFLAGS) -felide-constructors
+CXXFLAGS += -felide-constructors
 
 ifneq ($(STRICT),1)
 	CXXFLAGS += -Wno-reorder

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -162,14 +162,20 @@ include $(ARCH_BASE)/build.mk
 DEBUG_VARS			+= GCC_VERSION
 GCC_VERSION			:= $(shell $(CC) -dumpversion)
 
+# Use c11 by default. Every architecture can override it
+SMING_C_STD ?= c11
+CFLAGS	+= -std=$(SMING_C_STD)
+
 # Select C++17 if supported, defaulting to C++11 otherwise
-DEBUG_VARS			+= SMING_CPP_STD
+DEBUG_VARS			+= SMING_CXX_STD
 ifeq ($(GCC_VERSION),4.8.5)
-SMING_CPP_STD		?= c++11
+SMING_CXX_STD		?= c++11
 else
-SMING_CPP_STD		?= c++17
+SMING_CXX_STD		?= c++17
 endif
-CXXFLAGS			+= -std=$(SMING_CPP_STD)
+CXXFLAGS			+= -std=$(SMING_CXX_STD)
+
+
 
 # Component (user) libraries have a special prefix so linker script can identify them
 CLIB_PREFIX := clib-

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -108,20 +108,18 @@ else
 	vecho		:= @echo
 endif
 
-# Common flags passed to user libraries
-CFLAGS_COMMON = \
+# Common C/C++ flags passed to user libraries
+CPPFLAGS = \
 	-Wl,-EL \
 	-finline-functions \
 	-fdata-sections \
 	-ffunction-sections
 
-# compiler flags using during compilation of source files. Add '-pg' for debugging
-CPPFLAGS = \
+CPPFLAGS += \
 	-Wall \
 	-Wundef \
 	-Wpointer-arith \
 	-Wno-comment \
-	$(CFLAGS_COMMON) \
 	-DARDUINO=106
 
 # If STRICT is enabled, show all warnings but don't treat as errors

--- a/Sming/building.rst
+++ b/Sming/building.rst
@@ -637,11 +637,11 @@ These values must only be appended to (with ``+=``), never overwritten.
 
 .. envvar:: CXXFLAGS
 
-   Used when building application and custom targets.
-
-.. envvar:: COMPONENT_CFLAGS
-
    Used to provide **ONLY** C++ flags that are applied globally.
+
+.. envvar:: SMING_C_STD
+
+   Used to provide the C language standard. The default is ``c11``.
 
 .. important::
 

--- a/Sming/building.rst
+++ b/Sming/building.rst
@@ -38,12 +38,12 @@ These are the main variables you need to be aware of:
 
    -  **Esp8266** The default if not specified. :envvar:`ESP_HOME` must also be
       provided to locate SDK & tools.
-   
+
    -  **Esp32** {todo}
-   
+
    -  **Host** builds a version of the library for native host debugging on
       Linux or Windows
-   
+
 
 .. envvar:: SMING_CPP_STD
 
@@ -172,7 +172,7 @@ example::
             |_ MyComponent/
             |_ AnotherComponent/
             |_ spiffs/              Will be used instead of Sming version
-   
+
 User repositories are searched first, which allows replacement of any
 Component for a project. In this example, our ``spiffs`` component will
 be selected instead of the one provided with Sming.
@@ -366,7 +366,7 @@ one of the following lists:
 
    These variables have no effect on building, but are
    cached. Variables such as ``COM_SPEED_ESPTOOL`` fall into this category.
-  
+
 
 .. envvar:: DEBUG_VARS
 
@@ -456,7 +456,7 @@ These values are for reference only and should not be modified.
 .. envvar:: COMPONENT_NAME
 
    Name of the Component
-   
+
 .. envvar:: COMPONENT_PATH
 
    Base directory path for Component, no trailing path separator
@@ -464,14 +464,14 @@ These values are for reference only and should not be modified.
 .. envvar:: COMPONENT_BUILD_DIR
 
    The current directory.
-   
+
    This should be used if the Component provides any application code or targets to ensure it is
    built in the correct directory (but not by this makefile).
 
 .. envvar:: COMPONENT_LIBDIR
 
    Location to store created Component (shared) libraries
-   
+
 .. envvar:: COMPONENT_VARIANT
 
    Name of the library to build
@@ -487,7 +487,7 @@ changed as required.
 
    By default, the library has the same name as the Component but can be
    changed if required. Note that this will be used as the stem for any variants.
-   
+
    Set ``COMPONENT_LIBNAME :=`` if the Component doesn’t create a library.
    If you don’t do this, a default library will be built but will be empty if
    no source files are found.
@@ -496,7 +496,7 @@ changed as required.
 
    Set this to any additional targets to be built as
    part of the Component, prefixed with ``$(COMPONENT_RULE)``.
-   
+
    If targets should be built for each application, use :envvar:`CUSTOM_TARGETS` instead.
    See :component:`spiffs` for an example.
 
@@ -610,19 +610,43 @@ never overwritten.
    During initial parsing, many of these variables (specifically, the
    ``COMPONENT_xxx`` ones) *do not* keep their values. For this reason it
    is usually best to use simple variable assignment using ``:=``.
-   
+
    For example, in ``Esp8266/Components/gdbstub`` we define
    ``GDB_CMDLINE``. It may be tempting to do this::
-   
+
       GDB_CMDLINE = trap '' INT; $(GDB) -x $(COMPONENT_PATH)/gdbcmds -b $(COM_SPEED_GDB) -ex "target remote $(COM_PORT_GDB)"
-   
+
    That won’t work! By the time ``GDB_CMDLINE`` gets expanded,
    ``COMPONENT_PATH`` could contain anything. We need ``GDB_CMDLINE`` to be
    expanded only when used, so the solution is to take a simple copy of
    ``COMPONENT_PATH`` and use it instead, like this::
-   
+
       GDBSTUB_DIR := $(COMPONENT_PATH)
       GDB_CMDLINE = trap '' INT; $(GDB) -x $(GDBSTUB_DIR)/gdbcmds -b $(COM_SPEED_GDB) -ex "target remote $(COM_PORT_GDB)"
+
+These values are global and should be used ONLY in the ``Sming/Arch/*/build.mk`` files to tune the architecture compilation flags.
+These values must only be appended to (with ``+=``), never overwritten.
+
+.. envvar:: CPPFLAGS
+
+   Used to provide both C and C++ flags that are applied globally.
+
+.. envvar:: CFLAGS
+
+   Used to provide **ONLY** C flags that are applied globally.
+
+.. envvar:: CXXFLAGS
+
+   Used when building application and custom targets.
+
+.. envvar:: COMPONENT_CFLAGS
+
+   Used to provide **ONLY** C++ flags that are applied globally.
+
+.. important::
+
+   Do **NOT** set ``CPPFLAGS``, ``CFLAGS`` and ``CXXFLAGS`` outside of the ``Sming/Arch/*/build.mk`` files.
+
 
 Building
 ~~~~~~~~

--- a/Sming/component-wrapper.mk
+++ b/Sming/component-wrapper.mk
@@ -19,12 +19,12 @@ include $(SMING_HOME)/build.mk
 # Makefile runs in the build directory
 COMPONENT_BUILD_DIR := $(CURDIR)
 
-CFLAGS				:= $(CFLAGS) $(GLOBAL_CFLAGS) -DCOMPONENT_PATH=\"$(COMPONENT_PATH)\"
+CPPFLAGS		:= $(CPPFLAGS) $(GLOBAL_CFLAGS) -DCOMPONENT_PATH=\"$(COMPONENT_PATH)\"
 
 #
 CUSTOM_BUILD		:=
 COMPONENT_TARGETS	:=
-EXTRA_OBJ			:=
+EXTRA_OBJ		:=
 COMPONENT_CFLAGS	:=
 COMPONENT_CXXFLAGS	:=
 COMPONENT_VARS		:=
@@ -43,7 +43,7 @@ endif
 COMPONENT_SRCFILES	:=
 else
 # Legacy project
-MODULES				:= app
+MODULES			:= app
 EXTRA_INCDIR		:= include
 EXTRA_SRCFILES		:=
 include $(COMPONENT_PATH)/Makefile-user.mk
@@ -52,14 +52,14 @@ COMPONENT_SRCFILES	:= $(EXTRA_SRCFILES)
 endif
 
 ifeq (App,$(COMPONENT_NAME))
-CFLAGS				+= $(APP_CFLAGS)
+CPPFLAGS		+= $(APP_CFLAGS)
 else ifneq ($(STRICT),1)
 # Enforce strictest building for regular Components and treat as errors
-CFLAGS				:= $(filter-out -Wno-sign-compare -Wno-strict-aliasing,$(CFLAGS)) -Werror
-CXXFLAGS			:= $(filter-out -Wno-reorder,$(CXXFLAGS))
+CPPFLAGS		:= $(filter-out -Wno-sign-compare -Wno-strict-aliasing,$(CPPFLAGS)) -Werror
+CXXFLAGS		:= $(filter-out -Wno-reorder,$(CXXFLAGS))
 endif
 
-INCDIR				= $(EXTRA_INCDIR) $(COMPONENTS_EXTRA_INCDIR)
+INCDIR			= $(EXTRA_INCDIR) $(COMPONENTS_EXTRA_INCDIR)
 
 # Build a Component target using MAKE
 # The makefile should accept TARGET and BUILD_DIR variables
@@ -114,27 +114,27 @@ BUILD_DIRS += $2
 ifneq (,$(filter $1/%.s,$(SOURCE_FILES)))
 $2%.o: $1/%.s
 	$(vecho) "AS $$<"
-	$(Q) $(AS) $(addprefix -I,$(INCDIR)) $(CFLAGS) -c $$< -o $$@
+	$(Q) $(AS) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CFLAGS) -c $$< -o $$@
 endif
 ifneq (,$(filter $1/%.S,$(SOURCE_FILES)))
 $2%.o: $1/%.S
 	$(vecho) "AS $$<"
-	$(Q) $(AS) $(addprefix -I,$(INCDIR)) $(CFLAGS) -c $$< -o $$@
+	$(Q) $(AS) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CFLAGS) -c $$< -o $$@
 endif
 ifneq (,$(filter $1/%.c,$(SOURCE_FILES)))
 $2%.o: $1/%.c $2%.c.d
 	$(vecho) "CC $$<"
-	$(Q) $(CC) $(addprefix -I,$(INCDIR)) $(CFLAGS) -std=c11 -c $$< -o $$@
+	$(Q) $(CC) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CFLAGS) -c $$< -o $$@
 $2%.c.d: $1/%.c
-	$(Q) $(CC) $(addprefix -I,$(INCDIR)) $(CFLAGS) -std=c11 -MM -MT $2$$*.o $$< -MF $$@
+	$(Q) $(CC) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CFLAGS) -MM -MT $2$$*.o $$< -MF $$@
 .PRECIOUS: $2%.c.d
 endif
 ifneq (,$(filter $1/%.cpp,$(SOURCE_FILES)))
 $2%.o: $1/%.cpp $2%.cpp.d
 	$(vecho) "C+ $$<"
-	$(Q) $(CXX) $(addprefix -I,$(INCDIR)) $(CXXFLAGS) -c $$< -o $$@
+	$(Q) $(CXX) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CXXFLAGS) -c $$< -o $$@
 $2%.cpp.d: $1/%.cpp
-	$(Q) $(CXX) $(addprefix -I,$(INCDIR)) $(CXXFLAGS) -MM -MT $2$$*.o $$< -MF $$@
+	$(Q) $(CXX) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CXXFLAGS) -MM -MT $2$$*.o $$< -MF $$@
 .PRECIOUS: $2%.cpp.d
 endif
 endef

--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -61,18 +61,18 @@ $(info $(notdir $(PROJECT_DIR)): Invoking '$(MAKECMDGOALS)' for $(SMING_ARCH) ($
 # CFLAGS used for application and any custom targets
 DEBUG_VARS			+= APP_CFLAGS
 APP_CFLAGS			=
-CFLAGS				+= $(APP_CFLAGS)
+CPPFLAGS			+= $(APP_CFLAGS)
 
 # Changing USER_CFLAGS will cause an App rebuild automatically, but other Components must be rebuilt manually
 CONFIG_VARS			+= USER_CFLAGS
 
 # CFLAGS exported for every Component to use whilst building, including any CUSTOM_TARGETS
 DEBUG_VARS			+= GLOBAL_CFLAGS
-GLOBAL_CFLAGS		= $(USER_CFLAGS) -DPROJECT_DIR=\"$(PROJECT_DIR)\" -DSMING_HOME=\"$(SMING_HOME)\"
-CFLAGS				+= $(GLOBAL_CFLAGS)
+GLOBAL_CFLAGS			= $(USER_CFLAGS) -DPROJECT_DIR=\"$(PROJECT_DIR)\" -DSMING_HOME=\"$(SMING_HOME)\"
+CPPFLAGS			+= $(GLOBAL_CFLAGS)
 
 # Targets to be added as dependencies of the application, built directly in this make instance
-CUSTOM_TARGETS		:=
+CUSTOM_TARGETS			:=
 
 # Application libraries will be written here
 DEBUG_VARS			+= APP_LIBDIR


### PR DESCRIPTION
Before this PR it was impossible to set easily C only flag because CFLAGS was used to set both C and C++ flags.
With this PR the common C/C++ flags should be set using the CPPFLAGS, as in a standard makefile. 
With this change CFLAGS will be further on used ONLY for C compilation flags. 
This PR is part of the changes needed to allow the compilation of the upcoming ESP32 architecture.
With this PR CPPFLAGS, CFLAGS and CXXFLAGS are allowed only in the Sming/Arch/*/build.mk files and should not be used in a component or application makefile.