### PR TITLE
Fix Python path in Windows and validate

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -18,9 +18,6 @@ include build.mk
 all:
 	$(info Please run `make` from your project directory!)
 
-#
-DOXYGEN := $(shell command -v doxygen 2> /dev/null)
-
 
 ##@Cleaning
 

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -97,7 +97,19 @@ AWK ?= POSIXLY_CORRECT= awk
 
 # Python command
 DEBUG_VARS += PYTHON
-PYTHON ?= python
+ifdef PYTHON
+export PYTHON := $(call FixPath,$(PYTHON))
+else
+PYTHON := python
+endif
+
+PYTHON_VERSION := $(shell $(PYTHON) --version 2>&1)
+$(if $V,$(info PYTHON_VERSION = $(PYTHON_VERSION)))
+PYTHON_VERSION_OK := $(findstring Python,$(PYTHON_VERSION))
+ifndef PYTHON_VERSION_OK
+$(error Cannot find Python installation - check PATH or PYTHON environment variables)
+endif
+
 
 V ?= $(VERBOSE)
 ifeq ("$(V)","1")

--- a/docs/source/arch/esp8266/getting-started/windows-manual.rst
+++ b/docs/source/arch/esp8266/getting-started/windows-manual.rst
@@ -102,6 +102,23 @@ Install Python
 
 Get the current version from https://www.python.org/.
 
+By default, python gets installed here::
+
+   C:\Users\xxx\AppData\Local\Programs\Python\Python38\python.exe
+
+Wherever it ends up will either need to be in the path::
+
+   setx PATH "C:\Users\xxx\AppData\Local\Programs\Python\Python38;%PATH%"
+
+or located using the :envvar:`PYTHON` environment variable::
+
+   setx PYTHON "C:\Users\xxx\AppData\Local\Programs\Python\Python38"
+
+.. important::
+
+   The PYTHON variable may not contain spaces.
+   This is a MinGW restriction.
+
 
 Install GIT
 -----------


### PR DESCRIPTION
Raised in #2021 if python has not been set then the error message is very obscure and difficult to diagnose.

This PR validates that python is installed by checking its version number.

Windows installation documentation updated to ensure python is accessible by Sming build.

See https://github.com/SmingHub/Sming/issues/2021#issuecomment-638266670