### PR TITLE
Update Windows Host networking support

### DIFF
--- a/Sming/Arch/Host/Components/hostlib/sockets.cpp
+++ b/Sming/Arch/Host/Components/hostlib/sockets.cpp
@@ -104,14 +104,14 @@ bool CSockAddr::assign(const char* addr, unsigned port)
 bool CSockAddr::get_host(int fd)
 {
 	clear();
-	socklen_t len = sizeof(m_addr.sa);
+	host_socklen_t len = sizeof(m_addr.sa);
 	return (getsockname(fd, &m_addr.sa, &len) == 0);
 }
 
 bool CSockAddr::get_peer(int fd)
 {
 	clear();
-	socklen_t len = sizeof(m_addr.sa);
+	host_socklen_t len = sizeof(m_addr.sa);
 	return (getpeername(fd, &m_addr.sa, &len) == 0);
 }
 
@@ -439,7 +439,7 @@ CSocket* CServerSocket::try_connect()
 	}
 
 	struct sockaddr sa;
-	socklen_t len = sizeof(sa);
+	host_socklen_t len = sizeof(sa);
 	int fd = ::accept(m_fd, &sa, &len);
 	if(fd < 0) {
 		return nullptr;

--- a/Sming/Arch/Host/Components/hostlib/sockets.h
+++ b/Sming/Arch/Host/Components/hostlib/sockets.h
@@ -31,12 +31,13 @@
 #define MSG_DONTWAIT 0x40
 #define SHUT_RDWR SD_BOTH
 typedef char* sock_ptr_t;
-typedef int socklen_t;
+typedef int host_socklen_t;
 
 #else
 
 #include <arpa/inet.h>
 typedef void* sock_ptr_t;
+typedef socklen_t host_socklen_t;
 
 #endif
 

--- a/Sming/Arch/Host/Components/lwip/Windows/CMakeLists.txt
+++ b/Sming/Arch/Host/Components/lwip/Windows/CMakeLists.txt
@@ -8,12 +8,13 @@ set (CMAKE_C_STANDARD_REQUIRED ON)
 
 include (ExternalProject)
 
-set (PCAP_SRC npcap-sdk-1.03.zip)
+set (PCAP_SRC npcap-sdk-1.05.zip)
 set (PCAP_DIR src/npcap)
 ExternalProject_Add(npcap
 	PREFIX ${CMAKE_CURRENT_SOURCE_DIR}
 	URL https://nmap.org/npcap/dist/${PCAP_SRC}
-	URL_HASH MD5=b9bfe28d9c9dc1110d6d635d7e7f9e23
+	URL_HASH MD5=9af87ce508bee6a347be72b3e9adf777
+	PATCH_COMMAND patch -p1 -i ../../npcap.patch
 	CONFIGURE_COMMAND ""
 	BUILD_COMMAND ""
 	INSTALL_COMMAND ""

--- a/Sming/Arch/Host/Components/lwip/Windows/npcap.patch
+++ b/Sming/Arch/Host/Components/lwip/Windows/npcap.patch
@@ -1,0 +1,19 @@
+diff -Naur a/Include/pcap/socket.h b/Include/pcap/socket.h
+--- a/Include/pcap/socket.h	2019-04-25 17:20:00 +0100
++++ b/Include/pcap/socket.h	2020-06-16 12:20:11 +0100
+@@ -49,15 +49,6 @@
+   #include <ws2tcpip.h>
+ 
+   /*
+-   * Winsock doesn't have this UN*X type; it's used in the UN*X
+-   * sockets API.
+-   *
+-   * XXX - do we need to worry about UN*Xes so old that *they*
+-   * don't have it, either?
+-   */
+-  typedef int socklen_t;
+-
+-  /*
+    * Winsock doesn't have this POSIX type; it's used for the
+    * tv_usec value of struct timeval.
+    */


### PR DESCRIPTION
Updates NPCAP SDK to version 1.05 - see [changelog](https://github.com/nmap/npcap/blob/master/CHANGELOG.md)
Updating MinGW to latest version (`mingw-get upgrade`) adds conflicting definition of `socklen_t` which this PR addresses.