### PR TITLE
Allow HTTP server responses to be pended.

### DIFF
--- a/Sming/Core/Network/Http/HttpServerConnection.cpp
+++ b/Sming/Core/Network/Http/HttpServerConnection.cpp
@@ -200,6 +200,10 @@ void HttpServerConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 {
 	switch(state) {
 	case eHCS_StartSending: {
+		// Stream may be set but not yet contain any data, in which case hold off sending headers
+		if(response.stream != nullptr && response.stream->available() == 0 && !response.stream->isFinished()) {
+			break;
+		}
 		sendResponseHeaders(&response);
 		state = eHCS_SendingHeaders;
 	}
@@ -331,7 +335,7 @@ bool HttpServerConnection::sendResponseBody(HttpResponse* response)
 	}
 
 	if(stream == nullptr) {
-		// we are done for now
+		// No body to send, we're done
 		return true;
 	}
 

--- a/Sming/Core/Network/Http/HttpServerConnection.h
+++ b/Sming/Core/Network/Http/HttpServerConnection.h
@@ -60,8 +60,12 @@ public:
 
 	void send()
 	{
-		state = eHCS_StartSending;
-		onReadyToSendData(eTCE_Received);
+		if(state == eHCS_Ready) {
+			state = eHCS_StartSending;
+			onReadyToSendData(eTCE_Received);
+		} else {
+			onReadyToSendData(eTCE_Poll);
+		}
 	}
 
 	using TcpClient::send;

--- a/samples/Basic_WebSkeletonApp/app/DelayStream.cpp
+++ b/samples/Basic_WebSkeletonApp/app/DelayStream.cpp
@@ -1,0 +1,24 @@
+#include "DelayStream.h"
+
+void DelayStream::sendFile()
+{
+	auto response = connection.getResponse();
+
+	String fn = filename + _F(".gz");
+	if(::fileExist(fn)) {
+		response->headers[HTTP_HEADER_CONTENT_ENCODING] = F("gzip");
+	} else {
+		fn = filename;
+	}
+
+	if(FileStream::open(fn, eFO_ReadOnly)) {
+		debug_i("opened '%s', %u bytes", fn.c_str(), FileStream::available());
+		response->setContentType(ContentType::fromFullFileName(filename));
+	} else {
+		debug_e("open '%s' failed!", fn.c_str());
+		response->code = HTTP_STATUS_NOT_FOUND;
+	}
+
+	ready = true;
+	connection.send();
+}

--- a/samples/Basic_WebSkeletonApp/app/DelayStream.h
+++ b/samples/Basic_WebSkeletonApp/app/DelayStream.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <Network/Http/HttpServerConnection.h>
+#include <Data/Stream/FileStream.h>
+#include <Timer.h>
+
+/*
+ * It may not always be possible to fulfil an incoming HTTP request immediately.
+ * This class provides a simple demonstration of how to defer a file request using a timer.
+ * See sendFile() for further details.
+ *
+ * A more realistic example might be if we need to communicate with a slow Serial device, which
+ * might take several seconds. This can be handled asychronously without affecting other system
+ * operations.
+ */
+class DelayStream : public FileStream
+{
+public:
+	DelayStream(const String& filename, HttpServerConnection& connection) : filename(filename), connection(connection)
+	{
+		debug_i("DelayStream(\"%s\") %p", filename.c_str(), this);
+		timer.initializeMs<500>([this]() { sendFile(); });
+		timer.startOnce();
+	}
+
+	~DelayStream()
+	{
+		debug_i("~DelayStream() %p", this);
+	}
+
+	bool isValid() const override
+	{
+		return true;
+	}
+
+	int available() override
+	{
+		return ready ? FileStream::available() : 0;
+	}
+
+	bool isFinished() override
+	{
+		return ready && FileStream::isFinished();
+	}
+
+private:
+	void sendFile();
+
+	String filename;
+	HttpServerConnection& connection;
+	Timer timer;
+	bool ready{false};
+};

--- a/samples/Basic_WebSkeletonApp/include/tytherm.h
+++ b/samples/Basic_WebSkeletonApp/include/tytherm.h
@@ -6,8 +6,3 @@ extern unsigned long counter; // Kind of heartbeat counter
 
 // Webserver
 void startWebServer();
-
-// STA disconnecter
-const uint8_t StaConnectTimeout = 20; // 15 sec to connect in STA mode
-void StaConnectOk();
-void StaConnectFail();


### PR DESCRIPTION
See #1943 for discussion.

If stream `available()` == 0 then headers won't be sent until response is ready
Must implement `isValid()` or stream will be destroyed almost immediately

Revise Basic_WebSkeletonApp to demonstrate usage

