### PR TITLE
Add `CString` class

### DIFF
--- a/Sming/Core/Data/CString.h
+++ b/Sming/Core/Data/CString.h
@@ -1,0 +1,95 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * CString.h
+ *
+ * @author: 2020 - Mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#pragma once
+
+#include <WString.h>
+#include <memory>
+
+/**
+ * @brief Class to manage a NUL-terminated C-style string
+ * When storing persistent strings in RAM the regular String class can become inefficient,
+ * so using a regular `char*` can be preferable. This class provides that with additional
+ * methods to simplify lifetime management and provide some interoperability with
+ * Wiring String objects.
+ */
+class CString : public std::unique_ptr<char[]>
+{
+public:
+	CString() = default;
+
+	CString(const CString& src) = default;
+
+	CString(const String& src)
+	{
+		assign(src);
+	}
+
+	void assign(const String& src)
+	{
+		assign(src.c_str(), src.length());
+	}
+
+	void assign(const char* src)
+	{
+		assign(src, src ? strlen(src) : 0);
+	}
+
+	void assign(const char* src, size_t len)
+	{
+		if(src == nullptr || len == 0) {
+			reset();
+		} else {
+			++len;
+			reset(new char[len]);
+			memcpy(get(), src, len);
+		}
+	}
+
+	CString& operator=(const String& src)
+	{
+		assign(src);
+		return *this;
+	}
+
+	CString& operator=(const char* src)
+	{
+		assign(src);
+		return *this;
+	}
+
+	const char* c_str() const
+	{
+		return get() ?: "";
+	}
+
+	bool operator==(const CString& other) const
+	{
+		return strcmp(c_str(), other.c_str()) == 0;
+	}
+
+	bool operator==(const String& other) const
+	{
+		return strcmp(c_str(), other.c_str()) == 0;
+	}
+
+	size_t length() const
+	{
+		auto p = get();
+		return p ? strlen(p) : 0;
+	}
+
+	explicit operator String() const
+	{
+		return get();
+	}
+};

--- a/docs/source/framework/core/data/cstring.rst
+++ b/docs/source/framework/core/data/cstring.rst
@@ -1,0 +1,29 @@
+CString
+=======
+
+.. highlight:: c++
+
+Introduction
+------------
+
+Whilst use of `char*` pointers is very common in Sming code, it is generally advisable to avoid pointers in C++ where possible.
+
+The STL provides class templates such as `unique_ptr` which deals with memory alllocation and de-allocation
+to avoid issues with memory leaks.
+
+The `CString` class implements this on a `char[]` and adds some additional methods which are similar to the :cpp:class:`String` class.
+
+String vs. CString
+------------------
+
+:cpp:class:`String` objects each require a minimum of 24 bytes of RAM, and always contain a length field.
+A `CString` is much simpler and contains only a `char*` pointer, so a NULL string is only 4 bytes.
+
+When storing arrays or lists of strings (or objects containing those strings) which change infrequently,
+such as fixed configuration data, use a `CString` for memory efficiency.
+
+
+API Documentation
+-----------------
+
+.. doxygenclass:: CString

--- a/docs/source/information/strings.rst
+++ b/docs/source/information/strings.rst
@@ -4,5 +4,6 @@ Strings
 Sming provides three classes to deal with string content:
 
 -  :doc:`/framework/wiring/wstring` for flexible RAM string handling
+-  :doc:`/framework/core/data/cstring` for efficient storage of C-style `char*` RAM strings
 -  :doc:`/framework/core/data/cstringarray` for handling small strings lists
 -  :doc:`/_inc/Sming/Components/FlashString/string` for storing and handling strings stored in flash memory

--- a/tests/HostTests/app/test-json6.cpp
+++ b/tests/HostTests/app/test-json6.cpp
@@ -2,6 +2,7 @@
 #define ARDUINOJSON_USE_LONG_LONG 1
 #include <JsonObjectStream6.h>
 #include <Data/CStringArray.h>
+#include <Data/CString.h>
 
 class JsonTest6 : public TestGroup
 {
@@ -36,6 +37,11 @@ public:
 			String s = Json::serialize(doc);
 			debug_d("Test doc: %s", s.c_str());
 			REQUIRE(s == serialized1);
+
+			CString cs;
+			Json::serialize(doc, cs);
+			debug_d("Test doc: %s", cs.c_str());
+			REQUIRE(cs == serialized1);
 		}
 
 		TEST_CASE("Json::measure()")
@@ -120,6 +126,17 @@ public:
 			debug_d("Json::serialize(stream = nullptr) = %u", count);
 			REQUIRE(count == 0);
 			REQUIRE(Json::deserialize(doc, stream) == false);
+			debug_d("doc.memoryUsage = %u", doc.memoryUsage());
+		}
+
+		TEST_CASE("CString serialisation")
+		{
+			doc = sourceDoc;
+			CString cs;
+			Json::serialize(doc, cs);
+			debug_hex(DBG, "serialized", cs.c_str(), cs.length());
+			REQUIRE(cs.length() == 100);
+			REQUIRE(Json::deserialize(doc, cs) == true);
 			debug_d("doc.memoryUsage = %u", doc.memoryUsage());
 		}
 


### PR DESCRIPTION
Whilst use of `char*` pointers is very common in Sming code, it is generally advisable to avoid pointers in C++ where possible.

The STL provides class templates such as `unique_ptr` which deals with memory alllocation and de-allocation
to avoid issues with memory leaks.

The `CString` class implements this on a `char[]` and adds some additional methods which are similar to the :cpp:class:`String` class.