### PR TITLE
Add delegate callback support to TemplateStream

### DIFF
--- a/Sming/Core/Data/Stream/TemplateStream.h
+++ b/Sming/Core/Data/Stream/TemplateStream.h
@@ -14,33 +14,24 @@
 #include "WHashMap.h"
 #include "WString.h"
 
+/**
+ * @brief Maximum length of a template variable name
+ * @see See `TemplateStream`
+ */
 #define TEMPLATE_MAX_VAR_NAME_LEN 16
 
-/** @brief  Template variable (hash map) class
- *  @see    Wiring HashMap
- */
-class TemplateVariables : public HashMap<String, String>
-{
-};
-
-/** @brief  Template file stream expand state
- *  @ingroup constants
- *  @{
- */
-enum TemplateExpandState {
-	eTES_Wait,		///< Template expand state wait
-	eTES_Found,		///< Template expand state found
-	eTES_StartVar,  ///< Template expand state start variable
-	eTES_SendingVar ///< Template expand state sending variable
-};
-/** @} */
-
-/** @addtogroup stream
- *  @{
+/**
+ * @brief Stream which performs variable-value substitution on-the-fly
+ *
+ * Template uses {varname} style markers which are replaced as the stream is read
+ * using content from a hashmap.
+ *
+ * @ingroup stream
  */
 class TemplateStream : public IDataSourceStream
 {
 public:
+	using Variables = HashMap<String, String>;
 	using GetValueDelegate = Delegate<String(const char* name)>;
 
 	/** @brief Create a template stream
@@ -55,16 +46,13 @@ public:
 		delete stream;
 	}
 
-	//Use base class documentation
 	StreamType getStreamType() const override
 	{
 		return stream ? eSST_Template : eSST_Invalid;
 	}
 
-	//Use base class documentation
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	//Use base class documentation
 	bool seek(int len) override;
 
 	bool isFinished() override
@@ -85,7 +73,7 @@ public:
 	/** @brief  Set multiple variables in the template file
      *  @param  vars Template Variables
      */
-	void setVars(const TemplateVariables& vars)
+	void setVars(const Variables& vars)
 	{
 		templateData.setMultiple(vars);
 	}
@@ -93,7 +81,7 @@ public:
 	/** @brief  Get the template variables
      *  @retval TemplateVariables Reference to the template variables
      */
-	inline TemplateVariables& variables()
+	Variables& variables()
 	{
 		return templateData;
 	}
@@ -116,10 +104,17 @@ protected:
 	String getValue(const char* name);
 
 private:
+	enum class State {
+		Wait,
+		Found,
+		StartVar,
+		SendingVar,
+	};
+
 	IDataSourceStream* stream = nullptr;
-	TemplateVariables templateData;
+	Variables templateData;
 	GetValueDelegate getValueCallback;
-	TemplateExpandState state = eTES_Wait;
+	State state = State::Wait;
 	String value;
 	size_t skipBlockSize = 0;
 	size_t varDataPos = 0;

--- a/Sming/Core/Data/Stream/TemplateStream.h
+++ b/Sming/Core/Data/Stream/TemplateStream.h
@@ -38,17 +38,16 @@ enum TemplateExpandState {
 /** @addtogroup stream
  *  @{
  */
-
 class TemplateStream : public IDataSourceStream
 {
 public:
+	using GetValueDelegate = Delegate<String(const char* name)>;
+
 	/** @brief Create a template stream
      *  @param stream source of template data
      */
 	TemplateStream(IDataSourceStream* stream) : stream(stream)
 	{
-		// Pre-allocate string to maximum length
-		varName.reserve(TEMPLATE_MAX_VAR_NAME_LEN);
 	}
 
 	~TemplateStream()
@@ -105,22 +104,29 @@ public:
 	}
 
 	/**
-	 * @brief Return the total length of the stream
-	 * @retval int -1 is returned when the size cannot be determined
-	 *
-	 * We cannot reliably determine available size so use default method which returns -1.
-	 *
-	 * 	int available()
+	 * @brief Set a callback to obtain variable values
+	 * @param callback Invoked only if variable name not found in map
 	 */
+	void onGetValue(GetValueDelegate callback)
+	{
+		getValueCallback = callback;
+	}
+
+protected:
+	String getValue(const char* name);
 
 private:
 	IDataSourceStream* stream = nullptr;
 	TemplateVariables templateData;
+	GetValueDelegate getValueCallback;
 	TemplateExpandState state = eTES_Wait;
-	String varName;
+	String value;
 	size_t skipBlockSize = 0;
 	size_t varDataPos = 0;
 	size_t varWaitSize = 0;
 };
 
-/** @} */
+/**
+ * @deprecated Use `TemplateStream::Variables` instead
+ */
+typedef TemplateStream::Variables TemplateVariables;

--- a/tests/HostTests/app/modules.h
+++ b/tests/HostTests/app/modules.h
@@ -7,6 +7,7 @@
 	XX(arduino_string)                                                                                                 \
 	XX(crypto)                                                                                                         \
 	XX(cstringarray)                                                                                                   \
+	XX(stream)                                                                                                         \
 	XX(serial)                                                                                                         \
 	XX(objectmap)                                                                                                      \
 	XX(base64)                                                                                                         \

--- a/tests/HostTests/app/test-stream.cpp
+++ b/tests/HostTests/app/test-stream.cpp
@@ -1,0 +1,67 @@
+#include <SmingTest.h>
+#include <FlashString/TemplateStream.hpp>
+#include <Data/Stream/MemoryDataStream.h>
+
+DEFINE_FSTR_LOCAL(template1, "Stream containing {var1}, {var2} and {var3}. {} {{}} {{12345")
+DEFINE_FSTR_LOCAL(template1_1, "Stream containing value #1, value #2 and {var3}. {} {{}} {")
+DEFINE_FSTR_LOCAL(template1_2, "Stream containing value #1, value #2 and [value #3]. {} {{}} {")
+
+class StreamTest : public TestGroup
+{
+public:
+	StreamTest() : TestGroup(_F("Stream"))
+	{
+	}
+
+	void execute() override
+	{
+		TEST_CASE("template1.1")
+		{
+			FSTR::TemplateStream tmpl(template1);
+			tmpl.onGetValue([](const char* name) -> String {
+				if(FS("var1") == name) {
+					return F("value #1");
+				}
+				if(FS("var2") == name) {
+					return F("value #2");
+				}
+				return nullptr;
+			});
+
+			check(tmpl, template1_1);
+		}
+
+		TEST_CASE("template1.2")
+		{
+			FSTR::TemplateStream tmpl(template1);
+			tmpl.setVar("var3", "[value #3]");
+			tmpl.onGetValue([](const char* name) -> String {
+				if(FS("var1") == name) {
+					return F("value #1");
+				}
+				if(FS("var2") == name) {
+					return F("value #2");
+				}
+				return nullptr;
+			});
+
+			check(tmpl, template1_2);
+		}
+	}
+
+private:
+	void check(TemplateStream& stream, const FlashString& ref)
+	{
+		MemoryDataStream mem;
+		mem.copyFrom(&stream, 1024);
+		String tmpl = mem.readString();
+		debug_i("tmpl: %s", tmpl.c_str());
+		debug_i(" ref: %s", String(ref).c_str());
+		REQUIRE(ref == tmpl);
+	}
+};
+
+void REGISTER_TEST(stream)
+{
+	registerGroup<StreamTest>();
+}


### PR DESCRIPTION
Supports calculated values or external lookups. If variable is not found in list, the callback (if provided) is invoked.

Class has also been refactored:

* Cache variable value instead of name to avoid multiple lookups
* Reduce scope of definitions, i.e. `TemplateVariables` -> public `TemplateStream::Variables`, `TemplateExpandState` -> private `TemplateStream::State`

HostTests additions:

* Add stream tests module with basic TemplateStream test

Future work:

* Handling of malformed input is unclear and further improvements possible. e.g. how to escape { and } for inclusion in output?
