### PR TITLE
Apply String move semantics to reduce memory re-allocations

### DIFF
--- a/Sming/Core/Data/CStringArray.h
+++ b/Sming/Core/Data/CStringArray.h
@@ -72,11 +72,11 @@ public:
 	}
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-	CStringArray(String&& rval) : String(std::move(rval))
+	CStringArray(String&& rval) noexcept : String(std::move(rval))
 	{
 		init();
 	}
-	CStringArray(StringSumHelper&& rval) : String(std::move(rval))
+	CStringArray(StringSumHelper&& rval) noexcept : String(std::move(rval))
 	{
 		init();
 	}

--- a/Sming/Core/Data/MailMessage.cpp
+++ b/Sming/Core/Data/MailMessage.cpp
@@ -38,12 +38,18 @@ HttpHeaders& MailMessage::getHeaders()
 
 MailMessage& MailMessage::setBody(const String& body, MimeType mime)
 {
-	MemoryDataStream* memory = new MemoryDataStream();
-	auto written = memory->write((uint8_t*)body.c_str(), body.length());
+	auto memory = new MemoryDataStream();
+	auto written = memory->print(body);
 	if(written < body.length()) {
 		debug_e("MailMessage::setBody: Unable to store the complete body");
 	}
 
+	return setBody(memory, mime);
+}
+
+MailMessage& MailMessage::setBody(String&& body, MimeType mime)
+{
+	auto memory = new MemoryDataStream(std::move(body));
 	return setBody(memory, mime);
 }
 

--- a/Sming/Core/Data/MailMessage.cpp
+++ b/Sming/Core/Data/MailMessage.cpp
@@ -38,8 +38,8 @@ HttpHeaders& MailMessage::getHeaders()
 
 MailMessage& MailMessage::setBody(const String& body, MimeType mime)
 {
-	auto memory = new MemoryDataStream();
-	auto written = memory->print(body);
+	MemoryDataStream* memory = new MemoryDataStream();
+	auto written = memory->write(reinterpret_cast<const uint8_t*>(body.c_str()), body.length());
 	if(written < body.length()) {
 		debug_e("MailMessage::setBody: Unable to store the complete body");
 	}

--- a/Sming/Core/Data/MailMessage.cpp
+++ b/Sming/Core/Data/MailMessage.cpp
@@ -47,7 +47,7 @@ MailMessage& MailMessage::setBody(const String& body, MimeType mime)
 	return setBody(memory, mime);
 }
 
-MailMessage& MailMessage::setBody(String&& body, MimeType mime)
+MailMessage& MailMessage::setBody(String&& body, MimeType mime) noexcept
 {
 	auto memory = new MemoryDataStream(std::move(body));
 	return setBody(memory, mime);

--- a/Sming/Core/Data/MailMessage.h
+++ b/Sming/Core/Data/MailMessage.h
@@ -61,6 +61,14 @@ public:
 	MailMessage& setBody(const String& body, MimeType mime = MIME_TEXT);
 
 	/**
+	 * @brief Sets the body of the email using move semantics
+	 * @param body Will be moved into message then invalidated
+	 * @param mime
+	 * @retval MailMessage&
+	 */
+	MailMessage& setBody(String&& body, MimeType mime = MIME_TEXT);
+
+	/**
 	 * @brief Sets the body of the email
 	 * @param stream
 	 * @param mime

--- a/Sming/Core/Data/MailMessage.h
+++ b/Sming/Core/Data/MailMessage.h
@@ -66,7 +66,7 @@ public:
 	 * @param mime
 	 * @retval MailMessage&
 	 */
-	MailMessage& setBody(String&& body, MimeType mime = MIME_TEXT);
+	MailMessage& setBody(String&& body, MimeType mime = MIME_TEXT) noexcept;
 
 	/**
 	 * @brief Sets the body of the email

--- a/Sming/Core/Data/Stream/DataSourceStream.cpp
+++ b/Sming/Core/Data/Stream/DataSourceStream.cpp
@@ -30,17 +30,24 @@ int IDataSourceStream::peek()
 	return -1;
 }
 
+size_t IDataSourceStream::readBytes(char* buffer, size_t length)
+{
+	auto count = readMemoryBlock(buffer, length);
+	if(count > 0) {
+		seek(count);
+	}
+	return count;
+}
+
 String IDataSourceStream::readString(size_t maxLen)
 {
-	int avail = available();
-	if(avail < 0) {
-		return nullptr;
-	}
+	size_t avail = available();
+	size_t len = std::min(avail, maxLen);
 
 	String s;
-	size_t len = std::min(size_t(avail), maxLen);
 	if(s.setLength(len)) {
-		readMemoryBlock(s.begin(), len);
+		len = readBytes(s.begin(), len);
+		s.setLength(len);
 	}
 	return s;
 }

--- a/Sming/Core/Data/Stream/DataSourceStream.h
+++ b/Sming/Core/Data/Stream/DataSourceStream.h
@@ -166,4 +166,24 @@ public:
 	 * @note Stream position is updated by this call
 	 */
 	String readString(size_t maxLen) override;
+
+	/**
+	 * @brief Memory-based streams may be able to move content into a String
+	 * @param s String object to move data into
+	 * @retval bool true on success, false if there's a problem.
+	 *
+	 * If the operation is not supported by the stream, `s` will be invalidated and false returned.
+	 *
+	 * Because a String object must have a NUL terminator, this will be appended if there is
+	 * sufficient capacity. In this case, the method returns true.
+	 *
+	 * If there is no capacity to add a NUL terminator, then the final character of stream data
+	 * will be replaced with a NUL. The method returns false to indicate this.
+	 *
+	 */
+	virtual bool moveString(String& s)
+	{
+		s = nullptr;
+		return false;
+	};
 };

--- a/Sming/Core/Data/Stream/DataSourceStream.h
+++ b/Sming/Core/Data/Stream/DataSourceStream.h
@@ -57,6 +57,8 @@ public:
 		return getStreamType() != eSST_Invalid;
 	}
 
+	size_t readBytes(char* buffer, size_t length) override;
+
 	/** @brief  Read a block of memory
      *  @param  data Pointer to the data to be read
      *  @param  bufSize Quantity of chars to read
@@ -161,7 +163,7 @@ public:
 
 	/**
 	 * @brief Overrides Stream method for more efficient reading
-	 * @note Content is read using `readMemoryBlock()` so read position (for seekable streams) is not changed
+	 * @note Stream position is updated by this call
 	 */
-	String readString(size_t maxLen = UINT16_MAX);
+	String readString(size_t maxLen) override;
 };

--- a/Sming/Core/Data/Stream/FileStream.h
+++ b/Sming/Core/Data/Stream/FileStream.h
@@ -69,6 +69,14 @@ public:
 
 	size_t write(const uint8_t* buffer, size_t size) override;
 
+	int read() override
+	{
+		char c;
+		return readBytes(&c, 1) ? static_cast<unsigned char>(c) : -1;
+	}
+
+	size_t readBytes(char* buffer, size_t length) override;
+
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
 	int seekFrom(int offset, unsigned origin) override;

--- a/Sming/Core/Data/Stream/MemoryDataStream.cpp
+++ b/Sming/Core/Data/Stream/MemoryDataStream.cpp
@@ -10,6 +10,14 @@
 
 #include "MemoryDataStream.h"
 
+MemoryDataStream::MemoryDataStream(String&& string)
+{
+	auto buf = string.getBuffer();
+	buffer = buf.data;
+	size = buf.length;
+	capacity = buf.size;
+}
+
 bool MemoryDataStream::ensureCapacity(size_t minCapacity)
 {
 	if(capacity < minCapacity) {

--- a/Sming/Core/Data/Stream/MemoryDataStream.cpp
+++ b/Sming/Core/Data/Stream/MemoryDataStream.cpp
@@ -90,3 +90,18 @@ int MemoryDataStream::seekFrom(int offset, unsigned origin)
 	readPos = newPos;
 	return readPos;
 }
+
+bool MemoryDataStream::moveString(String& s)
+{
+	// Ensure size < capacity
+	bool sizeOk = ensureCapacity(size + 1);
+
+	// If we couldn't reallocate for the NUL terminator, drop the last character
+	assert(s.setBuffer({buffer, capacity, sizeOk ? size : size - 1}));
+
+	buffer = nullptr;
+	readPos = 0;
+	size = 0;
+	capacity = 0;
+	return sizeOk;
+}

--- a/Sming/Core/Data/Stream/MemoryDataStream.cpp
+++ b/Sming/Core/Data/Stream/MemoryDataStream.cpp
@@ -10,7 +10,7 @@
 
 #include "MemoryDataStream.h"
 
-MemoryDataStream::MemoryDataStream(String&& string)
+MemoryDataStream::MemoryDataStream(String&& string) noexcept
 {
 	auto buf = string.getBuffer();
 	buffer = buf.data;

--- a/Sming/Core/Data/Stream/MemoryDataStream.h
+++ b/Sming/Core/Data/Stream/MemoryDataStream.h
@@ -78,6 +78,8 @@ public:
 		return readPos >= size;
 	}
 
+	bool moveString(String& s) override;
+
 	/**
 	 * @brief Pre-allocate stream to given size
 	 * @param minCapacity Total minimum number of bytes required in stream

--- a/Sming/Core/Data/Stream/MemoryDataStream.h
+++ b/Sming/Core/Data/Stream/MemoryDataStream.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "ReadWriteStream.h"
+#include <WString.h>
 
 /**
  * @brief Read/write stream using expandable memory buffer
@@ -25,6 +26,13 @@
 class MemoryDataStream : public ReadWriteStream
 {
 public:
+	MemoryDataStream() = default;
+
+	/**
+	 * @brief Stream takes ownership of String content using move semantics
+	 */
+	MemoryDataStream(String&& string);
+
 	~MemoryDataStream()
 	{
 		free(buffer);

--- a/Sming/Core/Data/Stream/MemoryDataStream.h
+++ b/Sming/Core/Data/Stream/MemoryDataStream.h
@@ -31,7 +31,7 @@ public:
 	/**
 	 * @brief Stream takes ownership of String content using move semantics
 	 */
-	MemoryDataStream(String&& string);
+	MemoryDataStream(String&& string) noexcept;
 
 	~MemoryDataStream()
 	{

--- a/Sming/Core/Data/Stream/ReadWriteStream.h
+++ b/Sming/Core/Data/Stream/ReadWriteStream.h
@@ -39,5 +39,5 @@ public:
      *  @param  size Quantity of chars to write, determines size of intermediate buffer to use
      *  @retval size_t Quantity of chars actually written, may be less than requested
      */
-	virtual size_t copyFrom(IDataSourceStream* source, size_t size);
+	virtual size_t copyFrom(IDataSourceStream* source, size_t size = SIZE_MAX);
 };

--- a/Sming/Core/Network/Http/HttpBodyParser.cpp
+++ b/Sming/Core/Network/Http/HttpBodyParser.cpp
@@ -118,7 +118,7 @@ size_t bodyToStringParser(HttpRequest& request, const char* at, int length)
 	}
 
 	if(length == PARSE_DATAEND || length < 0) {
-		request.setBody(*data);
+		request.setBody(std::move(*data));
 		delete data;
 		request.args = nullptr;
 		return 0;

--- a/Sming/Core/Network/Http/HttpClientConnection.cpp
+++ b/Sming/Core/Network/Http/HttpClientConnection.cpp
@@ -92,11 +92,9 @@ HttpPartResult HttpClientConnection::multipartProducer()
 
 	if(outgoingRequest->postParams.count()) {
 		const String& name = outgoingRequest->postParams.keyAt(0);
-		const String& value = outgoingRequest->postParams.valueAt(0);
+		String& value = outgoingRequest->postParams.valueAt(0);
 
-		auto mStream = new MemoryDataStream();
-		mStream->print(value);
-		result.stream = mStream;
+		result.stream = new MemoryDataStream(std::move(value));
 
 		auto headers = new HttpHeaders();
 		(*headers)[HTTP_HEADER_CONTENT_DISPOSITION] = F("form-data; name=\"") + name + '"';

--- a/Sming/Core/Network/Http/HttpConnection.h
+++ b/Sming/Core/Network/Http/HttpConnection.h
@@ -125,7 +125,8 @@ public:
 	 */
 	String getResponseString() SMING_DEPRECATED
 	{
-		return response.getBody();
+		// Place a reasonable limit on returned content
+		return response.getBody(4096);
 	}
 
 protected:

--- a/Sming/Core/Network/Http/HttpRequest.cpp
+++ b/Sming/Core/Network/Http/HttpRequest.cpp
@@ -57,6 +57,11 @@ HttpRequest* HttpRequest::setBody(const uint8_t* rawData, size_t length)
 	return setBody(memory);
 }
 
+HttpRequest* HttpRequest::setBody(String&& body)
+{
+	return setBody(new MemoryDataStream(std::move(body)));
+}
+
 HttpRequest* HttpRequest::setBody(IDataSourceStream* stream)
 {
 	if(bodyStream != nullptr) {

--- a/Sming/Core/Network/Http/HttpRequest.cpp
+++ b/Sming/Core/Network/Http/HttpRequest.cpp
@@ -13,28 +13,6 @@
 #include "HttpRequest.h"
 #include "Data/Stream/MemoryDataStream.h"
 
-String HttpRequest::getBody()
-{
-	if(bodyStream == nullptr || bodyStream->getStreamType() != eSST_Memory) {
-		return nullptr;
-	}
-
-	int len = bodyStream->available();
-	if(len <= 0) {
-		// Cannot determine body size so need to use stream
-		return nullptr;
-	}
-
-	String ret;
-	if(ret.setLength(len)) {
-		len = bodyStream->readMemoryBlock(ret.begin(), len);
-		// Just in case read count is less than reported count
-		ret.setLength(len);
-	}
-
-	return ret;
-}
-
 HttpRequest* HttpRequest::setResponseStream(ReadWriteStream* stream)
 {
 	if(responseStream != nullptr) {

--- a/Sming/Core/Network/Http/HttpRequest.cpp
+++ b/Sming/Core/Network/Http/HttpRequest.cpp
@@ -35,7 +35,7 @@ HttpRequest* HttpRequest::setBody(const uint8_t* rawData, size_t length)
 	return setBody(memory);
 }
 
-HttpRequest* HttpRequest::setBody(String&& body)
+HttpRequest* HttpRequest::setBody(String&& body) noexcept
 {
 	return setBody(new MemoryDataStream(std::move(body)));
 }

--- a/Sming/Core/Network/Http/HttpRequest.h
+++ b/Sming/Core/Network/Http/HttpRequest.h
@@ -168,14 +168,19 @@ public:
 
 	/**
 	 * @brief Returns content from the body stream as string.
+	 * @param maxLen Limit size of returned String
 	 * @retval String
-	 *
-	 * @note This method consumes the stream and it will work only with text data.
-	 * 		 If you have binary data in the stream use getBodyStream instead.
-	 *
+	 * @note This method consumes the stream
 	 * @note Allocation of String doubles amount of memory required, so use with care.
 	 */
-	String getBody();
+	String getBody(size_t maxLen)
+	{
+		if(bodyStream == nullptr) {
+			return nullptr;
+		}
+
+		return bodyStream->readString(maxLen);
+	}
 
 	/**
 	 * @brief Return the current body stream

--- a/Sming/Core/Network/Http/HttpRequest.h
+++ b/Sming/Core/Network/Http/HttpRequest.h
@@ -201,7 +201,7 @@ public:
 		return setBody(reinterpret_cast<const uint8_t*>(body.c_str()), body.length());
 	}
 
-	HttpRequest* setBody(String&& body);
+	HttpRequest* setBody(String&& body) noexcept;
 
 	HttpRequest* setBody(IDataSourceStream* stream);
 

--- a/Sming/Core/Network/Http/HttpRequest.h
+++ b/Sming/Core/Network/Http/HttpRequest.h
@@ -193,9 +193,10 @@ public:
 	 */
 	HttpRequest* setBody(const String& body)
 	{
-		setBody(reinterpret_cast<const uint8_t*>(body.c_str()), body.length());
-		return this;
+		return setBody(reinterpret_cast<const uint8_t*>(body.c_str()), body.length());
 	}
+
+	HttpRequest* setBody(String&& body);
 
 	HttpRequest* setBody(IDataSourceStream* stream);
 

--- a/Sming/Core/Network/Http/HttpResponse.cpp
+++ b/Sming/Core/Network/Http/HttpResponse.cpp
@@ -64,7 +64,7 @@ bool HttpResponse::sendString(const String& text)
 	return memoryStream->print(text) == text.length();
 }
 
-bool HttpResponse::sendString(String&& text)
+bool HttpResponse::sendString(String&& text) noexcept
 {
 	auto memoryStream = new MemoryDataStream(std::move(text));
 	if(memoryStream == nullptr) {

--- a/Sming/Core/Network/Http/HttpResponse.cpp
+++ b/Sming/Core/Network/Http/HttpResponse.cpp
@@ -64,6 +64,16 @@ bool HttpResponse::sendString(const String& text)
 	return memoryStream->print(text) == text.length();
 }
 
+bool HttpResponse::sendString(String&& text)
+{
+	auto memoryStream = new MemoryDataStream(std::move(text));
+	if(memoryStream == nullptr) {
+		return false;
+	}
+	setStream(memoryStream);
+	return true;
+}
+
 bool HttpResponse::sendFile(const String& fileName, bool allowGzipFileCheck)
 {
 	IDataSourceStream* stream = nullptr;

--- a/Sming/Core/Network/Http/HttpResponse.cpp
+++ b/Sming/Core/Network/Http/HttpResponse.cpp
@@ -122,27 +122,6 @@ bool HttpResponse::sendDataStream(IDataSourceStream* newDataStream, const String
 	return true;
 }
 
-String HttpResponse::getBody()
-{
-	if(stream == nullptr) {
-		return nullptr;
-	}
-
-	String ret;
-	if(stream->available() > 0 && stream->getStreamType() == eSST_Memory) {
-		char buf[1024];
-		while(stream->available() > 0) {
-			int available = stream->readMemoryBlock(buf, 1024);
-			stream->seek(available);
-			ret += String(buf, available);
-			if(available < 1024) {
-				break;
-			}
-		}
-	}
-	return ret;
-}
-
 void HttpResponse::reset()
 {
 	code = HTTP_STATUS_OK;

--- a/Sming/Core/Network/Http/HttpResponse.h
+++ b/Sming/Core/Network/Http/HttpResponse.h
@@ -32,7 +32,7 @@ public:
 
 	bool sendString(const String& text);
 
-	bool sendString(String&& text);
+	bool sendString(String&& text) noexcept;
 
 	/**
 	 * @deprecated Use `headers.contains()` instead

--- a/Sming/Core/Network/Http/HttpResponse.h
+++ b/Sming/Core/Network/Http/HttpResponse.h
@@ -121,10 +121,18 @@ public:
 
 	/**
 	 * @brief Get response body as a string
+	 * @param maxLen Limit size of returned String
 	 * @retval String
 	 * @note Use with caution if response is large
 	 */
-	String getBody();
+	String getBody(size_t maxLen)
+	{
+		if(stream == nullptr) {
+			return nullptr;
+		}
+
+		return stream->readString(maxLen);
+	}
 
 	/**
 	 * @brief reset response so it can be re-used

--- a/Sming/Core/Network/Http/HttpResponse.h
+++ b/Sming/Core/Network/Http/HttpResponse.h
@@ -32,6 +32,8 @@ public:
 
 	bool sendString(const String& text);
 
+	bool sendString(String&& text);
+
 	/**
 	 * @deprecated Use `headers.contains()` instead
 	 */

--- a/Sming/Core/Network/HttpClient.h
+++ b/Sming/Core/Network/HttpClient.h
@@ -58,6 +58,16 @@ public:
 			requestComplete));
 	}
 
+	bool sendRequest(const HttpMethod method, const Url& url, const HttpHeaders& headers, String&& body,
+					 RequestCompletedDelegate requestComplete)
+	{
+		return send(createRequest(url)
+						->setMethod(method)
+						->setHeaders(headers)
+						->setBody(std::move(body))
+						->onRequestComplete(requestComplete));
+	}
+
 	/**
 	 * @brief Queue request to download content as string (in memory)
 	 * @param url URL from which the content will be fetched

--- a/Sming/Core/Network/HttpClient.h
+++ b/Sming/Core/Network/HttpClient.h
@@ -59,7 +59,7 @@ public:
 	}
 
 	bool sendRequest(const HttpMethod method, const Url& url, const HttpHeaders& headers, String&& body,
-					 RequestCompletedDelegate requestComplete)
+					 RequestCompletedDelegate requestComplete) noexcept
 	{
 		return send(createRequest(url)
 						->setMethod(method)

--- a/Sming/Core/Network/SmtpClient.cpp
+++ b/Sming/Core/Network/SmtpClient.cpp
@@ -98,6 +98,18 @@ bool SmtpClient::send(const String& from, const String& to, const String& subjec
 	return send(mail);
 }
 
+bool SmtpClient::send(const String& from, const String& to, const String& subject, String&& body)
+{
+	MailMessage* mail = new MailMessage();
+
+	mail->to = to;
+	mail->from = from;
+	mail->subject = subject;
+	mail->setBody(std::move(body));
+
+	return send(mail);
+}
+
 MailMessage* SmtpClient::getCurrentMessage()
 {
 	return outgoingMail;

--- a/Sming/Core/Network/SmtpClient.cpp
+++ b/Sming/Core/Network/SmtpClient.cpp
@@ -98,7 +98,7 @@ bool SmtpClient::send(const String& from, const String& to, const String& subjec
 	return send(mail);
 }
 
-bool SmtpClient::send(const String& from, const String& to, const String& subject, String&& body)
+bool SmtpClient::send(const String& from, const String& to, const String& subject, String&& body) noexcept
 {
 	MailMessage* mail = new MailMessage();
 

--- a/Sming/Core/Network/SmtpClient.h
+++ b/Sming/Core/Network/SmtpClient.h
@@ -111,8 +111,11 @@ public:
 	 * @param body The body in plain text format
 	 *
 	 * @retval bool true when the message was queued successfully, false otherwise
+	 * @{
 	 */
 	bool send(const String& from, const String& to, const String& subject, const String& body);
+	bool send(const String& from, const String& to, const String& subject, String&& body);
+	/** @} */
 
 	/**
 	 * @brief Powerful method to queues a single message before it is sent later to the SMTP server

--- a/Sming/Core/Network/SmtpClient.h
+++ b/Sming/Core/Network/SmtpClient.h
@@ -114,7 +114,7 @@ public:
 	 * @{
 	 */
 	bool send(const String& from, const String& to, const String& subject, const String& body);
-	bool send(const String& from, const String& to, const String& subject, String&& body);
+	bool send(const String& from, const String& to, const String& subject, String&& body) noexcept;
 	/** @} */
 
 	/**

--- a/Sming/Wiring/Stream.cpp
+++ b/Sming/Wiring/Stream.cpp
@@ -243,16 +243,14 @@ size_t Stream::readBytesUntil(char terminator, char *buffer, size_t length)
   return index; // return number of characters, not including null terminator
 }
 
-String Stream::readString()
+String Stream::readString(size_t maxLen)
 {
-  String ret;
-  int c = timedRead();
-  while (c >= 0)
-  {
-    ret += (char)c;
-    c = timedRead();
-  }
-  return ret;
+	String s;
+	int c;
+	while(s.length() < maxLen && (c = timedRead()) >= 0) {
+		s += char(c);
+	}
+	return s;
 }
 
 String Stream::readStringUntil(char terminator)

--- a/Sming/Wiring/Stream.h
+++ b/Sming/Wiring/Stream.h
@@ -67,7 +67,7 @@ class Stream : public Print
   
     float parseFloat();               // float version of parseInt
   
-    size_t readBytes( char *buffer, size_t length); // read chars from stream into buffer
+    virtual size_t readBytes( char *buffer, size_t length); // read chars from stream into buffer
     // terminates if length characters have been read or timeout (see setTimeout)
     // returns the number of characters placed in the buffer (0 means no valid data found)
   
@@ -76,7 +76,7 @@ class Stream : public Print
     // returns the number of characters placed in the buffer (0 means no valid data found)
   
     // Wiring String functions to be added here
-    String readString();
+    virtual String readString(size_t maxLen);
     String readStringUntil(char terminator);
 
     /*

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -198,6 +198,44 @@ bool String::reserve(size_t size)
 	return true;
 }
 
+String::Buffer String::getBuffer()
+{
+	String::Buffer buf;
+	if(sso.set) {
+		buf.size = sso.len + 1;
+		buf.length = sso.len;
+		buf.data = static_cast<char*>(malloc(buf.size));
+		memcpy(buf.data, sso.buffer, sso.len);
+		buf.data[sso.len] = '\0';
+	} else {
+		buf.data = ptr.buffer;
+		buf.size = ptr.capacity + 1;
+		buf.length = ptr.len;
+	}
+	sso.set = false;
+	ptr.buffer = nullptr;
+	ptr.capacity = 0;
+	ptr.len = 0;
+
+	return buf;
+}
+
+bool String::setBuffer(const Buffer& buffer)
+{
+	invalidate();
+	if(buffer.data == nullptr || buffer.size == 0) {
+		return true;
+	}
+	if(buffer.length >= buffer.size) {
+		return false;
+	}
+	ptr.capacity = buffer.size - 1;
+	ptr.len = buffer.length;
+	ptr.buffer = buffer.data;
+	ptr.buffer[ptr.len] = '\0';
+	return true;
+}
+
 /*********************************************/
 /*  Copy and Move                            */
 /*********************************************/

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -29,71 +29,72 @@ const String String::empty = "";
 /*  Constructors                             */
 /*********************************************/
 
-String::String(const char *cstr) : String()
+String::String(const char* cstr) : String()
 {
-  if (cstr) copy(cstr, strlen(cstr));
+	if(cstr)
+		copy(cstr, strlen(cstr));
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String::String(StringSumHelper &&rval) : String()
+String::String(StringSumHelper&& rval) : String()
 {
-  move(rval);
+	move(rval);
 }
 #endif
 
 String::String(char c) : String()
 {
-  if (setLength(1))
-	  buffer()[0] = c;
+	if(setLength(1))
+		buffer()[0] = c;
 }
 
 String::String(unsigned char value, unsigned char base) : String()
 {
-  char buf[8 + 8 * sizeof(value)];
-  ultoa(value, buf, base);
-  *this = buf;
+	char buf[8 + 8 * sizeof(value)];
+	ultoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(int value, unsigned char base) : String()
 {
-  char buf[8 + 8 * sizeof(value)];
-  itoa(value, buf, base);
-  *this = buf;
+	char buf[8 + 8 * sizeof(value)];
+	itoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(unsigned int value, unsigned char base) : String()
 {
-  char buf[8 + 8 * sizeof(value)];
-  ultoa(value, buf, base);
-  *this = buf;
+	char buf[8 + 8 * sizeof(value)];
+	ultoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(long value, unsigned char base) : String()
 {
-  char buf[8 + 8 * sizeof(value)];
-  ltoa(value, buf, base);
-  *this = buf;
+	char buf[8 + 8 * sizeof(value)];
+	ltoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(long long value, unsigned char base) : String()
 {
-  char buf[8 + 8 * sizeof(value)];
-  lltoa(value, buf, base);
-  *this = buf;
+	char buf[8 + 8 * sizeof(value)];
+	lltoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(unsigned long value, unsigned char base) : String()
 {
-  char buf[8 + 8 * sizeof(value)];
-  ultoa(value, buf, base);
-  *this = buf;
+	char buf[8 + 8 * sizeof(value)];
+	ultoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(unsigned long long value, unsigned char base) : String()
 {
-  char buf[8 + 8 * sizeof(value)];
-  ulltoa(value, buf, base);
-  *this = buf;
+	char buf[8 + 8 * sizeof(value)];
+	ulltoa(value, buf, base);
+	*this = buf;
 }
 
 String::String(float value, unsigned char decimalPlaces) : String()
@@ -108,30 +109,24 @@ String::String(double value, unsigned char decimalPlaces) : String()
 	*this = dtostrf(value, 0, decimalPlaces, buf);
 }
 
-void String::setString(const char *cstr, int length /* = -1 */)
+void String::setString(const char* cstr, int length /* = -1 */)
 {
-	if (cstr)
-	{
-		if (length < 0)
+	if(cstr) {
+		if(length < 0)
 			length = strlen(cstr);
 		copy(cstr, length);
-	}
-	else
-	{
+	} else {
 		invalidate();
 	}
 }
 
 void String::setString(flash_string_t pstr, int length /* = -1 */)
 {
-	if(pstr)
-	{
+	if(pstr) {
 		if(length < 0)
 			length = strlen_P((PGM_P)pstr);
 		copy(pstr, length);
-	}
-	else
-	{
+	} else {
 		invalidate();
 	}
 }
@@ -141,13 +136,13 @@ void String::setString(flash_string_t pstr, int length /* = -1 */)
 
 void String::invalidate(void)
 {
-  if (sso.set) {
-	  sso.set = false;
-  } else {
-	  free(ptr.buffer);
-  }
-  ptr.buffer = nullptr;
-  ptr.capacity = ptr.len = 0;
+	if(sso.set) {
+		sso.set = false;
+	} else {
+		free(ptr.buffer);
+	}
+	ptr.buffer = nullptr;
+	ptr.capacity = ptr.len = 0;
 }
 
 bool String::setLength(size_t size)
@@ -207,28 +202,24 @@ bool String::reserve(size_t size)
 /*  Copy and Move                            */
 /*********************************************/
 
-String & String::copy(const char *cstr, size_t length)
+String& String::copy(const char* cstr, size_t length)
 {
-  if (!reserve(length))
-  {
-    invalidate();
-    return *this;
-  }
-  memmove(buffer(), cstr, length);
-  setlen(length);
-  return *this;
+	if(!reserve(length)) {
+		invalidate();
+		return *this;
+	}
+	memmove(buffer(), cstr, length);
+	setlen(length);
+	return *this;
 }
 
-String &String::copy(flash_string_t pstr, size_t length)
+String& String::copy(flash_string_t pstr, size_t length)
 {
 	// If necessary, allocate additional space so copy can be aligned
 	size_t length_aligned = ALIGNUP4(length);
-	if(!reserve(length_aligned))
-	{
+	if(!reserve(length_aligned)) {
 		invalidate();
-	}
-	else
-	{
+	} else {
 		memcpy_aligned(buffer(), (PGM_P)pstr, length);
 		setlen(length);
 	}
@@ -236,7 +227,7 @@ String &String::copy(flash_string_t pstr, size_t length)
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-void String::move(String &rhs)
+void String::move(String& rhs)
 {
 	if(rhs.isNull()) {
 		invalidate();
@@ -272,62 +263,76 @@ void String::move(String &rhs)
 }
 #endif
 
-String & String::operator = (const String &rhs)
+String& String::operator=(const String& rhs)
 {
-  if (this == &rhs) return *this;
+	if(this == &rhs)
+		return *this;
 
-  if (rhs.isNull()) {
-	  invalidate();
-  } else {
-	  copy(rhs.cbuffer(), rhs.length());
-  }
+	if(rhs.isNull()) {
+		invalidate();
+	} else {
+		copy(rhs.cbuffer(), rhs.length());
+	}
 
-  return *this;
+	return *this;
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String & String::operator = (StringSumHelper && rval)
+String& String::operator=(StringSumHelper&& rval)
 {
-  if (this != &rval) move(rval);
-  return *this;
+	if(this != &rval) {
+		move(rval);
+	}
+	return *this;
 }
 #endif
 
-String & String::operator = (const char *cstr)
+String& String::operator=(const char* cstr)
 {
-  if (cstr) copy(cstr, strlen(cstr));
-  else invalidate();
+	if(cstr) {
+		copy(cstr, strlen(cstr));
+	} else {
+		invalidate();
+	}
 
-  return *this;
+	return *this;
 }
 
 /*********************************************/
 /*  concat                                   */
 /*********************************************/
 
-bool String::concat(const char *cstr, size_t length)
+bool String::concat(const char* cstr, size_t length)
 {
-  if (length == 0) return true; // Nothing to add
-  if (!cstr) return false; // Bad argument (length is non-zero)
+	if(length == 0) {
+		return true; // Nothing to add
+	}
+	if(!cstr) {
+		return false; // Bad argument (length is non-zero)
+	}
 
-  auto len = this->length();
-  size_t newlen = len + length;
+	auto len = this->length();
+	size_t newlen = len + length;
 
-  // Appending all or part of self requires special handling
-  auto buf = buffer();
-  if(cstr >= buf && cstr < (buf + len)) {
-	  auto offset = cstr - buf;
-	  if (!reserve(newlen)) return false;
-	  buf = buffer();
-	  memcpy(buf + len, buf + offset, length);
-	  setlen(newlen);
-	  return true;
-  }
+	// Appending all or part of self requires special handling
+	auto buf = buffer();
+	if(cstr >= buf && cstr < (buf + len)) {
+		auto offset = cstr - buf;
+		if(!reserve(newlen)) {
+			return false;
+		}
+		buf = buffer();
+		memcpy(buf + len, buf + offset, length);
+		setlen(newlen);
+		return true;
+	}
 
-  if (!reserve(newlen)) return false;
-  memcpy(buffer() + len, cstr, length);
-  setlen(newlen);
-  return true;
+	if(!reserve(newlen)) {
+		return false;
+	}
+	memcpy(buffer() + len, cstr, length);
+	setlen(newlen);
+	return true;
 }
 
 bool String::concat(const FlashString& fstr)
@@ -342,59 +347,61 @@ bool String::concat(const FlashString& fstr)
 	return true;
 }
 
-bool String::concat(const char *cstr)
+bool String::concat(const char* cstr)
 {
-  if (!cstr) return true; // Consider this an empty string, not a failure
-  return concat(cstr, strlen(cstr));
+	if(!cstr) {
+		return true; // Consider this an empty string, not a failure
+	}
+	return concat(cstr, strlen(cstr));
 }
 
 bool String::concat(unsigned char num)
 {
-  char buf[1 + 3 * sizeof(num)];
-  itoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[1 + 3 * sizeof(num)];
+	itoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 bool String::concat(int num)
 {
-  char buf[8 + 3 * sizeof(num)];
-  itoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[8 + 3 * sizeof(num)];
+	itoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 bool String::concat(unsigned int num)
 {
-  char buf[8 + 3 * sizeof(num)];
-  ultoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[8 + 3 * sizeof(num)];
+	ultoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 bool String::concat(long num)
 {
-  char buf[8 + 3 * sizeof(num)];
-  ltoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[8 + 3 * sizeof(num)];
+	ltoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 bool String::concat(long long num)
 {
-  char buf[8 + 3 * sizeof(num)];
-  lltoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[8 + 3 * sizeof(num)];
+	lltoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 bool String::concat(unsigned long num)
 {
-  char buf[8 + 3 * sizeof(num)];
-  ultoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[8 + 3 * sizeof(num)];
+	ultoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 bool String::concat(unsigned long long num)
 {
-  char buf[8 + 3 * sizeof(num)];
-  ulltoa(num, buf, 10);
-  return concat(buf, strlen(buf));
+	char buf[8 + 3 * sizeof(num)];
+	ulltoa(num, buf, 10);
+	return concat(buf, strlen(buf));
 }
 
 bool String::concat(float num)
@@ -415,73 +422,93 @@ bool String::concat(double num)
 /*  Concatenate                              */
 /*********************************************/
 
-StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs)
+StringSumHelper& operator+(const StringSumHelper& lhs, const String& rhs)
 {
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(rhs)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!cstr || !a.concat(cstr, strlen(cstr))) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, char c)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(c)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, unsigned char num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, int num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, unsigned int num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, long num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long num)
-{
-  StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-  if (!a.concat(num)) a.invalidate();
-  return a;
-}
-
-StringSumHelper & operator + (const StringSumHelper &lhs, float num)
-{
-	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-	if (!a.concat(num)) a.invalidate();
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(rhs)) {
+		a.invalidate();
+	}
 	return a;
 }
 
-StringSumHelper & operator + (const StringSumHelper &lhs, double num)
+StringSumHelper& operator+(const StringSumHelper& lhs, const char* cstr)
 {
-	StringSumHelper &a = const_cast<StringSumHelper&>(lhs);
-	if (!a.concat(num)) a.invalidate();
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!cstr || !a.concat(cstr, strlen(cstr))) {
+		a.invalidate();
+	}
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, char c)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(c)) {
+		a.invalidate();
+	}
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, unsigned char num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num)) {
+		a.invalidate();
+	}
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, int num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num)) {
+		a.invalidate();
+	}
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, unsigned int num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num)) {
+		a.invalidate();
+	}
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, long num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num)) {
+		a.invalidate();
+	}
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, unsigned long num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num)) {
+		a.invalidate();
+	}
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, float num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num)) {
+		a.invalidate();
+	}
+	return a;
+}
+
+StringSumHelper& operator+(const StringSumHelper& lhs, double num)
+{
+	StringSumHelper& a = const_cast<StringSumHelper&>(lhs);
+	if(!a.concat(num)) {
+		a.invalidate();
+	}
 	return a;
 }
 
@@ -491,72 +518,90 @@ StringSumHelper & operator + (const StringSumHelper &lhs, double num)
 
 int String::compareTo(const char* cstr, size_t length) const
 {
-  auto len = this->length();
-  if (len == 0 || length == 0) {
-	return len - length;
-  }
-  auto buf = cbuffer();
-  assert(buf != nullptr && cstr != nullptr);
-  if(len == length) {
-  	return memcmp(buf, cstr, len);
-  }
-  if(len < length) {
-	return memcmp(buf, cstr, len) ?: -1;
-  }
-  return memcmp(buf, cstr, length) ?: 1;
+	auto len = this->length();
+	if(len == 0 || length == 0) {
+		return len - length;
+	}
+	auto buf = cbuffer();
+	assert(buf != nullptr && cstr != nullptr);
+	if(len == length) {
+		return memcmp(buf, cstr, len);
+	}
+	if(len < length) {
+		return memcmp(buf, cstr, len) ?: -1;
+	}
+	return memcmp(buf, cstr, length) ?: 1;
 }
 
-bool String::equals(const char *cstr) const
+bool String::equals(const char* cstr) const
 {
-  auto len = length();
-  if (len == 0) return (cstr == nullptr || *cstr == '\0');
-  if (cstr == nullptr) return false;
-  auto cstrlen = strlen(cstr);
-  if (len != cstrlen) return false;
-  return memcmp(cbuffer(), cstr, len) == 0;
+	auto len = length();
+	if(len == 0) {
+		return (cstr == nullptr || *cstr == '\0');
+	}
+	if(cstr == nullptr) {
+		return false;
+	}
+	auto cstrlen = strlen(cstr);
+	if(len != cstrlen) {
+		return false;
+	}
+	return memcmp(cbuffer(), cstr, len) == 0;
 }
 
-bool String::equals(const char *cstr, size_t length) const
+bool String::equals(const char* cstr, size_t length) const
 {
-  auto len = this->length();
-  if (len != length) return false;
-  if (len == 0) return true;
-  return memcmp(cbuffer(), cstr, len) == 0;
+	auto len = this->length();
+	if(len != length) {
+		return false;
+	}
+	if(len == 0) {
+		return true;
+	}
+	return memcmp(cbuffer(), cstr, len) == 0;
 }
 
 bool String::equalsIgnoreCase(const char* cstr) const
 {
-  auto buf = cbuffer();
-  if(buf == cstr) return true;
-  return strcasecmp(cstr, buf) == 0;
+	auto buf = cbuffer();
+	if(buf == cstr) {
+		return true;
+	}
+	return strcasecmp(cstr, buf) == 0;
 }
 
 bool String::equalsIgnoreCase(const char* cstr, size_t length) const
 {
-  auto len = this->length();
-  if (len != length) return false;
-  if (len == 0) return true;
-  return memicmp(cbuffer(), cstr, len) == 0;
+	auto len = this->length();
+	if(len != length) {
+		return false;
+	}
+	if(len == 0) {
+		return true;
+	}
+	return memicmp(cbuffer(), cstr, len) == 0;
 }
 
-bool String::startsWith(const String &prefix, size_t offset) const
+bool String::startsWith(const String& prefix, size_t offset) const
 {
-  auto prefix_len = prefix.length();
-  auto len = length();
-  if(prefix_len == 0 || prefix_len > len || offset > len - prefix_len) {
-	  return false;
-  }
-  auto prefix_buffer = prefix.cbuffer();
-  return memcmp(&cbuffer()[offset], prefix_buffer, prefix_len) == 0;
+	auto prefix_len = prefix.length();
+	auto len = length();
+	if(prefix_len == 0 || prefix_len > len || offset > len - prefix_len) {
+		return false;
+	}
+	auto prefix_buffer = prefix.cbuffer();
+	return memcmp(&cbuffer()[offset], prefix_buffer, prefix_len) == 0;
 }
 
-bool String::endsWith(const String &suffix) const
+bool String::endsWith(const String& suffix) const
 {
-  auto len = length();
-  auto suffix_buffer = suffix.cbuffer();
-  auto suffix_len = suffix.length();
-  if (len < suffix_len || suffix_len == 0) return false;
-  return memcmp(&cbuffer()[len - suffix_len], suffix_buffer, suffix_len) == 0;
+	auto len = length();
+	auto suffix_buffer = suffix.cbuffer();
+	auto suffix_len = suffix.length();
+	if(len < suffix_len || suffix_len == 0) {
+		return false;
+	}
+	return memcmp(&cbuffer()[len - suffix_len], suffix_buffer, suffix_len) == 0;
 }
 
 /*********************************************/
@@ -565,40 +610,46 @@ bool String::endsWith(const String &suffix) const
 
 void String::setCharAt(size_t index, char c)
 {
-  if (index < length()) buffer()[index] = c;
+	if(index < length()) {
+		buffer()[index] = c;
+	}
 }
 
-char & String::operator[](size_t index)
+char& String::operator[](size_t index)
 {
-  if (index >= length())
-  {
-    static char dummy_writable_char;
-    dummy_writable_char = '\0';
-    return dummy_writable_char;
-  }
-  return buffer()[index];
+	if(index >= length()) {
+		static char dummy_writable_char;
+		dummy_writable_char = '\0';
+		return dummy_writable_char;
+	}
+	return buffer()[index];
 }
 
 char String::operator[](size_t index) const
 {
-  if (index >= length()) return '\0';
-  return cbuffer()[index];
+	if(index >= length()) {
+		return '\0';
+	}
+	return cbuffer()[index];
 }
 
-size_t String::getBytes(unsigned char *buf, size_t bufsize, size_t index) const
+size_t String::getBytes(unsigned char* buf, size_t bufsize, size_t index) const
 {
-  if (!bufsize || !buf) return 0;
-  auto len = length();
-  if (index >= len)
-  {
-    buf[0] = '\0';
-    return 0;
-  }
-  size_t n = bufsize - 1;
-  if (n > len - index) n = len - index;
-  memmove(buf, cbuffer() + index, n);
-  buf[n] = '\0';
-  return n;
+	if(!bufsize || !buf) {
+		return 0;
+	}
+	auto len = length();
+	if(index >= len) {
+		buf[0] = '\0';
+		return 0;
+	}
+	size_t n = bufsize - 1;
+	if(n > len - index) {
+		n = len - index;
+	}
+	memmove(buf, cbuffer() + index, n);
+	buf[n] = '\0';
+	return n;
 }
 
 /*********************************************/
@@ -607,22 +658,30 @@ size_t String::getBytes(unsigned char *buf, size_t bufsize, size_t index) const
 
 int String::indexOf(char ch, size_t fromIndex) const
 {
-  auto len = length();
-  if (fromIndex >= len) return -1;
-  auto buf = cbuffer();
-  auto temp = memchr(buf + fromIndex, ch, len - fromIndex);
-  if (temp == nullptr) return -1;
-  return static_cast<const char*>(temp) - buf;
+	auto len = length();
+	if(fromIndex >= len) {
+		return -1;
+	}
+	auto buf = cbuffer();
+	auto temp = memchr(buf + fromIndex, ch, len - fromIndex);
+	if(temp == nullptr) {
+		return -1;
+	}
+	return static_cast<const char*>(temp) - buf;
 }
 
 int String::indexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const
 {
-  auto len = length();
-  if (fromIndex >= len) return -1;
-  auto buf = cbuffer();
-  auto found = memmem(buf + fromIndex, len - fromIndex, s2_buf, s2_len);
-  if (found == nullptr) return -1;
-  return static_cast<const char*>(found) - buf;
+	auto len = length();
+	if(fromIndex >= len) {
+		return -1;
+	}
+	auto buf = cbuffer();
+	auto found = memmem(buf + fromIndex, len - fromIndex, s2_buf, s2_len);
+	if(found == nullptr) {
+		return -1;
+	}
+	return static_cast<const char*>(found) - buf;
 }
 
 int String::lastIndexOf(char theChar) const
@@ -650,41 +709,50 @@ int String::lastIndexOf(char ch, size_t fromIndex) const
 	return found ? (static_cast<const char*>(found) - buf) : -1;
 }
 
-int String::lastIndexOf(const String &s2) const
+int String::lastIndexOf(const String& s2) const
 {
-  return lastIndexOf(s2.cbuffer(), length() - s2.length(), s2.length());
+	return lastIndexOf(s2.cbuffer(), length() - s2.length(), s2.length());
 }
 
-int String::lastIndexOf(const String &s2, size_t fromIndex) const
+int String::lastIndexOf(const String& s2, size_t fromIndex) const
 {
 	return lastIndexOf(s2.cbuffer(), fromIndex, s2.length());
 }
 
 int String::lastIndexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const
 {
-  auto len = length();
-  if (s2_len == 0 || len == 0 || s2_len > len) return -1;
-  auto buf = cbuffer();
-  if (fromIndex >= len) fromIndex = len - 1;
-  int found = -1;
-  for (auto p = buf; p <= buf + fromIndex; p++)
-  {
-    p = static_cast<const char*>(memmem(p, buf + len - p, s2_buf, s2_len));
-    if (!p) break;
-    if (p <= buf + fromIndex) found = p - buf;
-  }
-  return found;
+	auto len = length();
+	if(s2_len == 0 || len == 0 || s2_len > len) {
+		return -1;
+	}
+	auto buf = cbuffer();
+	if(fromIndex >= len) {
+		fromIndex = len - 1;
+	}
+	int found = -1;
+	for(auto p = buf; p <= buf + fromIndex; p++) {
+		p = static_cast<const char*>(memmem(p, buf + len - p, s2_buf, s2_len));
+		if(!p) {
+			break;
+		}
+		if(p <= buf + fromIndex) {
+			found = p - buf;
+		}
+	}
+	return found;
 }
 
 String String::substring(size_t left, size_t right) const
 {
-  auto len = length();
-  if (left > right || left >= len) {
-	  return nullptr;
-  }
+	auto len = length();
+	if(left > right || left >= len) {
+		return nullptr;
+	}
 
-  if (right > len) right = len;
-  return String(cbuffer() + left, right - left);
+	if(right > len) {
+		right = len;
+	}
+	return String(cbuffer() + left, right - left);
 }
 
 /*********************************************/
@@ -708,71 +776,72 @@ bool String::replace(const String& find, const String& replace)
 
 bool String::replace(const char* find_buf, size_t find_len, const char* replace_buf, size_t replace_len)
 {
-  auto len = length();
-  auto buf = buffer();
-  if (len == 0 || find_len == 0) return true;
-  int diff = replace_len - find_len;
-  char *readFrom = buf;
-  const char* end = buf + len;
-  char *foundAt;
-  if (diff == 0)
-  {
-    while ((foundAt = (char*)memmem(readFrom, end - readFrom, find_buf, find_len)) != nullptr)
-    {
-      memcpy(foundAt, replace_buf, replace_len);
-      readFrom = foundAt + replace_len;
-    }
-  }
-  else if (diff < 0)
-  {
-    char *writeTo = buf;
-    while ((foundAt = (char*)memmem(readFrom, end - readFrom, find_buf, find_len)) != nullptr)
-    {
-      size_t n = foundAt - readFrom;
-      memcpy(writeTo, readFrom, n);
-      writeTo += n;
-      memcpy(writeTo, replace_buf, replace_len);
-      writeTo += replace_len;
-      readFrom = foundAt + find_len;
-      len += diff;
-    }
-    memcpy(writeTo, readFrom, end - readFrom);
-    setlen(len);
-  }
-  else
-  {
-    size_t size = len; // compute size needed for result
-    while ((foundAt = (char*)memmem(readFrom, end - readFrom, find_buf, find_len)) != nullptr)
-    {
-      readFrom = foundAt + find_len;
-      size += diff;
-    }
-    if (size == len) return true;
-    if(!reserve(size)) {
-    	return false;
-    }
-    buf = buffer();
-    int index = len - 1;
-    while ((index = lastIndexOf(find_buf, index, find_len)) >= 0)
-    {
-      readFrom = buf + index + find_len;
-      memmove(readFrom + diff, readFrom, len - (readFrom - buf));
-      len += diff;
-      memcpy(buf + index, replace_buf, replace_len);
-      index--;
-    }
-    setlen(len);
-  }
-  return true;
+	auto len = length();
+	auto buf = buffer();
+	if(len == 0 || find_len == 0) {
+		return true;
+	}
+	int diff = replace_len - find_len;
+	char* readFrom = buf;
+	const char* end = buf + len;
+	char* foundAt;
+	if(diff == 0) {
+		while((foundAt = (char*)memmem(readFrom, end - readFrom, find_buf, find_len)) != nullptr) {
+			memcpy(foundAt, replace_buf, replace_len);
+			readFrom = foundAt + replace_len;
+		}
+	} else if(diff < 0) {
+		char* writeTo = buf;
+		while((foundAt = (char*)memmem(readFrom, end - readFrom, find_buf, find_len)) != nullptr) {
+			size_t n = foundAt - readFrom;
+			memcpy(writeTo, readFrom, n);
+			writeTo += n;
+			memcpy(writeTo, replace_buf, replace_len);
+			writeTo += replace_len;
+			readFrom = foundAt + find_len;
+			len += diff;
+		}
+		memcpy(writeTo, readFrom, end - readFrom);
+		setlen(len);
+	} else {
+		size_t size = len; // compute size needed for result
+		while((foundAt = (char*)memmem(readFrom, end - readFrom, find_buf, find_len)) != nullptr) {
+			readFrom = foundAt + find_len;
+			size += diff;
+		}
+		if(size == len) {
+			return true;
+		}
+		if(!reserve(size)) {
+			return false;
+		}
+		buf = buffer();
+		int index = len - 1;
+		while((index = lastIndexOf(find_buf, index, find_len)) >= 0) {
+			readFrom = buf + index + find_len;
+			memmove(readFrom + diff, readFrom, len - (readFrom - buf));
+			len += diff;
+			memcpy(buf + index, replace_buf, replace_len);
+			index--;
+		}
+		setlen(len);
+	}
+	return true;
 }
 
 void String::remove(size_t index, size_t count)
 {
-	if (count == 0) { return; }
+	if(count == 0) {
+		return;
+	}
 	auto len = length();
-	if (index >= len) { return; }
-	if (count > len - index) { count = len - index; }
-	char *writeTo = buffer() + index;
+	if(index >= len) {
+		return;
+	}
+	if(count > len - index) {
+		count = len - index;
+	}
+	char* writeTo = buffer() + index;
 	len -= count;
 	memcpy(writeTo, writeTo + count, len - index);
 	setlen(len);
@@ -796,16 +865,24 @@ void String::toUpperCase(void)
 
 void String::trim(void)
 {
-  auto len = length();
-  if (len == 0) return;
-  auto buf = buffer();
-  char *begin = buf;
-  while (isspace(*begin)) begin++;
-  char *end = buf + len - 1;
-  while (isspace(*end) && end >= begin) end--;
-  len = end + 1 - begin;
-  if (begin > buf) memmove(buf, begin, len);
-  setlen(len);
+	auto len = length();
+	if(len == 0) {
+		return;
+	}
+	auto buf = buffer();
+	char* begin = buf;
+	while(isspace(*begin)) {
+		begin++;
+	}
+	char* end = buf + len - 1;
+	while(isspace(*end) && end >= begin) {
+		end--;
+	}
+	len = end + 1 - begin;
+	if(begin > buf) {
+		memmove(buf, begin, len);
+	}
+	setlen(len);
 }
 
 /*********************************************/

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -36,7 +36,7 @@ String::String(const char* cstr) : String()
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String::String(StringSumHelper&& rval) : String()
+String::String(StringSumHelper&& rval) noexcept : String()
 {
 	move(rval);
 }
@@ -331,7 +331,7 @@ String& String::operator=(const String& rhs)
 }
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-String& String::operator=(StringSumHelper&& rval)
+String& String::operator=(StringSumHelper&& rval) noexcept
 {
 	if(this != &rval) {
 		move(rval);

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -109,27 +109,42 @@ String::String(double value, unsigned char decimalPlaces) : String()
 	*this = dtostrf(value, 0, decimalPlaces, buf);
 }
 
-void String::setString(const char* cstr, int length /* = -1 */)
+void String::setString(const char* cstr)
 {
 	if(cstr) {
-		if(length < 0)
-			length = strlen(cstr);
+		copy(cstr, strlen(cstr));
+	} else {
+		invalidate();
+	}
+}
+
+void String::setString(const char* cstr, size_t length)
+{
+	if(cstr) {
 		copy(cstr, length);
 	} else {
 		invalidate();
 	}
 }
 
-void String::setString(flash_string_t pstr, int length /* = -1 */)
+void String::setString(flash_string_t pstr)
 {
 	if(pstr) {
-		if(length < 0)
-			length = strlen_P((PGM_P)pstr);
+		copy(pstr, strlen_P((PGM_P)pstr));
+	} else {
+		invalidate();
+	}
+}
+
+void String::setString(flash_string_t pstr, size_t length)
+{
+	if(pstr) {
 		copy(pstr, length);
 	} else {
 		invalidate();
 	}
 }
+
 /*********************************************/
 /*  Memory Management                        */
 /*********************************************/

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -174,9 +174,13 @@ public:
 	{
 		*this = str;
 	}
-	explicit String(flash_string_t pstr, int length = -1) : String()
+	explicit String(flash_string_t pstr, size_t length) : String()
 	{
 		setString(pstr, length);
+	}
+	explicit String(flash_string_t pstr) : String()
+	{
+		setString(pstr);
 	}
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
@@ -203,8 +207,10 @@ public:
 		invalidate();
 	}
 
-	void setString(const char* cstr, int length = -1);
-	void setString(flash_string_t pstr, int length = -1);
+	void setString(const char* cstr);
+	void setString(const char* cstr, size_t length);
+	void setString(flash_string_t pstr);
+	void setString(flash_string_t pstr, size_t length);
 
 	// memory management
 

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -135,22 +135,24 @@ typedef const __FlashStringHelper* flash_string_t;
  */
 class String
 {
-    // use a function pointer to allow for "if (s)" without the
-    // complications of an operator bool(). for more information, see:
-    // http://www.artima.com/cppsource/safebool.html
-    typedef void (String::*StringIfHelperType)() const;
-    void StringIfHelper() const {}
+	// use a function pointer to allow for "if (s)" without the
+	// complications of an operator bool(). for more information, see:
+	// http://www.artima.com/cppsource/safebool.html
+	typedef void (String::*StringIfHelperType)() const;
+	void StringIfHelper() const
+	{
+	}
 
-  public:
-    // Use these for const references, e.g. in function return values
-    static const String nullstr; ///< A null string evaluates to false
-    static const String empty; ///< An empty string evaluates to true
+public:
+	// Use these for const references, e.g. in function return values
+	static const String nullstr; ///< A null string evaluates to false
+	static const String empty;   ///< An empty string evaluates to true
 
-    /**
+	/**
      * @brief Default constructor
      * @note Creates a null String which evaluates to false.
      */
-    String() : ptr{nullptr, 0, 0}
+	String() : ptr{nullptr, 0, 0}
 	{
 	}
 
@@ -162,50 +164,51 @@ class String
      *
      * @{
     */
-    String(const char *cstr);
-    String(const char *cstr, size_t length) : String()
-    {
-      if (cstr) copy(cstr, length);
-    }
-    String(const String &str) : String()
-    {
-      *this = str;
-    }
-    explicit String(flash_string_t pstr, int length = -1) : String()
-    {
-      setString(pstr, length);
-    }
+	String(const char* cstr);
+	String(const char* cstr, size_t length) : String()
+	{
+		if(cstr)
+			copy(cstr, length);
+	}
+	String(const String& str) : String()
+	{
+		*this = str;
+	}
+	explicit String(flash_string_t pstr, int length = -1) : String()
+	{
+		setString(pstr, length);
+	}
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    String(String && rval) : String()
-    {
-   	  move(rval);
-    }
-    String(StringSumHelper && rval);
+	String(String&& rval) : String()
+	{
+		move(rval);
+	}
+	String(StringSumHelper&& rval);
 #endif
-    explicit String(char c);
-    explicit String(unsigned char, unsigned char base = 10);
-    explicit String(int, unsigned char base = 10);
-    explicit String(unsigned int, unsigned char base = 10);
-    explicit String(long, unsigned char base = 10);
-    explicit String(long long, unsigned char base = 10);
-    explicit String(unsigned long, unsigned char base = 10);
-    explicit String(unsigned long long, unsigned char base = 10);
-    explicit String(float, unsigned char decimalPlaces=2);
-    explicit String(double, unsigned char decimalPlaces=2);
-    /** @} */
+	explicit String(char c);
+	explicit String(unsigned char, unsigned char base = 10);
+	explicit String(int, unsigned char base = 10);
+	explicit String(unsigned int, unsigned char base = 10);
+	explicit String(long, unsigned char base = 10);
+	explicit String(long long, unsigned char base = 10);
+	explicit String(unsigned long, unsigned char base = 10);
+	explicit String(unsigned long long, unsigned char base = 10);
+	explicit String(float, unsigned char decimalPlaces = 2);
+	explicit String(double, unsigned char decimalPlaces = 2);
+	/** @} */
 
-    ~String(void)
-    {
-    	invalidate();
-    }
+	~String(void)
+	{
+		invalidate();
+	}
 
-    void setString(const char *cstr, int length = -1);
-    void setString(flash_string_t pstr, int length = -1);
+	void setString(const char* cstr, int length = -1);
+	void setString(flash_string_t pstr, int length = -1);
 
-    // memory management
+	// memory management
 
-    /**
+	/**
      * @brief Pre-allocate String memory
      * @param size
      * @retval bool true on success, false on failure
@@ -213,24 +216,24 @@ class String
      * On failure, the String is left unchanged.
      * reserve(0), if successful, will validate an invalid string (i.e., "if (s)" will be true afterwards)
      */
-    bool reserve(size_t size);
+	bool reserve(size_t size);
 
-    /** @brief set the string length accordingly, expanding if necessary
+	/** @brief set the string length accordingly, expanding if necessary
      *  @param length required for string (nul terminator additional)
      *  @retval true on success, false on failure
      *  @note extra characters are undefined
      */
-    bool setLength(size_t length);
+	bool setLength(size_t length);
 
-    /**
+	/**
      * @brief Obtain the String length in characters, excluding NUL terminator
      */
-    inline size_t length(void) const
-    {
-      return sso.set ? sso.len : ptr.len;
-    }
+	inline size_t length(void) const
+	{
+		return sso.set ? sso.len : ptr.len;
+	}
 
-    /**
+	/**
      * @name Copy operators
      *
      * If the value is null or invalid, or if the memory allocation fails,
@@ -238,11 +241,11 @@ class String
      *
      * @{
      */
-    String & operator = (const String &rhs);
-    String & operator = (const char *cstr);
-    /** @} */
+	String& operator=(const String& rhs);
+	String& operator=(const char* cstr);
+	/** @} */
 
-    /**
+	/**
      * @name Move operators
      *
      * Move content from one String to another without any heap allocation.
@@ -261,16 +264,17 @@ class String
      * @{
      */
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    String & operator = (String && rval)
-    {
-      if (this != &rval) move(rval);
-      return *this;
-    }
-    String & operator = (StringSumHelper && rval);
+	String& operator=(String&& rval)
+	{
+		if(this != &rval)
+			move(rval);
+		return *this;
+	}
+	String& operator=(StringSumHelper&& rval);
 #endif
-    /** @} */
+	/** @} */
 
-    /**
+	/**
      * @name Concatenation methods
      * @retval bool true on success, false on failure
      *
@@ -280,29 +284,29 @@ class String
      *
      * @{
      */
-    bool concat(const String &str)
-    {
-      return concat(str.cbuffer(), str.length());
-    }
-    bool concat(const FlashString& fstr);
-    bool concat(const char *cstr);
-    bool concat(const char *cstr, size_t length);
-    bool concat(char c)
-    {
-      return concat(&c, 1);
-    }
-    bool concat(unsigned char num);
-    bool concat(int num);
-    bool concat(unsigned int num);
-    bool concat(long num);
-    bool concat(long long num);
-    bool concat(unsigned long num);
-    bool concat(unsigned long long num);
-    bool concat(float num);
-    bool concat(double num);
-    /** @} */
-  
-    /**
+	bool concat(const String& str)
+	{
+		return concat(str.cbuffer(), str.length());
+	}
+	bool concat(const FlashString& fstr);
+	bool concat(const char* cstr);
+	bool concat(const char* cstr, size_t length);
+	bool concat(char c)
+	{
+		return concat(&c, 1);
+	}
+	bool concat(unsigned char num);
+	bool concat(int num);
+	bool concat(unsigned int num);
+	bool concat(long num);
+	bool concat(long long num);
+	bool concat(unsigned long num);
+	bool concat(unsigned long long num);
+	bool concat(float num);
+	bool concat(double num);
+	/** @} */
+
+	/**
      * @name Concatenation operators
      *
      * If there's not enough memory for the concatenated value, the string
@@ -310,96 +314,96 @@ class String
      *
      * @{
      */
-    String & operator += (const String &rhs)
-    {
-      concat(rhs);
-      return (*this);
-    }
-    String & operator += (const FlashString &rhs)
-    {
-      concat(rhs);
-      return (*this);
-    }
-    String & operator += (const char *cstr)
-    {
-      concat(cstr);
-      return (*this);
-    }
-    String & operator += (char c)
-    {
-      concat(c);
-      return (*this);
-    }
-    String & operator += (unsigned char num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (int num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (unsigned int num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (long num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (long long num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (unsigned long num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (unsigned long long num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (float num)
-    {
-      concat(num);
-      return (*this);
-    }
-    String & operator += (double num)
-    {
-      concat(num);
-      return (*this);
-    }
-    /** @} */
+	String& operator+=(const String& rhs)
+	{
+		concat(rhs);
+		return (*this);
+	}
+	String& operator+=(const FlashString& rhs)
+	{
+		concat(rhs);
+		return (*this);
+	}
+	String& operator+=(const char* cstr)
+	{
+		concat(cstr);
+		return (*this);
+	}
+	String& operator+=(char c)
+	{
+		concat(c);
+		return (*this);
+	}
+	String& operator+=(unsigned char num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(int num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(unsigned int num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(long num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(long long num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(unsigned long num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(unsigned long long num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(float num)
+	{
+		concat(num);
+		return (*this);
+	}
+	String& operator+=(double num)
+	{
+		concat(num);
+		return (*this);
+	}
+	/** @} */
 
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, const String &rhs);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, const char *cstr);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, char c);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned char num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, int num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned int num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, long num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, unsigned long long num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, float num);
-    friend StringSumHelper & operator + (const StringSumHelper &lhs, double num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, const String& rhs);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, const char* cstr);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, char c);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned char num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, int num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned int num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, long num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned long num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, unsigned long long num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, float num);
+	friend StringSumHelper& operator+(const StringSumHelper& lhs, double num);
 
-    /**
+	/**
      * @brief Provides safe bool() operator
      *
      * Evaluates as false if String is null, otherwise evaluates as true
      */
-    operator StringIfHelperType() const
-    {
-      return isNull() ? 0 : &String::StringIfHelper;
-    }
+	operator StringIfHelperType() const
+	{
+		return isNull() ? 0 : &String::StringIfHelper;
+	}
 
-    /**
+	/**
      * @name Comparison methods
      * Works with String and 'c' string
      * @retval int Returns < 0 if String is lexically before the argument, > 0 if after or 0 if the same
@@ -409,14 +413,14 @@ class String
      *
      * @{
      */
-    int compareTo(const char* cstr, size_t length) const;
-    int compareTo(const String &s) const
-    {
-   	  return compareTo(s.cbuffer(), s.length());
-    }
-    /** @} */
+	int compareTo(const char* cstr, size_t length) const;
+	int compareTo(const String& s) const
+	{
+		return compareTo(s.cbuffer(), s.length());
+	}
+	/** @} */
 
-    /**
+	/**
      * @name Test for equality
      * Compares content byte-for-byte using binary comparison
      * @retval bool Returns true if strings are identical
@@ -425,75 +429,75 @@ class String
      *
      * @{
      */
-    bool equals(const String &s) const
-    {
-    	return equals(s.cbuffer(), s.length());
-    }
-    bool equals(const char *cstr) const;
-    bool equals(const char *cstr, size_t length) const;
-    bool equals(const FlashString& fstr) const
-    {
-    	return fstr.equals(*this);
-    }
-    /** @} */
+	bool equals(const String& s) const
+	{
+		return equals(s.cbuffer(), s.length());
+	}
+	bool equals(const char* cstr) const;
+	bool equals(const char* cstr, size_t length) const;
+	bool equals(const FlashString& fstr) const
+	{
+		return fstr.equals(*this);
+	}
+	/** @} */
 
-    /**
+	/**
      * @name Equality operator ==
      * @retval bool true if Strings are identical
      * @{
      */
-    bool operator == (const String &rhs) const
-    {
-      return equals(rhs);
-    }
-    bool operator == (const char *cstr) const
-    {
-      return equals(cstr);
-    }
-    bool operator==(const FlashString& fstr) const
-    {
-      return equals(fstr);
-    }
-    /** @} */
+	bool operator==(const String& rhs) const
+	{
+		return equals(rhs);
+	}
+	bool operator==(const char* cstr) const
+	{
+		return equals(cstr);
+	}
+	bool operator==(const FlashString& fstr) const
+	{
+		return equals(fstr);
+	}
+	/** @} */
 
-    /**
+	/**
      * @name In-equality operator !=
      * @retval bool Returns true if strings are not identical
      * @{
      */
-    bool operator != (const String &rhs) const
-    {
-      return !equals(rhs);
-    }
-    bool operator != (const char *cstr) const
-    {
-      return !equals(cstr);
-    }
-    /** @} */
+	bool operator!=(const String& rhs) const
+	{
+		return !equals(rhs);
+	}
+	bool operator!=(const char* cstr) const
+	{
+		return !equals(cstr);
+	}
+	/** @} */
 
-    /**
+	/**
      * @name Comparison operators
      * @{
      */
-    bool operator < (const String &rhs) const
-    {
-      return compareTo(rhs) < 0;
-    }
-    bool operator > (const String &rhs) const
-    {
-      return compareTo(rhs) > 0;
-    }
-    bool operator <= (const String &rhs) const
+	bool operator<(const String& rhs) const
 	{
-	  return compareTo(rhs) <= 0;
+		return compareTo(rhs) < 0;
 	}
-    bool operator >= (const String &rhs) const
-    {
-      return compareTo(rhs) >= 0;
-    }
-    /** @} */
+	bool operator>(const String& rhs) const
+	{
+		return compareTo(rhs) > 0;
+	}
+	bool operator<=(const String& rhs) const
+	{
+		return compareTo(rhs) <= 0;
+	}
+	bool operator>=(const String& rhs) const
+	{
+		return compareTo(rhs) >= 0;
+	}
+	/** @} */
 
-    /**
+	/**
      * @name Test for equality, without case-sensitivity
      * @retval bool true if strings are considered the same
      *
@@ -501,30 +505,30 @@ class String
      *
      * @{
      */
-    bool equalsIgnoreCase(const char* cstr) const;
-    bool equalsIgnoreCase(const char* cstr, size_t length) const;
-    bool equalsIgnoreCase(const String &s2) const
-    {
-    	return equalsIgnoreCase(s2.cbuffer(), s2.length());
-    }
-    bool equalsIgnoreCase(const FlashString& fstr) const
-    {
-    	return fstr.equalsIgnoreCase(*this);
-    }
-    /** @} */
+	bool equalsIgnoreCase(const char* cstr) const;
+	bool equalsIgnoreCase(const char* cstr, size_t length) const;
+	bool equalsIgnoreCase(const String& s2) const
+	{
+		return equalsIgnoreCase(s2.cbuffer(), s2.length());
+	}
+	bool equalsIgnoreCase(const FlashString& fstr) const
+	{
+		return fstr.equalsIgnoreCase(*this);
+	}
+	/** @} */
 
-    /**
+	/**
      * @brief Compare the start of a String
      * Comparison is case-sensitive, must match exactly
      * @param prefix
      * @retval bool true on match
      */
-    bool startsWith(const String &prefix) const
-    {
-    	return startsWith(prefix, 0);
-    }
+	bool startsWith(const String& prefix) const
+	{
+		return startsWith(prefix, 0);
+	}
 
-    /**
+	/**
      * @brief Compare a string portion
      * @param prefix
      * @param offset Index to start comparison at
@@ -533,48 +537,48 @@ class String
      *
      * mis-named as does not necessarily compare from start
      */
-    bool startsWith(const String &prefix, size_t offset) const;
+	bool startsWith(const String& prefix, size_t offset) const;
 
-    /**
+	/**
      * @brief Compare the end of a String
      * @param suffix
      * @retval bool true on match
      */
-    bool endsWith(const String &suffix) const;
+	bool endsWith(const String& suffix) const;
 
-    // character acccess
+	// character acccess
 
-    /**
+	/**
      * @brief Obtain the character at the given index
      * @param index
      * @retval char
      * @note If index is invalid, returns NUL \0
      */
-    char charAt(size_t index) const
-    {
-      return operator[](index);
-    }
+	char charAt(size_t index) const
+	{
+		return operator[](index);
+	}
 
-    /**
+	/**
      * @brief Sets the character at a given index
      * @param index
      * @param c
      * @note If index is invalid, does nothing
      */
-    void setCharAt(size_t index, char c);
+	void setCharAt(size_t index, char c);
 
-    /**
+	/**
      * @name Array operators
      *
      * If index is invalid, returns NUL \0
      *
      * @{
      */
-    char operator [](size_t index) const;
-    char& operator [](size_t index);
-    /** @} */
+	char operator[](size_t index) const;
+	char& operator[](size_t index);
+	/** @} */
 
-    /** @brief Read contents of a String into a buffer
+	/** @brief Read contents of a String into a buffer
      *  @param buf buffer to write data
      *  @param bufsize size of buffer in bytes
      *  @param index offset to start
@@ -582,41 +586,56 @@ class String
      *  @note Returned data always nul terminated so buffer size needs to take this
      *  into account
      */
-    size_t getBytes(unsigned char *buf, size_t bufsize, size_t index = 0) const;
+	size_t getBytes(unsigned char* buf, size_t bufsize, size_t index = 0) const;
 
-    /**
+	/**
      * @brief Read contents of String into a buffer
      * @see See `getBytes()`
      */
-    void toCharArray(char *buf, size_t bufsize, size_t index = 0) const
-    {
-      getBytes((unsigned char *)buf, bufsize, index);
-    }
+	void toCharArray(char* buf, size_t bufsize, size_t index = 0) const
+	{
+		getBytes((unsigned char*)buf, bufsize, index);
+	}
 
-    /**
+	/**
      * @brief Get a constant (un-modifiable) pointer to String content
      * @retval const char* Always valid, even for a null string
      */
-    const char* c_str() const { return cbuffer() ?: empty.cbuffer(); }
+	const char* c_str() const
+	{
+		return cbuffer() ?: empty.cbuffer();
+	}
 
-    /**
+	/**
      * @brief Get a modifiable pointer to String content
      * @note If String is NUL, returns nullptr.
      */
-    char* begin() { return buffer(); }
+	char* begin()
+	{
+		return buffer();
+	}
 
-    /**
+	/**
      * @brief Get a modifiable pointer to one-past the end of the String
      * @note Points to the terminating NUL character.
      * If String is NUL, returns nullptr.
      */
-    char* end() { return buffer() + length(); }
-    const char* begin() const { return c_str(); }
-    const char* end() const { return c_str() + length(); }
-  
-    // search
+	char* end()
+	{
+		return buffer() + length();
+	}
+	const char* begin() const
+	{
+		return c_str();
+	}
+	const char* end() const
+	{
+		return c_str() + length();
+	}
 
-    /**
+	// search
+
+	/**
      * @name int indexOf(...)
      * Locate a character or String within another String.
      * @retval int Index if found, -1 if not found
@@ -626,19 +645,19 @@ class String
      *
      * @{
      */
-    int indexOf(char ch, size_t fromIndex = 0) const;
-    int indexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const;
-    int indexOf(const char* s2_buf, size_t fromIndex = 0) const
-    {
-    	return indexOf(s2_buf, fromIndex, strlen(s2_buf));
-    }
-    int indexOf(const String &s2, size_t fromIndex = 0) const
-    {
-    	return indexOf(s2.cbuffer(), fromIndex, s2.length());
-    }
-    /** @} */
+	int indexOf(char ch, size_t fromIndex = 0) const;
+	int indexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const;
+	int indexOf(const char* s2_buf, size_t fromIndex = 0) const
+	{
+		return indexOf(s2_buf, fromIndex, strlen(s2_buf));
+	}
+	int indexOf(const String& s2, size_t fromIndex = 0) const
+	{
+		return indexOf(s2.cbuffer(), fromIndex, s2.length());
+	}
+	/** @} */
 
-    /**
+	/**
      * @name int lastIndexOf(...)
      * Locate a character or String within another String
      * @retval int Index if found, -1 if not found
@@ -648,14 +667,14 @@ class String
      *
      * @{
      */
-    int lastIndexOf(char ch) const;
-    int lastIndexOf(char ch, size_t fromIndex) const;
-    int lastIndexOf(const String &s2) const;
-    int lastIndexOf(const String &s2, size_t fromIndex) const;
-    int lastIndexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const;
-    /** @} */
+	int lastIndexOf(char ch) const;
+	int lastIndexOf(char ch, size_t fromIndex) const;
+	int lastIndexOf(const String& s2) const;
+	int lastIndexOf(const String& s2, size_t fromIndex) const;
+	int lastIndexOf(const char* s2_buf, size_t fromIndex, size_t s2_len) const;
+	/** @} */
 
-    /**
+	/**
      * @name String substring(...)
      * Get a substring of a String.
      * @param from Index of first character to retrieve
@@ -677,16 +696,16 @@ class String
      *
      * @{
      */
-    String substring(size_t from, size_t to) const;
-    String substring(size_t from) const
-    {
-    	return substring(from, length());
-    }
-    /** @} */
+	String substring(size_t from, size_t to) const;
+	String substring(size_t from) const
+	{
+		return substring(from, length());
+	}
+	/** @} */
 
-    // modification
+	// modification
 
-    /**
+	/**
      * @name replace(...)
      * Replace all instances of a given character or substring with another character or substring.
      * @retval bool true on success, false on allocation failure
@@ -698,12 +717,12 @@ class String
      *
      * @{
      */
-    void replace(char find, char replace);
-    bool replace(const String& find, const String& replace);
-    bool replace(const char* find_buf, size_t find_len, const char* replace_buf, size_t replace_len);
-    /** @} */
+	void replace(char find, char replace);
+	bool replace(const String& find, const String& replace);
+	bool replace(const char* find_buf, size_t find_len, const char* replace_buf, size_t replace_len);
+	/** @} */
 
-    /**
+	/**
      * @name remove()
      * Remove characters from a String.
      * @param index Index of the first character to remove
@@ -715,41 +734,41 @@ class String
      *
      * @{
      */
-    void remove(size_t index)
-    {
-    	remove(index, SIZE_MAX);
-    }
-    void remove(size_t index, size_t count);
-    /** @} */
+	void remove(size_t index)
+	{
+		remove(index, SIZE_MAX);
+	}
+	void remove(size_t index, size_t count);
+	/** @} */
 
-    /**
+	/**
      * @brief Convert the entire String content to lower case
      */
-    void toLowerCase(void);
+	void toLowerCase(void);
 
-    /**
+	/**
      * @brief Convert the entire String content to upper case
      */
-    void toUpperCase(void);
+	void toUpperCase(void);
 
-    /**
+	/**
      * @brief Remove all leading and trailing whitespace characters from the String
      */
-    void trim(void);
+	void trim(void);
 
-    // parsing/conversion
-    long toInt(void) const;
-    float toFloat(void) const;
+	// parsing/conversion
+	long toInt(void) const;
+	float toFloat(void) const;
 
 	/// Max chars. (excluding NUL terminator) we can store in SSO mode
 	static constexpr size_t SSO_CAPACITY = STRING_OBJECT_SIZE - 2;
 
 protected:
-    /// Used when contents allocated on heap
+	/// Used when contents allocated on heap
 	struct PtrBuf {
-		char* buffer;		  // the actual char array
-		size_t len;			  // the String length (not counting the '\0')
-		size_t capacity;	  // the array length minus one (for the '\0')
+		char* buffer;	// the actual char array
+		size_t len;		 // the String length (not counting the '\0')
+		size_t capacity; // the array length minus one (for the '\0')
 	};
 	// For small strings we can store data directly without requiring the heap
 	struct SsoBuf {
@@ -771,47 +790,47 @@ protected:
 	// Free any heap memory and set to non-SSO mode; isNull() will return true
 	void invalidate(void);
 
-    // String is Null (invalid) by default, i.e. non-SSO and null buffer
-    __forceinline bool isNull() const
-    {
-    	return !sso.set && (ptr.buffer == nullptr);
-    }
+	// String is Null (invalid) by default, i.e. non-SSO and null buffer
+	__forceinline bool isNull() const
+	{
+		return !sso.set && (ptr.buffer == nullptr);
+	}
 
-    // Get writeable buffer pointer
-    __forceinline char* buffer()
-    {
-    	return sso.set ? sso.buffer : ptr.buffer;
-    }
+	// Get writeable buffer pointer
+	__forceinline char* buffer()
+	{
+		return sso.set ? sso.buffer : ptr.buffer;
+	}
 
-    // Get read-only buffer pointer
-    __forceinline const char* cbuffer() const
-    {
-    	return sso.set ? sso.buffer : ptr.buffer;
-    }
+	// Get read-only buffer pointer
+	__forceinline const char* cbuffer() const
+	{
+		return sso.set ? sso.buffer : ptr.buffer;
+	}
 
-    // Get currently assigned capacity for current mode
-    __forceinline size_t capacity() const
-    {
-    	return sso.set ? SSO_CAPACITY : ptr.capacity;
-    }
+	// Get currently assigned capacity for current mode
+	__forceinline size_t capacity() const
+	{
+		return sso.set ? SSO_CAPACITY : ptr.capacity;
+	}
 
-    // Called whenever string length changes to ensure NUL terminator is set
-    __forceinline void setlen(size_t len)
-    {
-    	if(sso.set) {
-    		sso.len = len;
-    		sso.buffer[len] = '\0';
-    	} else {
-    		ptr.len = len;
-    		ptr.buffer[len] = '\0';
-    	}
-    }
+	// Called whenever string length changes to ensure NUL terminator is set
+	__forceinline void setlen(size_t len)
+	{
+		if(sso.set) {
+			sso.len = len;
+			sso.buffer[len] = '\0';
+		} else {
+			ptr.len = len;
+			ptr.buffer[len] = '\0';
+		}
+	}
 
-    // copy and move
-    String & copy(const char *cstr, size_t length);
-    String& copy(flash_string_t pstr, size_t length);
+	// copy and move
+	String& copy(const char* cstr, size_t length);
+	String& copy(flash_string_t pstr, size_t length);
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-    void move(String &rhs);
+	void move(String& rhs);
 #endif
 };
 
@@ -819,21 +838,45 @@ protected:
 
 class StringSumHelper : public String
 {
-  public:
-    StringSumHelper(const String &s) : String(s) {}
-    StringSumHelper(const char *p) : String(p) {}
-    StringSumHelper(char c) : String(c) {}
-    StringSumHelper(unsigned char num) : String(num) {}
-    StringSumHelper(int num) : String(num) {}
-    StringSumHelper(unsigned int num) : String(num) {}
-    StringSumHelper(long num) : String(num) {}
-    StringSumHelper(long long num) : String(num) {}
-    StringSumHelper(unsigned long num) : String(num) {}
-    StringSumHelper(unsigned long long num) : String(num) {}
-    StringSumHelper(float num) : String(num) {}
-    StringSumHelper(double num) : String(num) {}
+public:
+	StringSumHelper(const String& s) : String(s)
+	{
+	}
+	StringSumHelper(const char* p) : String(p)
+	{
+	}
+	StringSumHelper(char c) : String(c)
+	{
+	}
+	StringSumHelper(unsigned char num) : String(num)
+	{
+	}
+	StringSumHelper(int num) : String(num)
+	{
+	}
+	StringSumHelper(unsigned int num) : String(num)
+	{
+	}
+	StringSumHelper(long num) : String(num)
+	{
+	}
+	StringSumHelper(long long num) : String(num)
+	{
+	}
+	StringSumHelper(unsigned long num) : String(num)
+	{
+	}
+	StringSumHelper(unsigned long long num) : String(num)
+	{
+	}
+	StringSumHelper(float num) : String(num)
+	{
+	}
+	StringSumHelper(double num) : String(num)
+	{
+	}
 };
 
 #include "SplitString.h"
 
-#endif  // __cplusplus
+#endif // __cplusplus

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -234,6 +234,30 @@ public:
 	}
 
 	/**
+     * @brief Used with setBuffer and getBuffer methods
+     */
+	struct Buffer {
+		char* data;	///< Allocated using malloc
+		size_t size;   ///< Size of memory allocation
+		size_t length; ///< Length of content, MUST be < size
+	};
+
+	/**
+     * @brief Set String content using move semantics from external memory buffer
+     * @param buffer We'll take ownership of this buffer
+     * @retval bool true on success; on failure, ownership of buffer is not transferred
+     * @note length MUST be < `size` - A NUL character is written at this location
+     */
+	bool setBuffer(const Buffer& buffer);
+
+	/**
+     * @brief Get String content using move semantics
+     * @retval Buffer
+     * @note String is invalidated by this call. Caller is responsible for buffer memory.
+     */
+	Buffer getBuffer();
+
+	/**
      * @name Copy operators
      *
      * If the value is null or invalid, or if the memory allocation fails,

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -184,11 +184,11 @@ public:
 	}
 
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-	String(String&& rval) : String()
+	String(String&& rval) noexcept : String()
 	{
 		move(rval);
 	}
-	String(StringSumHelper&& rval);
+	String(StringSumHelper&& rval) noexcept;
 #endif
 	explicit String(char c);
 	explicit String(unsigned char, unsigned char base = 10);
@@ -294,13 +294,13 @@ public:
      * @{
      */
 #ifdef __GXX_EXPERIMENTAL_CXX0X__
-	String& operator=(String&& rval)
+	String& operator=(String&& rval) noexcept
 	{
 		if(this != &rval)
 			move(rval);
 		return *this;
 	}
-	String& operator=(StringSumHelper&& rval);
+	String& operator=(StringSumHelper&& rval) noexcept;
 #endif
 	/** @} */
 

--- a/Sming/Wiring/WVector.h
+++ b/Sming/Wiring/WVector.h
@@ -84,7 +84,7 @@ public:
 			copyFrom(rhv);
 		return *this;
 	}
-	const Vector<Element>& operator=(const Vector<Element>&& other) // move assignment
+	const Vector<Element>& operator=(const Vector<Element>&& other)  noexcept // move assignment
 	{
 		if(_data != nullptr) {
 			removeAllElements();

--- a/docs/source/upgrading/4.1-4.2.rst
+++ b/docs/source/upgrading/4.1-4.2.rst
@@ -1,0 +1,34 @@
+*****************
+From v4.1 to v4.2
+*****************
+
+.. highlight:: c++
+
+
+Summary
+=======
+
+
+Stream methods
+--------------
+
+The :c:func:`Stream::readBytes` has been virtualised and overriden for :cpp:class:`IDataSourceStream`
+descendents for more efficient operation, especially with ArduinoJson.
+For normal read operations where the stream position is to be updated, applications should use
+this method in preference to :c:func:`IDataSourceStream::readMemoryBlock`.
+
+An addition method :cpp:func:`IDataSourceStream::moveString` has been added to support extracting
+the content of a memory-based stream into a String object without duplicating the data.
+This is supported by :cpp:class:`LimitedMemoryStream` and :cpp:class:`MemoryDataStream`.
+
+
+getBody methods
+---------------
+
+A ``size_t`` parameter has been added to :cpp:func:`HttpRequest::getBody` and :cpp:func:`HttpResponse::getBody`.
+This is to restrict the amount of memory which might be allocated to the returned :cpp:class:`String` object.
+
+This can be used to help mitigate memory-overflow attacks.
+You should generally choose a value no greater than absolutely necessary for the expected body size.
+
+For larger amounts of data use :cpp:func:`HttpResponse::getBodyStream` instead.

--- a/samples/Basic_WebSkeletonApp/app/webserver.cpp
+++ b/samples/Basic_WebSkeletonApp/app/webserver.cpp
@@ -99,7 +99,7 @@ int onConfiguration(HttpServerConnection& connection, HttpRequest& request, Http
 
 	debugf("Update config");
 	// Update config
-	if(request.getBody() == nullptr) {
+	if(request.getBodyStream() == nullptr) {
 		debugf("NULL bodyBuf");
 		return 0;
 	}

--- a/samples/Basic_WebSkeletonApp_LTS/README.rst
+++ b/samples/Basic_WebSkeletonApp_LTS/README.rst
@@ -26,5 +26,7 @@ This is how it was done:
 9. Update callback function parameter lists for ``STADisconnect`` and ``STAGotIP``.
    We can also get a description for disconnection reasons, so display that instead of just a number.
    See :source:`Sming/Platform/WifiEvents.h`.
+10.   In webserver.cpp, the `onConfiguration()` function uses `request.getBody()`.
+      It is more efficient to use streams, so just replace with `request.getBodyStream()`.
 
 That's it.

--- a/samples/Basic_WebSkeletonApp_LTS/app/webserver.cpp
+++ b/samples/Basic_WebSkeletonApp_LTS/app/webserver.cpp
@@ -14,12 +14,12 @@ void onConfiguration(HttpRequest& request, HttpResponse& response)
 	if(request.method == HTTP_POST) {
 		debugf("Update config");
 		// Update config
-		if(request.getBody() == nullptr) {
+		if(request.getBodyStream() == nullptr) {
 			debugf("NULL bodyBuf");
 			return;
 		} else {
 			StaticJsonBuffer<ConfigJsonBufferSize> jsonBuffer;
-			JsonObject& root = jsonBuffer.parseObject(request.getBody());
+			JsonObject& root = jsonBuffer.parseObject(*request.getBodyStream());
 			root.prettyPrintTo(Serial); //Uncomment it for debuging
 
 			if(root["StaSSID"].success()) // Settings

--- a/samples/HttpClient/app/application.cpp
+++ b/samples/HttpClient/app/application.cpp
@@ -16,7 +16,7 @@ int onDownload(HttpConnection& connection, bool success)
 	debugf("Got response code: %d", connection.getResponse()->code);
 	debugf("Success: %d", success);
 	if(connection.getRequest()->method != HTTP_HEAD) {
-		debugf("Got content starting with: %s", connection.getResponse()->getBody().substring(0, 1000).c_str());
+		debugf("Got content starting with: %s", connection.getResponse()->getBody(1000).c_str());
 	}
 
 	auto ssl = connection.getSsl();

--- a/samples/HttpClient_Instapush/app/application.cpp
+++ b/samples/HttpClient_Instapush/app/application.cpp
@@ -65,7 +65,7 @@ public:
 
 	int processed(HttpConnection& client, bool successful)
 	{
-		Serial.println(client.getResponse()->getBody());
+		Serial.copyFrom(client.getResponse()->stream);
 
 		return 0;
 	}

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -17,7 +17,7 @@ int onDataSent(HttpConnection& client, bool successful)
 	else
 		Serial.println("Failed");
 
-	String response = client.getResponse()->getBody();
+	String response = client.getResponse()->getBody(256);
 	Serial.println("Server response: '" + response + "'");
 	if(response.length() > 0) {
 		int intVal = response.toInt();

--- a/samples/RingTonePlayer/host/TuneSorting.cpp
+++ b/samples/RingTonePlayer/host/TuneSorting.cpp
@@ -52,7 +52,7 @@ void sortTunes()
 		const auto& header = parser.getHeader();
 		writer.beginTune(header);
 
-		String headerString = mem.readString();
+		String headerString = mem.readString(SIZE_MAX);
 		mem.clear();
 
 		RingTone::NoteDef note;
@@ -60,7 +60,7 @@ void sortTunes()
 			writer.addNote(note);
 		}
 
-		String content = mem.readString();
+		String content = mem.readString(SIZE_MAX);
 		mem.clear();
 
 		auto findContent = [&]() -> int {

--- a/samples/RingTonePlayer/host/TuneSorting.cpp
+++ b/samples/RingTonePlayer/host/TuneSorting.cpp
@@ -52,16 +52,16 @@ void sortTunes()
 		const auto& header = parser.getHeader();
 		writer.beginTune(header);
 
-		String headerString = mem.readString(SIZE_MAX);
-		mem.clear();
+		String headerString;
+		mem.moveString(headerString);
 
 		RingTone::NoteDef note;
 		while(parser.readNextNote(note)) {
 			writer.addNote(note);
 		}
 
-		String content = mem.readString(SIZE_MAX);
-		mem.clear();
+		String content;
+		mem.moveString(content);
 
 		auto findContent = [&]() -> int {
 			for(unsigned i = 0; i < tunes.count(); ++i) {

--- a/samples/SmtpClient/app/application.cpp
+++ b/samples/SmtpClient/app/application.cpp
@@ -58,9 +58,11 @@ void onConnected(IpAddress ip, IpAddress mask, IpAddress gateway)
 	mail->from = MAIL_FROM;
 	mail->to = MAIL_TO;
 	mail->subject = "Greetings from Sming";
-	mail->setBody("Hello.\r\n.\r\n"
-				  "This is test email from Sming <https://github.com/SmingHub/Sming>"
-				  "It contains attachment, Ümlauts, кирилица + etc");
+	String body = F("Hello.\r\n.\r\n"
+					"This is test email from Sming <https://github.com/SmingHub/Sming>"
+					"It contains attachment, Ümlauts, кирилица + etc");
+	// Note: Body can be quite large so use move semantics to avoid additional heap allocation
+	mail->setBody(std::move(body));
 
 	FileStream* file = new FileStream("image.png");
 	mail->addAttachment(file);

--- a/tests/HostTests/app/test-json6.cpp
+++ b/tests/HostTests/app/test-json6.cpp
@@ -216,7 +216,7 @@ public:
 			size_t serializedLength = Json::serialize(doc, stream);
 			debug_d("serialized length = %u", serializedLength);
 			REQUIRE(serializedLength == jsonTest.length());
-			String content = stream->readString();
+			String content = stream->readString(jsonTest.length() * 2);
 			debug_d("stream->read returned %u", content.length());
 			debug_d("%s", content.c_str(), content.length());
 			REQUIRE(content == jsonTest);

--- a/tests/HostTests/app/test-json6.cpp
+++ b/tests/HostTests/app/test-json6.cpp
@@ -216,7 +216,8 @@ public:
 			size_t serializedLength = Json::serialize(doc, stream);
 			debug_d("serialized length = %u", serializedLength);
 			REQUIRE(serializedLength == jsonTest.length());
-			String content = stream->readString(jsonTest.length() * 2);
+			String content;
+			REQUIRE(stream->moveString(content));
 			debug_d("stream->read returned %u", content.length());
 			debug_d("%s", content.c_str(), content.length());
 			REQUIRE(content == jsonTest);

--- a/tests/HostTests/app/test-stream.cpp
+++ b/tests/HostTests/app/test-stream.cpp
@@ -54,7 +54,7 @@ private:
 	{
 		MemoryDataStream mem;
 		mem.copyFrom(&stream, 1024);
-		String tmpl = mem.readString();
+		String tmpl = mem.readString(1024);
 		debug_i("tmpl: %s", tmpl.c_str());
 		debug_i(" ref: %s", String(ref).c_str());
 		REQUIRE(ref == tmpl);

--- a/tests/HostTests/app/test-stream.cpp
+++ b/tests/HostTests/app/test-stream.cpp
@@ -2,6 +2,7 @@
 #include <FlashString/TemplateStream.hpp>
 #include <Data/Stream/MemoryDataStream.h>
 
+IMPORT_FSTR_LOCAL(FS_abstract, PROJECT_DIR "/files/abstract.txt");
 DEFINE_FSTR_LOCAL(template1, "Stream containing {var1}, {var2} and {var3}. {} {{}} {{12345")
 DEFINE_FSTR_LOCAL(template1_1, "Stream containing value #1, value #2 and {var3}. {} {{}} {")
 DEFINE_FSTR_LOCAL(template1_2, "Stream containing value #1, value #2 and [value #3]. {} {{}} {")
@@ -47,6 +48,58 @@ public:
 
 			check(tmpl, template1_2);
 		}
+
+		TEST_CASE("MemoryDataStream::moveString")
+		{
+			FSTR::Stream src(FS_abstract);
+			MemoryDataStream dest;
+			dest.copyFrom(&src);
+			String s;
+			REQUIRE(dest.moveString(s) == true);
+			REQUIRE(FS_abstract == s);
+		}
+
+		TEST_CASE("MemoryDataStream(String&&)")
+		{
+			// Move Stream into String
+			String s(FS_abstract);
+			MemoryDataStream stream(std::move(s));
+			TEST_ASSERT(!s);
+			TEST_ASSERT(FS_abstract.length() == stream.available());
+			// And back again
+			stream.moveString(s);
+			TEST_ASSERT(FS_abstract == s);
+			REQUIRE(strlen(s.c_str()) == s.length());
+		}
+
+		TEST_CASE("LimitedMemoryStream::moveString (1)")
+		{
+			FSTR::Stream src(FS_abstract);
+			REQUIRE(src.available() == FS_abstract.length());
+			LimitedMemoryStream dest(FS_abstract.length());
+			// Operation will drop last character as this is converted to NUL
+			dest.copyFrom(&src);
+			String s;
+			REQUIRE(dest.moveString(s) == false);
+			debug_i("src length = %u, s length = %u", FS_abstract.length(), s.length());
+			String s1(FS_abstract);
+			s1.remove(s1.length() - 1);
+			REQUIRE(s1 == s);
+			REQUIRE(strlen(s.c_str()) == s.length());
+		}
+
+		TEST_CASE("LimitedMemoryStream::moveString (2)")
+		{
+			FSTR::Stream src(FS_abstract);
+			REQUIRE(src.available() == FS_abstract.length());
+			LimitedMemoryStream dest(FS_abstract.length() + 10);
+			// Operation will drop last character as this is converted to NUL
+			dest.copyFrom(&src);
+			String s;
+			REQUIRE(dest.moveString(s) == true);
+			REQUIRE(FS_abstract == s);
+			REQUIRE(strlen(s.c_str()) == s.length());
+		}
 	}
 
 private:
@@ -54,7 +107,8 @@ private:
 	{
 		MemoryDataStream mem;
 		mem.copyFrom(&stream, 1024);
-		String tmpl = mem.readString(1024);
+		String tmpl;
+		REQUIRE(mem.moveString(tmpl));
 		debug_i("tmpl: %s", tmpl.c_str());
 		debug_i(" ref: %s", String(ref).c_str());
 		REQUIRE(ref == tmpl);


### PR DESCRIPTION
* Apply coding style to WString
* Add `String::getBuffer` and `String::setBuffer` to support general move operations
* Optimise `readString` method for `MemoryDataStream`
* Add MemoryDataStream(String&&) constructor: heap allocation required only if String is using SSO mode.
* Provide MemoryDataStream::readString override to perform move when entire content of stream is requested.
* Add overloads to various classes to support r-values.
* Use overload instead of optional length parameter for String constructor and setString().
