### PR TITLE
Fix appveyor crashing issue and use latest MinGW

### DIFF
--- a/.appveyor/build.cmd
+++ b/.appveyor/build.cmd
@@ -1,11 +1,12 @@
 REM Windows build script
 
-set SMING_HOME=%APPVEYOR_BUILD_FOLDER%\Sming
+subst Z: %APPVEYOR_BUILD_FOLDER%
+set SMING_HOME=Z:\Sming
 
 if "%build_compiler%" == "udk" set ESP_HOME=%UDK_ROOT%
 if "%build_compiler%" == "eqt" set ESP_HOME=%EQT_ROOT%
 
-cd %SMING_HOME%
+cd /d %SMING_HOME%
 gcc -v
 
 set MAKE_PARALLEL=make -j2

--- a/.appveyor/build.cmd
+++ b/.appveyor/build.cmd
@@ -12,8 +12,8 @@ set MAKE_PARALLEL=make -j2
 
 REM Move samples and tests into directory outside of the Sming repo.
 set SMING_PROJECTS_DIR=%APPVEYOR_BUILD_FOLDER%\..
-move ../samples %SMING_PROJECTS_DIR%
-move ../tests %SMING_PROJECTS_DIR%
+move ..\samples %SMING_PROJECTS_DIR%
+move ..\tests %SMING_PROJECTS_DIR%
 
 REM This will build the Basic_Blink application and most of the framework Components
 cd %SMING_PROJECTS_DIR%/samples/Basic_Blink

--- a/.appveyor/install.cmd
+++ b/.appveyor/install.cmd
@@ -1,7 +1,7 @@
 REM Windows install script
 
 rmdir /s /q c:\MinGW
-curl -LO %SMINGTOOLS%/MinGW.7z
+curl -Lo MinGW.7z %SMINGTOOLS%/MinGW-2020-10-19.7z
 7z -oC:\ x MinGW.7z
 
 goto :%SMING_ARCH%

--- a/Sming/component-wrapper.mk
+++ b/Sming/component-wrapper.mk
@@ -166,10 +166,23 @@ include $(wildcard $(ABS_BUILD_DIRS:=/*.c.d))
 include $(wildcard $(ABS_BUILD_DIRS:=/*.cpp.d))
 
 # Provide a target unless Component is custom built, in which case the component.mk will have defined this already
-$(COMPONENT_LIBPATH): $(OBJ) $(EXTRA_OBJ)
+$(COMPONENT_LIBPATH): build.ar
 	$(vecho) "AR $@"
 	$(Q) test ! -f $@ || rm $@
-	$(Q) $(AR) rcsP $@ $^
+	$(Q) $(AR) -M < build.ar
+	$(Q) mv $(notdir $(COMPONENT_LIBPATH)) $(COMPONENT_LIBPATH)
+
+define addmod
+	@echo ADDMOD $2 >> $1
+
+endef
+
+build.ar: $(OBJ) $(EXTRA_OBJ)
+	@echo CREATE $(notdir $(COMPONENT_LIBPATH)) > $@
+	$(foreach o,$(OBJ) $(EXTRA_OBJ),$(call addmod,$@,$o))
+	@echo SAVE >> $@
+	@echo END >> $@
+
 
 endif # ifeq (,$(CUSTOM_BUILD))
 endif # ifneq (,$(COMPONENT_LIBNAME))


### PR DESCRIPTION
See also #2086 

I've been able to reproduce this problem on my dev. machine. The problem occurs during build of HostTests, specifically the `bearssl-esp8266` Component. It can be reproduced thus:

```
cd %SMING_HOME%\..\tests\HostTests
make bearssl-esp8266-clean
make bearssl-esp8266-build
```

(I add -j20 to speed things up, but it makes no difference.)

Now, if I remove *any* 3 files from the build (e.g. by renaming .c -> .cXX) and repeat the above commands, the problem does not occur. This puts the number of files passed to the `ar` tool at 292.

My first attempt was to invoke separate commands for each object file. The first 40 objects were added, then it failed!

So then I looked at path lengths. On my test build system, here's one of the commands:

`ar rcsP /s/sandboxes/sming-tmp/Sming/out/Host/debug/lib/clib-bearssl-esp8266.a bearssl/src/ec/ec_secp521r1.o`

So I did this:

```
subst Z: s:\sandboxes\sming-tmp
set SMING_HOME=Z:\Sming
```

And repeated the test. Success!

However, this only fixes the issue for appveyor unless users manually do the above.

So, part (2) of this fix is to change the makefiles to to generate a `build.ar` script. This keeps the command line small and actually fixes the problem, rather than works around it.
