### PR TITLE
BitSet enhancements

### DIFF
--- a/Sming/Core/Data/BitSet.cpp
+++ b/Sming/Core/Data/BitSet.cpp
@@ -1,0 +1,18 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * BitSet.cpp
+ *
+ * @author: 2020 - Mikee47 <mike@sillyhouse.net>
+ *
+ ****/
+
+#include "BitSet.h"
+
+String toString(uint8_t value)
+{
+	return String(value);
+}

--- a/Sming/Core/Data/BitSet.h
+++ b/Sming/Core/Data/BitSet.h
@@ -4,7 +4,7 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * BitSet.h
+ * BitSet.h - Strongly typed sets of values
  *
  * @author: 2020 - Mikee47 <mike@sillyhouse.net>
  *
@@ -13,96 +13,201 @@
 #pragma once
 
 #include <stdint.h>
+#include <limits>
+#include <type_traits>
 
 /**
  * @brief Manage a set of bit values using enumeration
  *
  * API is similar to a simplified std::bitset, but with added +/- operators.
  *
- * @tparam S Storage type (e.g. uint32_t)
- * @tparam E Element type e.g. enum class
+ * @tparam S Storage type (e.g. uint32_t).
+ * This determines how much space to use, and must be an unsigned integer.
+ * It is safe to use this class in structures, where it will occupy exactly the required space.
+ *
+ * @tparam E Element type e.g. enum class.
+ * You can use any enum or unsigned integer for the elements. These must have ordinal sequence starting at 0.
+ *
+ * @tparam size_ Number of possible values in the set. Defaults to maximum for given storage type.
+ * Number of possible values in the set. This must be at least 1, and cannot be more
+ * than the given Storage type may contain.
+ * For example, a :cpp:type:`uint8_t` may contain up to 8 values.
+ *
+ * @note It is important to specify **size** correctly when using enumerated values.
+ * In the ``FruitBasket`` example, we use a ``uint8_t`` storage type so can have up to 8 possible values.
+ * However, the ``Fruit`` enum contains only 7 values. The set operations will therefore be restricted to
+ * ensure that the unused bit is never set.
  */
-template <typename S, typename E> class BitSet
+template <typename S, typename E, size_t size_ = sizeof(S) * 8> class BitSet
 {
 public:
+	static_assert(std::is_integral<S>::value && std::is_unsigned<S>::value,
+				  "BitSet requires an unsigned integral storage type");
+	static_assert(std::is_enum<E>::value || (std::is_integral<E>::value && std::is_unsigned<E>::value),
+				  "BitSets may use only enum or unsigned integral type elements");
+	static_assert(size_ > 0, "BitSet size cannot be zero!");
+	static_assert(size_ <= (sizeof(S) * 8), "BitSet has too many elements for storage type");
+
 	class BitRef
 	{
 	public:
 		operator bool() const
 		{
-			return set.test(e);
+			return bitset.test(e);
 		}
 
 		BitRef& operator=(bool b)
 		{
-			if(b) {
-				set += e;
-			} else {
-				set -= e;
-			}
+			bitset.set(e, b);
 			return *this;
 		}
 
 	private:
 		friend BitSet;
-		BitRef(BitSet& set, E e) : set(set), e(e)
+		BitRef(BitSet& bitset, E e) : bitset(bitset), e(e)
 		{
 		}
 
-		BitSet& set;
+		BitSet& bitset;
 		E e;
 	};
 
 	/**
 	 * @brief Construct empty set
 	 */
-	BitSet() = default;
+	constexpr BitSet() = default;
 
 	/**
 	 * @brief Copy constructor
+	 * @param bitset The set to copy
 	 */
-	BitSet(const BitSet&) = default;
+	template <typename S2> constexpr BitSet(const BitSet<S2, E>& bitset) : value_(bitset.value())
+	{
+	}
+
+	/**
+	 * @brief Construct from a raw set of bits
+	 * @param value Integral type whose bits will be interpreted as set{E}
+	 */
+	constexpr BitSet(S value) : value_(value)
+	{
+	}
 
 	/**
 	 * @brief Construct set containing a single value
+	 * @param e Value to place in our new BitSet object
 	 */
-	BitSet(E e) : value{bitVal(e)}
+	constexpr BitSet(E e) : value_{bitVal(e)}
 	{
 	}
 
 	/**
-	 * @brief Add value to set
+	 * @brief Compare this set with another for equality
 	 */
-	BitSet& operator+=(BitSet rhs)
+	bool operator==(const BitSet& other) const
 	{
-		value |= rhs.value;
+		return value_ == other.value_;
+	}
+
+	/**
+	 * @brief Compare this set with another for inequality
+	 */
+	bool operator!=(const BitSet& other) const
+	{
+		return value_ != other.value_;
+	}
+
+	/**
+	 * @brief Obtain a set containing all elements not in this one
+	 */
+	constexpr BitSet operator~() const
+	{
+		return BitSet(~value_ & domain().value_);
+	}
+
+	/**
+	 * @brief Get the number of possible elements in the set
+	 */
+	static constexpr size_t size()
+	{
+		return size_;
+	}
+
+	/**
+	 * @brief Get the set of all possible values
+	 */
+	static constexpr BitSet domain()
+	{
+		return std::numeric_limits<S>::max() >> ((sizeof(S) * 8) - size_);
+	}
+
+	/**
+	 * @brief Get the bitmask corresponding to a given value
+	 */
+	static constexpr S bitVal(E e)
+	{
+		return S{1U} << unsigned(e);
+	}
+
+	/**
+	 * @brief Flip all bits in the set
+	 */
+	BitSet& flip()
+	{
+		value_ = ~value_ & domain().value_;
 		return *this;
 	}
 
 	/**
-	 * @brief Remove value from set
+	 * @brief Flip state of the given bit
 	 */
-	BitSet& operator-=(BitSet rhs)
+	BitSet& flip(E e)
 	{
-		value &= ~rhs.value;
+		value_ ^= bitVal(e);
 		return *this;
 	}
 
 	/**
-	 * @brief Intersection
+	 * @brief Get the number of elements in the set, i.e. bits set to 1
+	 */
+	size_t count() const
+	{
+		return __builtin_popcount(value_);
+	}
+
+	/**
+	 * @brief Union: Add elements to set
+	 */
+	BitSet& operator+=(const BitSet& rhs)
+	{
+		value_ |= rhs.value_;
+		return *this;
+	}
+
+	/**
+	 * @brief Remove elements from set
+	 */
+	BitSet& operator-=(const BitSet& rhs)
+	{
+		value_ &= ~rhs.value_;
+		return *this;
+	}
+
+	/**
+	 * @brief Intersection: Leave only elements common to both sets
 	 */
 	BitSet& operator&=(const BitSet& rhs)
 	{
-		value &= rhs.value;
+		value_ &= rhs.value_;
 		return *this;
 	}
 
 	/**
-	 * @brief Union
+	 * @brief Union: Add elements to set
 	 */
 	BitSet& operator|=(const BitSet& rhs)
 	{
-		value |= rhs.value;
+		value_ |= rhs.value_;
 		return *this;
 	}
 
@@ -111,130 +216,218 @@ public:
 	 */
 	BitSet& operator^=(const BitSet& rhs)
 	{
-		value ^= rhs.value;
+		value_ ^= rhs.value_;
 		return *this;
 	}
 
 	/**
-	 * @name Test to see if given value is in the set
-	 * @note Also allows assignment operations such as `set[x] = value`
-	 * @{
+	 * @brief Test to see if given element is in the set
+	 */
+	bool test(E e) const
+	{
+		return (value_ & bitVal(e)) != 0;
+	}
+
+	/**
+	 * @brief Read-only [] operator
+	 * @param e Element to test for
+	 * @retval bool true if given element is in the set
+	 */
+	bool operator[](E e) const
+	{
+		return test(e);
+	}
+
+	/**
+	 * @brief Read/write [] operator
+	 * @param e Element to read or write
+	 * @retval BitRef Temporary object used to do the read or write
+	 *
+	 * This returns a temporary BitRef object to support assignment operations such as `set[x] = value`
 	 */
 	BitRef operator[](E e)
 	{
 		return BitRef{*this, e};
 	}
 
-	bool operator[](E e) const
-	{
-		return test(e);
-	}
-
-	bool test(E e) const
-	{
-		return (value & bitVal(e)) != 0;
-	}
-
-	/** @} */
-
 	/**
 	 * @brief Determine if set contains any values
 	 */
 	bool any() const
 	{
-		return value != 0;
+		return value_ != 0;
 	}
 
 	/**
 	 * @brief Determine if set contains any values from another set
 	 * i.e. intersection != []
 	 */
-	bool any(const BitSet& states) const
+	bool any(const BitSet& other) const
 	{
-		return (value & states.value) != 0;
+		return (value_ & other.value_) != 0;
 	}
 
 	/**
-	 * @brief Determine if two sets are identical
+	 * @brief Test if set contains all possible values
 	 */
-	bool all(const BitSet& states) const
+	bool all() const
 	{
-		return (value & states.value) == states.value;
+		return value_ == domain().value_;
 	}
 
 	/**
-	 * @brief Determine if set is empty
+	 * @brief Test if set is empty
 	 */
 	bool none() const
 	{
-		return value == 0;
+		return value_ == S{0};
 	}
 
 	/**
-	 * @brief Determine if set contains one specific value
+	 * @brief Add all possible values to the bit set
+	 */
+	BitSet& set()
+	{
+		value_ = domain().value_;
+		return *this;
+	}
+
+	/**
+	 * @brief Set the state of the given bit (i.e. add to or remove from the set)
+	 * @param e Element to change
+	 * @param state true to add the element, false to remove it
+	 */
+	BitSet& set(E e, bool state = true)
+	{
+		if(state) {
+			value_ |= bitVal(e);
+		} else {
+			value_ &= ~bitVal(e);
+		}
+		return *this;
+	}
+
+	/**
+	 * @brief Remove all values from the set
+	 */
+	BitSet& reset()
+	{
+		value_ = S{0};
+		return *this;
+	}
+
+	/**
+	 * @brief Clear the state of the given bit (i.e. remove it from the set)
+	 */
+	BitSet& reset(E e)
+	{
+		return set(e, false);
+	}
+
+	/**
+	 * @brief Determine if set consists of only the one given element
 	 */
 	bool operator==(E e) const
 	{
-		return value == bitVal(e);
+		return value_ == bitVal(e);
 	}
 
 	/**
 	 * @brief Allow casts from the native storage type to get a numeric result for this set
 	 */
-	explicit operator S() const
+	explicit constexpr operator S() const
 	{
-		return value;
+		return value_;
+	}
+
+	/**
+	 * @brief Get stored bits for this bitset
+	 */
+	constexpr S value() const
+	{
+		return value_;
+	}
+
+	/*
+	 * use a function pointer to allow for "if (s)" without the
+	 * complications of an operator bool(). for more information,
+	 * see: http://www.artima.com/cppsource/safebool.html
+	 */
+	using IfHelperType = void (BitSet::*)() const;
+
+	/*
+     * Provides safe bool() operator
+     * Evaluates as false if set is empty
+     */
+	operator IfHelperType() const
+	{
+		return any() ? &BitSet::IfHelper : 0;
 	}
 
 private:
-	S bitVal(E e) const
+	void IfHelper() const
 	{
-		return S{1U} << unsigned(e);
 	}
 
-	S value{0};
+	S value_{0};
 };
 
-template <typename S, typename E> inline BitSet<S, E> operator&(const BitSet<S, E>& x, const BitSet<S, E>& y)
+template <typename S, typename E, size_t size_>
+inline constexpr BitSet<S, E, size_> operator&(const BitSet<S, E, size_>& x, const BitSet<S, E, size_>& y)
 {
-	BitSet<S, E> r(x);
-	r &= y;
-	return r;
+	return BitSet<S, E, size_>(S(x) & ~S(y));
 }
 
-template <typename S, typename E> inline BitSet<S, E> operator|(const BitSet<S, E>& x, const BitSet<S, E>& y)
+template <typename S, typename E, size_t size_>
+inline constexpr BitSet<S, E, size_> operator|(BitSet<S, E, size_> x, BitSet<S, E, size_> y)
 {
-	BitSet<S, E> r(x);
-	r |= y;
-	return r;
+	return BitSet<S, E, size_>(S(x) | S(y));
 }
 
-template <typename S, typename E> inline BitSet<S, E> operator+(const BitSet<S, E>& x, const BitSet<S, E>& y)
+template <typename S, typename E, size_t size_>
+inline constexpr BitSet<S, E, size_> operator|(BitSet<S, E, size_> x, E b)
 {
-	BitSet<S, E> r(x);
-	r += y;
-	return r;
+	return x | BitSet<S, E, size_>(b);
 }
 
-template <typename S, typename E> inline BitSet<S, E> operator-(const BitSet<S, E>& x, const BitSet<S, E>& y)
+template <typename S, typename E, size_t size_>
+inline constexpr BitSet<S, E, size_> operator+(const BitSet<S, E, size_>& x, const BitSet<S, E, size_>& y)
 {
-	BitSet<S, E> r(x);
-	r -= y;
-	return r;
+	return x | y;
 }
 
-template <typename S, typename E> inline BitSet<S, E> operator+(const BitSet<S, E>& x, E y)
+template <typename S, typename E, size_t size_>
+inline constexpr BitSet<S, E, size_> operator-(const BitSet<S, E, size_>& x, const BitSet<S, E, size_>& y)
 {
-	auto r(x);
-	r += y;
-	return r;
+	return BitSet<S, E, size_>(S(x) & ~S(y));
 }
 
-template <typename S, typename E> inline BitSet<S, E> operator-(const BitSet<S, E>& x, E y)
+template <typename S, typename E, size_t size_>
+inline constexpr BitSet<S, E, size_> operator+(const BitSet<S, E, size_>& x, E b)
 {
-	auto r(x);
-	r -= y;
-	return r;
+	return x | b;
+}
+
+template <typename S, typename E, size_t size_>
+inline constexpr BitSet<S, E, size_> operator-(const BitSet<S, E, size_>& x, E b)
+{
+	return BitSet<S, E, size_>(S(x) & ~BitSet<S, E, size_>::bitVal(b));
+}
+
+/*
+ * These allow construction of a maximally-sized BitSet in an expression,
+ * which is then copy-constructed to the actual value. For example:
+ *
+ * 		constexpr BitSet<uint8_t, Fruit> fixedBasket = Fruit::apple | Fruit::orange;
+ */
+template <typename E> inline constexpr BitSet<uint32_t, E> operator|(E a, E b)
+{
+	return BitSet<uint32_t, E>(BitSet<uint32_t, E>::bitVal(a) | BitSet<uint32_t, E>::bitVal(b));
+}
+
+template <typename E> inline constexpr BitSet<uint32_t, E> operator+(E a, E b)
+{
+	return a | b;
 }
 
 /**

--- a/Sming/Core/Data/BitSet.h
+++ b/Sming/Core/Data/BitSet.h
@@ -12,9 +12,11 @@
 
 #pragma once
 
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <type_traits>
+#include <WString.h>
 
 /**
  * @brief Manage a set of bit values using enumeration
@@ -414,26 +416,7 @@ inline constexpr BitSet<S, E, size_> operator-(const BitSet<S, E, size_>& x, E b
 	return BitSet<S, E, size_>(S(x) & ~BitSet<S, E, size_>::bitVal(b));
 }
 
-/*
- * These allow construction of a maximally-sized BitSet in an expression,
- * which is then copy-constructed to the actual value. For example:
- *
- * 		constexpr BitSet<uint8_t, Fruit> fixedBasket = Fruit::apple | Fruit::orange;
- */
-template <typename E> inline constexpr BitSet<uint32_t, E> operator|(E a, E b)
-{
-	return BitSet<uint32_t, E>(BitSet<uint32_t, E>::bitVal(a) | BitSet<uint32_t, E>::bitVal(b));
-}
-
-template <typename E> inline constexpr BitSet<uint32_t, E> operator+(E a, E b)
-{
-	return a | b;
-}
-
-inline String toString(uint8_t value)
-{
-	return String(value);
-}
+String toString(uint8_t value);
 
 /**
  * @brief Class template to print the contents of a BitSet to a String
@@ -442,6 +425,8 @@ inline String toString(uint8_t value)
 template <typename S, typename E, size_t size_>
 String toString(const BitSet<S, E, size_>& bitset, const String& separator = ", ")
 {
+	extern String toString(E e);
+
 	String s;
 
 	for(unsigned i = 0; i < bitset.size(); ++i) {

--- a/Sming/Core/Data/BitSet.h
+++ b/Sming/Core/Data/BitSet.h
@@ -430,6 +430,34 @@ template <typename E> inline constexpr BitSet<uint32_t, E> operator+(E a, E b)
 	return a | b;
 }
 
+inline String toString(uint8_t value)
+{
+	return String(value);
+}
+
+/**
+ * @brief Class template to print the contents of a BitSet to a String
+ * @note Requires an implementation of `toString(E)`
+ */
+template <typename S, typename E, size_t size_>
+String toString(const BitSet<S, E, size_>& bitset, const String& separator = ", ")
+{
+	String s;
+
+	for(unsigned i = 0; i < bitset.size(); ++i) {
+		if(!bitset[E(i)]) {
+			continue;
+		}
+
+		if(s) {
+			s += separator;
+		}
+		s += toString(E(i));
+	}
+
+	return s;
+}
+
 /**
  * @brief A set of 32 bits
  */

--- a/Sming/Core/Data/BitSet.h
+++ b/Sming/Core/Data/BitSet.h
@@ -416,6 +416,24 @@ inline constexpr BitSet<S, E, size_> operator-(const BitSet<S, E, size_>& x, E b
 	return BitSet<S, E, size_>(S(x) & ~BitSet<S, E, size_>::bitVal(b));
 }
 
+/*
+ * These allow construction of a maximally-sized BitSet in an expression,
+ * which is then copy-constructed to the actual value. For example:
+ *
+ * 		constexpr BitSet<uint8_t, Fruit> fixedBasket = Fruit::apple | Fruit::orange;
+ */
+template <typename E>
+constexpr typename std::enable_if<std::is_enum<E>::value, BitSet<uint32_t, E>>::type operator|(E a, E b)
+{
+	return BitSet<uint32_t, E>(BitSet<uint32_t, E>::bitVal(a) | BitSet<uint32_t, E>::bitVal(b));
+}
+
+template <typename E>
+constexpr typename std::enable_if<std::is_enum<E>::value, BitSet<uint32_t, E>>::type operator+(E a, E b)
+{
+	return a | b;
+}
+
 String toString(uint8_t value);
 
 /**

--- a/Sming/Core/Data/BitSet.h
+++ b/Sming/Core/Data/BitSet.h
@@ -83,7 +83,7 @@ public:
 	 * @brief Copy constructor
 	 * @param bitset The set to copy
 	 */
-	template <typename S2> constexpr BitSet(const BitSet<S2, E>& bitset) : value_(bitset.value())
+	template <typename S2> constexpr BitSet(const BitSet<S2, E>& bitset) : bitSetValue(bitset.value())
 	{
 	}
 
@@ -91,7 +91,7 @@ public:
 	 * @brief Construct from a raw set of bits
 	 * @param value Integral type whose bits will be interpreted as set{E}
 	 */
-	constexpr BitSet(S value) : value_(value)
+	constexpr BitSet(S value) : bitSetValue(value)
 	{
 	}
 
@@ -99,7 +99,7 @@ public:
 	 * @brief Construct set containing a single value
 	 * @param e Value to place in our new BitSet object
 	 */
-	constexpr BitSet(E e) : value_{bitVal(e)}
+	constexpr BitSet(E e) : bitSetValue{bitVal(e)}
 	{
 	}
 
@@ -108,7 +108,7 @@ public:
 	 */
 	bool operator==(const BitSet& other) const
 	{
-		return value_ == other.value_;
+		return bitSetValue == other.bitSetValue;
 	}
 
 	/**
@@ -116,7 +116,7 @@ public:
 	 */
 	bool operator!=(const BitSet& other) const
 	{
-		return value_ != other.value_;
+		return bitSetValue != other.bitSetValue;
 	}
 
 	/**
@@ -124,7 +124,7 @@ public:
 	 */
 	constexpr BitSet operator~() const
 	{
-		return BitSet(~value_ & domain().value_);
+		return BitSet(~bitSetValue & domain().bitSetValue);
 	}
 
 	/**
@@ -156,7 +156,7 @@ public:
 	 */
 	BitSet& flip()
 	{
-		value_ = ~value_ & domain().value_;
+		bitSetValue = ~bitSetValue & domain().bitSetValue;
 		return *this;
 	}
 
@@ -165,7 +165,7 @@ public:
 	 */
 	BitSet& flip(E e)
 	{
-		value_ ^= bitVal(e);
+		bitSetValue ^= bitVal(e);
 		return *this;
 	}
 
@@ -174,7 +174,7 @@ public:
 	 */
 	size_t count() const
 	{
-		return __builtin_popcount(value_);
+		return __builtin_popcount(bitSetValue);
 	}
 
 	/**
@@ -182,7 +182,7 @@ public:
 	 */
 	BitSet& operator+=(const BitSet& rhs)
 	{
-		value_ |= rhs.value_;
+		bitSetValue |= rhs.bitSetValue;
 		return *this;
 	}
 
@@ -191,7 +191,7 @@ public:
 	 */
 	BitSet& operator-=(const BitSet& rhs)
 	{
-		value_ &= ~rhs.value_;
+		bitSetValue &= ~rhs.bitSetValue;
 		return *this;
 	}
 
@@ -200,7 +200,7 @@ public:
 	 */
 	BitSet& operator&=(const BitSet& rhs)
 	{
-		value_ &= rhs.value_;
+		bitSetValue &= rhs.bitSetValue;
 		return *this;
 	}
 
@@ -209,7 +209,7 @@ public:
 	 */
 	BitSet& operator|=(const BitSet& rhs)
 	{
-		value_ |= rhs.value_;
+		bitSetValue |= rhs.bitSetValue;
 		return *this;
 	}
 
@@ -218,7 +218,7 @@ public:
 	 */
 	BitSet& operator^=(const BitSet& rhs)
 	{
-		value_ ^= rhs.value_;
+		bitSetValue ^= rhs.bitSetValue;
 		return *this;
 	}
 
@@ -227,7 +227,7 @@ public:
 	 */
 	bool test(E e) const
 	{
-		return (value_ & bitVal(e)) != 0;
+		return (bitSetValue & bitVal(e)) != 0;
 	}
 
 	/**
@@ -257,7 +257,7 @@ public:
 	 */
 	bool any() const
 	{
-		return value_ != 0;
+		return bitSetValue != 0;
 	}
 
 	/**
@@ -266,7 +266,7 @@ public:
 	 */
 	bool any(const BitSet& other) const
 	{
-		return (value_ & other.value_) != 0;
+		return (bitSetValue & other.bitSetValue) != 0;
 	}
 
 	/**
@@ -274,7 +274,7 @@ public:
 	 */
 	bool all() const
 	{
-		return value_ == domain().value_;
+		return bitSetValue == domain().bitSetValue;
 	}
 
 	/**
@@ -282,7 +282,7 @@ public:
 	 */
 	bool none() const
 	{
-		return value_ == S{0};
+		return bitSetValue == S{0};
 	}
 
 	/**
@@ -290,7 +290,7 @@ public:
 	 */
 	BitSet& set()
 	{
-		value_ = domain().value_;
+		bitSetValue = domain().bitSetValue;
 		return *this;
 	}
 
@@ -302,9 +302,9 @@ public:
 	BitSet& set(E e, bool state = true)
 	{
 		if(state) {
-			value_ |= bitVal(e);
+			bitSetValue |= bitVal(e);
 		} else {
-			value_ &= ~bitVal(e);
+			bitSetValue &= ~bitVal(e);
 		}
 		return *this;
 	}
@@ -314,7 +314,7 @@ public:
 	 */
 	BitSet& reset()
 	{
-		value_ = S{0};
+		bitSetValue = S{0};
 		return *this;
 	}
 
@@ -331,7 +331,7 @@ public:
 	 */
 	bool operator==(E e) const
 	{
-		return value_ == bitVal(e);
+		return bitSetValue == bitVal(e);
 	}
 
 	/**
@@ -339,7 +339,7 @@ public:
 	 */
 	explicit constexpr operator S() const
 	{
-		return value_;
+		return bitSetValue;
 	}
 
 	/**
@@ -347,7 +347,7 @@ public:
 	 */
 	constexpr S value() const
 	{
-		return value_;
+		return bitSetValue;
 	}
 
 	/*
@@ -371,7 +371,7 @@ private:
 	{
 	}
 
-	S value_{0};
+	S bitSetValue{0};
 };
 
 template <typename S, typename E, size_t size_>

--- a/docs/source/framework/core/data/bitset.rst
+++ b/docs/source/framework/core/data/bitset.rst
@@ -1,0 +1,77 @@
+BitSet
+======
+
+.. highlight:: c++
+
+Introduction
+------------
+
+The C++ STL provides `std::bitset <http://www.cplusplus.com/reference/bitset/bitset/>`__
+which emulates an array of ``bool`` elements.
+
+The :cpp:class:`BitSet` class template provides similar support for sets of strongly-typed elements.
+For example::
+
+   enum class Fruit {
+      apple,
+      banana,
+      kiwi,
+      orange,
+      passion,
+      pear,
+      tomato,
+   };
+
+   using FruitBasket = BitSet<uint8_t, Fruit, unsigned(Fruit::tomato) + 1>;
+
+   static constexpr FruitBasket fixedBasket = Fruit::orange | Fruit::banana | Fruit::tomato;
+
+A ``FruitBasket`` uses one byte of storage, with each bit representing an item of ``Fruit``.
+If the basket contains a piece of fruit, the corresponding bit is set.
+If it does not, the bit is clear.
+
+Without BitSet you implement this as follows::
+
+   using FruitBasket = uint8_t;
+
+   static constexpr FruitBasket fixedBasket = _BV(Fruit::orange) | _BV(Fruit::banana) | _BV(Fruit::tomato);
+
+
+To test whether the set contains a value you'd do this::
+
+   if(fixedBasket & _BV(Fruit::orange)) {
+      Serial.println("I have an orange");
+   }
+
+With a BitSet, you do this::
+
+   if(fixedBasket[Fruit::orange]) {
+      Serial.println("I have an orange");
+   }
+
+And you can add an element like this::
+
+   basket[Fruit::kiwi] = true;
+
+Bit manipulation operators are provided so you can do logical stuff like this::
+
+   FruitBasket basket1; // Create an empty basket
+
+   // Add a kiwi fruit
+   basket1 = fixedBasket + Fruit::kiwi;
+
+   // Create a second basket containing all fruit not in our first basket
+   FruitBasket basket2 = ~basket1;
+
+   // Remove some fruit
+   basket2 -= Fruit::orange | Fruit::tomato;   
+
+And so on.
+
+
+API
+---
+
+.. doxygenclass:: BitSet
+   :members:
+

--- a/docs/source/framework/core/data/bitset.rst
+++ b/docs/source/framework/core/data/bitset.rst
@@ -24,26 +24,11 @@ For example::
 
    using FruitBasket = BitSet<uint8_t, Fruit, unsigned(Fruit::tomato) + 1>;
 
-   static constexpr FruitBasket fixedBasket = FruitBasket(Fruit::orange) | Fruit::banana | Fruit::tomato;
+   static constexpr FruitBasket fixedBasket = Fruit::orange | Fruit::banana | Fruit::tomato;
 
 A ``FruitBasket`` uses one byte of storage, with each bit representing an item of ``Fruit``.
 If the basket contains a piece of fruit, the corresponding bit is set.
 If it does not, the bit is clear.
-
-.. note::
-
-   We must add the initial ``FruitBasket(Fruit::orange)`` cast to allow the | operator to function.
-   To avoid this, declare an operator like this::
-
-      inline constexpr FruitBasket operator|(Fruit a, Fruit b)
-      {
-         return FruitBasket(a) | b;
-      }
-
-   From now on, we can just write::
-
-      FruitBasket basket = Fruit::orange | Fruit::banana | Fruit::tomato;
-   
 
 Without BitSet you implement this as follows::
 

--- a/docs/source/framework/core/data/bitset.rst
+++ b/docs/source/framework/core/data/bitset.rst
@@ -68,6 +68,14 @@ Bit manipulation operators are provided so you can do logical stuff like this::
 
 And so on.
 
+To display the contents of a BitSet, do this::
+
+   Serial.print(_F("My basket contains: "));
+   Serial.println(basket1);
+
+You will also need to provide an implementation of ``toString(Fruit)``
+or whatever type you are using for the set elements.
+
 
 API
 ---

--- a/docs/source/framework/core/data/bitset.rst
+++ b/docs/source/framework/core/data/bitset.rst
@@ -24,11 +24,26 @@ For example::
 
    using FruitBasket = BitSet<uint8_t, Fruit, unsigned(Fruit::tomato) + 1>;
 
-   static constexpr FruitBasket fixedBasket = Fruit::orange | Fruit::banana | Fruit::tomato;
+   static constexpr FruitBasket fixedBasket = FruitBasket(Fruit::orange) | Fruit::banana | Fruit::tomato;
 
 A ``FruitBasket`` uses one byte of storage, with each bit representing an item of ``Fruit``.
 If the basket contains a piece of fruit, the corresponding bit is set.
 If it does not, the bit is clear.
+
+.. note::
+
+   We must add the initial ``FruitBasket(Fruit::orange)`` cast to allow the | operator to function.
+   To avoid this, declare an operator like this::
+
+      inline constexpr FruitBasket operator|(Fruit a, Fruit b)
+      {
+         return FruitBasket(a) | b;
+      }
+
+   From now on, we can just write::
+
+      FruitBasket basket = Fruit::orange | Fruit::banana | Fruit::tomato;
+   
 
 Without BitSet you implement this as follows::
 

--- a/tests/HostTests/app/modules.h
+++ b/tests/HostTests/app/modules.h
@@ -3,6 +3,7 @@
 #define TEST_MAP(XX)                                                                                                   \
 	XX(libc)                                                                                                           \
 	XX(precache)                                                                                                       \
+	XX(bitset)                                                                                                         \
 	XX(string)                                                                                                         \
 	XX(arduino_string)                                                                                                 \
 	XX(crypto)                                                                                                         \

--- a/tests/HostTests/app/test-bitset.cpp
+++ b/tests/HostTests/app/test-bitset.cpp
@@ -1,0 +1,133 @@
+#include <SmingTest.h>
+#include <Data/BitSet.h>
+
+namespace
+{
+enum class Fruit {
+	apple,
+	banana,
+	kiwi,
+	orange,
+	passion,
+	pear,
+	tomato,
+};
+
+using FruitBasket = BitSet<uint8_t, Fruit, unsigned(Fruit::tomato) + 1>;
+using NumberSet = BitSet<uint32_t, uint8_t>;
+
+static constexpr FruitBasket fixedBasket = Fruit::orange | Fruit::banana | Fruit::tomato;
+
+/*
+ * BitSet is safe to use embedded in structures.
+ * It can therefore be used in external interface definitions, or in data structures
+ * which are sent 'over the wire'.
+ */
+struct Struct {
+	FruitBasket basket1{fixedBasket};
+	uint8_t value;
+	FruitBasket basket2;
+};
+
+static_assert(sizeof(fixedBasket) == 1, "fixedBasket size wrong");
+static_assert(sizeof(Struct) == 3, "Struct size wrong");
+
+/*
+// Examples of declarations which will fail compilation
+
+BitSet<uint8_t, uint8_t, 9> badBitSet1;
+BitSet<uint32_t, uint8_t, 0> badBitSet2;
+BitSet<uint32_t, int, 5> badBitSet3;
+BitSet<uint32_t, float, 5> badBitSet4;
+BitSet<float, uint8_t, 9> badBitSet5;
+
+*/
+
+}; // namespace
+
+class BitSetTest : public TestGroup
+{
+public:
+	BitSetTest() : TestGroup(_F("BitSet"))
+	{
+	}
+
+	void execute() override
+	{
+		TEST_CASE("constexpr")
+		{
+			REQUIRE(fixedBasket.value() == (_BV(Fruit::orange) | _BV(Fruit::banana) | _BV(Fruit::tomato)));
+		}
+
+		TEST_CASE("Operations")
+		{
+			FruitBasket basket;
+			REQUIRE(basket.value() == 0);
+			REQUIRE(!basket);
+
+			basket += Fruit::pear + Fruit::tomato;
+			REQUIRE(basket);
+			REQUIRE(basket.value() == (_BV(Fruit::pear) | _BV(Fruit::tomato)));
+
+			basket += fixedBasket;
+			REQUIRE(basket.value() == (fixedBasket.value() | _BV(Fruit::pear)));
+
+			FruitBasket basket2 = Fruit::pear;
+			debug_i("basket = 0x%08x", basket.value());
+			debug_i("fixedBasket = 0x%08x", fixedBasket.value());
+			REQUIRE(basket != fixedBasket);
+			REQUIRE(!(basket == fixedBasket));
+			basket -= basket2;
+			REQUIRE(basket == fixedBasket);
+
+			FruitBasket empty;
+			REQUIRE(!(basket == empty));
+			REQUIRE(basket != empty);
+
+			basket -= Fruit::orange;
+			REQUIRE(basket.value() == (_BV(Fruit::banana) | _BV(Fruit::tomato)));
+
+			basket &= fixedBasket;
+
+			basket = ~fixedBasket;
+			debug_e("basket.value = 0x%08x", basket.value());
+			REQUIRE(basket.value() == (_BV(Fruit::apple) | _BV(Fruit::kiwi) | _BV(Fruit::passion) | _BV(Fruit::pear)));
+
+			REQUIRE(basket[Fruit::apple]);
+			REQUIRE(!basket[Fruit::tomato]);
+
+			REQUIRE(basket.domain().value() ==
+					(_BV(Fruit::apple) | _BV(Fruit::banana) | _BV(Fruit::kiwi) | _BV(Fruit::orange) |
+					 _BV(Fruit::passion) | _BV(Fruit::pear) | _BV(Fruit::tomato)));
+		}
+
+		TEST_CASE("Number set")
+		{
+			NumberSet numbers = 12U;
+			REQUIRE(numbers.value() == 12);
+
+			numbers = NumberSet{};
+			REQUIRE(numbers.value() == 0);
+
+			numbers |= uint8_t(1);
+			REQUIRE(numbers.value() == _BV(1));
+
+			numbers |= uint8_t(5);
+			numbers |= uint8_t(10);
+			REQUIRE(numbers.value() == (_BV(1) | _BV(5) | _BV(10)));
+		}
+
+		TEST_CASE("64-bit set")
+		{
+			BitSet<uint64_t, uint8_t, 35> large;
+
+			REQUIRE(sizeof(large) == 8);
+			REQUIRE(large.domain().value() == 0x7FFFFFFFFULL);
+		}
+	}
+};
+
+void REGISTER_TEST(bitset)
+{
+	registerGroup<BitSetTest>();
+}

--- a/tests/HostTests/app/test-bitset.cpp
+++ b/tests/HostTests/app/test-bitset.cpp
@@ -28,11 +28,6 @@ String toString(Fruit f)
 
 using FruitBasket = BitSet<uint8_t, Fruit, size_t(Fruit::MAX)>;
 
-inline constexpr FruitBasket operator|(Fruit a, Fruit b)
-{
-	return FruitBasket(a) | b;
-}
-
 static constexpr FruitBasket fixedBasket = Fruit::orange | Fruit::banana | Fruit::tomato;
 
 /*

--- a/tests/HostTests/app/test-bitset.cpp
+++ b/tests/HostTests/app/test-bitset.cpp
@@ -3,18 +3,32 @@
 
 namespace
 {
+#define FRUIT_ELEMENT_MAP(XX)                                                                                          \
+	XX(apple)                                                                                                          \
+	XX(banana)                                                                                                         \
+	XX(kiwi)                                                                                                           \
+	XX(orange)                                                                                                         \
+	XX(passion)                                                                                                        \
+	XX(pear)                                                                                                           \
+	XX(tomato)
+
 enum class Fruit {
-	apple,
-	banana,
-	kiwi,
-	orange,
-	passion,
-	pear,
-	tomato,
+#define XX(n) n,
+	FRUIT_ELEMENT_MAP(XX)
+#undef XX
+		MAX
 };
 
-using FruitBasket = BitSet<uint8_t, Fruit, unsigned(Fruit::tomato) + 1>;
-using NumberSet = BitSet<uint32_t, uint8_t>;
+#define XX(n) #n "\0"
+DEFINE_FSTR_LOCAL(fruitStrings, FRUIT_ELEMENT_MAP(XX))
+#undef XX
+
+String toString(Fruit f)
+{
+	return CStringArray(fruitStrings)[unsigned(f)];
+}
+
+using FruitBasket = BitSet<uint8_t, Fruit, size_t(Fruit::MAX)>;
 
 static constexpr FruitBasket fixedBasket = Fruit::orange | Fruit::banana | Fruit::tomato;
 
@@ -61,6 +75,9 @@ public:
 
 		TEST_CASE("Operations")
 		{
+			Serial.print(_F("fixedBasket contains: "));
+			Serial.println(toString(fixedBasket));
+
 			FruitBasket basket;
 			REQUIRE(basket.value() == 0);
 			REQUIRE(!basket);
@@ -103,8 +120,11 @@ public:
 
 		TEST_CASE("Number set")
 		{
-			NumberSet numbers = 12U;
-			REQUIRE(numbers.value() == 12);
+			using NumberSet = BitSet<uint32_t, uint8_t>;
+			NumberSet numbers = 0x12345678U;
+			Serial.print(_F("numbers = "));
+			Serial.println(toString(numbers));
+			REQUIRE(numbers.value() == 0x12345678U);
 
 			numbers = NumberSet{};
 			REQUIRE(numbers.value() == 0);

--- a/tests/HostTests/app/test-bitset.cpp
+++ b/tests/HostTests/app/test-bitset.cpp
@@ -1,8 +1,6 @@
 #include <SmingTest.h>
 #include <Data/BitSet.h>
 
-namespace
-{
 #define FRUIT_ELEMENT_MAP(XX)                                                                                          \
 	XX(apple)                                                                                                          \
 	XX(banana)                                                                                                         \
@@ -29,6 +27,11 @@ String toString(Fruit f)
 }
 
 using FruitBasket = BitSet<uint8_t, Fruit, size_t(Fruit::MAX)>;
+
+inline constexpr FruitBasket operator|(Fruit a, Fruit b)
+{
+	return FruitBasket(a) | b;
+}
 
 static constexpr FruitBasket fixedBasket = Fruit::orange | Fruit::banana | Fruit::tomato;
 
@@ -57,8 +60,6 @@ BitSet<float, uint8_t, 9> badBitSet5;
 
 */
 
-}; // namespace
-
 class BitSetTest : public TestGroup
 {
 public:
@@ -82,7 +83,7 @@ public:
 			REQUIRE(basket.value() == 0);
 			REQUIRE(!basket);
 
-			basket += Fruit::pear + Fruit::tomato;
+			basket += Fruit::pear | Fruit::tomato;
 			REQUIRE(basket);
 			REQUIRE(basket.value() == (_BV(Fruit::pear) | _BV(Fruit::tomato)));
 


### PR DESCRIPTION
* Make BitSet constexpr-compatible

    Allows construction of fixed values which may be used as pre-defined masks, e.g. FileOpenFlags.

* Add `size` template parameter

    Primary use case is enumerated types which only use a subset of the Storage.
    For example, uint32_t can store 32 values but an enum may only have 15.
    Attempting to use ~ operator would produce an incorrect result without this information.

    Use this to provide `domain()` (set containing all values).

* Add static asserts to check template parameters are compile time

* Add methods to correspond with std::bitset

    Also tested and fixed for old compiler (linux)

* Add page to framework docs

* Add bitset module to HostTests for integration testing

* Add `toString` support
