### PR TITLE
HttpClient improvements. Added support for servers that do not support connection reuse.

### DIFF
--- a/Sming/Core/Network/Http/HttpClientConnection.h
+++ b/Sming/Core/Network/Http/HttpClientConnection.h
@@ -52,6 +52,11 @@ public:
 
 	void reset() override;
 
+	bool isFinished()
+	{
+		return (waitingQueue.count() + executionQueue.count() == 0);
+	}
+
 protected:
 	// HTTP parser methods
 
@@ -62,6 +67,8 @@ protected:
 
 	// TCP methods
 	void onReadyToSendData(TcpConnectionEvent sourceEvent) override;
+
+	void onClosed() override;
 
 	void cleanup() override;
 

--- a/Sming/Core/Network/Http/HttpCommon.h
+++ b/Sming/Core/Network/Http/HttpCommon.h
@@ -47,7 +47,8 @@ enum HttpConnectionState {
 	eHCS_SendingHeaders,
 	eHCS_StartBody,
 	eHCS_SendingBody,
-	eHCS_Sent
+	eHCS_Sent,
+	eHCS_WaitResponse
 };
 
 typedef ObjectMap<String, ReadWriteStream> HttpFiles;

--- a/Sming/Core/Network/HttpClient.h
+++ b/Sming/Core/Network/HttpClient.h
@@ -23,6 +23,7 @@
 #include "Http/HttpRequest.h"
 #include "Http/HttpClientConnection.h"
 #include "Data/Stream/LimitedMemoryStream.h"
+#include <Timer.h>
 
 class HttpClient
 {
@@ -126,7 +127,7 @@ public:
 	}
 
 	/**
-	 * Use this method to clean all request queues and object pools
+	 * @brief Use this method to clean all object pools
 	 */
 	static void cleanup()
 	{
@@ -142,6 +143,10 @@ protected:
 protected:
 	typedef ObjectMap<String, HttpClientConnection> HttpConnectionPool;
 	static HttpConnectionPool httpConnectionPool;
+
+private:
+	static Timer cleanUpTimer;
+	static void cleanInactive();
 };
 
 /** @} */

--- a/Sming/Core/Network/TcpClient.cpp
+++ b/Sming/Core/Network/TcpClient.cpp
@@ -187,6 +187,13 @@ void TcpClient::onError(err_t err)
 	TcpConnection::onError(err);
 }
 
+void TcpClient::onClosed()
+{
+	onFinished(state);
+	TcpConnection::onClosed();
+	state = eTCS_Ready;
+}
+
 void TcpClient::onFinished(TcpClientState finishState)
 {
 	freeStreams();

--- a/Sming/Core/Network/TcpClient.h
+++ b/Sming/Core/Network/TcpClient.h
@@ -131,6 +131,8 @@ protected:
 	err_t onReceive(pbuf* buf) override;
 	err_t onSent(uint16_t len) override;
 	void onError(err_t err) override;
+	void onClosed() override;
+
 	void onReadyToSendData(TcpConnectionEvent sourceEvent) override;
 
 	virtual void onFinished(TcpClientState finishState);

--- a/Sming/Core/Network/TcpConnection.cpp
+++ b/Sming/Core/Network/TcpConnection.cpp
@@ -76,7 +76,7 @@ bool TcpConnection::connect(const String& server, int port, bool useSsl)
 		ssl->hostName = server;
 	}
 
-	debug_tcp_d("connect to \"%s\"", server.c_str());
+	debug_tcp_d("connect to \"%s:%d\"", server.c_str(), port);
 	canSend = false; // Wait for connection
 
 	struct DnsLookup {

--- a/Sming/Core/Network/TcpConnection.cpp
+++ b/Sming/Core/Network/TcpConnection.cpp
@@ -283,6 +283,8 @@ void TcpConnection::close()
 	tcp_arg(tcp, nullptr); // reset pointer to close connection on next callback
 	tcp = nullptr;
 
+	onClosed();
+
 	checkSelfFree();
 }
 
@@ -339,6 +341,8 @@ void TcpConnection::closeTcpConnection(tcp_pcb* tpcb)
 
 	debug_d("-TCP connection");
 
+	auto connection = reinterpret_cast<TcpConnection*>(tpcb->callback_arg);
+
 	tcp_arg(tpcb, nullptr);
 	tcp_sent(tpcb, nullptr);
 	tcp_recv(tpcb, nullptr);
@@ -351,6 +355,11 @@ void TcpConnection::closeTcpConnection(tcp_pcb* tpcb)
 		debug_d("tcp wait close connection");
 		/* error closing, try again later in poll */
 		tcp_poll(tpcb, staticOnPoll, 4);
+		return;
+	}
+
+	if(connection != nullptr) {
+		connection->onClosed();
 	}
 }
 

--- a/Sming/Core/Network/TcpConnection.h
+++ b/Sming/Core/Network/TcpConnection.h
@@ -162,6 +162,14 @@ protected:
 	virtual void onError(err_t err);
 	virtual void onReadyToSendData(TcpConnectionEvent sourceEvent);
 
+	/**
+	 * @brief Gets called when there is/was a tcp connection, the latter does not have to be established, that is closed due to error or normal disconnect.
+	 * @note This method can be used to trigger reconnects
+	 */
+	virtual void onClosed()
+	{
+	}
+
 	/*
 	 * If there is space in the TCP output buffer, then don't wait for TCP
 	 * sent confirmation but try to send more data now


### PR DESCRIPTION
- Add onClose callbacks to TcpConnection. Useful for retries and reacting on closing a connection. Will not be called if there was no connection at all.
- HttpClient now works with servers that don't support Tcp connection re-usage. 