### PR TITLE
Several null/range checks and minor fixes

### DIFF
--- a/Sming/Arch/Esp8266/Platform/StationImpl.cpp
+++ b/Sming/Arch/Esp8266/Platform/StationImpl.cpp
@@ -222,7 +222,7 @@ String StationImpl::getSSID() const
 	station_config config = {0};
 	if(!wifi_station_get_config(&config)) {
 		debugf("Can't read station configuration!");
-		return "";
+		return nullptr;
 	}
 	auto ssid = reinterpret_cast<const char*>(config.ssid);
 	debugf("SSID: '%s'", ssid);

--- a/Sming/Core/Data/BitSet.h
+++ b/Sming/Core/Data/BitSet.h
@@ -421,15 +421,22 @@ inline constexpr BitSet<S, E, size_> operator-(const BitSet<S, E, size_>& x, E b
  * which is then copy-constructed to the actual value. For example:
  *
  * 		constexpr BitSet<uint8_t, Fruit> fixedBasket = Fruit::apple | Fruit::orange;
+ *
+ * `is_convertible` prevents match to regular enums or integral values, but allows enum class.
+ *
  */
 template <typename E>
-constexpr typename std::enable_if<std::is_enum<E>::value, BitSet<uint32_t, E>>::type operator|(E a, E b)
+constexpr
+	typename std::enable_if<std::is_enum<E>::value && !std::is_convertible<E, int>::value, BitSet<uint32_t, E>>::type
+	operator|(E a, E b)
 {
 	return BitSet<uint32_t, E>(BitSet<uint32_t, E>::bitVal(a) | BitSet<uint32_t, E>::bitVal(b));
 }
 
 template <typename E>
-constexpr typename std::enable_if<std::is_enum<E>::value, BitSet<uint32_t, E>>::type operator+(E a, E b)
+constexpr
+	typename std::enable_if<std::is_enum<E>::value && !std::is_convertible<E, int>::value, BitSet<uint32_t, E>>::type
+	operator+(E a, E b)
 {
 	return a | b;
 }
@@ -445,14 +452,14 @@ String toString(const BitSet<S, E, size_>& bitset, const String& separator = ", 
 {
 	extern String toString(E e);
 
-	String s;
+	String s = String::empty;
 
 	for(unsigned i = 0; i < bitset.size(); ++i) {
 		if(!bitset[E(i)]) {
 			continue;
 		}
 
-		if(s) {
+		if(s.length() != 0) {
 			s += separator;
 		}
 		s += toString(E(i));

--- a/Sming/Core/Data/Stream/ReadWriteStream.cpp
+++ b/Sming/Core/Data/Stream/ReadWriteStream.cpp
@@ -22,7 +22,11 @@ size_t ReadWriteStream::copyFrom(IDataSourceStream* source, size_t size)
 	char buffer[bufSize];
 	size_t total = 0;
 	size_t count;
-	while((count = source->readMemoryBlock(buffer, sizeof(buffer))) != 0) {
+	while(!source->isFinished()) {
+		count = source->readMemoryBlock(buffer, sizeof(buffer));
+		if(count == 0) {
+			continue;
+		}
 		auto written = write(reinterpret_cast<uint8_t*>(buffer), count);
 		source->seek(written);
 		total += count;

--- a/Sming/Core/Data/Stream/TemplateStream.cpp
+++ b/Sming/Core/Data/Stream/TemplateStream.cpp
@@ -103,7 +103,10 @@ uint16_t TemplateStream::readMemoryBlock(char* data, int bufSize)
 			if(newlen + TEMPLATE_MAX_VAR_NAME_LEN > datalen) {
 				debug_d("trim end to %u from %u", newlen, datalen);
 				// It can be a incomplete variable name - don't split it
-				datalen = newlen;
+				// provided we're not at end of input stream
+				if(datalen == size_t(bufSize)) {
+					datalen = newlen;
+				}
 			}
 		}
 	}

--- a/Sming/Core/Data/StreamTransformer.cpp
+++ b/Sming/Core/Data/StreamTransformer.cpp
@@ -16,6 +16,10 @@
 
 uint16_t StreamTransformer::readMemoryBlock(char* data, int bufSize)
 {
+	if(!isValid()) {
+		return 0;
+	}
+
 	if(tempStream == nullptr) {
 		tempStream = new CircularBuffer(NETWORK_SEND_BUFFER_SIZE + 10);
 	}

--- a/Sming/Core/Data/StreamTransformer.h
+++ b/Sming/Core/Data/StreamTransformer.h
@@ -69,13 +69,15 @@ public:
 		return -1;
 	}
 
-	//Use base class documentation
+	bool isValid() const
+	{
+		return sourceStream != nullptr && sourceStream->isValid();
+	}
+
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	//Use base class documentation
 	bool seek(int len) override;
 
-	//Use base class documentation
 	bool isFinished() override;
 
 	String getName() const override

--- a/Sming/System/m_printf.cpp
+++ b/Sming/System/m_printf.cpp
@@ -237,6 +237,15 @@ void m_printHex(const char* tag, const void* data, size_t len, int addr, size_t 
 	auto buf = static_cast<const unsigned char*>(data);
 
 	unsigned taglen = tag ? strlen(tag) : 0;
+
+	if(len == 0) {
+		if(tag != nullptr) {
+			m_nputs(tag, taglen);
+			m_nputs("\r\n", 2);
+		}
+		return;
+	}
+
 	size_t offset = 0;
 	while (offset < len) {
 		if (taglen) {

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -616,6 +616,13 @@ bool String::equals(const char* cstr, size_t length) const
 
 bool String::equalsIgnoreCase(const char* cstr) const
 {
+	auto len = length();
+	if(len == 0) {
+		return (cstr == nullptr || *cstr == '\0');
+	}
+	if(cstr == nullptr) {
+		return false;
+	}
 	auto buf = cbuffer();
 	if(buf == cstr) {
 		return true;

--- a/tests/HostTests/app/test-stream.cpp
+++ b/tests/HostTests/app/test-stream.cpp
@@ -4,8 +4,8 @@
 
 IMPORT_FSTR_LOCAL(FS_abstract, PROJECT_DIR "/files/abstract.txt");
 DEFINE_FSTR_LOCAL(template1, "Stream containing {var1}, {var2} and {var3}. {} {{}} {{12345")
-DEFINE_FSTR_LOCAL(template1_1, "Stream containing value #1, value #2 and {var3}. {} {{}} {")
-DEFINE_FSTR_LOCAL(template1_2, "Stream containing value #1, value #2 and [value #3]. {} {{}} {")
+DEFINE_FSTR_LOCAL(template1_1, "Stream containing value #1, value #2 and {var3}. {} {{}} {{12345")
+DEFINE_FSTR_LOCAL(template1_2, "Stream containing value #1, value #2 and [value #3]. {} {{}} {{12345")
 
 class StreamTest : public TestGroup
 {


### PR DESCRIPTION
* ESP8266 `StationImpl::getSSID()`: Return invalid String for station SSID if not set

* m_printHex: If no data, just print the tag. Existing behaviour is to show nothing at all.

* Add nullptr handling in `String::equalsIgnoreCase`

* Fix copyFrom - may end early as readMemoryBlock() may return 0 but doesn't mean its finished

* BitSet fixes

    toString should return empty string for empty set, not invalid one
    Fix BitSet operators using is_convertible so regular enums don't get caught

* StreamTransformer nullptr check
