### PR TITLE
Update Streams and File functions to use `SeekOrigin` instead of `SeekOriginFlags`

### DIFF
--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbhostio.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbhostio.cpp
@@ -113,7 +113,7 @@ void ATTR_GDBEXTERNFN gdbHandleHostIo(char* commandBuffer, unsigned cmdLen)
 		debug_i("File:pread(%d, %u, %u)", fd, count, offset);
 
 		packet.writeChar('F');
-		if(fileSeek(fd, offset, eSO_FileStart) == int(offset)) {
+		if(fileSeek(fd, offset, SeekOrigin::Start) == int(offset)) {
 			count = fileRead(fd, commandBuffer, count);
 			if(int(count) >= 0) {
 				packet.writeHexWord16(count);
@@ -139,7 +139,7 @@ void ATTR_GDBEXTERNFN gdbHandleHostIo(char* commandBuffer, unsigned cmdLen)
 		debug_i("File:pwrite(%d, %u, %u)", fd, offset, size);
 
 		packet.writeChar('F');
-		if(fileSeek(fd, offset, eSO_FileStart) == int(offset)) {
+		if(fileSeek(fd, offset, SeekOrigin::Start) == int(offset)) {
 			int count = fileWrite(fd, data, size);
 			if(count >= 0) {
 				packet.writeHexWord16(count);

--- a/Sming/Arch/Host/Core/Data/Stream/HostFileStream.cpp
+++ b/Sming/Arch/Host/Core/Data/Stream/HostFileStream.cpp
@@ -133,17 +133,17 @@ uint16_t HostFileStream::readMemoryBlock(char* data, int bufSize)
 	return res;
 }
 
-int HostFileStream::seekFrom(int offset, unsigned origin)
+int HostFileStream::seekFrom(int offset, SeekOrigin origin)
 {
 	if(!isValid()) {
 		return -1;
 	}
 
-	if(origin == SEEK_CUR) {
-		origin = SEEK_SET;
+	if(origin == SeekOrigin::Current) {
+		origin = SeekOrigin::Start;
 		offset += pos;
 	}
-	int newPos = ::lseek(handle, offset, origin);
+	int newPos = ::lseek(handle, offset, int(origin));
 	if(!CHECK(newPos)) {
 		return -1;
 	}

--- a/Sming/Arch/Host/Core/Data/Stream/HostFileStream.h
+++ b/Sming/Arch/Host/Core/Data/Stream/HostFileStream.h
@@ -62,7 +62,7 @@ public:
 
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	int seekFrom(int offset, unsigned origin) override;
+	int seekFrom(int offset, SeekOrigin origin) override;
 
 	bool isFinished() override;
 

--- a/Sming/Core/Data/Stream/DataSourceStream.h
+++ b/Sming/Core/Data/Stream/DataSourceStream.h
@@ -11,9 +11,9 @@
 #pragma once
 
 #include <user_config.h>
-#include "Stream.h"
-#include "WString.h"
-#include <unistd.h>
+#include <Stream.h>
+#include <WString.h>
+#include "SeekOrigin.h"
 
 /** @defgroup   stream Stream functions
  *  @brief      Data stream classes
@@ -81,12 +81,12 @@ public:
 
 	/** @brief Change position in stream
 	 *  @param offset
-	 *  @param origin SEEK_SET, SEEK_CUR, SEEK_END
+	 *  @param origin
 	 *  @retval New position, < 0 on error
 	 *  @note This method is implemented by streams which support random seeking,
 	 *  such as files and memory streams.
 	 */
-	virtual int seekFrom(int offset, unsigned origin)
+	virtual int seekFrom(int offset, SeekOrigin origin)
 	{
 		return -1;
 	}
@@ -97,7 +97,7 @@ public:
 	 */
 	virtual bool seek(int len)
 	{
-		return seekFrom(len, SEEK_CUR) >= 0;
+		return seekFrom(len, SeekOrigin::Current) >= 0;
 	}
 
 	/** @brief  Check if all data has been read

--- a/Sming/Core/Data/Stream/FileStream.cpp
+++ b/Sming/Core/Data/Stream/FileStream.cpp
@@ -18,7 +18,7 @@ void FileStream::attach(file_t file, size_t size)
 	if(file >= 0) {
 		handle = file;
 		this->size = size;
-		fileSeek(handle, 0, eSO_FileStart);
+		fileSeek(handle, 0, SeekOrigin::Start);
 		pos = 0;
 		debug_d("attached file: '%s' (%u bytes) #0x%08X", fileName().c_str(), size, this);
 	}
@@ -35,7 +35,7 @@ bool FileStream::open(const String& fileName, FileOpenFlags openFlags)
 	}
 
 	// Get size
-	int size = fileSeek(file, 0, eSO_FileEnd);
+	int size = fileSeek(file, 0, SeekOrigin::End);
 	if(check(size)) {
 		attach(file, size);
 		return true;
@@ -79,7 +79,7 @@ uint16_t FileStream::readMemoryBlock(char* data, int bufSize)
 	size_t count = readBytes(data, bufSize);
 
 	// Move cursor back to start position
-	(void)fileSeek(handle, startPos, eSO_FileStart);
+	(void)fileSeek(handle, startPos, SeekOrigin::Start);
 
 	return count;
 }
@@ -91,7 +91,7 @@ size_t FileStream::write(const uint8_t* buffer, size_t size)
 	}
 
 	if(pos != this->size) {
-		int writePos = fileSeek(handle, 0, eSO_FileEnd);
+		int writePos = fileSeek(handle, 0, SeekOrigin::End);
 		if(!check(writePos)) {
 			return 0;
 		}
@@ -108,10 +108,10 @@ size_t FileStream::write(const uint8_t* buffer, size_t size)
 	return written > 0 ? written : 0;
 }
 
-int FileStream::seekFrom(int offset, unsigned origin)
+int FileStream::seekFrom(int offset, SeekOrigin origin)
 {
 	// Cannot rely on return value from fileSeek - failure does not mean position hasn't changed
-	fileSeek(handle, offset, SeekOriginFlags(origin));
+	fileSeek(handle, offset, origin);
 	int newpos = fileTell(handle);
 	if(check(newpos)) {
 		pos = size_t(newpos);

--- a/Sming/Core/Data/Stream/FileStream.h
+++ b/Sming/Core/Data/Stream/FileStream.h
@@ -79,7 +79,7 @@ public:
 
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	int seekFrom(int offset, unsigned origin) override;
+	int seekFrom(int offset, SeekOrigin origin) override;
 
 	bool isFinished() override
 	{

--- a/Sming/Core/Data/Stream/GdbFileStream.cpp
+++ b/Sming/Core/Data/Stream/GdbFileStream.cpp
@@ -104,9 +104,9 @@ size_t GdbFileStream::write(const uint8_t* buffer, size_t size)
 	return written;
 }
 
-int GdbFileStream::seekFrom(int offset, unsigned origin)
+int GdbFileStream::seekFrom(int offset, SeekOrigin origin)
 {
-	int newpos = gdb_syscall_lseek(handle, offset, origin);
+	int newpos = gdb_syscall_lseek(handle, offset, int(origin));
 	if(check(newpos)) {
 		pos = size_t(newpos);
 		if(pos > size) {

--- a/Sming/Core/Data/Stream/GdbFileStream.h
+++ b/Sming/Core/Data/Stream/GdbFileStream.h
@@ -54,7 +54,7 @@ public:
 
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	int seekFrom(int offset, unsigned origin) override;
+	int seekFrom(int offset, SeekOrigin origin) override;
 
 	bool isFinished() override
 	{

--- a/Sming/Core/Data/Stream/LimitedMemoryStream.cpp
+++ b/Sming/Core/Data/Stream/LimitedMemoryStream.cpp
@@ -18,17 +18,17 @@ uint16_t LimitedMemoryStream::readMemoryBlock(char* data, int bufSize)
 	return written;
 }
 
-int LimitedMemoryStream::seekFrom(int offset, unsigned origin)
+int LimitedMemoryStream::seekFrom(int offset, SeekOrigin origin)
 {
 	size_t newPos;
 	switch(origin) {
-	case SEEK_SET:
+	case SeekOrigin::Start:
 		newPos = offset;
 		break;
-	case SEEK_CUR:
+	case SeekOrigin::Current:
 		newPos = readPos + offset;
 		break;
-	case SEEK_END:
+	case SeekOrigin::End:
 		newPos = writePos + offset;
 		break;
 	default:

--- a/Sming/Core/Data/Stream/LimitedMemoryStream.h
+++ b/Sming/Core/Data/Stream/LimitedMemoryStream.h
@@ -67,7 +67,7 @@ public:
 
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	int seekFrom(int offset, unsigned origin) override;
+	int seekFrom(int offset, SeekOrigin origin) override;
 
 	size_t write(const uint8_t* buffer, size_t size) override;
 

--- a/Sming/Core/Data/Stream/MemoryDataStream.cpp
+++ b/Sming/Core/Data/Stream/MemoryDataStream.cpp
@@ -66,17 +66,17 @@ uint16_t MemoryDataStream::readMemoryBlock(char* data, int bufSize)
 	return available;
 }
 
-int MemoryDataStream::seekFrom(int offset, unsigned origin)
+int MemoryDataStream::seekFrom(int offset, SeekOrigin origin)
 {
 	size_t newPos;
 	switch(origin) {
-	case SEEK_SET:
+	case SeekOrigin::Start:
 		newPos = offset;
 		break;
-	case SEEK_CUR:
+	case SeekOrigin::Current:
 		newPos = readPos + offset;
 		break;
-	case SEEK_END:
+	case SeekOrigin::End:
 		newPos = size + offset;
 		break;
 	default:

--- a/Sming/Core/Data/Stream/MemoryDataStream.h
+++ b/Sming/Core/Data/Stream/MemoryDataStream.h
@@ -71,7 +71,7 @@ public:
 
 	uint16_t readMemoryBlock(char* data, int bufSize) override;
 
-	int seekFrom(int offset, unsigned origin) override;
+	int seekFrom(int offset, SeekOrigin origin) override;
 
 	bool isFinished() override
 	{

--- a/Sming/Core/Data/Stream/SeekOrigin.cpp
+++ b/Sming/Core/Data/Stream/SeekOrigin.cpp
@@ -1,0 +1,26 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SeekOrigin.cpp
+ *
+ ****/
+
+#include "SeekOrigin.h"
+#include <FlashString/Vector.hpp>
+
+String toString(SeekOrigin origin)
+{
+	switch(origin) {
+	case SeekOrigin::Start:
+		return F("Start");
+	case SeekOrigin::Current:
+		return F("Current");
+	case SeekOrigin::End:
+		return F("End");
+	default:
+		return nullptr;
+	}
+}

--- a/Sming/Core/Data/Stream/SeekOrigin.h
+++ b/Sming/Core/Data/Stream/SeekOrigin.h
@@ -1,0 +1,24 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * SeekOrigin.h
+ *
+ ****/
+
+#pragma once
+
+#include <WString.h>
+
+/**
+ * @brief Stream/file seek origins
+ */
+enum class SeekOrigin {
+	Start = 0,   ///< SEEK_SET: Start of file
+	Current = 1, ///< SEEK_CUR: Current position in file
+	End = 2,	 ///< SEEK_END: End of file
+};
+
+String toString(SeekOrigin origin);

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -53,9 +53,9 @@ int fileRead(file_t file, void* data, size_t size)
 	return res;
 }
 
-int fileSeek(file_t file, int offset, SeekOriginFlags origin)
+int fileSeek(file_t file, int offset, SeekOrigin origin)
 {
-	return SPIFFS_lseek(&_filesystemStorageHandle, file, offset, origin);
+	return SPIFFS_lseek(&_filesystemStorageHandle, file, offset, int(origin));
 }
 
 bool fileIsEOF(file_t file)
@@ -134,7 +134,7 @@ int fileSetContent(const String& fileName, const char* content, int length)
 uint32_t fileGetSize(const String& fileName)
 {
 	file_t file = fileOpen(fileName.c_str(), eFO_ReadOnly);
-	int size = fileSeek(file, 0, eSO_FileEnd);
+	int size = fileSeek(file, 0, SeekOrigin::End);
 	fileClose(file);
 	return (size < 0) ? 0 : size;
 }
@@ -165,11 +165,11 @@ String fileGetContent(const String& fileName)
 {
 	String res;
 	file_t file = fileOpen(fileName.c_str(), eFO_ReadOnly);
-	int size = fileSeek(file, 0, eSO_FileEnd);
+	int size = fileSeek(file, 0, SeekOrigin::End);
 	if(size == 0) {
 		res = ""; // Valid String, file is empty
 	} else if(size > 0) {
-		fileSeek(file, 0, eSO_FileStart);
+		fileSeek(file, 0, SeekOrigin::Start);
 		res.setLength(size);
 		if(fileRead(file, res.begin(), res.length()) != size) {
 			res = nullptr; // read failed, invalidate String
@@ -186,11 +186,11 @@ size_t fileGetContent(const String& fileName, char* buffer, size_t bufSize)
 	}
 
 	file_t file = fileOpen(fileName.c_str(), eFO_ReadOnly);
-	int size = fileSeek(file, 0, eSO_FileEnd);
+	int size = fileSeek(file, 0, SeekOrigin::End);
 	if(size <= 0 || bufSize <= size_t(size)) {
 		size = 0;
 	} else {
-		fileSeek(file, 0, eSO_FileStart);
+		fileSeek(file, 0, SeekOrigin::Start);
 		if(fileRead(file, buffer, size) != size) {
 			size = 0; // Error
 		}

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -18,6 +18,7 @@
 #include <spiffs_sming.h>
 #include <WVector.h>
 #include <WString.h>
+#include "Data/Stream/SeekOrigin.h"
 
 typedef signed short file_t; ///< File handle
 
@@ -38,11 +39,9 @@ static inline FileOpenFlags operator|(FileOpenFlags lhs, FileOpenFlags rhs)
 }
 
 /// File seek flags
-typedef enum {
-	eSO_FileStart = SPIFFS_SEEK_SET,  ///< Start of file
-	eSO_CurrentPos = SPIFFS_SEEK_CUR, ///< Current position in file
-	eSO_FileEnd = SPIFFS_SEEK_END	 ///< End of file
-} SeekOriginFlags;
+constexpr SeekOrigin eSO_FileStart{SeekOrigin::Start};	///< @deprecated use SeekOrigin::Start
+constexpr SeekOrigin eSO_CurrentPos{SeekOrigin::Current}; ///< @deprecated use SeekOrigin::Current
+constexpr SeekOrigin eSO_FileEnd{SeekOrigin::End};		  ///< @deprecated use SeekOrigin::End
 
 /** @brief  Open file
  *  @param  name File name
@@ -79,7 +78,7 @@ int fileRead(file_t file, void* data, size_t size);
  *  @param  origin Position from where to move cursor
  *  @retval Offset within file or negative error code
  */
-int fileSeek(file_t file, int offset, SeekOriginFlags origin);
+int fileSeek(file_t file, int offset, SeekOrigin origin);
 
 /** @brief  Check if at end of file
  *  @param  file File ID

--- a/Sming/Libraries/Adafruit_GFX/BMPDraw.h
+++ b/Sming/Libraries/Adafruit_GFX/BMPDraw.h
@@ -165,7 +165,7 @@ template <class Adafruit_TFT> bool bmpDraw(Adafruit_TFT& tft, String fileName, u
 				pos = bmpImageoffset + row * rowSize;
 			}
 			if(fileTell(handle) != int(pos)) {
-				fileSeek(handle, pos, eSO_FileStart);
+				fileSeek(handle, pos, SeekOrigin::Start);
 				buffidx = sizeof(sdbuffer); // Force buffer reload
 			}
 			for(int col = 0; col < w; col++) { // For each pixel...

--- a/Sming/Libraries/WebCam/src/Camera/FakeCamera.h
+++ b/Sming/Libraries/WebCam/src/Camera/FakeCamera.h
@@ -108,7 +108,7 @@ public:
 		}
 
 		// get the current picture and read the desired data from it.
-		file->seekFrom(offset, SEEK_SET);
+		file->seekFrom(offset, SeekOrigin::Start);
 		return file->readMemoryBlock(buffer, size);
 	}
 

--- a/docs/source/upgrading/4.1-4.2.rst
+++ b/docs/source/upgrading/4.1-4.2.rst
@@ -21,6 +21,19 @@ An addition method :cpp:func:`IDataSourceStream::moveString` has been added to s
 the content of a memory-based stream into a String object without duplicating the data.
 This is supported by :cpp:class:`LimitedMemoryStream` and :cpp:class:`MemoryDataStream`.
 
+Stream / file seeking
+---------------------
+
+To provide a consistent interface :cpp:type:`SeekOrigin` is now used with all *seek* methods for streams,
+and also by file system functions. Mappings are::
+
+   SeekOrigin::Start instead of eSO_FileStart
+   SeekOrigin::Current instead of eSO_CurrentPos
+   SeekOrigin::End instead of eSO_FileEnd
+ 
+These map to the standard C *SEEK_SET*, *SEEK_CUR* and *SEEK_END* but as SeekOrigin is strongly typed
+it offers compile-time checking, and has a `toString(SeekOrigin)` overload.
+
 
 getBody methods
 ---------------

--- a/tests/HostTests/app/test-files.cpp
+++ b/tests/HostTests/app/test-files.cpp
@@ -24,8 +24,8 @@ public:
 			debug_i("fileSetContent() returned %d", res);
 			REQUIRE(size_t(res) == testContent.length());
 			file = fileOpen(testFileName, eFO_ReadWrite);
-			size = fileSeek(file, 0, eSO_FileEnd);
-			pos = fileSeek(file, 100, eSO_FileStart);
+			size = fileSeek(file, 0, SeekOrigin::End);
+			pos = fileSeek(file, 100, SeekOrigin::Start);
 			debug_i("pos = %d, size = %d", pos, size);
 			REQUIRE(pos == 100);
 			REQUIRE(size_t(size) == testContent.length());
@@ -35,7 +35,7 @@ public:
 		{
 			res = fileTruncate(file, 555);
 			pos = fileTell(file);
-			size = fileSeek(file, 0, eSO_FileEnd);
+			size = fileSeek(file, 0, SeekOrigin::End);
 			debug_i("res = %d, pos = %d, size = %d", res, pos, size);
 			REQUIRE(res == 0);
 			REQUIRE(pos == 100);
@@ -45,7 +45,7 @@ public:
 		TEST_CASE("Increase file size")
 		{
 			res = fileTruncate(file, 12345);
-			size = fileSeek(file, 0, eSO_FileEnd);
+			size = fileSeek(file, 0, SeekOrigin::End);
 			debug_i("res = %d, size = %d", res, size);
 			REQUIRE(res < 0);
 			REQUIRE(size == 555);
@@ -123,7 +123,7 @@ public:
 		{
 			FileStream fs;
 			fs.open(testFileName, eFO_ReadWrite);
-			res = fs.seekFrom(101, eSO_FileStart);
+			res = fs.seekFrom(101, SeekOrigin::Start);
 			pos = fs.getPos();
 			size = fs.getSize();
 			debug_i("fs.seekFrom() returned %d, pos = %d, size = %d", res, pos, size);

--- a/tests/HostTests/app/test-json6.cpp
+++ b/tests/HostTests/app/test-json6.cpp
@@ -284,7 +284,7 @@ public:
 
 	void __attribute__((noinline)) loadStream(IDataSourceStream& stream)
 	{
-		stream.seekFrom(0, SEEK_SET);
+		stream.seekFrom(0, SeekOrigin::Start);
 		assert(Json::deserialize(doc, stream));
 	}
 

--- a/tests/HostTests/app/test-url.cpp
+++ b/tests/HostTests/app/test-url.cpp
@@ -105,7 +105,7 @@ public:
 			Url url(FS_url);
 			MemoryDataStream stream;
 			stream.print(url);
-			stream.seekFrom(0, SEEK_SET);
+			stream.seekFrom(0, SeekOrigin::Start);
 			String s(stream.getStreamPointer(), stream.available());
 			REQUIRE(s == FS_url_out);
 		}


### PR DESCRIPTION
Name is more appropriate (i.e. not a flag!)
SeekOrigin is strongly typed.

This should help to avoid silly errors using the wrong value, and also be more consistent as there are multiple 'C' defintions for the same thing.