### PR TITLE
Prefer `using` to typedef; Consistent enum/struct declarations

### DIFF
--- a/Sming/Arch/Esp32/Platform/RTC.cpp
+++ b/Sming/Arch/Esp32/Platform/RTC.cpp
@@ -22,11 +22,11 @@ RtcClass RTC;
 /** @brief  Structure to hold RTC data
  *  @addtogroup structures
  */
-typedef struct {
+struct RtcData {
 	uint64_t time;   ///< Quantity of nanoseconds since epoch
 	uint32_t magic;  ///< Magic ID used to identify that RTC has been initialised
 	uint32_t cycles; ///< Quantity of RTC cycles since last update
-} RtcData;
+};
 
 static bool hardwareReset;
 static void updateTime();

--- a/Sming/Arch/Esp8266/Platform/RTC.cpp
+++ b/Sming/Arch/Esp8266/Platform/RTC.cpp
@@ -20,11 +20,11 @@ RtcClass RTC;
 /** @brief  Structure to hold RTC data
  *  @addtogroup structures
  */
-typedef struct {
+struct RtcData {
 	uint64_t time;   ///< Quantity of nanoseconds since epoch
 	uint32_t magic;  ///< Magic ID used to identify that RTC has been initialised
 	uint32_t cycles; ///< Quantity of RTC cycles since last update
-} RtcData;
+};
 
 static bool hardwareReset;
 static bool saveTime(RtcData& data);

--- a/Sming/Arch/Host/Core/pins_arduino.h
+++ b/Sming/Arch/Host/Core/pins_arduino.h
@@ -20,7 +20,7 @@ const uint16_t A0 = 9999;
 //#define PB 2
 //#define PC 3
 
-typedef uint32_t GPIO_REG_TYPE;
+using GPIO_REG_TYPE = uint32_t;
 
 // We use maximum compatibility to standard Arduino logic.
 

--- a/Sming/Core/AtClient.h
+++ b/Sming/Core/AtClient.h
@@ -26,14 +26,19 @@
 
 class AtClient;
 
-typedef Delegate<bool(AtClient& atClient, Stream& source)> AtReceiveCallback;
-// ^ If the callback returns true then this means that we have
-//     finished successfully processing the command
-typedef Delegate<bool(AtClient& atClient, String& reply)> AtCompleteCallback;
-// ^ If the callback returns true then this means that we have
-//     finished successfully processing the command
+/**
+ * @brief If the callback returns true then this means that we have
+ * finished successfully processing the command
+ */
+using AtReceiveCallback = Delegate<bool(AtClient& atClient, Stream& source)>;
 
-typedef struct {
+/**
+ * @brief If the callback returns true then this means that we have
+ * finished successfully processing the command
+ */
+using AtCompleteCallback = Delegate<bool(AtClient& atClient, String& reply)>;
+
+struct AtCommand {
 	String text;				   ///< the actual AT command
 	String response2;			   ///< alternative successful response
 	unsigned timeout;			   ///< timeout in milliseconds
@@ -41,9 +46,13 @@ typedef struct {
 	bool breakOnError = true;	  ///< stop executing next command if that one has failed
 	AtReceiveCallback onReceive;   ///< if set you can process manually all incoming data in a callback
 	AtCompleteCallback onComplete; ///< if set then you can process the complete response manually
-} AtCommand;
+};
 
-typedef enum { eAtOK = 0, eAtRunning, eAtError } AtState;
+enum AtState {
+	eAtOK = 0,
+	eAtRunning,
+	eAtError,
+};
 
 /**
  * @brief Class that facilitates the communication with an AT device.

--- a/Sming/Core/CallbackTimer.h
+++ b/Sming/Core/CallbackTimer.h
@@ -20,8 +20,8 @@
  * @{
 */
 
-typedef void (*TimerCallback)(void* arg); ///< Interrupt-compatible C callback function pointer
-using TimerDelegate = Delegate<void()>;   ///< Delegate callback
+using TimerCallback = void (*)(void* arg); ///< Interrupt-compatible C callback function pointer
+using TimerDelegate = Delegate<void()>;	///< Delegate callback
 
 /**
  * @brief Callback timer API class template

--- a/Sming/Core/Data/StreamTransformer.h
+++ b/Sming/Core/Data/StreamTransformer.h
@@ -25,7 +25,7 @@
  * @brief Callback specification for the stream transformers
  * @see See `StreamTransformer::transform()` method for details
  */
-typedef Delegate<size_t(const uint8_t* in, size_t inLength, uint8_t* out, size_t outLength)> StreamTransformerCallback;
+using StreamTransformerCallback = Delegate<size_t(const uint8_t* in, size_t inLength, uint8_t* out, size_t outLength)>;
 
 class StreamTransformer : public IDataSourceStream
 {

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -56,7 +56,7 @@
 
 /** @brief  Days of week
 */
-typedef enum {
+enum dtDays_t {
 	dtSunday,	///< Sunday
 	dtMonday,	///< Monday
 	dtTuesday,   ///< Tuesday
@@ -64,7 +64,7 @@ typedef enum {
 	dtThursday,  ///< Thursday
 	dtFriday,	///< Friday
 	dtSaturday   ///< Saturday
-} dtDays_t;
+};
 
 /** @brief  Date and time class
  *

--- a/Sming/Core/Debug.h
+++ b/Sming/Core/Debug.h
@@ -16,25 +16,26 @@
 #include "Services/CommandProcessing/CommandProcessingIncludes.h"
 
 /** @brief  Delegate constructor usage: (&YourClass::method, this)
+ * 	Handler function for debug print
  *  @ingroup event_handlers
  */
-typedef Delegate<void(char dbgChar)> DebugPrintCharDelegate; ///<Handler function for debug print
+using DebugPrintCharDelegate = Delegate<void(char dbgChar)>;
 
 /** @brief  Structure for debug options
  *  @ingroup structures
  */
-typedef struct {
-	DebugPrintCharDelegate debugDelegate = nullptr; ///< Function to handle debug output
-	Stream* debugStream = nullptr;					///< Debug output stream
-} DebugOuputOptions;
+struct DebugOuputOptions {
+	DebugPrintCharDelegate debugDelegate; ///< Function to handle debug output
+	Stream* debugStream{nullptr};		  ///< Debug output stream
+};
 
 /** @brief  Debug prefix state
  *  @ingroup constants
  */
-typedef enum {
+enum eDBGPrefix {
 	eDBGnoPrefix = 0, ///< Do not use debug prefix
 	eDBGusePrefix = 1 ///< Use debug prefix
-} eDBGPrefix;
+};
 
 /** @defgroup   debug Debug functions
  *  @brief      Provides debug functions

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -20,7 +20,7 @@
 #include <WString.h>
 #include "Data/Stream/SeekOrigin.h"
 
-typedef signed short file_t; ///< File handle
+using file_t = signed short; ///< File handle
 
 /// File open flags
 enum FileOpenFlags {

--- a/Sming/Core/HardwareSerial.h
+++ b/Sming/Core/HardwareSerial.h
@@ -41,12 +41,12 @@ class HardwareSerial;
  * 	If no receive buffer has been allocated, or it's not big enough to contain the full message,
  * 	then this value will be incorrect as data is stored in the hardware FIFO until read out.
  */
-typedef Delegate<void(Stream& source, char arrivedChar, uint16_t availableCharsCount)> StreamDataReceivedDelegate;
+using StreamDataReceivedDelegate = Delegate<void(Stream& source, char arrivedChar, uint16_t availableCharsCount)>;
 
 /** @brief Delegate callback type for serial data transmit completion
  *  @note Invoked when the last byte has left the hardware FIFO
  */
-typedef Delegate<void(HardwareSerial& serial)> TransmitCompleteDelegate;
+using TransmitCompleteDelegate = Delegate<void(HardwareSerial& serial)>;
 
 class CommandExecutor;
 
@@ -78,7 +78,11 @@ enum SerialConfig {
 };
 
 /** @brief values equivalent to uart_mode_t */
-enum SerialMode { SERIAL_FULL = UART_FULL, SERIAL_RX_ONLY = UART_RX_ONLY, SERIAL_TX_ONLY = UART_TX_ONLY };
+enum SerialMode {
+	SERIAL_FULL = UART_FULL,
+	SERIAL_RX_ONLY = UART_RX_ONLY,
+	SERIAL_TX_ONLY = UART_TX_ONLY,
+};
 
 #ifndef DEFAULT_RX_BUFFER_SIZE
 #define DEFAULT_RX_BUFFER_SIZE 256

--- a/Sming/Core/Interrupts.h
+++ b/Sming/Core/Interrupts.h
@@ -20,8 +20,8 @@
 #include <WConstants.h>
 #include <sming_attr.h>
 
-typedef void (*InterruptCallback)();
-typedef Delegate<void()> InterruptDelegate;
+using InterruptCallback = void (*)();
+using InterruptDelegate = Delegate<void()>;
 
 /** @brief  Convert Arduino interrupt mode to Sming mode
  *  @param  mode Arduino mode type

--- a/Sming/Core/Network/Http/HttpBodyParser.cpp
+++ b/Sming/Core/Network/Http/HttpBodyParser.cpp
@@ -21,11 +21,11 @@
  * Content is received in chunks which we need to reassemble into name=value pairs.
  * This structure stores the temporary values during parsing.
  */
-typedef struct {
-	char searchChar = '=';
+struct FormUrlParserState {
+	char searchChar{'='};
 	String postName;
 	String postValue;
-} FormUrlParserState;
+};
 
 /*
  * The incoming URL is parsed

--- a/Sming/Core/Network/Http/HttpBodyParser.h
+++ b/Sming/Core/Network/Http/HttpBodyParser.h
@@ -33,12 +33,12 @@ const int PARSE_DATAEND = -2;   ///< End of incoming data
  * @see `PARSE_DATAEND`
  * @return parsed bytes
  */
-typedef Delegate<size_t(HttpRequest& request, const char* at, int length)> HttpBodyParserDelegate;
+using HttpBodyParserDelegate = Delegate<size_t(HttpRequest& request, const char* at, int length)>;
 
 /**
  * @brief Maps body parsers to a specific content type
  */
-typedef HashMap<String, HttpBodyParserDelegate> BodyParsers;
+using BodyParsers = HashMap<String, HttpBodyParserDelegate>;
 
 /**
  * @brief Parses application/x-www-form-urlencoded body data

--- a/Sming/Core/Network/Http/HttpClientConnection.h
+++ b/Sming/Core/Network/Http/HttpClientConnection.h
@@ -23,7 +23,7 @@
  *  @{
  */
 
-typedef ObjectQueue<HttpRequest, HTTP_REQUEST_POOL_SIZE> RequestQueue;
+using RequestQueue = ObjectQueue<HttpRequest, HTTP_REQUEST_POOL_SIZE>;
 
 class HttpClientConnection : public HttpConnection
 {

--- a/Sming/Core/Network/Http/HttpCommon.h
+++ b/Sming/Core/Network/Http/HttpCommon.h
@@ -91,7 +91,7 @@ enum HttpConnectionState {
 	eHCS_WaitResponse
 };
 
-typedef ObjectMap<String, ReadWriteStream> HttpFiles;
+using HttpFiles = ObjectMap<String, ReadWriteStream>;
 
 /**
  * @brief Return a descriptive string for the given error

--- a/Sming/Core/Network/Http/HttpRequest.h
+++ b/Sming/Core/Network/Http/HttpRequest.h
@@ -24,9 +24,9 @@
 
 class HttpConnection;
 
-typedef Delegate<int(HttpConnection& client, HttpResponse& response)> RequestHeadersCompletedDelegate;
-typedef Delegate<int(HttpConnection& client, const char* at, size_t length)> RequestBodyDelegate;
-typedef Delegate<int(HttpConnection& client, bool successful)> RequestCompletedDelegate;
+using RequestHeadersCompletedDelegate = Delegate<int(HttpConnection& client, HttpResponse& response)>;
+using RequestBodyDelegate = Delegate<int(HttpConnection& client, const char* at, size_t length)>;
+using RequestCompletedDelegate = Delegate<int(HttpConnection& client, bool successful)>;
 
 /**
  * @brief Encapsulates an incoming or outgoing request

--- a/Sming/Core/Network/Http/HttpResource.h
+++ b/Sming/Core/Network/Http/HttpResource.h
@@ -20,12 +20,12 @@
 
 class HttpServerConnection;
 
-typedef Delegate<int(HttpServerConnection& connection, HttpRequest&, const char* at, int length)>
-	HttpServerConnectionBodyDelegate;
-typedef Delegate<int(HttpServerConnection& connection, HttpRequest&, char* at, int length)>
-	HttpServerConnectionUpgradeDelegate;
-typedef Delegate<int(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)>
-	HttpResourceDelegate;
+using HttpServerConnectionBodyDelegate =
+	Delegate<int(HttpServerConnection& connection, HttpRequest&, const char* at, int length)>;
+using HttpServerConnectionUpgradeDelegate =
+	Delegate<int(HttpServerConnection& connection, HttpRequest&, char* at, int length)>;
+using HttpResourceDelegate =
+	Delegate<int(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)>;
 
 /**
  * @brief Instances of this class are registered with an HttpServer for a specific URL

--- a/Sming/Core/Network/Http/HttpResourceTree.h
+++ b/Sming/Core/Network/Http/HttpResourceTree.h
@@ -14,7 +14,7 @@
 
 #include "HttpResource.h"
 
-typedef Delegate<void(HttpRequest& request, HttpResponse& response)> HttpPathDelegate;
+using HttpPathDelegate = Delegate<void(HttpRequest& request, HttpResponse& response)>;
 
 /** @brief Identifies the default resource path */
 #define RESOURCE_PATH_DEFAULT String('*')

--- a/Sming/Core/Network/Http/HttpServerConnection.h
+++ b/Sming/Core/Network/Http/HttpServerConnection.h
@@ -26,9 +26,9 @@
 class HttpResourceTree;
 class HttpServerConnection;
 
-typedef Delegate<void(HttpServerConnection& connection)> HttpServerConnectionDelegate;
+using HttpServerConnectionDelegate = Delegate<void(HttpServerConnection& connection)>;
 
-typedef Delegate<bool()> HttpServerProtocolUpgradeCallback;
+using HttpServerProtocolUpgradeCallback = Delegate<bool()>;
 
 class HttpServerConnection : public HttpConnection
 {

--- a/Sming/Core/Network/Http/Websocket/WebsocketConnection.h
+++ b/Sming/Core/Network/Http/Websocket/WebsocketConnection.h
@@ -36,13 +36,17 @@ DECLARE_FSTR(WSSTR_SECRET)
 
 class WebsocketConnection;
 
-typedef Vector<WebsocketConnection*> WebsocketList;
+using WebsocketList = Vector<WebsocketConnection*>;
 
-typedef Delegate<void(WebsocketConnection&)> WebsocketDelegate;
-typedef Delegate<void(WebsocketConnection&, const String&)> WebsocketMessageDelegate;
-typedef Delegate<void(WebsocketConnection&, uint8_t* data, size_t size)> WebsocketBinaryDelegate;
+using WebsocketDelegate = Delegate<void(WebsocketConnection&)>;
+using WebsocketMessageDelegate = Delegate<void(WebsocketConnection&, const String&)>;
+using WebsocketBinaryDelegate = Delegate<void(WebsocketConnection&, uint8_t* data, size_t size)>;
 
-enum WsConnectionState { eWSCS_Ready, eWSCS_Open, eWSCS_Closed };
+enum WsConnectionState {
+	eWSCS_Ready,
+	eWSCS_Open,
+	eWSCS_Closed,
+};
 
 struct WsFrameInfo {
 	ws_frame_type_t type = WS_FRAME_TEXT;

--- a/Sming/Core/Network/HttpClient.h
+++ b/Sming/Core/Network/HttpClient.h
@@ -141,7 +141,7 @@ protected:
 	}
 
 protected:
-	typedef ObjectMap<String, HttpClientConnection> HttpConnectionPool;
+	using HttpConnectionPool = ObjectMap<String, HttpClientConnection>;
 	static HttpConnectionPool httpConnectionPool;
 
 private:

--- a/Sming/Core/Network/HttpServer.h
+++ b/Sming/Core/Network/HttpServer.h
@@ -24,14 +24,14 @@
 #include "Http/HttpServerConnection.h"
 #include "Http/HttpBodyParser.h"
 
-typedef struct {
+struct HttpServerSettings {
 	uint16_t maxActiveConnections = 10; ///< maximum number of concurrent requests..
 	uint16_t keepAliveSeconds = 0;		///< default seconds to keep the connection alive before closing it
 	int minHeapSize = -1; ///< min heap size that is required to accept connection, -1 means use server default
 	bool useDefaultBodyParsers = 1; ///< if the default body parsers,  as form-url-encoded, should be used
 	bool closeOnContentError =
 		true; ///< close the connection if a body parser or resource fails to parse the body content.
-} HttpServerSettings;
+};
 
 class HttpServer : public TcpServer
 {

--- a/Sming/Core/Network/Mqtt/MqttPayloadParser.h
+++ b/Sming/Core/Network/Mqtt/MqttPayloadParser.h
@@ -26,16 +26,16 @@
 
 #define MQTT_PAYLOAD_LENGTH 1024
 
-typedef struct {
+struct MqttPayloadParserState {
 	void* userData; ///< custom user data
 	size_t offset;  ///< bytes read so far.
-} MqttPayloadParserState;
+};
 
 /**
  * A payload parser must return 0 on success
  */
-typedef Delegate<int(MqttPayloadParserState& state, mqtt_message_t* message, const char* buffer, int length)>
-	MqttPayloadParser;
+using MqttPayloadParser =
+	Delegate<int(MqttPayloadParserState& state, mqtt_message_t* message, const char* buffer, int length)>;
 
 int defaultPayloadParser(MqttPayloadParserState& state, mqtt_message_t* message, const char* buffer, int length);
 

--- a/Sming/Core/Network/MqttClient.h
+++ b/Sming/Core/Network/MqttClient.h
@@ -44,14 +44,14 @@ enum MqttClientState { eMCS_Ready = 0, eMCS_SendingData };
 
 class MqttClient;
 
-typedef Delegate<int(MqttClient& client, mqtt_message_t* message)> MqttDelegate;
-typedef ObjectQueue<mqtt_message_t, MQTT_REQUEST_POOL_SIZE> MqttRequestQueue;
+using MqttDelegate = Delegate<int(MqttClient& client, mqtt_message_t* message)>;
+using MqttRequestQueue = ObjectQueue<mqtt_message_t, MQTT_REQUEST_POOL_SIZE>;
 
 #ifndef MQTT_NO_COMPAT
 /** @deprecated Use MqttDelegate instead */
-typedef Delegate<void(String topic, String message)> MqttStringSubscriptionCallback;
+using MqttStringSubscriptionCallback = Delegate<void(String topic, String message)>;
 /** @deprecated Use MqttDelegate instead */
-typedef Delegate<void(uint16_t msgId, int type)> MqttMessageDeliveredCallback;
+using MqttMessageDeliveredCallback = Delegate<void(uint16_t msgId, int type)>;
 #endif
 
 class MqttClient : protected TcpClient

--- a/Sming/Core/Network/NtpClient.h
+++ b/Sming/Core/Network/NtpClient.h
@@ -36,7 +36,7 @@
 class NtpClient;
 
 // Delegate constructor usage: (&YourClass::method, this)
-typedef Delegate<void(NtpClient& client, time_t ntpTime)> NtpTimeResultDelegate;
+using NtpTimeResultDelegate = Delegate<void(NtpClient& client, time_t ntpTime)>;
 
 /** @brief  NTP client class */
 class NtpClient : protected UdpConnection

--- a/Sming/Core/Network/SmtpClient.h
+++ b/Sming/Core/Network/SmtpClient.h
@@ -85,7 +85,7 @@ enum SmtpState {
 
 class SmtpClient;
 
-typedef Delegate<int(SmtpClient& client, int code, char* status)> SmtpClientCallback;
+using SmtpClientCallback = Delegate<int(SmtpClient& client, int code, char* status)>;
 
 class SmtpClient : protected TcpClient
 {

--- a/Sming/Core/Network/TcpClient.h
+++ b/Sming/Core/Network/TcpClient.h
@@ -22,9 +22,9 @@ class TcpClient;
 class ReadWriteStream;
 class IpAddress;
 
-typedef Delegate<void(TcpClient& client, TcpConnectionEvent sourceEvent)> TcpClientEventDelegate;
-typedef Delegate<void(TcpClient& client, bool successful)> TcpClientCompleteDelegate;
-typedef Delegate<bool(TcpClient& client, char* data, int size)> TcpClientDataDelegate;
+using TcpClientEventDelegate = Delegate<void(TcpClient& client, TcpConnectionEvent sourceEvent)>;
+using TcpClientCompleteDelegate = Delegate<void(TcpClient& client, bool successful)>;
+using TcpClientDataDelegate = Delegate<bool(TcpClient& client, char* data, int size)>;
 
 enum TcpClientState {
 	eTCS_Ready,

--- a/Sming/Core/Network/TcpConnection.h
+++ b/Sming/Core/Network/TcpConnection.h
@@ -34,7 +34,7 @@ class String;
 class IDataSourceStream;
 class TcpConnection;
 
-typedef Delegate<void(TcpConnection&)> TcpConnectionDestroyedDelegate;
+using TcpConnectionDestroyedDelegate = Delegate<void(TcpConnection&)>;
 
 class TcpConnection : public IpConnection
 {

--- a/Sming/Core/Network/TcpServer.h
+++ b/Sming/Core/Network/TcpServer.h
@@ -20,10 +20,12 @@
 #include "TcpConnection.h"
 #include "TcpClient.h"
 
-typedef Delegate<void(TcpClient* client)> TcpClientConnectDelegate;
+using TcpClientConnectDelegate = Delegate<void(TcpClient* client)>;
 
 // By default a TCP server will wait for a new remote client connection to get established for 20 seconds
+#ifndef TCP_SERVER_TIMEOUT
 #define TCP_SERVER_TIMEOUT 20
+#endif
 
 class TcpServer : public TcpConnection
 {

--- a/Sming/Core/Network/TelnetServer.h
+++ b/Sming/Core/Network/TelnetServer.h
@@ -25,17 +25,15 @@
 #include "SystemClock.h"
 #include "Services/CommandProcessing/CommandExecutor.h"
 
+#ifndef TELNETSERVER_MAX_COMMANDSIZE
 #define TELNETSERVER_MAX_COMMANDSIZE 64
+#endif
 
-typedef Delegate<void(TcpClient* client, char* data, int size)> TelnetServerCommandDelegate;
+using TelnetServerCommandDelegate = Delegate<void(TcpClient* client, char* data, int size)>;
 
 class TelnetServer : public TcpServer
 {
 public:
-	TelnetServer()
-	{
-	}
-
 	//	void setCommandDelegate(TelnetServerCommandDelegate reqDelegate);
 	void enableDebug(bool reqStatus);
 	void enableCommand(bool reqStatus);

--- a/Sming/Core/Network/UdpConnection.h
+++ b/Sming/Core/Network/UdpConnection.h
@@ -20,8 +20,8 @@
 
 class UdpConnection;
 
-typedef Delegate<void(UdpConnection& connection, char* data, int size, IpAddress remoteIP, uint16_t remotePort)>
-	UdpConnectionDataDelegate;
+using UdpConnectionDataDelegate =
+	Delegate<void(UdpConnection& connection, char* data, int size, IpAddress remoteIP, uint16_t remotePort)>;
 
 class UdpConnection : public IpConnection
 {

--- a/Sming/Libraries/MultipartParser/src/HttpMultipartResource.h
+++ b/Sming/Libraries/MultipartParser/src/HttpMultipartResource.h
@@ -16,7 +16,7 @@
 #include <Network/Http/HttpResource.h>
 #include <WString.h>
 
-typedef Delegate<void(HttpFiles&)> HttpFilesMapper;
+using HttpFilesMapper = Delegate<void(HttpFiles&)>;
 
 /** 
  * @brief HttpResource that allows handling of HTTP file upload.

--- a/Sming/Libraries/OtaUpgrade/OtaUpgrade/BasicStream.h
+++ b/Sming/Libraries/OtaUpgrade/OtaUpgrade/BasicStream.h
@@ -131,10 +131,10 @@ private:
 	State state = State::Header;
 
 #ifdef ENABLE_OTA_SIGNING
-	typedef SignatureVerifier Verifier;
+	using Verifier = SignatureVerifier;
 	static const uint32_t expectedHeaderMagic = OTA_HEADER_MAGIC_SIGNED;
 #else
-	typedef ChecksumVerifier Verifier;
+	using Verifier = ChecksumVerifier;
 	static const uint32_t expectedHeaderMagic = OTA_HEADER_MAGIC_NOT_SIGNED;
 #endif
 	Verifier verifier;

--- a/Sming/Libraries/OtaUpgrade/OtaUpgrade/ChecksumVerifier.h
+++ b/Sming/Libraries/OtaUpgrade/OtaUpgrade/ChecksumVerifier.h
@@ -22,7 +22,7 @@ namespace OtaUpgrade
 class ChecksumVerifier : public Crypto::Md5
 {
 public:
-	typedef Hash VerificationData; ///< Checksum type
+	using VerificationData = Hash; ///< Checksum type
 
 	/** Verify the given \c checksum.
 	 * @return `true` if checksum matches content, `false` otherwise.

--- a/Sming/Libraries/OtaUpgrade/OtaUpgrade/FileFormat.h
+++ b/Sming/Libraries/OtaUpgrade/OtaUpgrade/FileFormat.h
@@ -21,20 +21,20 @@ extern "C" {
 
 /** File header of an unencrypted OTA upgrade file.
  */
-typedef struct {
+struct OtaFileHeader {
 	uint32_t magic; ///< File type identification, either #OTA_HEADER_MAGIC_SIGNED or #OTA_HEADER_MAGIC_NOT_SIGNED.
 	uint32_t buildTimestampLow;  ///< File creation timestamp, Milliseconds since 1900/01/01 (lower 32 bits)
 	uint32_t buildTimestampHigh; ///< File creation timestamp, Milliseconds since 1900/01/01 (lower 32 bits)
 	uint8_t romCount;			 ///< Number of ROM images in this filem, each preceeded with an #OTA_RomHeader.
 	uint8_t reserved[3];		 ///< Reserved bytes, must be zero for compatibility with future versions.
-} OtaFileHeader;
+};
 
 /** Header of ROM image inside an OTA upgrade file.
  */
-typedef struct {
+struct OtaRomHeader {
 	uint32_t address; ///< Flash memory destination offset for this ROM image.
 	uint32_t size;	///< Size of ROM image content following this header, in bytes.
-} OtaRomHeader;
+};
 
 /** Expected value for OTA_FileHeader::magic for digitally signed upgrad file. */
 #define OTA_HEADER_MAGIC_SIGNED 0xf01af02a

--- a/Sming/Platform/BssInfo.h
+++ b/Sming/Platform/BssInfo.h
@@ -25,7 +25,7 @@ enum WifiAuthMode {
 };
 #else
 #include <esp_systemapi.h>
-typedef AUTH_MODE WifiAuthMode;
+using WifiAuthMode = AUTH_MODE;
 #endif
 
 class BssInfo
@@ -61,4 +61,4 @@ public:
 	bool hidden;				///< True if AP is hidden
 };
 
-typedef Vector<BssInfo> BssList; ///< List of BSS
+using BssList = Vector<BssInfo>; ///< List of BSS

--- a/Sming/Platform/OsMessageInterceptor.h
+++ b/Sming/Platform/OsMessageInterceptor.h
@@ -49,14 +49,14 @@
 /**
  * @brief Fixed-size buffer for OS messages
  */
-typedef LineBuffer<128> OsMessage;
+using OsMessage = LineBuffer<128>;
 
 /**
  * @brief Callback to receive OS message line
  * @param msg The message
  * @note We don't use std::function because it produces a more elaborate stack trace without any real benefit
  */
-typedef void (*OsMessageCallback)(OsMessage& message);
+using OsMessageCallback = void (*)(OsMessage& message);
 
 /**
  * @brief Class to handle interception of OS messages

--- a/Sming/Platform/Station.h
+++ b/Sming/Platform/Station.h
@@ -74,7 +74,7 @@ enum WpsStatus {
 /**
  * @brief Scan complete handler function
  */
-typedef Delegate<void(bool success, BssList& list)> ScanCompletedDelegate;
+using ScanCompletedDelegate = Delegate<void(bool success, BssList& list)>;
 
 /**
  * @brief Smart configuration handler function
@@ -82,14 +82,14 @@ typedef Delegate<void(bool success, BssList& list)> ScanCompletedDelegate;
  * @param info
  * @retval bool return true to perform default configuration
  */
-typedef Delegate<bool(SmartConfigEvent event, const SmartConfigEventInfo& info)> SmartConfigDelegate;
+using SmartConfigDelegate = Delegate<bool(SmartConfigEvent event, const SmartConfigEventInfo& info)>;
 
 /**
  * @brief WPS configuration callback function
  * @param status
  * @retval bool return true to perform default configuration
  */
-typedef Delegate<bool(WpsStatus status)> WPSConfigDelegate;
+using WPSConfigDelegate = Delegate<bool(WpsStatus status)>;
 
 /** @brief  WiFi station class
  */

--- a/Sming/Platform/System.h
+++ b/Sming/Platform/System.h
@@ -34,20 +34,20 @@
 /** @brief Task callback function type, uint32_t parameter
  * 	@note Callback code does not need to be in IRAM
  */
-typedef void (*TaskCallback32)(uint32_t param);
+using TaskCallback32 = void (*)(uint32_t param);
 
 /** @brief Task callback function type, void* parameter
  * 	@note Callback code does not need to be in IRAM
  */
-typedef void (*TaskCallback)(void* param);
+using TaskCallback = void (*)(void* param);
 
 /** @brief Task Delegate callback type
  */
-typedef Delegate<void()> TaskDelegate;
+using TaskDelegate = Delegate<void()>;
 
 /** @brief Handler function for system ready
  */
-typedef TaskDelegate SystemReadyDelegate;
+using SystemReadyDelegate = TaskDelegate;
 
 /**
  * @brief Interface class implemented by classes to support on-ready callback

--- a/Sming/Platform/WifiEvents.h
+++ b/Sming/Platform/WifiEvents.h
@@ -90,7 +90,7 @@ enum WifiDisconnectReason {
  * @note This event occurs when the station successfully connects to the target AP. Upon receiving this event,
  * the DHCP client begins the process of getting an IP address.
  */
-typedef Delegate<void(const String& ssid, MacAddress bssid, uint8_t channel)> StationConnectDelegate;
+using StationConnectDelegate = Delegate<void(const String& ssid, MacAddress bssid, uint8_t channel)>;
 
 /**
  * @brief Delegate type for 'station disconnected' event
@@ -105,7 +105,7 @@ typedef Delegate<void(const String& ssid, MacAddress bssid, uint8_t channel)> St
  * 	- When the Wi-Fi connection is disrupted because of specific reasons, e.g., the station continuously loses N beacons, the AP kicks off the station,
  * 	  the AP's authentication mode is changed, etc.
  */
-typedef Delegate<void(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)> StationDisconnectDelegate;
+using StationDisconnectDelegate = Delegate<void(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)>;
 
 /**
  * @brief Delegate type for 'station authorisation mode changed' event
@@ -114,7 +114,7 @@ typedef Delegate<void(const String& ssid, MacAddress bssid, WifiDisconnectReason
  * @note This event arises when the AP to which the station is connected changes its authentication mode,
  * e.g., from 'no auth' to WPA. Generally, the application event callback does not need to handle this.
  */
-typedef Delegate<void(WifiAuthMode oldMode, WifiAuthMode newMode)> StationAuthModeChangeDelegate;
+using StationAuthModeChangeDelegate = Delegate<void(WifiAuthMode oldMode, WifiAuthMode newMode)>;
 
 /**
  * @brief Delegate type for 'station got IP address' event
@@ -127,7 +127,7 @@ typedef Delegate<void(WifiAuthMode oldMode, WifiAuthMode newMode)> StationAuthMo
  *	- The DHCP client rebinds to a different address.
  *	- The static-configured IPV4 address is changed.
  */
-typedef Delegate<void(IpAddress ip, IpAddress netmask, IpAddress gateway)> StationGotIPDelegate;
+using StationGotIPDelegate = Delegate<void(IpAddress ip, IpAddress netmask, IpAddress gateway)>;
 
 /**
  * @brief Delegate type for 'Access Point Connect' event
@@ -135,7 +135,7 @@ typedef Delegate<void(IpAddress ip, IpAddress netmask, IpAddress gateway)> Stati
  * @param aid Association ID representing the connected station
  * @note This event occurs every time a station is connected to our Access Point.
  */
-typedef Delegate<void(MacAddress mac, uint16_t aid)> AccessPointConnectDelegate;
+using AccessPointConnectDelegate = Delegate<void(MacAddress mac, uint16_t aid)>;
 
 /**
  * @brief Delegate type for 'Access Point Disconnect' event
@@ -143,7 +143,7 @@ typedef Delegate<void(MacAddress mac, uint16_t aid)> AccessPointConnectDelegate;
  * @param aid Association ID assigned to the station
  * @note This event occurs every time a station is disconnected from our Access Point.
  */
-typedef Delegate<void(MacAddress mac, uint16_t aid)> AccessPointDisconnectDelegate;
+using AccessPointDisconnectDelegate = Delegate<void(MacAddress mac, uint16_t aid)>;
 
 /**
  * @brief Delegate type for 'Access Point Probe Request Received' event
@@ -152,7 +152,7 @@ typedef Delegate<void(MacAddress mac, uint16_t aid)> AccessPointDisconnectDelega
  * @note Probe Requests are a low-level management frame which are used to determine
  * informaton about our Access Point, such as which authentication modes are supported.
  */
-typedef Delegate<void(int rssi, MacAddress mac)> AccessPointProbeReqRecvedDelegate;
+using AccessPointProbeReqRecvedDelegate = Delegate<void(int rssi, MacAddress mac)>;
 
 /** @brief  WiFi events class
  */
@@ -226,13 +226,13 @@ public:
 	}
 
 protected:
-	StationConnectDelegate onSTAConnect = nullptr;
-	StationDisconnectDelegate onSTADisconnect = nullptr;
-	StationAuthModeChangeDelegate onSTAAuthModeChange = nullptr;
-	StationGotIPDelegate onSTAGotIP = nullptr;
-	AccessPointConnectDelegate onSOFTAPConnect = nullptr;
-	AccessPointDisconnectDelegate onSOFTAPDisconnect = nullptr;
-	AccessPointProbeReqRecvedDelegate onSOFTAPProbeReqRecved = nullptr;
+	StationConnectDelegate onSTAConnect;
+	StationDisconnectDelegate onSTADisconnect;
+	StationAuthModeChangeDelegate onSTAAuthModeChange;
+	StationGotIPDelegate onSTAGotIP;
+	AccessPointConnectDelegate onSOFTAPConnect;
+	AccessPointDisconnectDelegate onSOFTAPDisconnect;
+	AccessPointProbeReqRecvedDelegate onSOFTAPProbeReqRecved;
 };
 
 /**

--- a/Sming/Platform/WifiSniffer.h
+++ b/Sming/Platform/WifiSniffer.h
@@ -89,9 +89,9 @@ public:
 	}
 };
 
-typedef Delegate<void(uint8_t* data, uint16_t length)> WifiSnifferCallback;
-typedef Delegate<void(const BeaconInfo& beacon)> WifiBeaconCallback;
-typedef Delegate<void(const ClientInfo& client)> WifiClientCallback;
+using WifiSnifferCallback = Delegate<void(uint8_t* data, uint16_t length)>;
+using WifiBeaconCallback = Delegate<void(const BeaconInfo& beacon)>;
+using WifiClientCallback = Delegate<void(const ClientInfo& client)>;
 
 class WifiSniffer : public ISystemReadyHandler
 {

--- a/Sming/Services/CommandProcessing/CommandDelegate.h
+++ b/Sming/Services/CommandProcessing/CommandDelegate.h
@@ -20,7 +20,7 @@
  *  @note   CommandFunctionDelegate defines the structure of a function that handles individual commands
  *  @note   Can use standard print functions on commandOutput
  */
-typedef Delegate<void(String commandLine, CommandOutput* commandOutput)> CommandFunctionDelegate;
+using CommandFunctionDelegate = Delegate<void(String commandLine, CommandOutput* commandOutput)>;
 
 /** @deprecated Use `CommandFunctionDelegate` instead */
 typedef CommandFunctionDelegate commandFunctionDelegate SMING_DEPRECATED;

--- a/Sming/Services/CommandProcessing/CommandHandler.h
+++ b/Sming/Services/CommandProcessing/CommandHandler.h
@@ -31,10 +31,10 @@
 
 /** @brief  Verbose mode
 */
-typedef enum {
+enum VerboseMode {
 	VERBOSE, ///< Verbose mode
 	SILENT   ///< Silent mode
-} VerboseMode;
+};
 
 /** @brief  Command handler class */
 class CommandHandler

--- a/Sming/System/include/gdb/gdb_syscall.h
+++ b/Sming/System/include/gdb/gdb_syscall.h
@@ -99,7 +99,7 @@ struct GdbSyscallInfo;
  * @brief GDB Syscall completion callback function
  * @param info Reference to request information, containing result code and user-provided 'param'
  */
-typedef void (*gdb_syscall_callback_t)(const GdbSyscallInfo& info);
+using gdb_syscall_callback_t = void (*)(const GdbSyscallInfo& info);
 
 /**
  * @brief GDB Syscall request information

--- a/Sming/System/include/m_printf.h
+++ b/Sming/System/include/m_printf.h
@@ -24,7 +24,7 @@ extern "C++" {
  *  @retval number of characters written, which may be less than the requested size
  *  @note data does not need to be nul terminated and may contain any 8-bit values including nul
  */
-typedef Delegate<size_t(const char* str, size_t length)> nputs_callback_t;
+using nputs_callback_t = Delegate<size_t(const char* str, size_t length)>;
 
 /** @brief set the character output routine
  *  @param callback

--- a/Sming/Wiring/IpAddress.h
+++ b/Sming/Wiring/IpAddress.h
@@ -26,8 +26,8 @@
 #if LWIP_VERSION_MAJOR == 2
 #define LWIP_IP_ADDR_T const ip_addr_t
 #else
-typedef struct ip_addr ip_addr_t;
-typedef ip_addr_t ip4_addr_t;
+using ip_addr_t = struct ip_addr;
+using ip4_addr_t = ip_addr_t;
 #define IP_ADDR4(IP, A, B, C, D) IP4_ADDR(IP, A, B, C, D)
 #define ip_addr_set_ip4_u32(IP, U32) ip4_addr_set_u32(IP, U32)
 #define ip_addr_get_ip4_u32(IP) ip4_addr_get_u32(IP)
@@ -43,7 +43,7 @@ typedef ip_addr_t ip4_addr_t;
 class IpAddress : public Printable
 {
 private:
-	ip_addr_t address = {0}; ///< IPv4 address
+	ip_addr_t address{0}; ///< IPv4 address
 
 	void fromString(const String& address);
 
@@ -63,18 +63,18 @@ public:
 		ip_addr_set_ip4_u32(&this->address, address);
 	}
 
-	IpAddress(ip_addr_t &addr)
+	IpAddress(ip_addr_t& addr)
 	{
 		address = addr;
 	}
 
-	IpAddress(const ip_addr_t &addr)
+	IpAddress(const ip_addr_t& addr)
 	{
 		address = addr;
 	}
 
 #if LWIP_VERSION_MAJOR == 2 && LWIP_IPV6
-	IpAddress(ip4_addr_t &addr)
+	IpAddress(ip4_addr_t& addr)
 	{
 		ip_addr_copy_from_ip4(address, addr);
 	}

--- a/Sming/Wiring/MacAddress.h
+++ b/Sming/Wiring/MacAddress.h
@@ -38,13 +38,13 @@
 class MacAddress : public Printable
 {
 	// https://www.artima.com/cppsource/safebool.html
-	typedef void (MacAddress::*bool_type)() const;
+	using bool_type = void (MacAddress::*)() const;
 	void Testable() const
 	{
 	}
 
 public:
-	typedef uint8_t Octets[6];
+	using Octets = uint8_t[6];
 
 	MacAddress() = default;
 

--- a/Sming/Wiring/WConstants.h
+++ b/Sming/Wiring/WConstants.h
@@ -34,46 +34,45 @@
  * Constants
  *************************************************************/
 
-#define LOW      0x0
-#define HIGH     0x1
+#define LOW 0x0
+#define HIGH 0x1
 //#define HIGH     0xFF
 
 //GPIO FUNCTIONS
-#define INPUT             0x00
-#define INPUT_PULLUP      0x02
+#define INPUT 0x00
+#define INPUT_PULLUP 0x02
 #define INPUT_PULLDOWN_16 0x04 // PULLDOWN only possible for pin16
-#define OUTPUT            0x01
+#define OUTPUT 0x01
 #define OUTPUT_OPEN_DRAIN 0x03
-#define WAKEUP_PULLUP     0x05
-#define WAKEUP_PULLDOWN   0x07
-#define SPECIAL           0xF8 //defaults to the usable BUSes uart0rx/tx uart1tx and hspi
-#define FUNCTION_0        0x08
-#define FUNCTION_1        0x18
-#define FUNCTION_2        0x28
-#define FUNCTION_3        0x38
-#define FUNCTION_4        0x48
+#define WAKEUP_PULLUP 0x05
+#define WAKEUP_PULLDOWN 0x07
+#define SPECIAL 0xF8 //defaults to the usable BUSes uart0rx/tx uart1tx and hspi
+#define FUNCTION_0 0x08
+#define FUNCTION_1 0x18
+#define FUNCTION_2 0x28
+#define FUNCTION_3 0x38
+#define FUNCTION_4 0x48
 
-#define CHANGE   32 // to avoid conflict with HIGH value
-#define FALLING  2
-#define RISING   3
+#define CHANGE 32 // to avoid conflict with HIGH value
+#define FALLING 2
+#define RISING 3
 
 #define LSBFIRST 0x0
 #define MSBFIRST 0x1
 
-#define null     NULL
+#define null NULL
 
-#define DEC      10
-#define HEX      16
-#define OCT      8
-#define BIN      2
+#define DEC 10
+#define HEX 16
+#define OCT 8
+#define BIN 2
 
-#define PI                             (3.1415926535897932384626433832795)
-#define TWO_PI                         (6.283185307179586476925286766559)
-#define HALF_PI                        (1.5707963267948966192313216916398)
-#define EPSILON                        (0.0001)
-#define DEG_TO_RAD                     (0.017453292519943295769236907684886)
-#define RAD_TO_DEG                     (57.295779513082320876798154814105)
-
+#define PI (3.1415926535897932384626433832795)
+#define TWO_PI (6.283185307179586476925286766559)
+#define HALF_PI (1.5707963267948966192313216916398)
+#define EPSILON (0.0001)
+#define DEG_TO_RAD (0.017453292519943295769236907684886)
+#define RAD_TO_DEG (57.295779513082320876798154814105)
 
 /*************************************************************
  * Digital Constants
@@ -90,33 +89,29 @@
 #define PORT8 8
 #define PORT9 9
 
-
 /*************************************************************
  * Useful macros
  *************************************************************/
 
 #define word(...) makeWord(__VA_ARGS__)
 
-#define sq(x)                          ((x)*(x))
-#define radians(deg)                   ((deg)*DEG_TO_RAD)
-#define degrees(rad)                   ((rad)*RAD_TO_DEG)
-#define constrain(amt,low,high)        ((amt)<(low)?(low):((amt)>(high)?(high):(amt)))
+#define sq(x) ((x) * (x))
+#define radians(deg) ((deg)*DEG_TO_RAD)
+#define degrees(rad) ((rad)*RAD_TO_DEG)
+#define constrain(amt, low, high) ((amt) < (low) ? (low) : ((amt) > (high) ? (high) : (amt)))
 
-#define lowByte(x)                     ((uint8_t) ((x) & 0x00ff))
-#define highByte(x)                    ((uint8_t) ((x)>>8))
+#define lowByte(x) ((uint8_t)((x)&0x00ff))
+#define highByte(x) ((uint8_t)((x) >> 8))
 
-
-#define clockCyclesPerMicrosecond()    (F_CPU / 1000000L)
-#define clockCyclesToMicroseconds(a)   ((a) / clockCyclesPerMicrosecond())
-#define microsecondsToClockCycles(a)   ((a) * clockCyclesPerMicrosecond())
-
-
+#define clockCyclesPerMicrosecond() (F_CPU / 1000000L)
+#define clockCyclesToMicroseconds(a) ((a) / clockCyclesPerMicrosecond())
+#define microsecondsToClockCycles(a) ((a)*clockCyclesPerMicrosecond())
 
 /*************************************************************
  * Typedefs
  *************************************************************/
 
-typedef unsigned int word;
-typedef uint8_t byte;
-typedef uint8_t boolean;
-typedef void (*voidFuncPtr)(void);
+using word = unsigned int;
+using byte = uint8_t;
+using boolean = uint8_t;
+using voidFuncPtr = void (*)(void);

--- a/Sming/Wiring/WHashMap.h
+++ b/Sming/Wiring/WHashMap.h
@@ -37,7 +37,7 @@
 template <typename K, typename V> class HashMap
 {
 public:
-	typedef bool (*comparator)(const K&, const K&);
+	using Comparator = bool (*)(const K&, const K&);
 
 	/*
     || @constructor
@@ -55,7 +55,7 @@ public:
     ||
     || @parameter compare optional function for comparing a key against another (for complex types)
     */
-	HashMap(comparator compare) : cb_comparator(compare)
+	HashMap(Comparator compare) : cb_comparator(compare)
 	{
 	}
 
@@ -228,7 +228,7 @@ protected:
 	V nil;
 	uint16_t currentIndex = 0;
 	uint16_t size = 0;
-	comparator cb_comparator = nullptr;
+	Comparator cb_comparator = nullptr;
 
 private:
 	HashMap(const HashMap<K, V>& that);

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -93,7 +93,7 @@ class __FlashStringHelper; // Never actually defined
  * @brief Provides a strongly-typed pointer to allow safe implicit
  * operation using String class methods.
  */
-typedef const __FlashStringHelper* flash_string_t;
+using flash_string_t = const __FlashStringHelper*;
 
 /**
  * @brief Cast a PGM_P (flash memory) pointer to a flash string pointer
@@ -138,7 +138,7 @@ class String
 	// use a function pointer to allow for "if (s)" without the
 	// complications of an operator bool(). for more information, see:
 	// http://www.artima.com/cppsource/safebool.html
-	typedef void (String::*StringIfHelperType)() const;
+	using StringIfHelperType = void (String::*)() const;
 	void StringIfHelper() const
 	{
 	}

--- a/Sming/Wiring/WVector.h
+++ b/Sming/Wiring/WVector.h
@@ -29,7 +29,7 @@
 template <typename Element> class Vector : public Countable<Element>
 {
 public:
-	typedef int (*Comparer)(const Element& lhs, const Element& rhs);
+	using Comparer = int (*)(const Element& lhs, const Element& rhs);
 
 	// constructors
 	Vector(unsigned int initialCapacity = 10, unsigned int capacityIncrement = 10);
@@ -84,7 +84,7 @@ public:
 			copyFrom(rhv);
 		return *this;
 	}
-	const Vector<Element>& operator=(const Vector<Element>&& other)  noexcept // move assignment
+	const Vector<Element>& operator=(const Vector<Element>&& other) noexcept // move assignment
 	{
 		if(_data != nullptr) {
 			removeAllElements();

--- a/Sming/Wiring/wiring_private.h
+++ b/Sming/Wiring/wiring_private.h
@@ -7,7 +7,7 @@
 #include "Arduino.h"
 
 #ifdef __cplusplus
-extern "C"{
+extern "C" {
 #endif
 
 #ifndef cbi

--- a/docs/source/contribute/clang-tools.rst
+++ b/docs/source/contribute/clang-tools.rst
@@ -1,0 +1,111 @@
+Clang Tools
+===========
+
+`clang-format <https://releases.llvm.org/6.0.0/tools/clang/docs/ClangFormat.html>`__
+is a tool that implements automatic source code formatting.
+It can be used to automatically enforce the layout rules for Sming.
+
+`clang-tidy <https://releases.llvm.org/6.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html>`__
+is a C++ “linter” tool to assist with diagnosing and fixing  typical programming errors
+such as style violations, interface misuse, or bugs that can be deduced via static analysis.
+It is provided as part of 
+
+You can find details for the current release at https://releases.llvm.org/download.html.
+Note that *clang-format* is part of the main **Clang** project, whilst *clang-tidy* can be
+found in **clang-tools-extra**.
+
+
+Installation
+------------
+
+In Ubuntu you should be able to install them using the following command::
+
+   sudo apt-get install clang-format clang-tidy
+
+See the the `download <http://releases.llvm.org/download.html>`__ page
+of the Clang project for installation instructions for other operating
+systems.
+
+We are using version 6.0 of clang-format and clang-tidy on our
+Continuous Integration (CI) System. You should install the same
+version or newer on your development computer.
+
+
+Configuration
+-------------
+
+Rules
+~~~~~
+
+The coding rules are described in the
+`.clang-format <https://github.com/SmingHub/Sming/blob/develop/.clang-format>`__
+file, located in the root directory of the framework.
+
+You should not edit this file unless it is a discussed and agreed coding
+style change.
+
+IDE integration
+~~~~~~~~~~~~~~~
+
+There are multiple existing integrations for IDEs. You can find details
+in the `ClangFormat documentation <https://clang.llvm.org/docs/ClangFormat.html>`__.
+
+Eclipse IDE
+^^^^^^^^^^^
+
+For our Eclipse IDE, which is our preferred IDE, we recommend installing
+the `CppStyle plugin <https://github.com/wangzw/CppStyle>`__. You can
+configure your IDE to auto-format the code on “Save” using the
+recommended coding style and/or format according to our coding style
+rules using Ctrl-Shift-F (for formatting of whole file or selection of
+lines). Read
+`Configure CppStyle <https://github.com/wangzw/CppStyle#configure-cppstyle>`__
+for details.
+
+Usage
+-----
+
+Command Line
+~~~~~~~~~~~~
+
+Single File
+
+   If you want to directly apply the coding standards from the command line
+   you can run the following command::
+   
+      cd $SMING_HOME
+      clang-format -style=file -i Core/<modified-file>
+   
+   Where ``Core/<modified-file>`` should be replaced with the path to
+   the file that you have modified.
+
+All files
+
+   The following command will run again the coding standards formatter over
+   all C, C++ and header files inside the ``Sming/Core``, ``samples`` and 
+   other key directories::
+   
+      cd $SMING_HOME
+      make cs
+   
+   The command needs time to finish. So be patient. It will go over all
+   files and will try to fix any coding style issues.
+   
+   If you wish to apply coding style to your own project, add an empty ``.cs`` marker file
+   to any directory containing source code or header files. All source/header files
+   in that directory and any sub-directories will be formatted when you run::
+   
+      make cs
+   
+   from your project directory.
+   
+Eclipse
+~~~~~~~
+
+If you have installed CppStyle as described above you can
+configure Eclipse to auto-format your files on *Save*.
+
+Alternatively, you can manually apply the coding style rules by selecting the source code of a
+C, C++ or header file or a selection in it and run the ``Format`` command
+(usually Ctrl-Shift-F).
+

--- a/docs/source/contribute/coding-style.rst
+++ b/docs/source/contribute/coding-style.rst
@@ -482,3 +482,51 @@ Some notes on commonly occurring issues::
        */
        unsigned length = 0;
    };
+
+
+Use of ``typedef`` in C++
+-------------------------
+
+Use of ``typedef`` in C++ code is not recommended.
+
+The `using` keyword has been available since C++11 and offers a more natural way to express type definitions.
+It is also necessary in certain situations such as templating.
+
+For example::
+
+   using ValueType = uint32_t;
+
+is more readable than::
+
+   typdef uint32_t ValueType;
+
+Especially in multiple type declarations the subject is always immediately after the ``using`` keyword
+and makes reading much easier.
+
+https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#t43-prefer-using-over-typedef-for-defining-aliases
+https://www.nextptr.com/tutorial/ta1193988140/how-cplusplus-using-or-aliasdeclaration-is-better-than-typedef
+
+enum/struct declarations
+------------------------
+
+This::
+
+   typedef struct _MyStructTag {
+     ...
+   } MyStruct;
+   
+   typedef enum _MyEnumTag {
+     ...
+   } MyEnum;
+   
+is overly verbose and un-necessary. It's a hangover from 'C' code and should generally be avoided for readability and consistency.
+This is the preferred definition::
+
+   struct MyStruct {
+     ...
+   };
+   enum MyEnum {
+   .............
+   };
+
+It's also un-necessary to qualify usage with `enum`. i.e. `MyEnum e;` is sufficient, don't need `enum MyEnum e;`.

--- a/docs/source/contribute/coding-style.rst
+++ b/docs/source/contribute/coding-style.rst
@@ -1,159 +1,44 @@
-******************
 Coding Style Rules
-******************
+==================
 
-.. highlight:: bash
+.. highlight:: c++
 
 The benefits of coding standards are readability, maintainability and
 compatibility. Any member of the development team in Sming should be
 able to read the code of another developer. The developer who maintains
 a piece of code tomorrow may not be the coder who programmed it today.
 
-Therefore we enforce coding standards described in our
-`Style Guide <#style-guide>`__. The coding style rules are mandatory for the
-``Sming/SmingCore`` and ``samples`` directories and all their
-sub-directories. And they should be applied to all C, C++ and header
-files in those directories.
-
-A Pull Request that does not adhere to the coding style rules will not
+Therefore we enforce coding standards as described in this guide.
+The coding style rules are mandatory for most of the framework,
+and Pull Request that does not adhere to the coding style rules will not
 be merged until those rules are applied.
 
-Please also bookmark the `C++ Core Guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines>`__
-as this is an invaluable reference for writing good code and making the best use of this powerful language.
+The rules are optional for libraries, but recommended.
+
+Tools will help you adhere to these coding standards without the need to know them by heart.
+See :doc:`clang-tools` for further details.
+
+Please also bookmark the `C++ Core Guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines>`__.
+This is an invaluable reference for writing good code and making the best use of this powerful language.
 
 
-
-Tools
-=====
-
-Tools will help you easily adhere to the coding standards described in
-our `Style Guide <#style-guide>`__ without the need to know them by
-heart.
-
-Installation
-------------
-
-Clang-Format and Clang-Tidy
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In order to automatically check and apply our coding standards you need
-to install ``clang-format`` and optionally ``clang-tidy``.
-
-In Ubuntu you should be able to install them using the following command::
-
-   sudo apt-get install clang-format clang-tidy
-
-See the the `download <http://releases.llvm.org/download.html>`__ page
-of the Clang project for installation instructions for other operating
-systems.
-
-We are using version 6.0 of clang-format and clang-tidy on our
-Continuous Integration (CI) System. If possible try to install the same
-version or newer on your development computer.
-
-Configuration
--------------
-
-Rules
-~~~~~
-
-The coding rules are described in the
-`.clang-format <https://github.com/SmingHub/Sming/blob/develop/.clang-format>`__
-which can be found in the root directory of the project. You don’t have
-to change anything on this file unless it is discussed and agreed coding
-style change.
-
-IDE integration
-~~~~~~~~~~~~~~~
-
-There are multiple existing integrations for IDEs that can be found at
-the bottom of that page
-`ClangFormat.html <https://clang.llvm.org/docs/ClangFormat.html>`__.
-
-Eclipse IDE
-^^^^^^^^^^^
-
-For our Eclipse IDE, which is our preferred IDE, we recommend installing
-the `CppStyle plugin <https://github.com/wangzw/CppStyle>`__. You can
-configure your IDE to auto-format the code on “Save” using the
-recommended coding style and/or format according to our coding style
-rules using Ctrl-Shift-F (for formatting of whole file or selection of
-lines). Read
-`Configure CppStyle <https://github.com/wangzw/CppStyle#configure-cppstyle>`__
-for details.
-
-Usage
------
-
-Command Line
-~~~~~~~~~~~~
-
-Single File
-^^^^^^^^^^^
-
-If you want to directly apply the coding standards from the command line
-you can run the following command::
-
-   cd $SMING_HOME
-   clang-format -style=file -i Core/<modified-file>
-
-Where ``Core/<modified-file>`` should be replaced with the path to
-the file that you have modified.
-
-All files
-~~~~~~~~~
-
-The following command will run again the coding standards formatter over
-all C, C++ and header files inside the ``Sming/Core``, ``samples`` and 
-other key directories::
-
-   cd $SMING_HOME
-   make cs
-
-The command needs time to finish. So be patient. It will go over all
-files and will try to fix any coding style issues.
-
-If you wish to apply coding style to your own project, add an empty ``.cs`` marker file
-to any directory containing source code or header files. All source/header files
-in that directory and any sub-directories will be formatted when you run::
-
-   make cs
-
-from your project directory.
-
-Eclipse
-~~~~~~~
-
-If you have installed CppStyle as described above you can either
-configure Eclipse to auto-format your files on “Save” or you can
-manually apply the coding style rules by selecting the source code of a
-C,C++ or header file or a selection in it and run the ``Format`` command
-(usually Ctrl-Shift-F).
-
-Style Guide
-===========
-
-.. highlight:: c++
-
-You don’t have to know by heart the coding style but it is worth having
-an idea about our rules. Below are described some of them. Those rules
-will be can be automatically applied as mentioned in the previous
-chapter.
 
 Indentation
 -----------
 
 We use tabs for indentation. Configure your editor to display a tab as
-long as 4 spaces. The corresponding settings in clang-format are::
+long as 4 spaces. For reference, the corresponding settings in clang-format are::
 
    TabWidth:        4
    UseTab:          Always
    IndentWidth:     4
 
+
+
 Naming
 ------
 
-Classes
+Classes, Structures, type aliases
 
    Must be nouns in UpperCamelCase, with the first letter of  every word capitalised.
    Use whole words — avoid acronyms and abbreviations (unless the abbreviation is much more widely
@@ -162,7 +47,28 @@ Classes
    Examples::
 
       class HttpClient {}
+
       class HttpClientConnection {}
+
+      using LargeValue = uint32_t;
+
+      struct MyStruct {
+         ...
+      };
+
+      enum MyEnum {
+         a, ///< Comment if required
+         b,
+         c,
+      };
+
+   .. note::
+   
+      The trailing , on the final item in an enumeration declaration will ensure that clang-format
+      places each item on a separate line. This makes for easier reading and the addition of line
+      comments if appropriate.
+
+
 
 Methods
 
@@ -172,6 +78,7 @@ Methods
    Examples::
 
       bind();
+
       getStatus();
 
 
@@ -189,7 +96,9 @@ Variables
    Examples::
 
       int i;
+
       char c;                  
+
       WebsocketClient* client;
 
 
@@ -207,6 +116,55 @@ Constants
    Names **MUST NOT** be all-uppercase as these may be confused with #defined values.
 
    See `C++ Core Guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum5-dont-use-all_caps-for-enumerators>`__.
+
+
+Use of ``typedef`` in C++
+-------------------------
+
+Use of ``typedef`` in C++ code is not recommended.
+
+The `using` keyword has been available since C++11 and offers a more natural way to express type definitions.
+It is also necessary in certain situations such as templating.
+
+For example::
+
+   using ValueType = uint32_t;
+
+is more readable than::
+
+   typedef uint32_t ValueType;
+
+Especially in multiple type declarations the subject is always immediately after the ``using`` keyword
+and makes reading much easier.
+
+https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#t43-prefer-using-over-typedef-for-defining-aliases
+
+https://www.nextptr.com/tutorial/ta1193988140/how-cplusplus-using-or-aliasdeclaration-is-better-than-typedef
+
+enum/struct declarations
+------------------------
+
+This::
+
+   typedef struct _MyStructTag {
+     ...
+   } MyStruct;
+   
+   typedef enum _MyEnumTag {
+     ...
+   } MyEnum;
+   
+is overly verbose and un-necessary. It's a hangover from 'C' code and should generally be avoided for readability and consistency.
+This is the preferred definition::
+
+   struct MyStruct {
+     ...
+   };
+   enum MyEnum {
+   .............
+   };
+
+It's also un-necessary to qualify usage with `enum`. i.e. `MyEnum e;` is sufficient, don't need `enum MyEnum e;`.
 
 
 .. highlight:: text
@@ -305,11 +263,6 @@ Spaces
 For readability put always spaces before assignment operators::
 
    SpaceBeforeAssignmentOperators: true
-
-Other Elements
-==============
-
-.. highlight:: c++
 
 Standard file headers
 ---------------------
@@ -484,49 +437,3 @@ Some notes on commonly occurring issues::
    };
 
 
-Use of ``typedef`` in C++
--------------------------
-
-Use of ``typedef`` in C++ code is not recommended.
-
-The `using` keyword has been available since C++11 and offers a more natural way to express type definitions.
-It is also necessary in certain situations such as templating.
-
-For example::
-
-   using ValueType = uint32_t;
-
-is more readable than::
-
-   typdef uint32_t ValueType;
-
-Especially in multiple type declarations the subject is always immediately after the ``using`` keyword
-and makes reading much easier.
-
-https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#t43-prefer-using-over-typedef-for-defining-aliases
-https://www.nextptr.com/tutorial/ta1193988140/how-cplusplus-using-or-aliasdeclaration-is-better-than-typedef
-
-enum/struct declarations
-------------------------
-
-This::
-
-   typedef struct _MyStructTag {
-     ...
-   } MyStruct;
-   
-   typedef enum _MyEnumTag {
-     ...
-   } MyEnum;
-   
-is overly verbose and un-necessary. It's a hangover from 'C' code and should generally be avoided for readability and consistency.
-This is the preferred definition::
-
-   struct MyStruct {
-     ...
-   };
-   enum MyEnum {
-   .............
-   };
-
-It's also un-necessary to qualify usage with `enum`. i.e. `MyEnum e;` is sufficient, don't need `enum MyEnum e;`.

--- a/docs/source/contribute/coding-style.rst
+++ b/docs/source/contribute/coding-style.rst
@@ -18,6 +18,11 @@ files in those directories.
 A Pull Request that does not adhere to the coding style rules will not
 be merged until those rules are applied.
 
+Please also bookmark the `C++ Core Guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines>`__
+as this is an invaluable reference for writing good code and making the best use of this powerful language.
+
+
+
 Tools
 =====
 
@@ -148,47 +153,61 @@ long as 4 spaces. The corresponding settings in clang-format are::
 Naming
 ------
 
-+---------------------------+-----------------------+-----------------------------------+
-| Identifier type           |   Rules for naming    | Examples                          |
-+===========================+=======================+===================================+
-| Classes                   |   |class-names|       | ::                                |
-|                           |                       |                                   |
-|                           |                       |    class HttpClient {}            |
-|                           |                       |    class HttpClientConnection {}  |
-+---------------------------+-----------------------+-----------------------------------+
-| Methods                   |   |methods|           | ::                                |
-|                           |                       |                                   |
-|                           |                       |    bind();                        |
-|                           |                       |    getStatus();                   |
-+---------------------------+-----------------------+-----------------------------------+
-| Variables                 |   |local-vars|        | ::                                |
-|                           |                       |                                   |
-|                           |                       |    int i;                         |
-|                           |   |varnames|          |    char c;                        |
-|                           |                       |    WebsocketClient* client;       |
-+---------------------------+-----------------------+-----------------------------------+
-| Constants                 |   |constants|         | ::                                |
-|                           |                       |                                   |
-|                           |                       |    #define MAX_PARTICIPANTS 10    |
-+---------------------------+-----------------------+-----------------------------------+
+Classes
 
-.. |methods| replace:: Methods must be either verbs in lowerCamelCase, or a multi-word name that begins with a verb in lowercase; 
+   Must be nouns in UpperCamelCase, with the first letter of  every word capitalised.
+   Use whole words — avoid acronyms and abbreviations (unless the abbreviation is much more widely
+   used than the long form, such as URL or HTML).
+   
+   Examples::
+
+      class HttpClient {}
+      class HttpClientConnection {}
+
+Methods
+
+   Must be either verbs in lowerCamelCase, or a multi-word name that begins with a verb in lowercase;
    that is, with the first letter lowercase and the first letters of subsequent words in uppercase.
+   
+   Examples::
 
-.. |class-names| replace:: Class names must be nouns in UpperCamelCase, with the first letter of  every word capitalised.
-   Use whole words — avoid acronyms and abbreviations (unless the abbreviation is much more widely used than the long form, such as URL or HTML).
+      bind();
+      getStatus();
 
-.. |local-vars| replace:: Local variables, instance variables, and class variables must also be written in lowerCamelCase.
+
+Variables
+
+   Local variables, instance variables, and class variables must also be written in lowerCamelCase.
    Variable names must not start with, end with or contain underscore (\_) or dollar sign ($) characters.
    This is in constrast to some coding conventions which prefix all instance variables with underscore,
    however this is reserved by the C++ standard and can create problems.
 
-.. |varnames| replace:: Variable names should be short yet meaningful. The choice of a variable name should be mnemonic — that is,
+   Variable names should be short yet meaningful. The choice of a variable name should be mnemonic — that is,
    designed to indicate to the casual observer the intent of its use. One-character variable names should be avoided except for
    temporary “throwaway” variables. Common names for temporary variables are i, j, k, m, and n for integers; c, d, and e for characters.
+   
+   Examples::
 
-.. |constants| replace:: Constants must be written in uppercase characters separated by underscores.
-   Constant names may contain digits if appropriate, but not as the first character.
+      int i;
+      char c;                  
+      WebsocketClient* client;
+
+
+Pre-processor definitions
+
+   #defined macros must be written in uppercase characters separated by underscores.
+   Names may contain digits if appropriate, but not as the first character. For example::
+
+      #define MAX_PARTICIPANTS 10
+
+
+Constants
+
+   Typically declared using ``const`` or ``constexpr`` and, like variables, should be lower-camelcase.
+   Names **MUST NOT** be all-uppercase as these may be confused with #defined values.
+
+   See `C++ Core Guidelines <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum5-dont-use-all_caps-for-enumerators>`__.
+
 
 .. highlight:: text
 

--- a/docs/source/experimental/signed-ota.rst
+++ b/docs/source/experimental/signed-ota.rst
@@ -30,10 +30,10 @@ To use it, you can subclass RbootOutputStream like this:
 
    const u8 _my_prefix[6] = { PREFIX_MAGIC, PREFIX_TYPE };
 
-   typedef struct {
+   struct MyHdr {
        u8  prefix[PREFIX_SIZE];
        u8  signature[SIGNATURE_SIZE];
-   } MyHdr;
+   };
 
    //-----------------------------------------------------------------------------
    class MyStream : public RbootOutputStream {

--- a/samples/Basic_Delegates/app/speed.cpp
+++ b/samples/Basic_Delegates/app/speed.cpp
@@ -12,8 +12,8 @@ const unsigned ITERATIONS = 10000000;
 const unsigned ITERATIONS = 100000;
 #endif
 
-typedef Delegate<void(int)> TestDelegate;
-typedef void (*TestCallback)(int);
+using TestDelegate = Delegate<void(int)>;
+using TestCallback = void (*)(int);
 
 // Use for high resolution loop timing
 static CpuCycleTimer timer;

--- a/samples/Basic_Serial/include/SerialReadingDelegateDemo.h
+++ b/samples/Basic_Serial/include/SerialReadingDelegateDemo.h
@@ -3,7 +3,7 @@
 
 #include <SmingCore.h>
 
-typedef Delegate<void(const String& command)> CommandCallbackFunction;
+using CommandCallbackFunction = Delegate<void(const String& command)>;
 
 //*** Example of class callback processing
 class SerialReadingDelegateDemo

--- a/tests/HostTests/app/test-rational.cpp
+++ b/tests/HostTests/app/test-rational.cpp
@@ -14,7 +14,7 @@ public:
 
 	void execute() override
 	{
-		typedef uint32_t T;
+		using T = uint32_t;
 
 		const T max = 0x10000;
 


### PR DESCRIPTION
Contains updates to the coding style rules. The section on tool installation is now on a separate page to keep the
actual rules uncluttered. Substantive changes are:

* Deprecate `typedef` in C++ code in favour of `using` https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#t43-prefer-using-over-typedef-for-defining-aliases.
* Declaration of struct/enum types don't require `typedef`
* UpperCamelCase naming convention extended to include structures and type aliases (was just classes)
* Use of UPPER_CASE constants specifically now reserved for pre-processor directives https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum5-dont-use-all_caps-for-enumerators
