### PR TITLE
GCC compilers version 8 or newer are highly recommended.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ Please note Version 4 documentation is at [sming.readthedocs.io](https://sming.r
 
 ## Compatibility
 
+
+### GCC compiler >= 8
+
+Your GCC compiler should be version 8 or newer! See the different architectures for details.
+Newer compilers
+
+- produce smaller and better code
+- have features which improve code quality, easy of use, etc.
+
 ### Architecture: ESP8266
 
 OS/SDK | Linux | Mac OS X | Windows | FreeBSD-current |

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Table of Contents
 
 * [Summary](#summary)
 * [Compatibility](#compatibility)
+   * [Architecture: Esp32](#architecture-esp32-experimental)
    * [Architecture: ESP8266](#architecture-esp8266)
    * [Architecture: Host](#architecture-host)
 * [Releases](#releases)
@@ -80,8 +81,9 @@ Please note Version 4 documentation is at [sming.readthedocs.io](https://sming.r
 Your GCC compiler should be version 8 or newer! See the different architectures for details.
 Newer compilers
 
+- contain bugfixes
 - produce smaller and better code
-- have features which improve code quality, easy of use, etc.
+- have features which facilitate code quality, ease of use, etc.
 
 ### Architecture: ESP8266
 

--- a/Sming/Arch/Esp8266/build.mk
+++ b/Sming/Arch/Esp8266/build.mk
@@ -40,6 +40,8 @@ OBJCOPY			 	:= $(TOOLSPEC)objcopy
 OBJDUMP			 	:= $(TOOLSPEC)objdump
 GDB				:= $(TOOLSPEC)gdb
 
+GCC_UPGRADE_URL := https://sming.readthedocs.io/en/latest/arch/esp8266/getting-started/eqt.html
+
 CPPFLAGS += \
 	-nostdlib \
 	-mlongcalls \

--- a/Sming/Arch/Host/build.mk
+++ b/Sming/Arch/Host/build.mk
@@ -17,6 +17,8 @@ OBJCOPY		:= $(TOOLSPEC)objcopy
 OBJDUMP		:= $(TOOLSPEC)objdump
 GDB		:= $(TOOLSPEC)gdb
 
+GCC_UPGRADE_URL := https://sming.readthedocs.io/en/latest/arch/host/host-emulator.html\#c-c-32-bit-compiler-and-libraries
+
 CPPFLAGS += \
 	-m32 \
 	-Wno-deprecated-declarations

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -189,7 +189,15 @@ SMING_CXX_STD		?= c++17
 endif
 CXXFLAGS			+= -std=$(SMING_CXX_STD)
 
+GCC_MIN_MAJOR_VERSION = 8
+GCC_VERSION_COMPATIBLE := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= $(GCC_MIN_MAJOR_VERSION))
 
+ifeq ($(GCC_VERSION_COMPATIBLE),0)
+$(warning ***** Please, upgrade your GCC compiler to version $(GCC_MIN_MAJOR_VERSION) or newer *************)
+ifneq ($(GCC_UPGRADE_URL),)
+$(info Instructions for upgrading your compiler can be found here: $(GCC_UPGRADE_URL))
+endif 
+endif
 
 # Component (user) libraries have a special prefix so linker script can identify them
 CLIB_PREFIX := clib-

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -189,11 +189,11 @@ SMING_CXX_STD		?= c++17
 endif
 CXXFLAGS			+= -std=$(SMING_CXX_STD)
 
-GCC_MIN_MAJOR_VERSION = 8
-GCC_VERSION_COMPATIBLE := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= $(GCC_MIN_MAJOR_VERSION))
+GCC_MIN_VERSION := "8.0"
+GCC_VERSION_COMPATIBLE := $(shell expr "$(GCC_VERSION)" ">=" "$(GCC_MIN_VERSION)")
 
 ifeq ($(GCC_VERSION_COMPATIBLE),0)
-$(warning ***** Please, upgrade your GCC compiler to version $(GCC_MIN_MAJOR_VERSION) or newer *************)
+$(warning ***** Please, upgrade your GCC compiler to version $(GCC_MIN_VERSION) or newer *****)
 ifneq ($(GCC_UPGRADE_URL),)
 $(info Instructions for upgrading your compiler can be found here: $(GCC_UPGRADE_URL))
 endif 

--- a/docs/source/arch/esp8266/getting-started/eqt.rst
+++ b/docs/source/arch/esp8266/getting-started/eqt.rst
@@ -1,10 +1,6 @@
 ESP Quick Toolchain
 ===================
 
-.. attention::
-
-   This is pre-release documentation and subject to change.
-
 Introduction
 ------------
 
@@ -28,7 +24,7 @@ Download links for the ``3.0.0-gnu5`` release (8 December 2019) as follows:
 - Linux 32-bit: `i686-linux-gnu.xtensa-lx106-elf.tar.gz <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/i686-linux-gnu.xtensa-lx106-elf-a5c9861.1575819473.tar.gz>`__
 - Linux 64-bit: `x86_64-linux-gnu.xtensa-lx106-elf.tar.gz <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/x86_64-linux-gnu.xtensa-lx106-elf-a5c9861.1575819473.tar.gz>`__
 - MacOS: `x86_64-apple-darwin14.xtensa-lx106-elf.tar.gz <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/ x86_64-apple-darwin14.xtensa-lx106-elf-a5c9861.1575819473.tar.gz>`__
-- Windows 32-bit: `i686-w64-mingw32.xtensa-lx106-elf.zip <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/i686-w64-mingw32.xtensa-lx106-elf-a5c9861.1575819473.zip>`__ 
+- Windows 32-bit: `i686-w64-mingw32.xtensa-lx106-elf.zip <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/i686-w64-mingw32.xtensa-lx106-elf-a5c9861.1575819473.zip>`__
 - Windows 64-bit: `x86_64-w64-mingw32.xtensa-lx106-elf.zip <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/x86_64-w64-mingw32.xtensa-lx106-elf-a5c9861.1575819473.zip>`__
 
 Extract the toolchain to a suitable location, such as:

--- a/docs/source/arch/esp8266/getting-started/macos.rst
+++ b/docs/source/arch/esp8266/getting-started/macos.rst
@@ -124,7 +124,7 @@ for your ESP8266. You can change it like this::
 
 Next, ensure that you can build the :sample:`Basic_Blink` from a terminal window::
 
-   cd $SMING_HOME/samples/Basic_Blink
+   cd $SMING_HOME/../samples/Basic_Blink
    make
 
 This will also build the required framework components, so may take a few minutes.

--- a/docs/source/arch/host/host-emulator.rst
+++ b/docs/source/arch/host/host-emulator.rst
@@ -23,25 +23,21 @@ develop only with Ubuntu 16.04 and 18.04.
 C/C++ 32 bit compiler and libraries
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The latest versions of Sming require GCC version 8 or newer.
 If your OS is 64 bit then you should install also 32 bit C/C++ compiler and libraries.
-For Ubuntu, install like this::
-
-   sudo apt-get install gcc-multilib g++-multilib
-
-You may wish to install the latest compilers for testing alongside the recent
-:doc:`/arch/esp8266/getting-started/eqt` updates. Here's a summary of how to do this::
+Here's a summary of how to do this::
 
    sudo add-apt-repository ppa:ubuntu-toolchain-r/test
    sudo apt update
    sudo apt install gcc-9 g++-9
-   
+
    # For 64-bit systems
    sudo apt install gcc-9-multilib g++-9-multilib
 
    # Set GCC 9 as default
    sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 60 --slave /usr/bin/g++ g++ /usr/bin/g++-9
 
-The current version is `GCC 9.2.1 <https://www.gnu.org/software/gcc/gcc-9>`__.
+The current version is `GCC 9.3.0 <https://www.gnu.org/software/gcc/gcc-9>`__.
 
 CMake 3.8 or newer
 ~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Start warning when older compiler is used.
Middle of 2021 we should enforce the usage of newer compilers only.