### PR TITLE
Add pong delegate support for websoket connection and resource

### DIFF
--- a/Sming/Core/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Core/Network/Http/Websocket/WebsocketConnection.cpp
@@ -166,6 +166,9 @@ int WebsocketConnection::staticOnControlEnd(void* userData)
 		connection->send(connection->controlFrame.payload, connection->controlFrame.payloadLength, WS_FRAME_PONG);
 	}
 
+	if(connection->controlFrame.type == WS_FRAME_PONG && connection->wsPong) {
+		connection->wsPong(*connection);
+	}
 	return WS_OK;
 }
 

--- a/Sming/Core/Network/Http/Websocket/WebsocketConnection.h
+++ b/Sming/Core/Network/Http/Websocket/WebsocketConnection.h
@@ -73,7 +73,6 @@ public:
 
 	virtual ~WebsocketConnection()
 	{
-		state = eWSCS_Closed;
 		close();
 	}
 
@@ -214,7 +213,14 @@ public:
 	{
 		wsBinary = handler;
 	}
-
+	/**
+	 * @brief Sets the callback handler to be called when pong reply received
+	 * @param handler
+	 */
+	void setPongHandler(WebsocketDelegate handler)
+	{
+		wsPong = handler;
+	}
 	/**
 	 * @brief Sets the callback handler to be called before closing a websocket connection
 	 * @param handler
@@ -298,6 +304,7 @@ protected:
 	WebsocketDelegate wsConnect = nullptr;
 	WebsocketMessageDelegate wsMessage = nullptr;
 	WebsocketBinaryDelegate wsBinary = nullptr;
+	WebsocketDelegate wsPong = nullptr;
 	WebsocketDelegate wsDisconnect = nullptr;
 
 	void* userData = nullptr;

--- a/Sming/Core/Network/Http/Websocket/WebsocketResource.cpp
+++ b/Sming/Core/Network/Http/Websocket/WebsocketResource.cpp
@@ -23,6 +23,7 @@ int WebsocketResource::checkHeaders(HttpServerConnection& connection, HttpReques
 	socket->setBinaryHandler(wsBinary);
 	socket->setMessageHandler(wsMessage);
 	socket->setConnectionHandler(wsConnect);
+	socket->setPongHandler(wsPong);
 	socket->setDisconnectionHandler(wsDisconnect);
 	if(!socket->bind(request, response)) {
 		debug_w("Not a valid WebsocketRequest?");

--- a/Sming/Core/Network/Http/Websocket/WebsocketResource.h
+++ b/Sming/Core/Network/Http/Websocket/WebsocketResource.h
@@ -48,6 +48,11 @@ public:
 		wsBinary = handler;
 	}
 
+	void setPongHandler(WebsocketDelegate handler)
+	{
+		wsPong = handler;
+	}
+
 	void setDisconnectionHandler(WebsocketDelegate handler)
 	{
 		wsDisconnect = handler;
@@ -60,5 +65,6 @@ protected:
 	WebsocketDelegate wsConnect = nullptr;
 	WebsocketMessageDelegate wsMessage = nullptr;
 	WebsocketBinaryDelegate wsBinary = nullptr;
+	WebsocketDelegate wsPong = nullptr;
 	WebsocketDelegate wsDisconnect = nullptr;
 };


### PR DESCRIPTION
Add ability to call delegate on pong frame reception. This is useful for
closing stalled connections. Websocket server can send ping frames periodically and check for pong back from clients. On pong reception server can reset some counters attached to websocket connection via setUserData. Also server periodically checks for counter not reaching some minimum value for every connection and close connections that do not reply to ping request assuming them as stalled. Connection may stall if some hard network problem occurs and there is no proper way to close client connection nor by websocket protocol or tcp.
Remove websocket state change before calling close() in
WebsocketConnection destructor. Without this change if connection was
removed by WebsocketRecource, onDisconnect delegate for Websocket
connection will not run.