### PR TITLE
Fix null pointer access in WString.h

### DIFF
--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -852,7 +852,9 @@ protected:
 			sso.buffer[len] = '\0';
 		} else {
 			ptr.len = len;
-			ptr.buffer[len] = '\0';
+			if(ptr.buffer != nullptr) {
+				ptr.buffer[len] = '\0';
+			}
 		}
 	}
 


### PR DESCRIPTION
Under certain conditions, during a `move()` the `setlen` internal method gets called when buffer is null. So add a check for this.