### PR TITLE
HttpClient: SSL adjustments

### DIFF
--- a/samples/HttpClient/app/application.cpp
+++ b/samples/HttpClient/app/application.cpp
@@ -36,6 +36,19 @@ int onDownload(HttpConnection& connection, bool success)
 
 void sslRequestInit(Ssl::Session& session, HttpRequest& request)
 {
+	// Go with maximum buffer sizes
+	session.maxBufferSize = Ssl::MaxBufferSize::K16;
+
+	/**
+	 * If there is not enough RAM and the response from the server is not a big one
+	 * you may prefer to set the size to a lower value. One useful value would be 4K
+	 *
+	 * 	session.maxBufferSize = Ssl::MaxBufferSize::K4;
+	 *
+	 * Unfortunately most of the servers may ignore this plea from
+	 * our HTTP client and send big SSL packet.
+	 */
+
 	/*
 	 * SSL validation: We check the remote server certificate against a fingerprint
 	 * Note that fingerprints _may_ change, in which case these need to be updated.

--- a/samples/HttpClient/component.mk
+++ b/samples/HttpClient/component.mk
@@ -1,4 +1,5 @@
 ## size of the flash chip
 SPI_SIZE  ?= 4M
 
-ENABLE_SSL = 1
+## Prefer BearSSL as it can handle more gracefully big SSL packets.
+ENABLE_SSL ?= Bearssl


### PR DESCRIPTION
The remote HTTP server is returning SSL packets that are 9K which is bigger than our default 4K.

This change increases the SSL max buffer size to 16K and recommends the use of BearSSL as it handles
better bigger SSL packets.