### PR TITLE
Improve connection:close handling for HTTP clients.

### DIFF
--- a/Sming/Core/Network/Http/HttpClientConnection.cpp
+++ b/Sming/Core/Network/Http/HttpClientConnection.cpp
@@ -143,7 +143,8 @@ int HttpClientConnection::onMessageComplete(http_parser* parser)
 		// if the server does not support keep-alive -> close the connection
 		// see: https://tools.ietf.org/html/rfc2616#section-14.10
 		debug_d("HCC::onMessageComplete: Closing as requested by server");
-		close();
+		state = eHCS_WaitResponse; // put the other requests on hold...
+		setTimeOut(0);			   // schedule for closing...
 
 		return hasError;
 	}
@@ -312,7 +313,6 @@ void HttpClientConnection::onClosed()
 		debug_d("HCC::onClosed: Trying to reconnect and send pending requests");
 
 		cleanup();
-		init(HTTP_RESPONSE);
 		auto request = waitingQueue.peek();
 		if(request != nullptr) {
 			bool useSsl = (request->uri.Scheme == URI_SCHEME_HTTP_SECURE);

--- a/Sming/Core/Network/Http/HttpClientConnection.h
+++ b/Sming/Core/Network/Http/HttpClientConnection.h
@@ -86,6 +86,7 @@ protected:
 	{
 		if(err == ERR_OK) {
 			state = eHCS_Ready;
+			init(HTTP_RESPONSE);
 		}
 
 		return HttpConnection::onConnected(err);


### PR DESCRIPTION
Attempt to fix #2158.

- [x] Test against real UPnP devices that cannot handle keep-alives/pipelining.