### PR TITLE
Fixed issues in toString methods in:

### DIFF
--- a/Sming/Core/Network/Http/HttpRequest.cpp
+++ b/Sming/Core/Network/Http/HttpRequest.cpp
@@ -73,16 +73,21 @@ String HttpRequest::toString() const
 	content += ' ';
 	content += uri.getPathWithQuery();
 	content += _F(" HTTP/1.1\r\n");
-	content += headers.toString(HTTP_HEADER_HOST, uri.getHostWithPort());
+	if(!headers.contains(HTTP_HEADER_HOST)) {
+		content += headers.toString(HTTP_HEADER_HOST, uri.getHostWithPort());
+	}
 	for(unsigned i = 0; i < headers.count(); i++) {
 		content += headers[i];
 	}
 
-	if(bodyStream != nullptr && bodyStream->available() >= 0) {
-		content += headers.toString(HTTP_HEADER_CONTENT_LENGTH, String(bodyStream->available()));
-	} else {
-		content += "\r\n";
+	if(!headers.contains(HTTP_HEADER_CONTENT_LENGTH)) {
+		if(bodyStream == nullptr) {
+			content += headers.toString(HTTP_HEADER_CONTENT_LENGTH, "0");
+		} else if(bodyStream->available() >= 0) {
+			content += headers.toString(HTTP_HEADER_CONTENT_LENGTH, String(bodyStream->available()));
+		}
 	}
+	content += "\r\n";
 
 	return content;
 }

--- a/Sming/Core/Network/Http/HttpResponse.cpp
+++ b/Sming/Core/Network/Http/HttpResponse.cpp
@@ -122,12 +122,7 @@ String HttpResponse::toString() const
 	for(unsigned i = 0; i < headers.count(); i++) {
 		content += headers[i];
 	}
-
-	if(stream != nullptr && stream->available() >= 0) {
-		content += headers.toString(HTTP_HEADER_CONTENT_LENGTH, String(stream->available()));
-	} else {
-		content += "\r\n";
-	}
+	content += "\r\n";
 
 	return content;
 }


### PR DESCRIPTION
- Response: printing Content-Length header even when such one was not provided
- Request: Overwriting the host header and printing it two times.