### PR TITLE
Fix CI toolchains

### DIFF
--- a/.appveyor/install.cmd
+++ b/.appveyor/install.cmd
@@ -15,8 +15,8 @@ goto :%SMING_ARCH%
 
 	REM New toolchain
 	mkdir %EQT_ROOT%
-	set TOOLCHAIN=i686-w64-mingw32.xtensa-lx106-elf-a5c9861.1575819473.zip
-	curl -LO https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/%TOOLCHAIN%
+	set TOOLCHAIN=x86_64-w64-mingw32.xtensa-lx106-elf-e6a192b.201211.zip
+	curl -LO %SMINGTOOLS%/%TOOLCHAIN%
 	7z -o%EQT_ROOT% x %TOOLCHAIN%
 
 	goto :EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
-language: cpp
+language: python
+python: 3.8.6
 os: linux
+dist: focal
 env:
   global:
   - SMINGTOOLS=https://github.com/SmingHub/SmingTools/releases/download/1.0
@@ -9,6 +11,7 @@ env:
 jobs:
   include:
   - stage: test
+    name: Host
     addons:
       apt:
         packages:
@@ -50,17 +53,8 @@ git:
   submodules: false
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    - sourceline: ppa:libreoffice/libreoffice-4-2
-    - llvm-toolchain-trusty-6.0
+    update: true
     packages:
-    - bsdtar
-    - doxygen
-    - doxygen-doc
-    - doxygen-latex
-    - doxygen-gui
-    - graphviz
     - xmlstarlet
 install: ".travis/install.sh"
 script: ".travis/build.sh"

--- a/Sming/Arch/Esp32/Tools/travis/install.sh
+++ b/Sming/Arch/Esp32/Tools/travis/install.sh
@@ -6,12 +6,11 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
                 cmake ninja-build ccache libffi-dev libssl-dev dfu-util \
                 python3 python3-pip python3-setuptools
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-    python -m pip install --upgrade virtualenv==16.7.9
     mkdir -p $TRAVIS_BUILD_DIR/opt
     cd $TRAVIS_BUILD_DIR/opt
     git clone -b v4.1 --recursive https://github.com/espressif/esp-idf.git
     export IDF_PATH=$TRAVIS_BUILD_DIR/opt/esp-idf
     $IDF_PATH/install.sh
 
-    python -m pip install --user -r $IDF_PATH/requirements.txt
+    python -m pip install -r $IDF_PATH/requirements.txt
 fi

--- a/Sming/Arch/Esp8266/Components/esp-open-lwip/esp-open-lwip.patch
+++ b/Sming/Arch/Esp8266/Components/esp-open-lwip/esp-open-lwip.patch
@@ -548,3 +548,30 @@ index 52cd0b0..0ea6ab0 100644
  	remot_info *pinfo = NULL;
  	espconn_msg *pdelete_msg = NULL;
  	struct tcp_pcb *pcb = NULL;
+diff --git a/lwip/core/sntp.c b/lwip/core/sntp.c
+index 677de93..b645772 100644
+--- a/lwip/core/sntp.c
++++ b/lwip/core/sntp.c
+@@ -295,7 +295,6 @@ static ip_addr_t sntp_last_server_address;
+  * to compare against in response */
+ static u32_t sntp_last_timestamp_sent[2];
+ #endif /* SNTP_CHECK_RESPONSE >= 2 */
+-typedef long     time_t;
+ //uint32 current_stamp_1 = 0;
+ //uint32 current_stamp_2 = 0;
+ uint32 realtime_stamp = 0;
+
+diff --git a/include/lwip/sntp.h b/include/lwip/sntp.h
+index 14e802e..61d36de 100644
+--- a/include/lwip/sntp.h
++++ b/include/lwip/sntp.h
+@@ -28,7 +28,7 @@ extern "C" {
+  * #define SNTP_SERVER_ADDRESS "pool.ntp.org"
+  */
+ uint32 sntp_get_current_timestamp();
+-char* sntp_get_real_time(long t);
++char* sntp_get_real_time(time_t);
+ 
+ void sntp_init(void);
+ void sntp_stop(void);
+

--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbhostio.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbhostio.cpp
@@ -17,7 +17,7 @@
 #if GDBSTUB_ENABLE_HOSTIO
 
 #include "GdbPacket.h"
-#include <sys/errno.h>
+#include <errno.h>
 #include <fcntl.h>
 #include "FileSystem.h"
 #include "WString.h"

--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbstub.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbstub.cpp
@@ -26,7 +26,7 @@
 *********************************************************************************/
 
 #include <xtensa/corebits.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #include "gdbstub.h"
 #include "gdbstub-entry.h"

--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbsyscall.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbsyscall.cpp
@@ -17,7 +17,7 @@
 #include "gdbsyscall.h"
 #include "GdbPacket.h"
 #include <gdb/gdb_syscall.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include "Platform/System.h"
 
 // Whilst GCC has intrinsics to do this, they eat IRAM

--- a/Sming/Arch/Esp8266/Components/heap/custom_heap.c
+++ b/Sming/Arch/Esp8266/Components/heap/custom_heap.c
@@ -8,6 +8,7 @@
 #include "umm_malloc_cfg.h"
 #include "umm_malloc.h"
 
+#undef IRAM_ATTR
 #define IRAM_ATTR __attribute__((section(".iram.text")))
 
 #ifdef UMM_POISON_CHECK

--- a/Sming/Arch/Esp8266/Tools/travis/build.run.sh
+++ b/Sming/Arch/Esp8266/Tools/travis/build.run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex # exit with nonzero exit code if anything fails
 
-make -C "$SMING_PROJECTS_DIR/samples/HttpServer_FirmwareUpload" python-requirements PIP_ARGS=--user
+make -C "$SMING_PROJECTS_DIR/samples/HttpServer_FirmwareUpload" python-requirements
 $MAKE_PARALLEL samples
 make clean samples-clean
 $MAKE_PARALLEL Basic_Blink ENABLE_CUSTOM_HEAP=1 DEBUG_VERBOSE_LEVEL=3

--- a/Sming/Arch/Esp8266/Tools/travis/install.sh
+++ b/Sming/Arch/Esp8266/Tools/travis/install.sh
@@ -10,8 +10,8 @@ if [ "$TRAVIS_OS_NAME" == "linux" ]; then
 	ln -s $(pwd)/esp-open-sdk/xtensa-lx106-elf $TRAVIS_BUILD_DIR/opt/esp-alt-sdk/.
 
 	# New toolchain
-	TOOLCHAIN=x86_64-linux-gnu.xtensa-lx106-elf-a5c9861.1575819473.tar.gz
-	wget --no-verbose https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/$TOOLCHAIN
+	TOOLCHAIN=x86_64-linux-gnu.xtensa-lx106-elf-e6a192b.201211.tar.gz
+	wget --no-verbose $SMINGTOOLS/$TOOLCHAIN
 	mkdir -p opt/esp-quick-toolchain
   	tar -zxf $TOOLCHAIN -C opt/esp-quick-toolchain --totals
 fi

--- a/Sming/Arch/Esp8266/build.mk
+++ b/Sming/Arch/Esp8266/build.mk
@@ -58,7 +58,7 @@ $(error ESP_HOME not set correctly: "$(ESP_HOME)")
 endif
 
 # Identifies which library we're building with
-USE_NEWLIB			= $(if $(filter 9%,$(GCC_VERSION)),1,0)
+USE_NEWLIB = $(GCC_VERSION_COMPATIBLE)
 
 # => Tools
 MEMANALYZER = $(PYTHON) $(ARCH_TOOLS)/memanalyzer.py $(OBJDUMP)$(TOOL_EXT)

--- a/Sming/Arch/Host/Components/gdbstub/gdb_syscall.cpp
+++ b/Sming/Arch/Host/Components/gdbstub/gdb_syscall.cpp
@@ -1,4 +1,5 @@
 #include <gdb/gdb_syscall.h>
+#include <errno.h>
 
 int gdb_syscall(const GdbSyscallInfo& info)
 {

--- a/Sming/Components/axtls-8266/axtls-8266.patch
+++ b/Sming/Components/axtls-8266/axtls-8266.patch
@@ -84,19 +84,20 @@ index dca7e5f..5f4ec51 100644
      {
 
 diff --git a/replacements/time.c b/replacements/time.c
-index 4972119..19431b4 100644
+index 4972119..d3f0d1e 100644
 --- a/replacements/time.c
 +++ b/replacements/time.c
-@@ -16,6 +16,8 @@
+@@ -16,6 +16,9 @@
   *
   */
  
-+#ifndef ARCH_ESP32
++#define _C_TYPES_H_
++#include <c_types.h>
 +
  #include <time.h>
  #include <sntp.h>
  
-@@ -24,21 +26,14 @@ extern uint64_t system_mktime(uint32_t year, uint32_t mon, uint32_t day, uint32_
+@@ -24,21 +27,14 @@ extern uint64_t system_mktime(uint32_t year, uint32_t mon, uint32_t day, uint32_
  
  static int errno_var = 0;
  
@@ -122,7 +123,7 @@ index 4972119..19431b4 100644
  #ifndef _TIMEVAL_DEFINED
  #define _TIMEVAL_DEFINED
  struct timeval {
-@@ -60,12 +55,12 @@ static time_t s_bootTime = 0;
+@@ -60,12 +56,12 @@ static time_t s_bootTime = 0;
  // calculate offset used in gettimeofday
  static void ensureBootTimeIsSet()
  {
@@ -138,7 +139,7 @@ index 4972119..19431b4 100644
          }
      }
  }
-@@ -79,7 +74,7 @@ static void setServer(int id, const char* name_or_ip)
+@@ -79,7 +75,7 @@ static void setServer(int id, const char* name_or_ip)
      }
  }
  
@@ -147,7 +148,7 @@ index 4972119..19431b4 100644
  {
      sntp_stop();
  
-@@ -93,22 +88,24 @@ void configTime(int timezone, int daylightOffset_sec, const char* server1, const
+@@ -93,22 +89,24 @@ void configTime(int timezone, int daylightOffset_sec, const char* server1, const
      sntp_init();
  }
  
@@ -177,7 +178,7 @@ index 4972119..19431b4 100644
  {
      time_t seconds = sntp_get_current_timestamp();
      if (t)
-@@ -118,30 +115,35 @@ time_t time(time_t * t)
+@@ -118,30 +116,32 @@ time_t time(time_t * t)
      return seconds;
  }
  
@@ -216,9 +217,7 @@ index 4972119..19431b4 100644
      }
      return 0;
  }
-+
-+
-+#endif /* ARCH_ESP32 */
+
 diff --git a/ssl/tls1.c b/ssl/tls1.c
 index 8f0fbfb..35ad4f3 100644
 --- a/ssl/tls1.c

--- a/Sming/Components/axtls-8266/component.mk
+++ b/Sming/Components/axtls-8266/component.mk
@@ -6,7 +6,7 @@ COMPONENT_SRCDIRS := \
 
 COMPONENT_DEPENDS += crypto
 
-ifneq ($(SMING_ARCH),Host)
+ifeq ($(SMING_ARCH),Esp8266)
 COMPONENT_SRCDIRS += \
 	axtls-8266/replacements
 endif

--- a/Sming/Platform/OsMessageInterceptor.cpp
+++ b/Sming/Platform/OsMessageInterceptor.cpp
@@ -16,7 +16,7 @@ extern void smg_uart_debug_putc(char);
 
 OsMessageInterceptor* OsMessageInterceptor::self;
 
-void OsMessageInterceptor::putc(char c)
+void OsMessageInterceptor::putch(char c)
 {
 	c = message.addChar(c);
 	if(c == '\n' && callback) {

--- a/Sming/Platform/OsMessageInterceptor.h
+++ b/Sming/Platform/OsMessageInterceptor.h
@@ -85,11 +85,11 @@ public:
 	void end();
 
 protected:
-	void putc(char c);
+	void putch(char c);
 
 	static void static_putc(char c)
 	{
-		self->putc(c);
+		self->putch(c);
 	}
 
 private:

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include <stdio.h>
 #include <esp_attr.h>
 #include <sys/pgmspace.h>
 

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -105,7 +105,7 @@ DEBUG_VARS += PYTHON
 ifdef PYTHON
 export PYTHON := $(call FixPath,$(PYTHON))
 else
-PYTHON := python
+PYTHON := python3
 endif
 
 PYTHON_VERSION := $(shell $(PYTHON) --version 2>&1)

--- a/Sming/component-wrapper.mk
+++ b/Sming/component-wrapper.mk
@@ -107,6 +107,13 @@ ifeq (,$(CUSTOM_BUILD))
 CFLAGS		+= $(COMPONENT_CFLAGS)
 CXXFLAGS	+= $(COMPONENT_CXXFLAGS)
 
+# GCC 10 escapes ':' in path names which breaks GNU make for Windows so filter them
+ifeq ($(UNAME),Windows)
+OUTPUT_DEPS := | sed "s/\\\\:/:/g" > $$@
+else
+OUTPUT_DEPS := -MF $$@
+endif
+
 # $1 -> absolute source directory, no trailing path separator
 # $2 -> relative output build directory, with trailing path separator
 define GenerateCompileTargets
@@ -126,7 +133,7 @@ $2%.o: $1/%.c $2%.c.d
 	$(vecho) "CC $$<"
 	$(Q) $(CC) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CFLAGS) -c $$< -o $$@
 $2%.c.d: $1/%.c
-	$(Q) $(CC) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CFLAGS) -MM -MT $2$$*.o $$< -MF $$@
+	$(Q) $(CC) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CFLAGS) -MM -MT $2$$*.o $$< $(OUTPUT_DEPS)
 .PRECIOUS: $2%.c.d
 endif
 ifneq (,$(filter $1/%.cpp,$(SOURCE_FILES)))
@@ -134,7 +141,7 @@ $2%.o: $1/%.cpp $2%.cpp.d
 	$(vecho) "C+ $$<"
 	$(Q) $(CXX) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CXXFLAGS) -c $$< -o $$@
 $2%.cpp.d: $1/%.cpp
-	$(Q) $(CXX) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CXXFLAGS) -MM -MT $2$$*.o $$< -MF $$@
+	$(Q) $(CXX) $(addprefix -I,$(INCDIR)) $(CPPFLAGS) $(CXXFLAGS) -MM -MT $2$$*.o $$< $(OUTPUT_DEPS)
 .PRECIOUS: $2%.cpp.d
 endif
 endef

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,8 @@ os: Windows Server 2012 R2
 
 environment:
   SMINGTOOLS: https://github.com/SmingHub/SmingTools/releases/download/1.0
-  PATH: C:\MinGW\msys\1.0\bin;C:\MinGW\bin;C:\Python38\scripts;%PATH%
+  PATH: C:\MinGW\msys\1.0\bin;C:\MinGW\bin;%PATH%
+  PYTHON: C:\Python38\python
   UDK_ROOT: C:\Espressif
   EQT_ROOT: C:\esp-quick-toolchain
   matrix:

--- a/docs/source/arch/esp8266/getting-started/eqt.rst
+++ b/docs/source/arch/esp8266/getting-started/eqt.rst
@@ -4,13 +4,14 @@ ESP Quick Toolchain
 Introduction
 ------------
 
-In Sming 4.0.1 support was added for the `ESP Quick Toolchain <https://github.com/earlephilhower/esp-quick-toolchain>`__
-for `GCC 9.2.0 <https://www.gnu.org/software/gcc/gcc-9>`__.
+In Sming 4.0.1 support was added for the `ESP Quick Toolchain <https://github.com/earlephilhower/esp-quick-toolchain>`__.
+
+At time of writing the current release is 
+`3.0.0-newlib4.0.0-gnu20 <https://github.com/earlephilhower/esp-quick-toolchain/releases/tag/3.0.0-newlib4.0.0-gnu20>`__
+for `GCC 10.2 <https://www.gnu.org/software/gcc/gcc-10>`__.
 
 This also updates the runtime libraries (`NewLib <https://github.com/earlephilhower/newlib-xtensa>`__)
 to version 2.2 with integrated PROGMEM handling code.
-
-See :pull-request:`1825` for further details.
 
 The new toolchain is consistent across development platforms and adds support for the latest compiler features,
 as discussed in `What are the new features in C++17? <https://stackoverflow.com/questions/38060436/what-are-the-new-features-in-c17>`__.
@@ -19,13 +20,8 @@ Installation
 ------------
 
 The toolchains are currently at pre-release, available `here <https://github.com/earlephilhower/esp-quick-toolchain/releases>`__.
-Download links for the ``3.0.0-gnu5`` release (8 December 2019) as follows:
 
-- Linux 32-bit: `i686-linux-gnu.xtensa-lx106-elf.tar.gz <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/i686-linux-gnu.xtensa-lx106-elf-a5c9861.1575819473.tar.gz>`__
-- Linux 64-bit: `x86_64-linux-gnu.xtensa-lx106-elf.tar.gz <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/x86_64-linux-gnu.xtensa-lx106-elf-a5c9861.1575819473.tar.gz>`__
-- MacOS: `x86_64-apple-darwin14.xtensa-lx106-elf.tar.gz <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/ x86_64-apple-darwin14.xtensa-lx106-elf-a5c9861.1575819473.tar.gz>`__
-- Windows 32-bit: `i686-w64-mingw32.xtensa-lx106-elf.zip <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/i686-w64-mingw32.xtensa-lx106-elf-a5c9861.1575819473.zip>`__
-- Windows 64-bit: `x86_64-w64-mingw32.xtensa-lx106-elf.zip <https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-gnu5/x86_64-w64-mingw32.xtensa-lx106-elf-a5c9861.1575819473.zip>`__
+Tested versions are available at `SmingTools <https://github.com/SmingHub/SmingTools>`.
 
 Extract the toolchain to a suitable location, such as:
 

--- a/docs/source/arch/esp8266/getting-started/linux.rst
+++ b/docs/source/arch/esp8266/getting-started/linux.rst
@@ -26,8 +26,8 @@ We recommend ``/opt/`` but you can use anything you want::
    mkdir -p /opt/
    cd /opt/
 
-Build/Install Toolchain
------------------------
+Install Toolchain
+-----------------
 
 This builds the cross-compiler, linker, etc. required for the ESP8266::
 
@@ -43,6 +43,14 @@ This builds the cross-compiler, linker, etc. required for the ESP8266::
 
 You can find pre-compiled toolchains in the `SmingTools <https://github.com/SmingHub/SmingTools/releases>`__ repository.
 
+Manual installation::
+
+   export ESP_HOME=/opt/esp-quick-toolchain
+   sudo mkdir $(ESP_HOME)
+   sudo chown $USER:$USER $(ESP_HOME)
+   wget https://github.com/SmingHub/SmingTools/releases/download/1.0/x86_64-linux-gnu.xtensa-lx106-elf-e6a192b.201211.tar.gz
+   tar -zxf x86_64-linux-gnu.xtensa-lx106-elf-e6a192b.201211.tar.gz -C $(ESP_HOME)
+
 Espressif SDK
 -------------
 
@@ -56,13 +64,14 @@ Environment Variables
 
 From the command line::
 
-   export ESP_HOME=/opt/esp-open-sdk
+   export ESP_HOME=/opt/esp-quick-toolchain
    export SMING_HOME=/opt/Sming/Sming
 
 To set these permanently, add them to your home ``.profile`` file.
 
 You can alternatively add them to ``/etc/environment`` for all users, like this::
 
+   ESP_HOME="/opt/esp-quick-toolchain"
    SMING_HOME="/opt/Sming/Sming"
 
 

--- a/docs/source/arch/esp8266/getting-started/macos.rst
+++ b/docs/source/arch/esp8266/getting-started/macos.rst
@@ -53,10 +53,11 @@ ESP8266 Toolchain
 We pull this in from the `SmingTools <https://github.com/SmingHub/SmingTools/releases>`__ repository::
 
    cd ~/
-   curl -L -O https://github.com/SmingHub/SmingTools/releases/download/1.0/esp-open-sdk-macosx.tar.gz
-   sudo mkdir -p /opt/
-   sudo tar -zxf esp-open-sdk-macosx.tar.gz -C /opt/
-   sudo chmod -R 775 /opt/esp-open-sdk
+   export ESP_HOME=/opt/esp-quick-toolchain
+   curl -L -O https://github.com/SmingHub/SmingTools/releases/download/1.0/x86_64-apple-darwin14.xtensa-lx106-elf-e6a192b.201211.tar.gz
+   sudo mkdir -p $(ESP_HOME)
+   sudo tar -zxf x86_64-apple-darwin14.xtensa-lx106-elf-e6a192b.201211.tar.gz-C $(ESP_HOME)
+   sudo chmod -R 775 -C $(ESP_HOME)
 
 You can also build it yourself
 `with Homebrew <https://github.com/pfalcon/esp-open-sdk#macos>`__ or
@@ -92,7 +93,7 @@ Environment Variables
 
 Open with a text editor the ``.profile`` file in your home directory, and add these lines::
 
-   export ESP_HOME=/opt/esp-open-sdk
+   export ESP_HOME=/opt/esp-quick-toolchain
    export SMING_HOME=<your-favourite-development-folder>/Sming/Sming
 
 Make sure to replace ``<your-favourite-development-folder>`` in the

--- a/docs/source/arch/esp8266/getting-started/windows-manual.rst
+++ b/docs/source/arch/esp8266/getting-started/windows-manual.rst
@@ -80,15 +80,15 @@ To install from the original MinGW source repository:
 Install ESP8266 Toolchain
 -------------------------
 
-1. Download toolchain `esp-udk-win32.7z <https://github.com/SmingHub/SmingTools/releases/download/1.0/esp-udk-win32.7z>`__.
+1. Download toolchain `ESP Quick Toolchain <https://github.com/SmingHub/SmingTools/releases/download/1.0/x86_64-w64-mingw32.xtensa-lx106-elf-e6a192b.201211.zip>`__.
 
 2. Unzip to default location::
 
-      7z -oC:\Espressif x esp-udk-win32.7z
+      7z -oC:\tools\esp-quick-toolchain x x86_64-w64-mingw32.xtensa-lx106-elf-e6a192b.201211.zip
 
 3. Set :envvar:`ESP_HOME` environment variable::
 
-      SETX ESP_HOME C:\Espressif
+      SETX ESP_HOME C:\tools\esp-quick-toolchain
 
 .. note::
    There is NO trailing slash on the path!


### PR DESCRIPTION
Linux toolchain updated to latest. HostTests compiles and runs without issue on esp8266.
Fix Python3 building

Note: GCC #10 escapes ':' in dependency files which breaks build on Windows.
Fixed by modified build step. Closes #2181.