### PR TITLE
ESP32 network / time fixes

### DIFF
--- a/Sming/Arch/Esp32/Platform/RTC.cpp
+++ b/Sming/Arch/Esp32/Platform/RTC.cpp
@@ -9,85 +9,40 @@
  ****/
 
 #include <Platform/RTC.h>
-
-#include "esp_systemapi.h"
-#include <soc/rtc.h>
-#include <esp32/rom/rtc.h>
+#include <esp32/clk.h>
+#include <debug_progmem.h>
 
 RtcClass RTC;
 
-#define RTC_MAGIC 0x55aaaa55
-#define NS_PER_SECOND 1000000000
+namespace
+{
+constexpr uint64_t US_PER_SECOND{1000000};
+constexpr uint64_t NS_PER_SECOND{US_PER_SECOND * 1000};
+uint64_t clockOffset;
 
-/** @brief  Structure to hold RTC data
- *  @addtogroup structures
- */
-struct RtcData {
-	uint64_t time;   ///< Quantity of nanoseconds since epoch
-	uint32_t magic;  ///< Magic ID used to identify that RTC has been initialised
-	uint32_t cycles; ///< Quantity of RTC cycles since last update
-};
-
-static bool hardwareReset;
-static void updateTime();
-static void loadTime();
-
-static RTC_DATA_ATTR RtcData rtcTime = {};
+} // namespace
 
 RtcClass::RtcClass()
 {
-	rst_info* info = system_get_rst_info();
-	hardwareReset = (info->reason == REASON_WDT_RST);
 }
 
 uint64_t RtcClass::getRtcNanoseconds()
 {
-	loadTime();
-	updateTime();
-	return rtcTime.time;
+	return (clockOffset + esp_clk_rtc_time()) * 1000ULL;
 }
 
 uint32_t RtcClass::getRtcSeconds()
 {
-	return (getRtcNanoseconds() / NS_PER_SECOND);
+	return (clockOffset + esp_clk_rtc_time()) / US_PER_SECOND;
 }
 
 bool RtcClass::setRtcNanoseconds(uint64_t nanoseconds)
 {
-	loadTime();
-	updateTime();
-	rtcTime.time = nanoseconds;
+	clockOffset = (nanoseconds / 1000) - esp_clk_rtc_time();
 	return true;
 }
 
 bool RtcClass::setRtcSeconds(uint32_t seconds)
 {
-	return setRtcNanoseconds((uint64_t)seconds * NS_PER_SECOND);
-}
-
-void updateTime()
-{
-	uint32 rtc_cycles = rtc_time_get();
-	uint32 cal = REG_READ(RTC_SLOW_CLK_CAL_REG);
-
-	// hardware reset causes rtc cycles to start at 0 so we need to check and act accordingly
-	uint32_t delta = hardwareReset ? rtc_cycles : rtc_cycles - rtcTime.cycles;
-
-	//  reset hardware flag so we can deal with the next overflow as a reset needs to be dealt differently
-	hardwareReset = false;
-	// increment number of nano seconds that have elapsed since last update
-	rtcTime.time += delta * ((uint64)((cal * 1000) >> 12));
-	// update last number of cycles
-	rtcTime.cycles = rtc_cycles;
-}
-
-void loadTime()
-{
-	// Initialise the time struct
-	if(rtcTime.magic != RTC_MAGIC) {
-		debugf("rtc time init...");
-		rtcTime.magic = RTC_MAGIC;
-		rtcTime.time = 0;
-		rtcTime.cycles = 0;
-	}
+	return setRtcNanoseconds(uint64_t(seconds) * NS_PER_SECOND);
 }

--- a/Sming/Arch/Esp32/Platform/StationImpl.h
+++ b/Sming/Arch/Esp32/Platform/StationImpl.h
@@ -73,6 +73,6 @@ private:
 private:
 	bool runScan = false;
 #ifdef ENABLE_SMART_CONFIG
-	SmartConfigEventInfo* smartConfigEventInfo = nullptr; ///< Set during smart handling
+	std::unique_ptr<SmartConfigEventInfo> smartConfigEventInfo; ///< Set during smart handling
 #endif
 };


### PR DESCRIPTION
**Network station AP**

* Casting uint8_t t wifi_mode_t* is dangerous (causes weird behaviour/spurious crashes in DS3232RTC_NTP_Setter sample)
* In enable(), don't bother with update if mode hasn't changed
* Update wifi mode when enable(false) is called
* Additional return value error checks

**RTC**

* Use IDF code for class implementation