### PR TITLE
MacOS build fixes

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/component.mk
+++ b/Sming/Arch/Esp8266/Components/esp8266/component.mk
@@ -63,7 +63,7 @@ COMPONENT_TARGETS += $(LIBCRYPTO_ORIG)
 # Make backup then modify original
 $(COMPONENT_RULE)$(LIBCRYPTO_ORIG): $(LIBCRYPTO)
 	cp $^ $@
-	ar -d $^ aes-internal-dec.o
+	$(AR) -d $^ aes-internal-dec.o
 
 # Define linker symbols
 EXTRA_LDFLAGS += -Wl,--just-symbols=$(COMPONENT_PATH)/ld/crypto.sym

--- a/Sming/Libraries/OtaUpgrade/component.mk
+++ b/Sming/Libraries/OtaUpgrade/component.mk
@@ -96,7 +96,7 @@ OTA_DATE_REF := -2208988800000LL
 _ota-make-build-timestamp: | $(OTA_GENCODE_DIR)
 	$(Q) echo '#include <FakePgmSpace.h>' > $(OTA_BUILD_TIMESTAMP_SRC)
 	$(Q) echo 'namespace OtaUpgrade {' >> $(OTA_BUILD_TIMESTAMP_SRC)
-	$(Q) echo 'extern const uint64_t BuildTimestamp PROGMEM = $(shell date +%s%3NLL) - $(OTA_DATE_REF);' >> $(OTA_BUILD_TIMESTAMP_SRC)
+	$(Q) echo 'extern const uint64_t BuildTimestamp PROGMEM = $(shell $(PYTHON) -c "import time; print('%uLL' % (1000 * time.time()))") - $(OTA_DATE_REF);' >> $(OTA_BUILD_TIMESTAMP_SRC)
 	$(Q) echo '} // namespace OtaUpgrade' >> $(OTA_BUILD_TIMESTAMP_SRC)
 
 App-build: _ota-make-build-timestamp

--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -336,7 +336,7 @@ COMPONENT_DIRS := $(foreach d,$(ALL_SEARCH_DIRS),$(wildcard $d/*))
 %/component.mk:
 	@if [ -f $(@D)/../.patches/$(notdir $(@D))/component.mk ]; then \
 		echo Patching $(abspath $(@D)/../.patches/$(notdir $(@D))/component.mk); \
-		cp -u $(@D)/../.patches/$(notdir $(@D))/component.mk $@; \
+		cp $(@D)/../.patches/$(notdir $(@D))/component.mk $@; \
 	fi
 
 SUBMODULES_FOUND = $(wildcard $(SUBMODULES:=/.submodule))


### PR DESCRIPTION
Also (probably) applies to FreeBSD.

* Archive format seems to be different for MacOS so must use correct version of `ar` for linking.
* `cp` command does not have `-u` option.
* Fix OtaUpgrade scripted timestamp computation for MacOS/FreeBSD compatibility. FreeBSD `date` variant does not support nanoseconds. Use python scriptlet.
