### PR TITLE
Fix handling of `.gz` files in HttpResponse

### DIFF
--- a/Sming/Core/Data/Stream/IFS/FileStream.cpp
+++ b/Sming/Core/Data/Stream/IFS/FileStream.cpp
@@ -184,6 +184,15 @@ String FileStream::fileName() const
 	return (res < 0 || stat.name.length == 0) ? nullptr : stat.name.buffer;
 }
 
+MimeType FileStream::getMimeType() const
+{
+	String name = fileName();
+	if(name.endsWith(".gz")) {
+		name.remove(name.length() - 3);
+	}
+	return ContentType::fromFullFileName(name, MIME_UNKNOWN);
+}
+
 String FileStream::id() const
 {
 	auto fs = getFileSystem();

--- a/Sming/Core/Data/Stream/IFS/FileStream.h
+++ b/Sming/Core/Data/Stream/IFS/FileStream.h
@@ -92,6 +92,8 @@ public:
 		return fileName();
 	}
 
+	MimeType getMimeType() const override;
+
 	bool isValid() const override
 	{
 		return fileExist();

--- a/Sming/Core/Network/Http/HttpResponse.cpp
+++ b/Sming/Core/Network/Http/HttpResponse.cpp
@@ -77,14 +77,14 @@ bool HttpResponse::sendFile(const String& fileName, bool allowGzipFileCheck)
 		if(fileStats(fnCompressed, stat) >= 0) {
 			debug_d("found %s", stat.name);
 			stat.compression.type = IFS::Compression::Type::GZip;
-			stat.name = IFS::NameBuffer((char*)fileName.c_str(), fileName.length(), fileName.length());
+			stat.name = IFS::NameBuffer(const_cast<String&>(fileName));
 			return sendFile(stat);
 		}
 	}
 
 	if(fileStats(fileName, stat) >= 0) {
 		debug_d("found %s", fileName.c_str());
-		stat.name = IFS::NameBuffer((char*)fileName.c_str(), fileName.length(), fileName.length());
+		stat.name = IFS::NameBuffer(const_cast<String&>(fileName));
 		return sendFile(stat);
 	}
 

--- a/Sming/Core/Network/Http/HttpResponse.cpp
+++ b/Sming/Core/Network/Http/HttpResponse.cpp
@@ -77,7 +77,7 @@ bool HttpResponse::sendFile(const String& fileName, bool allowGzipFileCheck)
 		if(fileStats(fnCompressed, stat) >= 0) {
 			debug_d("found %s", stat.name);
 			stat.compression.type = IFS::Compression::Type::GZip;
-			stat.name = IFS::NameBuffer(fnCompressed);
+			stat.name = IFS::NameBuffer((char*)fileName.c_str(), fileName.length(), fileName.length());
 			return sendFile(stat);
 		}
 	}


### PR DESCRIPTION
Most browsers expect correct mime type of data otherwise they refuse to load CSS, JavaScript and so on.