### PR TITLE
Replace `toString(uint8_t)` with template to avoid unintentional truncation of values

### DIFF
--- a/Sming/Core/Data/BitSet.h
+++ b/Sming/Core/Data/BitSet.h
@@ -453,7 +453,10 @@ constexpr
 	return a | b;
 }
 
-String toString(uint8_t value);
+template <typename T> typename std::enable_if<std::is_integral<T>::value, String>::type toString(T value)
+{
+	return String(value);
+}
 
 /**
  * @brief Class template to print the contents of a BitSet to a String

--- a/tests/HostTests/modules/BitSet.cpp
+++ b/tests/HostTests/modules/BitSet.cpp
@@ -144,6 +144,13 @@ public:
 			REQUIRE(sizeof(large) == 8);
 			REQUIRE(large.domain().value() == 0x7FFFFFFFFULL);
 		}
+
+		TEST_CASE("toString")
+		{
+			REQUIRE(toString(12) == "12");
+			REQUIRE(toString(12345678) == "12345678");
+			REQUIRE(toString(12345678912345ULL) == "12345678912345");
+		}
 	}
 };
 


### PR DESCRIPTION
e.g. uint32_t -> uint8_t gets truncated without warning