### PR TITLE
Provide `LinkedObject` for general use

### DIFF
--- a/Sming/Components/Storage/src/include/Storage/Device.h
+++ b/Sming/Components/Storage/src/include/Storage/Device.h
@@ -10,7 +10,7 @@
 #pragma once
 
 #include <WString.h>
-#include "ObjectList.h"
+#include <Core/Data/LinkedObjectList.h>
 #include "PartitionTable.h"
 
 #define STORAGE_TYPE_MAP(XX)                                                                                           \
@@ -29,11 +29,11 @@ class SpiFlash;
 /**
  * @brief Represents a storage device (e.g. flash memory)
  */
-class Device : public ObjectTemplate<Device>
+class Device : public LinkedObjectTemplate<Device>
 {
 public:
-	using List = ObjectListTemplate<Device>;
-	using OwnedList = OwnedObjectListTemplate<Device>;
+	using List = LinkedObjectListTemplate<Device>;
+	using OwnedList = OwnedLinkedObjectListTemplate<Device>;
 
 	/**
 	 * @brief Storage type

--- a/Sming/Core/Data/LinkedObject.h
+++ b/Sming/Core/Data/LinkedObject.h
@@ -4,7 +4,7 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * Object.h - Base Storage object definition
+ * LinkedObject.h
  *
  ****/
 #pragma once
@@ -12,46 +12,48 @@
 #include <iterator>
 #include <algorithm>
 
-namespace Storage
-{
-class ObjectList;
-
-class Object
+/**
+ * @brief Base virtual class to allow objects to be linked together
+ * 
+ * This can be more efficient than defining a separate list, as each object
+ * requires only an additional pointer field for 'next'.
+ */
+class LinkedObject
 {
 public:
-	virtual ~Object()
+	virtual ~LinkedObject()
 	{
 	}
 
-	virtual Object* next() const
-	{
-		return mNext;
-	}
-
-	Object* getNext() const
+	virtual LinkedObject* next() const
 	{
 		return mNext;
 	}
 
-	bool operator==(const Object& other) const
+	LinkedObject* getNext() const
+	{
+		return mNext;
+	}
+
+	bool operator==(const LinkedObject& other) const
 	{
 		return this == &other;
 	}
 
-	bool operator!=(const Object& other) const
+	bool operator!=(const LinkedObject& other) const
 	{
 		return this != &other;
 	}
 
 private:
-	friend class ObjectList;
-	Object* mNext{nullptr};
+	friend class LinkedObjectList;
+	LinkedObject* mNext{nullptr};
 };
 
 /**
  * @brief Base class template for linked items with type casting
  */
-template <typename ObjectType> class ObjectTemplate : public Object
+template <typename ObjectType> class LinkedObjectTemplate : public LinkedObject
 {
 public:
 	template <typename T, typename TPtr, typename TRef>
@@ -140,5 +142,3 @@ public:
 		return ConstIterator(nullptr);
 	}
 };
-
-} // namespace Storage

--- a/Sming/Core/Data/LinkedObjectList.cpp
+++ b/Sming/Core/Data/LinkedObjectList.cpp
@@ -4,21 +4,19 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * ObjectList.cpp
+ * LinkedObjectList.cpp
  *
  ****/
 
-#include "include/Storage/ObjectList.h"
+#include "LinkedObjectList.h"
 
-namespace Storage
-{
-bool ObjectList::add(Object* object)
+bool LinkedObjectList::add(LinkedObject* object)
 {
 	if(object == nullptr) {
 		return false;
 	}
 
-	Object* prev = nullptr;
+	LinkedObject* prev = nullptr;
 	auto it = mHead;
 	while(it != nullptr) {
 		if(it == object) {
@@ -38,7 +36,7 @@ bool ObjectList::add(Object* object)
 	return true;
 }
 
-bool ObjectList::remove(Object* object)
+bool LinkedObjectList::remove(LinkedObject* object)
 {
 	if(object == nullptr || mHead == nullptr) {
 		return false;
@@ -61,5 +59,3 @@ bool ObjectList::remove(Object* object)
 
 	return false;
 }
-
-} // namespace Storage

--- a/Sming/Core/Data/LinkedObjectList.h
+++ b/Sming/Core/Data/LinkedObjectList.h
@@ -4,51 +4,48 @@
  * http://github.com/SmingHub/Sming
  * All files of the Sming Core are provided under the LGPL v3 license.
  *
- * Object.h - Base Storage object definition
+ * LinkedObjectList.h
  *
  ****/
 #pragma once
 
-#include "Object.h"
-#include <vector>
+#include "LinkedObject.h"
 
-namespace Storage
-{
 /**
  * @brief Singly-linked list of objects
  * @note We don't own the items, just keep references to them
  */
-class ObjectList
+class LinkedObjectList
 {
 public:
-	ObjectList()
+	LinkedObjectList()
 	{
 	}
 
-	ObjectList(Object* object) : mHead(object)
+	LinkedObjectList(LinkedObject* object) : mHead(object)
 	{
 	}
 
-	bool add(Object* object);
+	bool add(LinkedObject* object);
 
-	bool add(const Object* object)
+	bool add(const LinkedObject* object)
 	{
-		return add(const_cast<Object*>(object));
+		return add(const_cast<LinkedObject*>(object));
 	}
 
-	bool remove(Object* object);
+	bool remove(LinkedObject* object);
 
 	void clear()
 	{
 		mHead = nullptr;
 	}
 
-	Object* head()
+	LinkedObject* head()
 	{
 		return mHead;
 	}
 
-	const Object* head() const
+	const LinkedObject* head() const
 	{
 		return mHead;
 	}
@@ -59,15 +56,15 @@ public:
 	}
 
 protected:
-	Object* mHead{nullptr};
+	LinkedObject* mHead{nullptr};
 };
 
-template <typename ObjectType> class ObjectListTemplate : public ObjectList
+template <typename ObjectType> class LinkedObjectListTemplate : public LinkedObjectList
 {
 public:
-	ObjectListTemplate() = default;
+	LinkedObjectListTemplate() = default;
 
-	ObjectListTemplate(ObjectType* object) : ObjectList(object)
+	LinkedObjectListTemplate(ObjectType* object) : LinkedObjectList(object)
 	{
 	}
 
@@ -116,12 +113,12 @@ public:
  * @brief Class template for singly-linked list of objects
  * @note We own the objects so are responsible for destroying them when removed
  */
-template <typename ObjectType> class OwnedObjectListTemplate : public ObjectListTemplate<ObjectType>
+template <typename ObjectType> class OwnedLinkedObjectListTemplate : public LinkedObjectListTemplate<ObjectType>
 {
 public:
 	bool remove(ObjectType* object)
 	{
-		bool res = ObjectList::remove(object);
+		bool res = LinkedObjectList::remove(object);
 		delete object;
 		return res;
 	}
@@ -133,5 +130,3 @@ public:
 		}
 	}
 };
-
-} // namespace Storage


### PR DESCRIPTION
This PR moves the 'linked object' classes out of `Storage` and into `Core/Data`, renamed as `LinkedObject...`.

Here's a nice article with pictures illustrating the concept https://www.softwaretestinghelp.com/linked-list/

These classes are templated so code can be a bit neater.
Iterator support included.

See Storage Component for how it's used.