### PR TITLE
Replace SimpleHTTPServer with http.server

### DIFF
--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -545,7 +545,7 @@ SERVER_OTA_PORT		?= 9999
 .PHONY: otaserver
 otaserver: all ##Launch a simple python HTTP server for testing OTA updates
 	$(info Starting OTA server for TESTING)
-	$(Q) cd $(FW_BASE) && $(PYTHON) -m SimpleHTTPServer $(SERVER_OTA_PORT)
+	$(Q) cd $(FW_BASE) && $(PYTHON) -m http.server $(SERVER_OTA_PORT)
 
 
 #


### PR DESCRIPTION
Python2 is not longer maintained. Most of the Linux distro swiched to it.
In python3 `SimpleHTTPServer` module was replaced with `http.server`