### PR TITLE
vscode config generator fixes

### DIFF
--- a/Tools/vscode/setup.py
+++ b/Tools/vscode/setup.py
@@ -42,6 +42,14 @@ class Env:
     def isWsl(self):
         return self.WSL_ROOT != ''
 
+    def update(self, env):
+        env['SMING_HOME'] = self.SMING_HOME
+        if self.SMING_ARCH == 'Esp8266':
+            env['ESP_HOME'] = self.ESP_HOME
+        if self.SMING_ARCH == 'Esp32':
+            env['IDF_PATH'] = self.IDF_PATH
+            env['IDF_TOOLS_PATH'] = self.IDF_PATH
+
 
 env = Env()
 
@@ -107,6 +115,7 @@ def update_intellisense():
     else:
         properties = load_template('intellisense/properties.json')
 
+    env.update(get_property(properties, 'env', {}))
     configurations = get_property(properties, 'configurations', [])
 
     config = find_object(configurations, env.SMING_ARCH)

--- a/Tools/vscode/setup.py
+++ b/Tools/vscode/setup.py
@@ -55,8 +55,16 @@ env = Env()
 
 
 def fix_path(path):
+    """Fix path so it conforms to makefile specs"""
     if path[1:3] == ':/':
         return '/' + path[0] + path[2:]
+    return path
+
+def check_path(path):
+    """Fix path so it conforms to vscode specs"""
+    if sys.platform == 'win32':
+        if path[:1] == '/':
+            return path[1:2] + ':' + path[2:]
     return path
 
 def find_tool(name):
@@ -107,7 +115,7 @@ def get_property(data, name, default):
 def update_intellisense():
     dirs = os.environ['COMPONENTS_EXTRA_INCDIR'].split()
     for i, d in enumerate(dirs):
-        dirs[i] = env.subst_path(d)
+        dirs[i] = check_path(env.subst_path(d))
 
     propertiesFile = '.vscode/c_cpp_properties.json'
     if os.path.exists(propertiesFile):

--- a/Tools/vscode/setup.py
+++ b/Tools/vscode/setup.py
@@ -52,6 +52,9 @@ def fix_path(path):
     return path
 
 def find_tool(name):
+    if sys.platform == 'win32':
+        if os.path.splitext(name)[1] != '.exe':
+            name += '.exe'
     if os.path.isabs(name):
         path = name
     else:

--- a/Tools/vscode/template/intellisense/properties.json
+++ b/Tools/vscode/template/intellisense/properties.json
@@ -1,4 +1,5 @@
 {
+    "env": {},
     "configurations": [],
     "version": 4
 }


### PR DESCRIPTION
Windows requires file extensions for tools (.exe)
Update `env` section in intellisense information, keeps them in sync with command-line (which may be running in different shell)
Fix file paths emitted for windows, require "c:/path/to/file" structure instead of "/c/path/to/file"