### PR TITLE
Storage improvements

### DIFF
--- a/Sming/Arch/Esp32/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Esp32/Components/spi_flash/flashmem.cpp
@@ -13,6 +13,7 @@
 #include <soc/dport_reg.h>
 #include <esp_app_format.h>
 #include <esp_flash_partitions.h>
+#include <esp_flash.h>
 
 /*
  * Physical <-> Virtual address mapping is handled in `$IDF_COMPONENTS/spi_flash/flash_mmap.c`.
@@ -114,4 +115,13 @@ uint32_t flashmem_find_sector(uint32_t address, uint32_t* pstart, uint32_t* pend
 uint32_t flashmem_get_sector_of_address(uint32_t addr)
 {
 	return flashmem_find_sector(addr, NULL, NULL);
+}
+
+uint32_t spi_flash_get_id(void)
+{
+	uint32_t id{0};
+	if(esp_flash_read_id(esp_flash_default_chip, &id) != ESP_OK) {
+		id = 0;
+	}
+	return id;
 }

--- a/Sming/Arch/Esp32/Components/spi_flash/include/esp_spi_flash.h
+++ b/Sming/Arch/Esp32/Components/spi_flash/include/esp_spi_flash.h
@@ -149,6 +149,8 @@ uint32_t flashmem_get_sector_of_address(uint32_t addr);
 
 /** @} */
 
+uint32_t spi_flash_get_id(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/Arch/Esp32/standard.hw
+++ b/Sming/Arch/Esp32/standard.hw
@@ -26,7 +26,7 @@
 		},
 		"factory": {
 			"address": "0x010000",
-			"size": "0x1f0000",
+			"size": "0x180000",
 			"type": "app",
 			"subtype": "factory",
 			"filename": "$(TARGET_BIN)"

--- a/Sming/Arch/Host/app.mk
+++ b/Sming/Arch/Host/app.mk
@@ -43,3 +43,10 @@ $(RUN_SCRIPT)::
 	$(foreach id,$(ENABLE_HOST_UARTID),echo '$(call RunHostTerminal,$(id))' >> $@;) \
 	echo '$(TARGET_OUT_0) $(CLI_TARGET_OPTIONS) -- $(HOST_PARAMETERS)' >> $@; \
 	chmod a+x $@
+
+##@Flashing
+
+.PHONY: flashconfig
+flashconfig: kill_term ##Erase the rBoot config sector
+	$(info Erasing rBoot config sector)
+	$(call WriteFlash,$(FLASH_RBOOT_ERASE_CONFIG_CHUNKS))

--- a/Sming/Components/Storage/Tools/hwconfig/config.py
+++ b/Sming/Components/Storage/Tools/hwconfig/config.py
@@ -10,7 +10,7 @@ from builtins import classmethod
 def findConfig(name):
     dirs = os.environ['HWCONFIG_DIRS'].split(' ')
     for d in dirs:
-        path = os.path.join(fixpath(d), name + '.hw')
+        path = fixpath(d) + '/' + name + '.hw'
         if os.path.exists(path):
             return path
     raise InputError("Config '%s' not found" % name)

--- a/Sming/Components/Storage/src/Iterator.cpp
+++ b/Sming/Components/Storage/src/Iterator.cpp
@@ -10,7 +10,6 @@
 
 #include "include/Storage/Iterator.h"
 #include "include/Storage/SpiFlash.h"
-#include <debug_progmem.h>
 
 namespace Storage
 {

--- a/Sming/Components/Storage/src/SpiFlash.cpp
+++ b/Sming/Components/Storage/src/SpiFlash.cpp
@@ -22,7 +22,7 @@ String SpiFlash::getName() const
 	return FS_SPIFLASH;
 }
 
-uint32_t SpiFlash::getID() const
+uint32_t SpiFlash::getId() const
 {
 	return spi_flash_get_id();
 }

--- a/Sming/Components/Storage/src/SpiFlash.cpp
+++ b/Sming/Components/Storage/src/SpiFlash.cpp
@@ -22,6 +22,11 @@ String SpiFlash::getName() const
 	return FS_SPIFLASH;
 }
 
+uint32_t SpiFlash::getID() const
+{
+	return spi_flash_get_id();
+}
+
 size_t SpiFlash::getBlockSize() const
 {
 	return SPI_FLASH_SEC_SIZE;

--- a/Sming/Components/Storage/src/include/Storage/Device.h
+++ b/Sming/Components/Storage/src/include/Storage/Device.h
@@ -92,7 +92,7 @@ public:
 	 * @brief Obtain device ID
 	 * @retval uint32_t typically flash chip ID
 	 */
-	virtual uint32_t getID() const
+	virtual uint32_t getId() const
 	{
 		return 0;
 	}

--- a/Sming/Components/Storage/src/include/Storage/Device.h
+++ b/Sming/Components/Storage/src/include/Storage/Device.h
@@ -89,6 +89,15 @@ public:
 	virtual String getName() const = 0;
 
 	/**
+	 * @brief Obtain device ID
+	 * @retval uint32_t typically flash chip ID
+	 */
+	virtual uint32_t getID() const
+	{
+		return 0;
+	}
+
+	/**
 	 * @brief Obtain smallest allocation unit for erase operations
 	 */
 	virtual size_t getBlockSize() const = 0;

--- a/Sming/Components/Storage/src/include/Storage/SpiFlash.h
+++ b/Sming/Components/Storage/src/include/Storage/SpiFlash.h
@@ -30,6 +30,8 @@ public:
 		return Type::flash;
 	}
 
+	uint32_t getID() const;
+
 	bool read(uint32_t address, void* dst, size_t size) override;
 	bool write(uint32_t address, const void* src, size_t size) override;
 	bool erase_range(uint32_t address, size_t size) override;

--- a/Sming/Components/Storage/src/include/Storage/SpiFlash.h
+++ b/Sming/Components/Storage/src/include/Storage/SpiFlash.h
@@ -30,7 +30,7 @@ public:
 		return Type::flash;
 	}
 
-	uint32_t getID() const;
+	uint32_t getId() const;
 
 	bool read(uint32_t address, void* dst, size_t size) override;
 	bool write(uint32_t address, const void* src, size_t size) override;

--- a/Sming/Components/rboot/component.mk
+++ b/Sming/Components/rboot/component.mk
@@ -129,6 +129,7 @@ COMPONENT_CXXFLAGS += \
 
 ifdef RBOOT_EMULATION
 FLASH_BOOT_CHUNKS		= 0x00000=$(BLANK_BIN)
+FLASH_RBOOT_ERASE_CONFIG_CHUNKS	:= 0x01000=$(BLANK_BIN)
 else
 export RBOOT_ROM0_ADDR
 export RBOOT_ROM1_ADDR
@@ -151,7 +152,7 @@ endif
 
 # Define our flash chunks
 FLASH_BOOT_CHUNKS				:= 0x00000=$(RBOOT_BIN)
-FLASH_RBOOT_ERASE_CONFIG_CHUNKS	:= 0x01000=$(SDK_BASE)/bin/blank.bin
+FLASH_RBOOT_ERASE_CONFIG_CHUNKS	:= 0x01000=$(BLANK_BIN)
 
 # => Automatic linker script generation from template
 # $1 -> application target

--- a/samples/Basic_Storage/app/application.cpp
+++ b/samples/Basic_Storage/app/application.cpp
@@ -5,6 +5,23 @@
 
 IMPORT_FSTR(FS_app, PROJECT_DIR "/app/application.cpp")
 
+void listDevices()
+{
+	Serial.println();
+	Serial.println(_F("Registered storage devices:"));
+	for(auto& dev : Storage::getDevices()) {
+		Serial.print("  name = '");
+		Serial.print(dev.getName());
+		Serial.print(_F("', type = "));
+		Serial.print(toString(dev.getType()));
+		Serial.print(_F(", size = 0x"));
+		Serial.print(dev.getSize(), HEX);
+		Serial.print(_F(", ID = 0x"));
+		Serial.println(dev.getID(), HEX);
+	}
+	Serial.println();
+}
+
 void listSpiffsPartitions()
 {
 	Serial.println(_F("** Enumerate registered SPIFFS partitions"));
@@ -62,6 +79,8 @@ void init()
 {
 	Serial.begin(SERIAL_BAUD_RATE);
 	Serial.systemDebugOutput(true);
+
+	listDevices();
 
 	listSpiffsPartitions();
 

--- a/samples/Basic_Storage/app/application.cpp
+++ b/samples/Basic_Storage/app/application.cpp
@@ -17,7 +17,7 @@ void listDevices()
 		Serial.print(_F(", size = 0x"));
 		Serial.print(dev.getSize(), HEX);
 		Serial.print(_F(", ID = 0x"));
-		Serial.println(dev.getID(), HEX);
+		Serial.println(dev.getId), HEX);
 	}
 	Serial.println();
 }

--- a/samples/Basic_Storage/basic_storage.hw
+++ b/samples/Basic_Storage/basic_storage.hw
@@ -4,7 +4,6 @@
 	"devices": {
 		// Override default (conservative) flash settings for maximum performance
 		"spiFlash": {
-			"mode": "qio",
 			"speed": 80
 		}
 	},

--- a/samples/Basic_rBoot/app/application.cpp
+++ b/samples/Basic_rBoot/app/application.cpp
@@ -121,9 +121,9 @@ void ShowInfo()
 	conf = rboot_get_config();
 
 	debugf("Count: %d", conf.count);
-	debugf("ROM 0: %d", conf.roms[0]);
-	debugf("ROM 1: %d", conf.roms[1]);
-	debugf("ROM 2: %d", conf.roms[2]);
+	debugf("ROM 0: 0x%08x", conf.roms[0]);
+	debugf("ROM 1: 0x%08x", conf.roms[1]);
+	debugf("ROM 2: 0x%08x", conf.roms[2]);
 	debugf("GPIO ROM: %d", conf.gpio_rom);
 }
 

--- a/samples/Basic_rBoot/app/application.cpp
+++ b/samples/Basic_rBoot/app/application.cpp
@@ -115,7 +115,7 @@ void ShowInfo()
 	Serial.printf("Free Heap: %d\r\n", system_get_free_heap_size());
 	Serial.printf("CPU Frequency: %d MHz\r\n", system_get_cpu_freq());
 	Serial.printf("System Chip ID: %x\r\n", system_get_chip_id());
-	Serial.printf("SPI Flash ID: %x\r\n", Storage::spiFlash->getID());
+	Serial.printf("SPI Flash ID: %x\r\n", Storage::spiFlash->getId());
 	//Serial.printf("SPI Flash Size: %d\r\n", (1 << ((spi_flash_get_id() >> 16) & 0xff)));
 
 	rboot_config conf;

--- a/samples/Basic_rBoot/app/application.cpp
+++ b/samples/Basic_rBoot/app/application.cpp
@@ -1,5 +1,6 @@
 #include <SmingCore.h>
 #include <Network/RbootHttpUpdater.h>
+#include <Storage/SpiFlash.h>
 
 // download urls, set appropriately
 #define ROM_0_URL "http://192.168.7.5:80/rom0.bin"
@@ -114,7 +115,7 @@ void ShowInfo()
 	Serial.printf("Free Heap: %d\r\n", system_get_free_heap_size());
 	Serial.printf("CPU Frequency: %d MHz\r\n", system_get_cpu_freq());
 	Serial.printf("System Chip ID: %x\r\n", system_get_chip_id());
-	Serial.printf("SPI Flash ID: %x\r\n", spi_flash_get_id());
+	Serial.printf("SPI Flash ID: %x\r\n", Storage::spiFlash->getID());
 	//Serial.printf("SPI Flash Size: %d\r\n", (1 << ((spi_flash_get_id() >> 16) & 0xff)));
 
 	rboot_config conf;

--- a/samples/Basic_rBoot/component.mk
+++ b/samples/Basic_rBoot/component.mk
@@ -8,6 +8,4 @@ ifeq ($(SMING_ARCH),Esp8266)
 HWCONFIG := basic_rboot
 else
 HWCONFIG := spiffs
-# Emulate UART 0
-ENABLE_HOST_UARTID := 0
 endif

--- a/tests/HostTests/modules/Spiffs.cpp
+++ b/tests/HostTests/modules/Spiffs.cpp
@@ -36,7 +36,7 @@ public:
 	 */
 	void cycleFlash()
 	{
-		spiffs_unmount();
+		fileFreeFileSystem();
 		if(!spiffs_mount()) {
 			debug_e("SPIFFS mount failed");
 			return;
@@ -68,7 +68,7 @@ public:
 		debug_i("Sector #0 erased after %u writes", writeCount);
 
 		// Re-mount file system and confirm test file is still present
-		spiffs_unmount();
+		fileFreeFileSystem();
 		spiffs_mount();
 		auto content = fileGetContent(testFile);
 		REQUIRE(testContent == content);


### PR DESCRIPTION
Basic_rBoot

- Show ROM addresses in Hex
- Basic_rBoot use console by default instead of telnet emulation in Host


Add `Storage::Device::getID()` method

Add `spi_flash_get_id()` implementation for ESP32

Update Basic_Storage sample

- Reduce default esp32 app partition size, bit big
- QIO mode doesn't always work, remove it
- List storage devices, with ID


Add `flashconfig` target for Host

Fix inconsistent HWCONFIG path separation in Windows

- Using GNU make / mingw conventions


Remove unused header
Fix use of deprecated functions
