### PR TITLE
Upgrade to clang-format 8

### DIFF
--- a/Sming/Core/Network/NtpClient.cpp
+++ b/Sming/Core/Network/NtpClient.cpp
@@ -46,13 +46,14 @@ void NtpClient::requestTime()
 	}
 
 	ip_addr_t resolvedIp;
-	int result = dns_gethostbyname(server.c_str(), &resolvedIp,
-								   [](const char* name, LWIP_IP_ADDR_T* ip, void* arg) {
-									   // We do a new request since the last one was never done.
-									   if(ip)
-										   reinterpret_cast<NtpClient*>(arg)->internalRequestTime(*ip);
-								   },
-								   this);
+	int result = dns_gethostbyname(
+		server.c_str(), &resolvedIp,
+		[](const char* name, LWIP_IP_ADDR_T* ip, void* arg) {
+			// We do a new request since the last one was never done.
+			if(ip)
+				reinterpret_cast<NtpClient*>(arg)->internalRequestTime(*ip);
+		},
+		this);
 
 	debug_d("dns_gethostbyname() returned %d", result);
 

--- a/Sming/Core/Network/TcpConnection.cpp
+++ b/Sming/Core/Network/TcpConnection.cpp
@@ -89,15 +89,16 @@ bool TcpConnection::connect(const String& server, int port, bool useSsl)
 		int port;
 	};
 	DnsLookup* look = new DnsLookup{this, port};
-	err_t dnslook = dns_gethostbyname(server.c_str(), &addr,
-									  [](const char* name, LWIP_IP_ADDR_T* ipaddr, void* arg) {
-										  auto dlook = static_cast<DnsLookup*>(arg);
-										  if(dlook != nullptr) {
-											  dlook->con->internalOnDnsResponse(name, ipaddr, dlook->port);
-											  delete dlook;
-										  }
-									  },
-									  look);
+	err_t dnslook = dns_gethostbyname(
+		server.c_str(), &addr,
+		[](const char* name, LWIP_IP_ADDR_T* ipaddr, void* arg) {
+			auto dlook = static_cast<DnsLookup*>(arg);
+			if(dlook != nullptr) {
+				dlook->con->internalOnDnsResponse(name, ipaddr, dlook->port);
+				delete dlook;
+			}
+		},
+		look);
 	if(dnslook == ERR_INPROGRESS) {
 		// Operation pending - see internalOnDnsResponse()
 		return true;

--- a/Sming/Core/Task.h
+++ b/Sming/Core/Task.h
@@ -112,14 +112,15 @@ public:
 		switch(state) {
 		case State::Suspended:
 		case State::Running:
-			sleepTimer.initializeMs(interval,
-									[](void* param) {
-										auto task = static_cast<Task*>(param);
-										task->notify(Notify::Waking);
-										task->state = State::Running;
-										task->service();
-									},
-									this);
+			sleepTimer.initializeMs(
+				interval,
+				[](void* param) {
+					auto task = static_cast<Task*>(param);
+					task->notify(Notify::Waking);
+					task->state = State::Running;
+					task->service();
+				},
+				this);
 			sleepTimer.startOnce();
 			notify(Notify::Sleeping);
 			state = State::Sleeping;

--- a/Tools/install.sh
+++ b/Tools/install.sh
@@ -93,7 +93,7 @@ if [ -n "$APPVEYOR" ] || [ -n "$GITHUB_ACTION" ]; then
 
     sudo apt-get -y update
     $PKG_INSTALL \
-        clang-format-6.0 \
+        clang-format-8 \
         g++-9-multilib \
         python3-setuptools
 
@@ -105,7 +105,7 @@ else
         debian)
             sudo apt-get -y update
             $PKG_INSTALL \
-                clang-format-6.0 \
+                clang-format-8 \
                 cmake \
             	curl \
             	git \
@@ -143,7 +143,7 @@ else
 
 fi
 
-sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-6.0 100
+sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8 100
 
 python3 -m pip install --upgrade pip -r $SMING_HOME/../Tools/requirements.txt
 

--- a/docs/source/information/develop/clang-tools.rst
+++ b/docs/source/information/develop/clang-tools.rst
@@ -1,11 +1,11 @@
 Clang Tools
 ===========
 
-`clang-format <https://releases.llvm.org/6.0.0/tools/clang/docs/ClangFormat.html>`__
+`clang-format <https://releases.llvm.org/8.0.1/tools/clang/docs/ClangFormat.html>`__
 is a tool that implements automatic source code formatting.
 It can be used to automatically enforce the layout rules for Sming.
 
-`clang-tidy <https://releases.llvm.org/6.0.0/tools/clang/tools/extra/docs/clang-tidy/index.html>`__
+`clang-tidy <https://releases.llvm.org/8.0.1/tools/clang/tools/extra/docs/clang-tidy/index.html>`__
 is a C++ “linter” tool to assist with diagnosing and fixing  typical programming errors
 such as style violations, interface misuse, or bugs that can be deduced via static analysis.
 It is provided as part of 
@@ -26,9 +26,16 @@ See the the `download <http://releases.llvm.org/download.html>`__ page
 of the Clang project for installation instructions for other operating
 systems.
 
-We are using version 6.0 of clang-format and clang-tidy on our
-Continuous Integration (CI) System. You should install the same
-version or newer on your development computer.
+.. important::
+
+   Different versions of clang-format can produce different results,
+   despite using the same configuration file.
+
+   We are using version 8.0.1 of clang-format and clang-tidy on our
+   Continuous Integration (CI) System.
+   
+   You should install the same version on your development computer.
+
 
 
 Configuration


### PR DESCRIPTION
This PR upgrades the standard clang-format tool to version 8.0.1 (final). It produces (slightly) different results to version 6.

Version 6 can no longer be used to submit core changes. Users should upgrade to verison 8 first: `sudo apt install clang-format-8`

Note that cf9 produces yet different results, however at present version 8 is available from Ubuntu 16.04 up to the latest 20.10 (groovy gorilla) release. (Note: cf6 no longer provided in the latter - see #2246).

Existing settings produce different results with version 8.
This seems to be related to the `AlignAfterOpenBracket: Align` setting which appears to use different break rules.
There may be another setting which fixes this but I've not found it!

Setting `AlignAfterOpenBracket: AlwaysBreak` produces consistent results with either version, however the code changes are significant and this is not desirable.