### PR TITLE
Update directory enumeration and FTP server

### DIFF
--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -357,9 +357,9 @@ inline int fileRename(const String& oldName, const String& newName)
 /** @brief  Get list of files on file system
  *  @retval Vector<String> Vector of strings.
             Each string element contains the name of a file on the file system
-    @deprecated use fileOpenDir / fileReadDir / fileCloseDir
+    @deprecated use `Directory` object (or fileOpenDir / fileReadDir / fileCloseDir)
  */
-Vector<String> fileList();
+Vector<String> fileList() SMING_DEPRECATED;
 
 /** @brief  Read content of a file
  *  @param  fileName Name of file to read from

--- a/Sming/Core/Network/Ftp/FtpDataFileList.h
+++ b/Sming/Core/Network/Ftp/FtpDataFileList.h
@@ -12,12 +12,20 @@
 
 #include "FtpDataStream.h"
 #include "FileSystem.h"
+#include <DateTime.h>
 
 class FtpDataFileList : public FtpDataStream
 {
 public:
-	explicit FtpDataFileList(FtpServerConnection& connection) : FtpDataStream(connection)
+	explicit FtpDataFileList(FtpServerConnection& connection, const String& path = nullptr) : FtpDataStream(connection)
 	{
+		auto& stat = const_cast<FileStat&>(dir.stat());
+		if(fileStats(path, stat) == FS_OK && !stat.attr[FileAttribute::Directory]) {
+			isFile = true;
+		} else {
+			isFile = false;
+			dir.open(path);
+		}
 	}
 
 	void transferData(TcpConnectionEvent sourceEvent) override
@@ -25,17 +33,39 @@ public:
 		if(completed) {
 			return;
 		}
-		Vector<String> list = fileList();
-		debug_d("send file list: %d", list.count());
-		for(unsigned i = 0; i < list.count(); i++) {
-			String s = F("01-01-15  01:00AM               ");
-			s += fileGetSize(list[i]);
-			s += ' ';
-			s += list[i];
-			s += "\r\n";
-			writeString(s);
+
+		if(isFile) {
+			writeStat(dir.stat());
+			completed = true;
+			return;
 		}
+
+		if(dir.next()) {
+			writeStat(dir.stat());
+			return;
+		}
+
+		debug_d("sent file list: %u", dir.count());
 		completed = true;
 		finishTransfer();
 	}
+
+	void writeStat(const FileStat& stat)
+	{
+		DateTime dt{stat.mtime};
+		char buf[64];
+		int n = m_snprintf(buf, sizeof(buf), _F("%02u-%02u-%02u  %02u:%02u%cM               %-6u "), dt.Day, dt.Month,
+						   dt.Year - 2000, (dt.Hour % 12) ?: 12, dt.Minute, dt.Hour >= 12 ? 'P' : 'A', stat.size);
+		if(n <= 0) {
+			writeString(F("ERROR"));
+		} else {
+			write(buf, n);
+		}
+		write(stat.name, stat.name.length);
+		write("\r\n", 2);
+	}
+
+private:
+	Directory dir;
+	bool isFile;
 };

--- a/Sming/Core/Network/Ftp/FtpDataStream.h
+++ b/Sming/Core/Network/Ftp/FtpDataStream.h
@@ -16,7 +16,7 @@
 class FtpDataStream : public TcpConnection
 {
 public:
-	explicit FtpDataStream(FtpServerConnection& connection) : TcpConnection(true), parent(connection)
+	explicit FtpDataStream(FtpServerConnection& control) : TcpConnection(true), control(control)
 	{
 	}
 
@@ -29,12 +29,12 @@ public:
 	void finishTransfer()
 	{
 		close();
-		parent.dataTransferFinished(this);
+		control.dataTransferFinished(this);
 	}
 
 	void response(int code, String text = nullptr)
 	{
-		parent.response(code, text);
+		control.response(code, text);
 	}
 
 	void onReadyToSendData(TcpConnectionEvent sourceEvent) override
@@ -51,6 +51,6 @@ public:
 	}
 
 protected:
-	FtpServerConnection& parent;
+	FtpServerConnection& control;
 	bool completed{false};
 };

--- a/Sming/Core/Network/Ftp/FtpDataStream.h
+++ b/Sming/Core/Network/Ftp/FtpDataStream.h
@@ -44,6 +44,11 @@ public:
 	{
 	}
 
+	~FtpDataStream()
+	{
+		control.dataStreamDestroyed(this);
+	}
+
 	err_t onConnected(err_t err) override
 	{
 		setTimeOut(300);

--- a/Sming/Core/Network/Ftp/FtpDataStream.h
+++ b/Sming/Core/Network/Ftp/FtpDataStream.h
@@ -22,19 +22,8 @@ public:
 
 	err_t onConnected(err_t err) override
 	{
-		//response(125, "Connected");
-		setTimeOut(300); // Update timeout
+		setTimeOut(300);
 		return TcpConnection::onConnected(err);
-	}
-
-	err_t onSent(uint16_t len) override
-	{
-		sent += len;
-		if(written < sent || !completed) {
-			return TcpConnection::onSent(len);
-		}
-		finishTransfer();
-		return TcpConnection::onSent(len);
 	}
 
 	void finishTransfer()
@@ -48,21 +37,13 @@ public:
 		parent.response(code, text);
 	}
 
-	int write(const char* data, int len, uint8_t apiflags = 0) override
-	{
-		written += len;
-		return TcpConnection::write(data, len, apiflags);
-	}
-
 	void onReadyToSendData(TcpConnectionEvent sourceEvent) override
 	{
-		if(!parent.isCanTransfer()) {
-			return;
-		}
-		if(completed && written == 0) {
+		if(completed) {
 			finishTransfer();
+		} else {
+			transferData(sourceEvent);
 		}
-		transferData(sourceEvent);
 	}
 
 	virtual void transferData(TcpConnectionEvent sourceEvent)
@@ -72,6 +53,4 @@ public:
 protected:
 	FtpServerConnection& parent;
 	bool completed{false};
-	unsigned written{0};
-	unsigned sent{0};
 };

--- a/Sming/Core/Network/Ftp/FtpDataStream.h
+++ b/Sming/Core/Network/Ftp/FtpDataStream.h
@@ -13,6 +13,30 @@
 #include "FtpServerConnection.h"
 #include "Network/TcpConnection.h"
 
+/*
+	RFC959:
+
+	User-DTP listens on data port when required.
+
+	Server is responsible for creating the data connection.
+
+	The server MUST close the data connection under the following conditions:
+
+		1. The server has completed sending data in a transfer mode
+		that requires a close to indicate EOF.
+
+		2. The server receives an ABORT command from the user.
+
+		3. The port specification is changed by a command from the user.
+
+		4. The control connection is closed legally or otherwise.
+
+		5. An irrecoverable error condition occurs.
+
+	Otherwise the close is a server option, the exercise of which the
+	server must indicate to the user-process by either a 250 or 226
+	reply only.
+*/
 class FtpDataStream : public TcpConnection
 {
 public:

--- a/Sming/Core/Network/Ftp/FtpServerConnection.cpp
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.cpp
@@ -225,7 +225,8 @@ void FtpServerConnection::onCommand(String cmd, String data)
 	// Strong security check :)
 	case Command::USER:
 		// Authenticate or re-authenticate, wiping existing credentials
-		user = User{data};
+		user = User{};
+		user.name = data;
 		response(331); // User name OK, need password
 		break;
 

--- a/Sming/Core/Network/Ftp/FtpServerConnection.cpp
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.cpp
@@ -318,7 +318,7 @@ void FtpServerConnection::response(int code, String text)
 	response += "\r\n";
 
 	debug_d("> %s", response.c_str());
-	writeString(response, TCP_WRITE_FLAG_COPY); // Dynamic memory, should copy
+	writeString(response);
 	canTransfer = false;
 	flush();
 }
@@ -327,7 +327,7 @@ void FtpServerConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 {
 	switch(state) {
 	case State::Ready:
-		writeString(_F("220 Welcome to Sming FTP\r\n"), 0);
+		writeString(_F("220 Welcome to Sming FTP\r\n"));
 		state = State::Authorization;
 		break;
 

--- a/Sming/Core/Network/Ftp/FtpServerConnection.cpp
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.cpp
@@ -116,6 +116,7 @@ err_t FtpServerConnection::onReceive(pbuf* buf)
 	int prev = 0;
 
 	while(true) {
+		debug_hex(DBG, "CTRL < ", buf->payload, buf->len);
 		int p = NetUtils::pbufFindStr(buf, "\r\n", prev);
 		if(p < 0 || size_t(p - prev) > MAX_FTP_CMD) {
 			break;
@@ -385,6 +386,15 @@ void FtpServerConnection::createDataConnection(FtpDataStream* connection)
 	dataConnection = connection;
 	dataConnection->connect(ip, port);
 	response(150, F("Connecting"));
+}
+
+void FtpServerConnection::dataStreamDestroyed(TcpConnection* connection)
+{
+	if(connection != dataConnection) {
+		SYSTEM_ERROR("FTP Wrong state: connection != dataConnection");
+	}
+
+	dataConnection = nullptr;
 }
 
 void FtpServerConnection::dataTransferFinished(TcpConnection* connection)

--- a/Sming/Core/Network/Ftp/FtpServerConnection.cpp
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.cpp
@@ -273,19 +273,20 @@ void FtpServerConnection::onCommand(String cmd, String data)
 		break;
 
 	default:
-		debug_e("Invalid state");
-		assert(false);
+		debug_e("Invalid state %u", state);
 	}
 }
 
 err_t FtpServerConnection::onSent(uint16_t len)
 {
-	canTransfer = true;
+	if(dataConnection != nullptr) {
+		dataConnection->onReadyToSendData(eTCE_Poll);
+	}
 
 	return ERR_OK;
 }
 
-void FtpServerConnection::createDataConnection(TcpConnection* connection)
+void FtpServerConnection::createDataConnection(FtpDataStream* connection)
 {
 	dataConnection = connection;
 	dataConnection->connect(ip, port);
@@ -319,7 +320,6 @@ void FtpServerConnection::response(int code, String text)
 
 	debug_d("> %s", response.c_str());
 	writeString(response);
-	canTransfer = false;
 	flush();
 }
 

--- a/Sming/Core/Network/Ftp/FtpServerConnection.h
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.h
@@ -13,7 +13,7 @@
 #include "Network/TcpConnection.h"
 #include "IpAddress.h"
 #include "WString.h"
-#include <FileSystem.h>
+#include <IFS/FileSystem.h>
 
 /**
  * @defgroup ftp FTP
@@ -55,6 +55,9 @@ public:
 		return user;
 	}
 
+	// Get the active filesystem, send an error response if undefined
+	IFS::FileSystem* getFileSystem();
+
 	virtual void response(int code, String text = nullptr, char sep = ' ');
 
 protected:
@@ -62,7 +65,7 @@ protected:
 
 	void cmdPort(const String& data);
 	void createDataConnection(FtpDataStream* connection);
-	bool checkFileAccess(const String& filename, FileOpenFlags flags);
+	bool checkFileAccess(const String& filename, IFS::OpenFlags flags);
 
 private:
 	CustomFtpServer& server;

--- a/Sming/Core/Network/Ftp/FtpServerConnection.h
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.h
@@ -21,6 +21,7 @@
  */
 
 class FtpServer;
+class FtpDataStream;
 
 class FtpServerConnection : public TcpConnection
 {
@@ -46,12 +47,7 @@ protected:
 	virtual void response(int code, String text = "");
 
 	void cmdPort(const String& data);
-	void createDataConnection(TcpConnection* connection);
-
-	bool isCanTransfer()
-	{
-		return canTransfer;
-	}
+	void createDataConnection(FtpDataStream* connection);
 
 private:
 	enum class State {
@@ -67,8 +63,7 @@ private:
 
 	IpAddress ip;
 	int port{0};
-	TcpConnection* dataConnection{nullptr};
-	bool canTransfer{true};
+	FtpDataStream* dataConnection{nullptr};
 };
 
 typedef FtpServerConnection FTPServerConnection SMING_DEPRECATED; // @deprecated Use `FtpServerConnection` instead

--- a/Sming/Core/Network/Ftp/FtpServerConnection.h
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.h
@@ -31,7 +31,7 @@ class FtpServerConnection : public TcpConnection
 
 public:
 	struct User {
-		String name;
+		CString name;
 		IFS::UserRole role{};
 
 		bool isValid() const
@@ -65,16 +65,18 @@ protected:
 
 	void cmdPort(const String& data);
 	void setDataConnection(FtpDataStream* connection);
-	bool checkFileAccess(const String& filename, IFS::OpenFlags flags);
+	String resolvePath(const char* name);
+	bool checkFileAccess(const char* filename, IFS::OpenFlags flags);
 
 private:
 	CustomFtpServer& server;
 	User user{};
-	String renameFrom;
+	CString renameFrom;
 
 	IpAddress ip;
 	uint16_t port{20};
-	String cwd;
+	bool readyForData{false};
+	CString cwd;
 	FtpDataStream* dataConnection{nullptr};
 };
 

--- a/Sming/Core/Network/Ftp/FtpServerConnection.h
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.h
@@ -48,6 +48,7 @@ public:
 	err_t onSent(uint16_t len) override;
 
 	void dataTransferFinished(TcpConnection* connection);
+	void dataStreamDestroyed(TcpConnection* connection);
 
 	const User& getUser() const
 	{

--- a/Sming/Core/Network/Ftp/FtpServerConnection.h
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.h
@@ -64,7 +64,7 @@ protected:
 	virtual void onCommand(String cmd, String data);
 
 	void cmdPort(const String& data);
-	void createDataConnection(FtpDataStream* connection);
+	void setDataConnection(FtpDataStream* connection);
 	bool checkFileAccess(const String& filename, IFS::OpenFlags flags);
 
 private:

--- a/Sming/Core/Network/Ftp/FtpServerConnection.h
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.h
@@ -13,7 +13,7 @@
 #include "Network/TcpConnection.h"
 #include "IpAddress.h"
 #include "WString.h"
-#include <IFS/Access.h>
+#include <FileSystem.h>
 
 /**
  * @defgroup ftp FTP
@@ -61,6 +61,7 @@ protected:
 
 	void cmdPort(const String& data);
 	void createDataConnection(FtpDataStream* connection);
+	bool checkFileAccess(const String& filename, FileOpenFlags flags);
 
 private:
 	CustomFtpServer& server;

--- a/Sming/Core/Network/FtpServer.cpp
+++ b/Sming/Core/Network/FtpServer.cpp
@@ -32,8 +32,11 @@ IFS::UserRole FtpServer::validateUser(const String& login, const String& pass)
 bool FtpServer::onCommand(String cmd, String data, FtpServerConnection& connection)
 {
 	if(cmd == _F("FSFORMAT")) {
-		int err = fileSystemFormat();
-		connection.response(200, F("File system format: ") + fileGetErrorString(err));
+		auto fs = connection.getFileSystem();
+		if(fs != nullptr) {
+			int err = fs->format();
+			connection.response(200, F("File system format: ") + fileGetErrorString(err));
+		}
 		return true;
 	}
 	return false;

--- a/Sming/Core/Network/FtpServer.cpp
+++ b/Sming/Core/Network/FtpServer.cpp
@@ -10,34 +10,30 @@
 
 #include "FtpServer.h"
 #include "Ftp/FtpServerConnection.h"
-#include "FileSystem.h"
 
-TcpConnection* FtpServer::createClient(tcp_pcb* clientTcp)
+TcpConnection* CustomFtpServer::createClient(tcp_pcb* clientTcp)
 {
 	return new FtpServerConnection(*this, clientTcp);
 }
 
-void FtpServer::addUser(const String& login, const String& pass)
+void FtpServer::addUser(const String& login, const String& pass, IFS::UserRole role)
 {
-	debug_d("addUser: %s %s", login.c_str(), pass.c_str());
-	users[login] = pass;
+	debug_d("addUser: %s %s (%s)", login.c_str(), pass.c_str(), toString(role).c_str());
+	users[login] = User{pass, role};
 }
 
-bool FtpServer::checkUser(const String& login, const String& pass)
+IFS::UserRole FtpServer::validateUser(const String& login, const String& pass)
 {
-	debug_d("checkUser: %s %s", login.c_str(), pass.c_str());
-	if(!users.contains(login)) {
-		return false;
-	}
-
-	return users[login] == pass;
+	debug_d("validateUser: %s %s", login.c_str(), pass.c_str());
+	auto& user = static_cast<const UserList&>(users)[login];
+	return (user.password == pass) ? user.role : IFS::UserRole::None;
 }
 
 bool FtpServer::onCommand(String cmd, String data, FtpServerConnection& connection)
 {
 	if(cmd == _F("FSFORMAT")) {
-		fileSystemFormat();
-		connection.response(200, F("File system successfully formatted"));
+		int err = fileSystemFormat();
+		connection.response(200, F("File system format: ") + fileGetErrorString(err));
 		return true;
 	}
 	return false;

--- a/Sming/Core/Network/FtpServer.cpp
+++ b/Sming/Core/Network/FtpServer.cpp
@@ -22,9 +22,9 @@ void FtpServer::addUser(const String& login, const String& pass, IFS::UserRole r
 	users[login] = User{pass, role};
 }
 
-IFS::UserRole FtpServer::validateUser(const String& login, const String& pass)
+IFS::UserRole FtpServer::validateUser(const char* login, const char* pass)
 {
-	debug_d("validateUser: %s %s", login.c_str(), pass.c_str());
+	debug_d("validateUser: %s %s", login, pass);
 	auto& user = static_cast<const UserList&>(users)[login];
 	return (user.password == pass) ? user.role : IFS::UserRole::None;
 }

--- a/Sming/Core/Network/FtpServer.h
+++ b/Sming/Core/Network/FtpServer.h
@@ -25,7 +25,7 @@ class CustomFtpServer : public TcpServer
 	friend class FtpServerConnection;
 
 public:
-	CustomFtpServer()
+	CustomFtpServer(IFS::IFileSystem* fileSystem = nullptr) : fileSystem(fileSystem)
 	{
 		setTimeOut(900);
 	}
@@ -52,6 +52,14 @@ protected:
 	{
 		return false;
 	}
+
+	IFS::FileSystem* getFileSystem() const
+	{
+		return fileSystem ? IFS::FileSystem::cast(fileSystem) : ::getFileSystem();
+	}
+
+private:
+	IFS::IFileSystem* fileSystem;
 };
 
 /** @defgroup   ftpserver FTP server

--- a/Sming/Core/Network/FtpServer.h
+++ b/Sming/Core/Network/FtpServer.h
@@ -36,7 +36,7 @@ public:
 	 * @param pass User password
 	 * @retval IFS::UserRole Returns assigned user role, None if user not validated
 	 */
-	virtual IFS::UserRole validateUser(const String& login, const String& pass) = 0;
+	virtual IFS::UserRole validateUser(const char* login, const char* pass) = 0;
 
 protected:
 	TcpConnection* createClient(tcp_pcb* clientTcp) override;
@@ -70,7 +70,7 @@ class FtpServer : public CustomFtpServer
 {
 public:
 	void addUser(const String& login, const String& pass, IFS::UserRole userRole = IFS::UserRole::Admin);
-	IFS::UserRole validateUser(const String& login, const String& pass) override;
+	IFS::UserRole validateUser(const char* login, const char* pass) override;
 
 	/**
 	 * @brief Legacy user validation
@@ -78,7 +78,7 @@ public:
 	 */
 	bool checkUser(const String& login, const String& pass) SMING_DEPRECATED
 	{
-		return validateUser(login, pass) != IFS::UserRole::None;
+		return validateUser(login.c_str(), pass.c_str()) != IFS::UserRole::None;
 	}
 
 protected:

--- a/Sming/Core/Network/NetUtils.cpp
+++ b/Sming/Core/Network/NetUtils.cpp
@@ -13,13 +13,17 @@
 #include <Data/CStringArray.h>
 #include <WString.h>
 
+namespace
+{
 #ifdef FIX_NETWORK_ROUTING
-bool NetUtils::ipClientRoutingFixed = false;
+bool ipClientRoutingFixed{false};
 #endif
 
-/// HELPERS ///
+} // namespace
 
-int NetUtils::pbufFindChar(const pbuf* buf, char wtf, unsigned startPos)
+namespace NetUtils
+{
+int pbufFindChar(const pbuf* buf, char wtf, unsigned startPos)
 {
 	unsigned ofs = 0;
 
@@ -48,7 +52,7 @@ int NetUtils::pbufFindChar(const pbuf* buf, char wtf, unsigned startPos)
 	return -1;
 }
 
-bool NetUtils::pbufIsStrEqual(const pbuf* buf, const char* compared, unsigned startPos)
+bool pbufIsStrEqual(const pbuf* buf, const char* compared, unsigned startPos)
 {
 	unsigned cur = startPos;
 
@@ -78,7 +82,7 @@ bool NetUtils::pbufIsStrEqual(const pbuf* buf, const char* compared, unsigned st
 	return true;
 }
 
-int NetUtils::pbufFindStr(const pbuf* buf, const char* wtf, unsigned startPos)
+int pbufFindStr(const pbuf* buf, const char* wtf, unsigned startPos)
 {
 	if(wtf == nullptr) {
 		return -1;
@@ -100,7 +104,7 @@ int NetUtils::pbufFindStr(const pbuf* buf, const char* wtf, unsigned startPos)
 	return -1;
 }
 
-char* NetUtils::pbufAllocateStrCopy(const pbuf* buf, unsigned startPos, unsigned length)
+char* pbufAllocateStrCopy(const pbuf* buf, unsigned startPos, unsigned length)
 {
 	char* stringPtr = new char[length + 1];
 	if(stringPtr == nullptr) {
@@ -111,7 +115,7 @@ char* NetUtils::pbufAllocateStrCopy(const pbuf* buf, unsigned startPos, unsigned
 	return stringPtr;
 }
 
-String NetUtils::pbufStrCopy(const pbuf* buf, unsigned startPos, unsigned length)
+String pbufStrCopy(const pbuf* buf, unsigned startPos, unsigned length)
 {
 	char* stringPtr = new char[length + 1];
 	if(stringPtr == nullptr) {
@@ -125,7 +129,7 @@ String NetUtils::pbufStrCopy(const pbuf* buf, unsigned startPos, unsigned length
 }
 
 #ifdef FIX_NETWORK_ROUTING
-bool NetUtils::FixNetworkRouting()
+bool FixNetworkRouting()
 {
 	if(ipClientRoutingFixed) {
 		return true;
@@ -187,9 +191,11 @@ static void debugPrintTcp(const char* type, const struct tcp_pcb* pcb)
 	}
 }
 
-void NetUtils::debugPrintTcpList()
+void debugPrintTcpList()
 {
 	debugPrintTcp(_F("Active"), tcp_active_pcbs);
 	debugPrintTcp(_F("Listen"), tcp_listen_pcbs.pcbs);
 	debugPrintTcp(_F("TIME-WAIT"), tcp_tw_pcbs);
 }
+
+} // namespace NetUtils

--- a/Sming/Core/Network/NetUtils.h
+++ b/Sming/Core/Network/NetUtils.h
@@ -8,10 +8,6 @@
  *
  ****/
 
-/** @defgroup   networking Networking
- *  @{
- */
-
 #pragma once
 
 #ifdef ARCH_ESP8266
@@ -23,32 +19,31 @@
 struct pbuf;
 class String;
 
-class NetUtils
+/** @defgroup   networking Networking
+ *  @{
+ */
+
+namespace NetUtils
 {
-public:
-	// Helpers
-	static bool pbufIsStrEqual(const pbuf* buf, const char* compared, unsigned startPos);
-	static int pbufFindChar(const pbuf* buf, char wtf, unsigned startPos = 0);
-	static int pbufFindStr(const pbuf* buf, const char* wtf, unsigned startPos = 0);
-	static char* pbufAllocateStrCopy(const pbuf* buf, unsigned startPos, unsigned length);
-	static String pbufStrCopy(const pbuf* buf, unsigned startPos, unsigned length);
+// Helpers
+bool pbufIsStrEqual(const pbuf* buf, const char* compared, unsigned startPos);
+int pbufFindChar(const pbuf* buf, char wtf, unsigned startPos = 0);
+int pbufFindStr(const pbuf* buf, const char* wtf, unsigned startPos = 0);
+char* pbufAllocateStrCopy(const pbuf* buf, unsigned startPos, unsigned length);
+String pbufStrCopy(const pbuf* buf, unsigned startPos, unsigned length);
 
 #ifdef FIX_NETWORK_ROUTING
-	static bool FixNetworkRouting();
+bool FixNetworkRouting();
 #else
-	static bool FixNetworkRouting()
-	{
-		return true; // Should work on standard lwip
-	}
+inline bool FixNetworkRouting()
+{
+	return true; // Should work on standard lwip
+}
 #endif
 
-	// Debug
-	static void debugPrintTcpList();
+// Debug
+void debugPrintTcpList();
 
-private:
-#ifdef FIX_NETWORK_ROUTING
-	static bool ipClientRoutingFixed;
-#endif
-};
+}; // namespace NetUtils
 
 /** @} */

--- a/Sming/Services/CommandProcessing/CommandHandler.h
+++ b/Sming/Services/CommandProcessing/CommandHandler.h
@@ -162,7 +162,11 @@ private:
 
 	VerboseMode verboseMode = VERBOSE;
 	String currentPrompt;
+#ifdef ARCH_HOST
+	char currentEOL = '\n';
+#else
 	char currentEOL = '\r';
+#endif
 	String currentWelcomeMessage;
 };
 

--- a/samples/Basic_Storage/app/application.cpp
+++ b/samples/Basic_Storage/app/application.cpp
@@ -32,12 +32,14 @@ void listSpiffsPartitions()
 		bool ok = spiffs_mount(*it);
 		Serial.println(ok ? "OK, listing files:" : "Mount failed!");
 		if(ok) {
-			auto list = fileList();
-			for(auto& f : fileList()) {
-				Serial.print("  ");
-				Serial.println(f);
+			Directory dir;
+			if(dir.open()) {
+				while(dir.next()) {
+					Serial.print("  ");
+					Serial.println(dir.stat().name);
+				}
 			}
-			Serial.print(list.count());
+			Serial.print(dir.count());
 			Serial.println(F(" files found"));
 			Serial.println();
 		}

--- a/samples/Basic_rBoot/app/application.cpp
+++ b/samples/Basic_rBoot/app/application.cpp
@@ -156,16 +156,23 @@ void serialCallBack(Stream& stream, char arrivedChar, unsigned short availableCh
 		} else if(!strcmp(str, "restart")) {
 			System.restart();
 		} else if(!strcmp(str, "ls")) {
-			Vector<String> files = fileList();
-			Serial.printf("filecount %d\r\n", files.count());
-			for(unsigned int i = 0; i < files.count(); i++) {
-				Serial.println(files[i]);
+			Directory dir;
+			if(dir.open()) {
+				while(dir.next()) {
+					Serial.print("  ");
+					Serial.println(dir.stat().name);
+				}
 			}
+			Serial.printf("filecount %d\r\n", dir.count());
 		} else if(!strcmp(str, "cat")) {
-			Vector<String> files = fileList();
-			if(files.count() > 0) {
-				Serial.printf("dumping file %s:\r\n", files[0].c_str());
-				Serial.println(fileGetContent(files[0]));
+			Directory dir;
+			if(dir.open() && dir.next()) {
+				Serial.printf("dumping file %s:\r\n", dir.stat().name.c_str());
+				// We don't know how big the is, so streaming it is safest
+				FileStream fs;
+				fs.open(dir.stat());
+				Serial.copyFrom(&fs);
+				Serial.println();
 			} else {
 				Serial.println("Empty spiffs!");
 			}

--- a/samples/CommandProcessing_Debug/include/ExampleCommand.h
+++ b/samples/CommandProcessing_Debug/include/ExampleCommand.h
@@ -3,8 +3,7 @@
  *
  */
 
-#ifndef SMINGCORE_EXAMPLE_COMMAND_H_
-#define SMINGCORE_EXAMPLE_COMMAND_H_
+#pragma once
 
 #include "WString.h"
 #include <Services/CommandProcessing/CommandProcessingIncludes.h>
@@ -20,5 +19,3 @@ private:
 	bool status = true;
 	void processExampleCommands(String commandLine, CommandOutput* commandOutput);
 };
-
-#endif /* SMINGCORE_DEBUG_H_ */

--- a/samples/FtpServer_Files/README.rst
+++ b/samples/FtpServer_Files/README.rst
@@ -3,7 +3,18 @@ FTP Server Files
 
 .. highlight:: bash
 
-This example sets up a simple FTP server with a couple of files stored in SPIFFS.
+This example sets up an FTP server with a couple of files stored in SPIFFS.
+It mounts this on top of an FWFS volume (a hybrid filesystem).
+
+The sample creates three users with different roles (guest, user and administrator).
+
+======  ========  =======
+User    Password  Role
+------  --------  -------
+guest   (none)    Guest
+me      "123"     User
+admin   "1234"    Admin
+======  ========  =======
 
 You'll need to have WiFi configured. You can set this information when building like this::
 
@@ -11,12 +22,12 @@ You'll need to have WiFi configured. You can set this information when building 
 
 substituting your actual Access Point details for *ssid* and *password*.
 
-After flashing::
+Flash to your device::
 
-   make flashapp
+   make flash
 
 You should be able to connect using an FTP client:
 
    ftp ipaddress
 
-The default user is ``me``, password ``123``.
+and when prompted log in with one of the above usernames.

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -14,7 +14,10 @@ void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 	Serial.println(ip);
 	// Start FTP server
 	ftp.listen(21);
-	ftp.addUser("me", "123"); // FTP account
+	// Add user accounts
+	ftp.addUser("guest", nullptr, IFS::UserRole::Guest);
+	ftp.addUser("me", "123", IFS::UserRole::User);
+	ftp.addUser("admin", "1234", IFS::UserRole::Admin);
 	// You can also use special FTP comand: "fsformat" for clearing file system (for example from TotalCMD)
 }
 
@@ -33,7 +36,8 @@ void init()
 
 	// Mount file system, in order to work with files
 	// spiffs_mount();
-	fwfs_mount();
+	// fwfs_mount();
+	hyfs_mount();
 
 	fileSetContent("example.txt", "hello world!");
 	fileSetContent("data.bin", "\1\2\3\4\5");

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -25,8 +25,6 @@ void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	Serial.println("I'm NOT CONNECTED. Need help!!! :(");
-
-	// .. some you code for configuration ..
 }
 
 void init()
@@ -34,9 +32,28 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
 
-	// Mount file system, in order to work with files
+	/*
+	 * Mount file system, in order to work with files.
+	 *
+	 * This sample uses an FWFS (Firmware FileSystem) partition to store
+	 * files which don't change. This considerably reduces the amount of data
+	 * which might be erased in the event of write failure, etc.
+	 */
+
+	// This option mounts just the SPIFFS partition
 	// spiffs_mount();
+
+	// Mount only the FWFS partition
 	// fwfs_mount();
+
+	/*
+	 * Use the 'Hybrid' filesystem, with SPIFFS layered over FWFS.
+	 * 
+	 * When a file is opened for writing it is transparently copied to the SPIFFS partition so it can be updated.
+	 * Wiping the SPIFFS partition reverts the filesystem to its original state.
+	 *
+	 * Note that files marked as ‘read-only’ may not be written in this manner.
+	 */
 	hyfs_mount();
 
 	fileSetContent("example.txt", "hello world!");

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -28,10 +28,12 @@ void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reas
 
 void init()
 {
-	spiffs_mount(); // Mount file system, in order to work with files
-
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable debug output to serial
+
+	// Mount file system, in order to work with files
+	// spiffs_mount();
+	fwfs_mount();
 
 	fileSetContent("example.txt", "hello world!");
 	fileSetContent("data.bin", "\1\2\3\4\5");

--- a/samples/FtpServer_Files/component.mk
+++ b/samples/FtpServer_Files/component.mk
@@ -1,2 +1,2 @@
-HWCONFIG := spiffs
+HWCONFIG := ftpserver
 SPIFF_FILES :=

--- a/samples/FtpServer_Files/fsimage.fwfs
+++ b/samples/FtpServer_Files/fsimage.fwfs
@@ -8,11 +8,13 @@
     "mountpoints": {},
     "rules": [
         {
+            // By default, all files require at least User role and only Admins can write
             "mask": "*",
             "read": "user",
             "write": "admin"
         },
         {
+            // In general, anything starting with . is considered a system file so restrict to admin
             "mask": ".*",
             "read": "admin"
         },
@@ -21,11 +23,12 @@
             "readonly": true
         },
         {
+            // These files won't be readable locally, the client will have to un-compress them
             "mask": "/Network/Mqtt/*",
             "compress": "gzip"
         },
         {
-            // Permit access to one file if user isn't logged in
+            // If no user is logged in, permit listing of root directory and reading of one file
             "mask": [
                 "/",
                 "index.rst"

--- a/samples/FtpServer_Files/fsimage.fwfs
+++ b/samples/FtpServer_Files/fsimage.fwfs
@@ -1,0 +1,36 @@
+{
+    "name": "FTP Server Demo Volume",
+    "id": "0x12345678",
+    "source": {
+        "/": "${SMING_HOME}/../docs/source/framework/core/network",
+        "Network": "${SMING_HOME}/Core/Network"
+    },
+    "mountpoints": {},
+    "rules": [
+        {
+            "mask": "*",
+            "read": "user",
+            "write": "admin"
+        },
+        {
+            "mask": ".*",
+            "read": "admin"
+        },
+        {
+            "mask": "*.rst",
+            "readonly": true
+        },
+        {
+            "mask": "/Network/Mqtt/*",
+            "compress": "gzip"
+        },
+        {
+            // Permit access to one file if user isn't logged in
+            "mask": [
+                "/",
+                "index.rst"
+            ],
+            "read": "any"
+        }
+    ]
+}

--- a/samples/FtpServer_Files/ftpserver.hw
+++ b/samples/FtpServer_Files/ftpserver.hw
@@ -1,0 +1,26 @@
+{
+    "name": "FTP Server sample",
+    "base_config": "standard",
+    "partitions": {
+        "rom0": {
+            "size": "480K"
+        },
+        "spiffs0": {
+            "type": "data",
+            "subtype": "spiffs",
+            "address": "0x80000",
+            "size": "0x20000"
+        },
+        "fwfs1": {
+            "address": "0xA0000",
+            "size": "330K",
+            "type": "data",
+            "subtype": "fwfs",
+            "filename": "out/fwfs1.bin",
+            "build": {
+                "target": "fwfs-build",
+                "config": "fsimage.fwfs"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR deals with directory listings in the framework.
Using a Vector<String> is inefficient, `Directory` object is almost as simple and more flexible.

The FTP framework and sample have been updated accordingly, with improvements to demonstrate use of
IFS file permissions.

Fully deprecate `fileList` and update framework using `Directory` object instead

Fix command handler in Host mode - requires different EOL character

Various minor updates and fixes to IFS component.

**Revise FTP Server**

Fix bad TcpConnection write calls
Simplify operation - some logic involving `canTransfer` doesn't seem to be necessary
Re-structure command handling, add login and file access checks.
More commands available if user isn't logged in, permissions handled by filesystem
Note: Default file permissions for new files written to SPIFFS are read/write for Admin only.
Extended directory listings: displayed 'w' value combines READ attribute with user permissions
Add HELP, NLST, CDUP, XCWD and XPWD commands
Base `FtpServer` on `CustomFtpServer` class, user may choose to manage users differently
FTP server can use separate filesystem if required

**Update FtpServer_Files sample**

Add FWFS and mount together with SPIFFS as a hybrid volume (makes things a bit more interesting)
Add another two user accounts with different roles
