### PR TITLE
Improve SPIFFS directory handling

### DIFF
--- a/Sming/Core/Data/Stream/IFS/HtmlDirectoryTemplate.cpp
+++ b/Sming/Core/Data/Stream/IFS/HtmlDirectoryTemplate.cpp
@@ -27,7 +27,7 @@ String HtmlDirectoryTemplate::getValue(const char* name)
 		auto& stat = dir().stat();
 
 		if(FS("icon") == name) {
-			if(stat.attr[FileAttribute::Directory]) {
+			if(stat.isDir()) {
 				return F("&#128193;");
 			}
 

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -510,11 +510,22 @@ inline int fileCloseDir(DirHandle dir)
 /** @brief Read a directory entry
  *  @param dir The directory object returned by fileOpenDir()
  *  @param stat The returned information, owned by DirHandle object
+ *  @retval int Error code
  */
 inline int fileReadDir(DirHandle dir, FileStat& stat)
 {
 	CHECK_FS(readdir)
 	return fileSystem->readdir(dir, stat);
+}
+
+/** @brief Rewind to start of directory entries
+ *  @param dir The directory object returned by fileOpenDir()
+ *  @retval int Error code
+ */
+inline int fileRewindDir(DirHandle dir)
+{
+	CHECK_FS(rewinddir)
+	return fileSystem->rewinddir(dir);
 }
 
 /** @brief Get basic file system information

--- a/Sming/Core/Network/Ftp/FtpDataFileList.h
+++ b/Sming/Core/Network/Ftp/FtpDataFileList.h
@@ -29,7 +29,7 @@ public:
 			return;
 		}
 
-		if(stat.attr[FileAttribute::Directory]) {
+		if(stat.isDir()) {
 			dir.open(path);
 			statValid = dir.next();
 		} else {
@@ -78,13 +78,13 @@ public:
 			char buf[128];
 			PSTR_ARRAY(fmt, "--- %-6u %s ");
 			m_snprintf(buf, sizeof(buf), fmt, stat.size, timestr.c_str());
-			buf[0] = stat.attr[FileAttribute::Directory] ? 'd' : '-';
+			buf[0] = stat.isDir() ? 'd' : '-';
 			buf[1] = (user.role >= stat.acl.readAccess) ? 'r' : '-';
 			buf[2] = stat.attr[FileAttribute::ReadOnly] && (user.role >= stat.acl.writeAccess) ? 'w' : '-';
 			line = buf;
 		}
 		line.concat(stat.name, stat.name.length);
-		if(stat.attr[FileAttribute::Directory]) {
+		if(stat.isDir()) {
 			line += '/';
 		}
 	}

--- a/Sming/Core/Network/Ftp/FtpServerConnection.cpp
+++ b/Sming/Core/Network/Ftp/FtpServerConnection.cpp
@@ -267,7 +267,7 @@ void FtpServerConnection::onCommand(String cmd, String data)
 		}
 		debug_i("CWD: '%s'", path.c_str());
 		FileStat stat;
-		if(getFileSystem()->stat(path, stat) == FS_OK && stat.attr[FileAttribute::Directory]) {
+		if(getFileSystem()->stat(path, stat) == FS_OK && stat.isDir()) {
 			cwd = path;
 			response(250, F("directory changed to /") + cwd.c_str()); // OK
 		} else {

--- a/samples/Basic_IFS/app/application.cpp
+++ b/samples/Basic_IFS/app/application.cpp
@@ -58,7 +58,7 @@ void onFile(HttpRequest& request, HttpResponse& response)
 		return;
 	}
 
-	if(stat.attr[FileAttribute::Directory]) {
+	if(stat.isDir()) {
 		auto dir = new Directory;
 		IFS::DirectoryTemplate* tmpl;
 		String fmt = request.uri.Query["format"];


### PR DESCRIPTION
The SPIFFS IFS wrapper has limited directory emulation, so that `opendir`, `readdir`, etc. work consistently across filesystems.

This PR fixes `readdir` so that 'directories' are included in the output. (This requires de-duplication so if there are multiple files such as `/dir/file.txt`, `/dir/file2.txt` then 'dir' is reported only once.)

Also add a `rewinddir` implementation.

Note: If there is a file called `/dir` in addition to the above files, then readdir() will report two entries, one as a directory and the other as the file.