### PR TITLE
Fix SMTP issues

### DIFF
--- a/Sming/Components/ssl/src/Session.cpp
+++ b/Sming/Components/ssl/src/Session.cpp
@@ -145,7 +145,10 @@ void Session::close()
 
 int Session::read(InputBuffer& input, uint8_t*& output)
 {
-	assert(connection != nullptr);
+	if(connection == nullptr) {
+		debug_w("SSL: no connection");
+		return -1;
+	}
 	int len = connection->read(input, output);
 	if(len < 0) {
 		debug_w("SSL: Got error: %d (%s)", len, connection->getErrorString(len).c_str());

--- a/Sming/Core/Network/SmtpClient.cpp
+++ b/Sming/Core/Network/SmtpClient.cpp
@@ -264,7 +264,7 @@ void SmtpClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 	}
 
 	case eSMTP_Disconnect: {
-		close();
+		setTimeOut(1);
 		return;
 	}
 
@@ -492,7 +492,6 @@ int SmtpClient::smtpParse(char* buffer, size_t len)
 
 		case eSMTP_Quitting: {
 			RETURN_ON_ERROR(SMTP_CODE_BYE);
-			close();
 			state = eSMTP_Disconnect;
 
 			break;

--- a/Sming/Core/Network/SmtpClient.h
+++ b/Sming/Core/Network/SmtpClient.h
@@ -90,7 +90,10 @@ using SmtpClientCallback = Delegate<int(SmtpClient& client, int code, char* stat
 class SmtpClient : protected TcpClient
 {
 public:
-	SmtpClient(bool autoDestroy = false);
+	SmtpClient(bool autoDestroy = false) : TcpClient(autoDestroy)
+	{
+	}
+
 	~SmtpClient();
 
 	/**

--- a/Sming/Core/Network/SmtpClient.h
+++ b/Sming/Core/Network/SmtpClient.h
@@ -183,18 +183,18 @@ private:
 	Url url;
 	Vector<String> authMethods;
 	ObjectQueue<MailMessage, SMTP_QUEUE_SIZE> mailQ;
-	char code[4] = {0};
-	int codeValue = 0;
+	char code[4]{0};
+	int codeValue{0};
 	String authChallenge;
-	char message[SMTP_ERROR_LENGTH + 1] = {0};
-	bool isLastLine = false;
-	uint8_t codeLength = 0;
-	int options = 0;
-	MailMessage* outgoingMail = nullptr;
-	SmtpState state = eSMTP_Banner;
+	char message[SMTP_ERROR_LENGTH + 1]{0};
+	bool isLastLine{false};
+	uint8_t codeLength{0};
+	int options{0};
+	MailMessage* outgoingMail{nullptr};
+	SmtpState state{eSMTP_Banner};
 
-	SmtpClientCallback errorCallback = nullptr;
-	SmtpClientCallback messageSentCallback = nullptr;
+	SmtpClientCallback errorCallback;
+	SmtpClientCallback messageSentCallback;
 
 private:
 	/**


### PR DESCRIPTION
This PR should fix the exception raised in #2276, where a read is attempted after the SSL connection is closed. This creates an assertion, which has been replaced with a debug statement. The SMTP connection closure is now handled with a timeout to allow the connection to close gracefully.

Note that other problems were found during investigation and addressed via #2283, #2284. The latter caused corruption in attachments because the source file position got out of sync.

Also fixes bug introduced in #1505 25/10/2018 which messes up SMTP state machine.

Note: Behaviour is clearly observable by compiling with `DEBUG_VERBOSE_LEVEL=3`.