### PR TITLE
Fix `buildpart` target

### DIFF
--- a/Sming/Components/Storage/component.mk
+++ b/Sming/Components/Storage/component.mk
@@ -145,7 +145,7 @@ endef
 
 .PHONY: buildpart
 buildpart: ##Rebuild all partition targets
-	@if [ "$(PARTITION_BUILD_TARGETS)" -eq "" ]; then \
+	$(Q) if [ "$(PARTITION_BUILD_TARGETS)" -eq "" ]; then \
 		echo "No partitions have build targets"; \
 	else \
 		rm -f $(PARTITION_BUILD_TARGETS); \

--- a/Sming/Components/Storage/component.mk
+++ b/Sming/Components/Storage/component.mk
@@ -145,12 +145,12 @@ endef
 
 .PHONY: buildpart
 buildpart: ##Rebuild all partition targets
-ifeq (,$(PARTITION_BUILD_TARGETS))
-	@echo "No partitions have build targets"
-else
-	$(Q) rm -f $(PARTITION_BUILD_TARGETS)
-	$(MAKE) $(PARTITION_BUILD_TARGETS)
-endif
+	@if [ "$(PARTITION_BUILD_TARGETS)" -eq "" ]; then \
+		echo "No partitions have build targets"; \
+	else \
+		rm -f $(PARTITION_BUILD_TARGETS); \
+		$(MAKE) $(PARTITION_BUILD_TARGETS); \
+	fi
 
 ##@Flashing
 


### PR DESCRIPTION
Incorrectly reports `No partitions have build targets`