### PR TITLE
Base64 size calculations wrong

### DIFF
--- a/Sming/Core/Network/WebHelpers/base64.cpp
+++ b/Sming/Core/Network/WebHelpers/base64.cpp
@@ -14,16 +14,17 @@
 #include "libb64/cencode.h"
 #include "libb64/cdecode.h"
 
-// Base-64 encoding produces 3 output bytes for every 2 input bytes
-#define MIN_ENCODE_LEN(_in_len) (((_in_len)*3 + 1) / 2)
-#define MIN_DECODE_LEN(_in_len) (((_in_len)*2 + 2) / 3)
+// Base-64 encodes 6 bits into one character (4 output chars for every 3 input bytes)
+#define MIN_ENCODE_LEN(_in_len) (((_in_len)*4 + 2) / 3)
+#define MIN_DECODE_LEN(_in_len) (((_in_len)*3 + 3) / 4)
 
 int base64_encode(size_t in_len, const unsigned char* in, size_t out_len, char* out)
 {
 	// Base-64 encoding produces 3 output bytes for every 2 input bytes
 	unsigned min_out_len = MIN_ENCODE_LEN(in_len);
-	if(out_len < min_out_len)
+	if(out_len < min_out_len) {
 		return -1;
+	}
 
 	base64_encodestate state;
 	base64_init_encodestate(&state, 0); // Don't include any linebreaks
@@ -35,12 +36,14 @@ int base64_encode(size_t in_len, const unsigned char* in, size_t out_len, char* 
 String base64_encode(const unsigned char* in, size_t in_len)
 {
 	String s;
-	if(!s.setLength(MIN_ENCODE_LEN(in_len)))
+	if(!s.setLength(MIN_ENCODE_LEN(in_len))) {
 		return nullptr;
+	}
 
 	int len = base64_encode(in_len, in, s.length(), s.begin());
-	if(len < 0)
+	if(len < 0) {
 		return nullptr;
+	}
 
 	s.setLength(len);
 	return s;
@@ -49,8 +52,9 @@ String base64_encode(const unsigned char* in, size_t in_len)
 /* decode a base64 string in one shot */
 int base64_decode(size_t in_len, const char* in, size_t out_len, unsigned char* out)
 {
-	if(out_len < MIN_DECODE_LEN(in_len))
+	if(out_len < MIN_DECODE_LEN(in_len)) {
 		return -1;
+	}
 
 	base64_decodestate _state;
 	base64_init_decodestate(&_state);
@@ -60,12 +64,14 @@ int base64_decode(size_t in_len, const char* in, size_t out_len, unsigned char* 
 String base64_decode(const char* in, size_t in_len)
 {
 	String s;
-	if(!s.setLength(MIN_DECODE_LEN(in_len)))
+	if(!s.setLength(MIN_DECODE_LEN(in_len))) {
 		return nullptr;
+	}
 
 	int outlen = base64_decode(in_len, in, s.length(), (unsigned char*)s.begin());
-	if(outlen < 0)
+	if(outlen < 0) {
 		return nullptr;
+	}
 
 	s.setLength(outlen);
 	return s;


### PR DESCRIPTION
Can result in severe buffer overflows