### PR TITLE
Update ArduinoFFT library to latest, fix patch filename

### DIFF
--- a/Sming/Libraries/.patches/ArduinoFFT.patch
+++ b/Sming/Libraries/.patches/ArduinoFFT.patch
@@ -1,16 +1,16 @@
 diff --git a/src/arduinoFFT.h b/src/arduinoFFT.h
-index 73927dc..3436c9d 100644
+index c3c1a0b..8f7e2e4 100644
 --- a/src/arduinoFFT.h
 +++ b/src/arduinoFFT.h
-@@ -75,21 +75,11 @@
+@@ -75,7 +75,6 @@
  class arduinoFFT {
  public:
  	/* Constructor */
 -	arduinoFFT(void);
  	arduinoFFT(double *vReal, double *vImag, uint16_t samples, double samplingFrequency);
--	/* Destructor */
--	~arduinoFFT(void);
- 	/* Functions */
+ 	/* Destructor */
+ 	~arduinoFFT(void);
+@@ -83,13 +82,7 @@ public:
  	uint8_t Revision(void);
  	uint8_t Exponent(uint16_t value);
  
@@ -19,13 +19,13 @@ index 73927dc..3436c9d 100644
 -	void Compute(double *vReal, double *vImag, uint16_t samples, uint8_t power, uint8_t dir);
 -	void DCRemoval(double *vData, uint16_t samples);
 -	double MajorPeak(double *vD, uint16_t samples, double samplingFrequency);
--	void MajorPeak(double *vD, uint16_t samples, double samplingFrequency, double *f, double *v);
+ 	void MajorPeak(double *vD, uint16_t samples, double samplingFrequency, double *f, double *v);
 -	void Windowing(double *vData, uint16_t samples, uint8_t windowType, uint8_t dir);
  
  	void ComplexToMagnitude();
  	void Compute(uint8_t dir);
 diff --git a/src/arduinoFFT.cpp b/src/arduinoFFT.cpp
-index 790da4f..dcdcfae 100644
+index fb602a9..e038b41 100644
 --- a/src/arduinoFFT.cpp
 +++ b/src/arduinoFFT.cpp
 @@ -21,11 +21,6 @@
@@ -40,17 +40,7 @@ index 790da4f..dcdcfae 100644
  arduinoFFT::arduinoFFT(double *vReal, double *vImag, uint16_t samples, double samplingFrequency)
  {// Constructor
  	this->_vReal = vReal;
-@@ -35,22 +30,11 @@ arduinoFFT::arduinoFFT(double *vReal, double *vImag, uint16_t samples, double sa
- 	this->_power = Exponent(samples);
- }
- 
--arduinoFFT::~arduinoFFT(void)
--{
--// Destructor
--}
--
- uint8_t arduinoFFT::Revision(void)
- {
+@@ -45,12 +40,6 @@ uint8_t arduinoFFT::Revision(void)
  	return(FFT_LIB_REV);
  }
  
@@ -63,7 +53,7 @@ index 790da4f..dcdcfae 100644
  void arduinoFFT::Compute(uint8_t dir)
  {// Computes in-place complex-to-complex FFT /
  	// Reverse bits /
-@@ -115,71 +99,6 @@ void arduinoFFT::Compute(uint8_t dir)
+@@ -115,71 +104,6 @@ void arduinoFFT::Compute(uint8_t dir)
  	}
  }
  
@@ -135,7 +125,7 @@ index 790da4f..dcdcfae 100644
  void arduinoFFT::ComplexToMagnitude()
  { // vM is half the size of vReal and vImag
  	for (uint16_t i = 0; i < this->_samples; i++) {
-@@ -187,14 +106,6 @@ void arduinoFFT::ComplexToMagnitude()
+@@ -187,14 +111,6 @@ void arduinoFFT::ComplexToMagnitude()
  	}
  }
  
@@ -150,7 +140,7 @@ index 790da4f..dcdcfae 100644
  void arduinoFFT::DCRemoval()
  {
  	// calculate the mean of vData
-@@ -211,23 +122,6 @@ void arduinoFFT::DCRemoval()
+@@ -211,23 +127,6 @@ void arduinoFFT::DCRemoval()
  	}
  }
  
@@ -174,7 +164,7 @@ index 790da4f..dcdcfae 100644
  void arduinoFFT::Windowing(uint8_t windowType, uint8_t dir)
  {// Weighing factors are computed once before multiple use of FFT
  // The weighing function is symetric; half the weighs are recorded
-@@ -285,63 +179,6 @@ void arduinoFFT::Windowing(uint8_t windowType, uint8_t dir)
+@@ -285,63 +184,6 @@ void arduinoFFT::Windowing(uint8_t windowType, uint8_t dir)
  }
  
  
@@ -238,7 +228,7 @@ index 790da4f..dcdcfae 100644
  double arduinoFFT::MajorPeak()
  {
  	double maxY = 0;
-@@ -391,61 +228,8 @@ void arduinoFFT::MajorPeak(double *f, double *v)
+@@ -391,58 +233,6 @@ void arduinoFFT::MajorPeak(double *f, double *v)
  	#endif
  }
  
@@ -294,10 +284,14 @@ index 790da4f..dcdcfae 100644
 -	#endif
 -}
 -
+ double arduinoFFT::MajorPeakParabola()
+ {
+ 	double maxY = 0;
+@@ -492,7 +282,6 @@ void arduinoFFT::Parabola(double x1, double y1, double x2, double y2, double x3,
+ 
  uint8_t arduinoFFT::Exponent(uint16_t value)
  {
 -	#warning("This method may not be accessible on future revisions.")
  	// Calculates the base 2 logarithm of a value
  	uint8_t result = 0;
  	while (((value >> result) & 1) != 1) result++;
- 	


### PR DESCRIPTION
Removes warnings from build (all Esp8266 samples will build without STRICT)