### PR TITLE
Compilation fixes for ESP8266 EQT toolchain.

### DIFF
--- a/Sming/Libraries/OtaUpgrade/OtaUpgrade/EncryptedStream.h
+++ b/Sming/Libraries/OtaUpgrade/OtaUpgrade/EncryptedStream.h
@@ -12,6 +12,7 @@
 
 #include "BasicStream.h"
 #include <sodium/crypto_secretstream_xchacha20poly1305.h>
+#include <memory>
 
 namespace OtaUpgrade
 {
@@ -20,7 +21,7 @@ namespace OtaUpgrade
  *
  * The class processes encrypted firmware upgrade files created by otatool.py.
  * A buffer is allocated dynamically to fit the largest chunk of the encryption container
- * (2kB unless otatool.py was modified). The actual processing of the decrypted data is 
+ * (2kB unless otatool.py was modified). The actual processing of the decrypted data is
  * defered to #BasicStream.
  */
 class EncryptedStream : public BasicStream


### PR DESCRIPTION
Solves the following compilation errors:
1)   'unique_ptr' in namespace 'std' does not name a template type
```
error: 'unique_ptr' in namespace 'std' does not name a template type
   57 |  std::unique_ptr<uint8_t[]> buffer;
      |       ^~~~~~~~~~
/opt/Sming/Sming/Libraries/OtaUpgrade/OtaUpgrade/EncryptedStream.h:15:1: note: 'std::unique_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
   14 | #include <sodium/crypto_secretstream_xchacha20poly1305.h>
  +++ |+#include <memory>
   15 | 
```