### PR TITLE
Add support for repeated HTTP header fields

### DIFF
--- a/Sming/Core/Network/Http/HttpHeaderFields.cpp
+++ b/Sming/Core/Network/Http/HttpHeaderFields.cpp
@@ -35,6 +35,23 @@ String HttpHeaderFields::toString(HttpHeaderFieldName name) const
 	return customFieldNames[unsigned(name) - unsigned(HTTP_HEADER_CUSTOM)];
 }
 
+String HttpHeaderFields::toString(HttpHeaderFieldName name, const String& value) const
+{
+	if(isMultiHeader(name)) {
+		String s;
+		Vector<String> splits;
+		String values(value);
+		int m = splitString(values, '\0', splits);
+		for(int i = 0; i < m; i++) {
+			s += toString(toString(name), splits[i]);
+		}
+
+		return s;
+	}
+
+	return toString(toString(name), value);
+}
+
 String HttpHeaderFields::toString(const String& name, const String& value)
 {
 	String s;

--- a/Sming/Core/Network/Http/HttpHeaderFields.cpp
+++ b/Sming/Core/Network/Http/HttpHeaderFields.cpp
@@ -14,13 +14,27 @@
 #include <FlashString/Vector.hpp>
 
 // Define field name strings and a lookup table
-#define XX(_tag, _str, _comment) DEFINE_FSTR_LOCAL(hhfnStr_##_tag, _str);
+#define XX(tag, str, flags, comment) DEFINE_FSTR_LOCAL(hhfnStr_##tag, str);
 HTTP_HEADER_FIELDNAME_MAP(XX)
 #undef XX
 
-#define XX(_tag, _str, _comment) &hhfnStr_##_tag,
+#define XX(tag, str, flags, comment) &hhfnStr_##tag,
 DEFINE_FSTR_VECTOR_LOCAL(fieldNameStrings, FlashString, HTTP_HEADER_FIELDNAME_MAP(XX));
 #undef XX
+
+HttpHeaderFields::Flags HttpHeaderFields::getFlags(HttpHeaderFieldName name) const
+{
+	switch(name) {
+#define XX(tag, str, flags, comment)                                                                                   \
+	case HttpHeaderFieldName::tag:                                                                                     \
+		return flags;
+		HTTP_HEADER_FIELDNAME_MAP(XX)
+#undef XX
+	default:
+		// Custom fields
+		return 0;
+	}
+}
 
 String HttpHeaderFields::toString(HttpHeaderFieldName name) const
 {
@@ -37,19 +51,22 @@ String HttpHeaderFields::toString(HttpHeaderFieldName name) const
 
 String HttpHeaderFields::toString(HttpHeaderFieldName name, const String& value) const
 {
-	if(isMultiHeader(name)) {
+	String tag = toString(name);
+	if(getFlags(name)[Flag::Multi]) {
+		tag += ": ";
+		CStringArray values(value);
 		String s;
-		Vector<String> splits;
-		String values(value);
-		int m = splitString(values, '\0', splits);
-		for(int i = 0; i < m; i++) {
-			s += toString(toString(name), splits[i]);
+		s.reserve((tag.length() + 2) * values.count() + value.length());
+		for(auto p : values) {
+			s += tag;
+			s += p;
+			s += "\r\n";
 		}
 
 		return s;
 	}
 
-	return toString(toString(name), value);
+	return toString(tag, value);
 }
 
 String HttpHeaderFields::toString(const String& name, const String& value)

--- a/Sming/Core/Network/Http/HttpHeaderFields.h
+++ b/Sming/Core/Network/Http/HttpHeaderFields.h
@@ -14,6 +14,7 @@
 
 #include "Data/CStringArray.h"
 #include "WString.h"
+#include <Data/BitSet.h>
 
 /*
  * Common HTTP header field names. Enumerating these simplifies matching
@@ -25,86 +26,90 @@
  * A brief description of each header field is given for information purposes.
  * For details see https://www.iana.org/assignments/message-headers/message-headers.xhtml
  *
+ * Entries are formatted thus: XX(tag, str, flags, comment)
+ *   tag:     Identifier used in code (without HTTP_HEADER_ prefix)
+ *   str:     String used in HTTP protocol
+ *   flags:   Additional flags (see HttpHeaderFields::Flag)
+ *   comment: Further details
  */
 #define HTTP_HEADER_FIELDNAME_MAP(XX)                                                                                  \
-	XX(ACCEPT, "Accept", "Limit acceptable response types")                                                            \
-	XX(ACCESS_CONTROL_ALLOW_ORIGIN, "Access-Control-Allow-Origin", "")                                                 \
-	XX(AUTHORIZATION, "Authorization", "Basic user agent authentication")                                              \
-	XX(CC, "Cc", "email field")                                                                                        \
-	XX(CONNECTION, "Connection", "Indicates sender's desired control options")                                         \
-	XX(CONTENT_DISPOSITION, "Content-Disposition", "Additional information about how to process response payload")     \
-	XX(CONTENT_ENCODING, "Content-Encoding", "Applied encodings in addition to content type")                          \
-	XX(CONTENT_LENGTH, "Content-Length", "Anticipated size for payload when not using transfer encoding")              \
-	XX(CONTENT_TYPE, "Content-Type",                                                                                   \
+	XX(ACCEPT, "Accept", 0, "Limit acceptable response types")                                                         \
+	XX(ACCESS_CONTROL_ALLOW_ORIGIN, "Access-Control-Allow-Origin", 0, "")                                              \
+	XX(AUTHORIZATION, "Authorization", 0, "Basic user agent authentication")                                           \
+	XX(CC, "Cc", 0, "email field")                                                                                     \
+	XX(CONNECTION, "Connection", 0, "Indicates sender's desired control options")                                      \
+	XX(CONTENT_DISPOSITION, "Content-Disposition", 0, "Additional information about how to process response payload")  \
+	XX(CONTENT_ENCODING, "Content-Encoding", 0, "Applied encodings in addition to content type")                       \
+	XX(CONTENT_LENGTH, "Content-Length", 0, "Anticipated size for payload when not using transfer encoding")           \
+	XX(CONTENT_TYPE, "Content-Type", 0,                                                                                \
 	   "Payload media type indicating both data format and intended manner of processing by recipient")                \
-	XX(CONTENT_TRANSFER_ENCODING, "Content-Transfer-Encoding", "Coding method used in a MIME message body part")       \
-	XX(CACHE_CONTROL, "Cache-Control", "Directives for caches along the request/response chain")                       \
-	XX(DATE, "Date", "Message originating date/time")                                                                  \
-	XX(EXPECT, "Expect", "Behaviours to be supported by the server in order to properly handle this request.")         \
-	XX(ETAG, "ETag",                                                                                                   \
+	XX(CONTENT_TRANSFER_ENCODING, "Content-Transfer-Encoding", 0, "Coding method used in a MIME message body part")    \
+	XX(CACHE_CONTROL, "Cache-Control", 0, "Directives for caches along the request/response chain")                    \
+	XX(DATE, "Date", 0, "Message originating date/time")                                                               \
+	XX(EXPECT, "Expect", 0, "Behaviours to be supported by the server in order to properly handle this request.")      \
+	XX(ETAG, "ETag", 0,                                                                                                \
 	   "Validates resource, such as a file, so recipient can confirm whether it has changed - generally more "         \
 	   "reliable than Date")                                                                                           \
-	XX(FROM, "From", "email address of human user who controls the requesting user agent")                             \
-	XX(HOST, "Host",                                                                                                   \
+	XX(FROM, "From", 0, "email address of human user who controls the requesting user agent")                          \
+	XX(HOST, "Host", 0,                                                                                                \
 	   "Request host and port information for target URI; allows server to service requests for multiple hosts on a "  \
 	   "single IP address")                                                                                            \
-	XX(IF_MATCH, "If-Match",                                                                                           \
+	XX(IF_MATCH, "If-Match", 0,                                                                                        \
 	   "Precondition check using ETag to avoid accidental overwrites when servicing multiple user requests. Ensures "  \
 	   "resource entity tag matches before proceeding.")                                                               \
-	XX(IF_MODIFIED_SINCE, "If-Modified-Since", "Precondition check using Date")                                        \
-	XX(LAST_MODIFIED, "Last-Modified", "Server timestamp indicating date and time resource was last modified")         \
-	XX(LOCATION, "Location", "Used in redirect responses, amongst other places")                                       \
-	XX(SEC_WEBSOCKET_ACCEPT, "Sec-WebSocket-Accept", "Server response to opening Websocket handshake")                 \
-	XX(SEC_WEBSOCKET_VERSION, "Sec-WebSocket-Version",                                                                 \
+	XX(IF_MODIFIED_SINCE, "If-Modified-Since", 0, "Precondition check using Date")                                     \
+	XX(LAST_MODIFIED, "Last-Modified", 0, "Server timestamp indicating date and time resource was last modified")      \
+	XX(LOCATION, "Location", 0, "Used in redirect responses, amongst other places")                                    \
+	XX(SEC_WEBSOCKET_ACCEPT, "Sec-WebSocket-Accept", 0, "Server response to opening Websocket handshake")              \
+	XX(SEC_WEBSOCKET_VERSION, "Sec-WebSocket-Version", 0,                                                              \
 	   "Websocket opening request indicates acceptable protocol version. Can appear more than once.")                  \
-	XX(SEC_WEBSOCKET_KEY, "Sec-WebSocket-Key", "Websocket opening request validation key")                             \
-	XX(SEC_WEBSOCKET_PROTOCOL, "Sec-WebSocket-Protocol",                                                               \
+	XX(SEC_WEBSOCKET_KEY, "Sec-WebSocket-Key", 0, "Websocket opening request validation key")                          \
+	XX(SEC_WEBSOCKET_PROTOCOL, "Sec-WebSocket-Protocol", 0,                                                            \
 	   "Websocket opening request indicates supported protocol(s), response contains negotiated protocol(s)")          \
-	XX(SERVER, "Server", "Identifies software handling requests")                                                      \
-	XX(SET_COOKIE, "Set-Cookie", "Server may pass name/value pairs and associated metadata to user agent (client)")    \
-	XX(SUBJECT, "Subject", "email subject line")                                                                       \
-	XX(TO, "To", "email intended recipient address")                                                                   \
-	XX(TRANSFER_ENCODING, "Transfer-Encoding", "e.g. Chunked, compress, deflate, gzip")                                \
-	XX(UPGRADE, "Upgrade",                                                                                             \
+	XX(SERVER, "Server", 0, "Identifies software handling requests")                                                   \
+	XX(SET_COOKIE, "Set-Cookie", Flag::Multi,                                                                          \
+	   "Server may pass name/value pairs and associated metadata to user agent (client)")                              \
+	XX(SUBJECT, "Subject", 0, "email subject line")                                                                    \
+	XX(TO, "To", 0, "email intended recipient address")                                                                \
+	XX(TRANSFER_ENCODING, "Transfer-Encoding", 0, "e.g. Chunked, compress, deflate, gzip")                             \
+	XX(UPGRADE, "Upgrade", 0,                                                                                          \
 	   "Used to transition from HTTP to some other protocol on the same connection. e.g. Websocket")                   \
-	XX(USER_AGENT, "User-Agent", "Information about the user agent originating the request")                           \
-	XX(WWW_AUTHENTICATE, "WWW-Authenticate", "Indicates HTTP authentication scheme(s) and applicable parameters")      \
-	XX(PROXY_AUTHENTICATE, "Proxy-Authenticate", "Indicates proxy authentication scheme(s) and applicable parameters")
+	XX(USER_AGENT, "User-Agent", 0, "Information about the user agent originating the request")                        \
+	XX(WWW_AUTHENTICATE, "WWW-Authenticate", Flag::Multi,                                                              \
+	   "Indicates HTTP authentication scheme(s) and applicable parameters")                                            \
+	XX(PROXY_AUTHENTICATE, "Proxy-Authenticate", Flag::Multi,                                                          \
+	   "Indicates proxy authentication scheme(s) and applicable parameters")
 
 enum class HttpHeaderFieldName {
 	UNKNOWN = 0,
-#define XX(tag, str, comment) tag,
+#define XX(tag, str, flags, comment) tag,
 	HTTP_HEADER_FIELDNAME_MAP(XX)
 #undef XX
 		CUSTOM // First custom header tag value
 };
 
-#define XX(tag, str, comment) constexpr HttpHeaderFieldName HTTP_HEADER_##tag = HttpHeaderFieldName::tag;
-XX(UNKNOWN, "", "")
+#define XX(tag, str, flags, comment) constexpr HttpHeaderFieldName HTTP_HEADER_##tag = HttpHeaderFieldName::tag;
+XX(UNKNOWN, "", 0, "")
 HTTP_HEADER_FIELDNAME_MAP(XX)
-XX(CUSTOM, "", "")
+XX(CUSTOM, "", 0, "")
 #undef XX
 
 class HttpHeaderFields
 {
 public:
 	/**
-	 * @brief Checks if a header is allowed to have multiple values
-	 * @retval bool true if allowed
+	 * @brief Flag values providing additional information about header fields
 	 */
-	bool isMultiHeader(HttpHeaderFieldName name) const
-	{
-		switch(name) {
-		case HTTP_HEADER_SET_COOKIE:
-		case HTTP_HEADER_WWW_AUTHENTICATE:
-		case HTTP_HEADER_PROXY_AUTHENTICATE:
-			break;
-		default:
-			return false;
-		}
+	enum class Flag {
+		Multi, ///< Field may have multiple values
+	};
+	using Flags = BitSet<uint8_t, Flag, 1>;
 
-		return true;
-	}
+	/**
+	 * @brief Get flags (if any) for given header field
+	 * @retval Flags
+	 */
+	Flags getFlags(HttpHeaderFieldName name) const;
 
 	String toString(HttpHeaderFieldName name) const;
 

--- a/Sming/Core/Network/Http/HttpHeaderFields.h
+++ b/Sming/Core/Network/Http/HttpHeaderFields.h
@@ -68,7 +68,8 @@
 	XX(UPGRADE, "Upgrade",                                                                                             \
 	   "Used to transition from HTTP to some other protocol on the same connection. e.g. Websocket")                   \
 	XX(USER_AGENT, "User-Agent", "Information about the user agent originating the request")                           \
-	XX(WWW_AUTHENTICATE, "WWW-Authenticate", "Indicates HTTP authentication scheme(s) and applicable parameters")
+	XX(WWW_AUTHENTICATE, "WWW-Authenticate", "Indicates HTTP authentication scheme(s) and applicable parameters")      \
+	XX(PROXY_AUTHENTICATE, "Proxy-Authenticate", "Indicates proxy authentication scheme(s) and applicable parameters")
 
 enum class HttpHeaderFieldName {
 	UNKNOWN = 0,
@@ -87,6 +88,24 @@ XX(CUSTOM, "", "")
 class HttpHeaderFields
 {
 public:
+	/**
+	 * @brief Checks if a header is allowed to have multiple values
+	 * @retval bool true if allowed
+	 */
+	bool isMultiHeader(HttpHeaderFieldName name) const
+	{
+		switch(name) {
+		case HTTP_HEADER_SET_COOKIE:
+		case HTTP_HEADER_WWW_AUTHENTICATE:
+		case HTTP_HEADER_PROXY_AUTHENTICATE:
+			break;
+		default:
+			return false;
+		}
+
+		return true;
+	}
+
 	String toString(HttpHeaderFieldName name) const;
 
 	/** @brief Produce a string for output in the HTTP header, with line ending
@@ -96,10 +115,7 @@ public:
 	 */
 	static String toString(const String& name, const String& value);
 
-	String toString(HttpHeaderFieldName name, const String& value) const
-	{
-		return toString(toString(name), value);
-	}
+	String toString(HttpHeaderFieldName name, const String& value) const;
 
 	/** @brief Find the enumerated value for the given field name string
 	 *  @param name

--- a/Sming/Core/Network/Http/HttpHeaders.cpp
+++ b/Sming/Core/Network/Http/HttpHeaders.cpp
@@ -1,0 +1,48 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HttpHeaders.cpp
+ *
+ ****/
+
+#include "HttpHeaders.h"
+#include <debug_progmem.h>
+
+const String& HttpHeaders::operator[](const String& name) const
+{
+	auto field = fromString(name);
+	if(field == HTTP_HEADER_UNKNOWN) {
+		return nil;
+	}
+	return operator[](field);
+}
+
+bool HttpHeaders::append(const HttpHeaderFieldName& name, const String& value)
+{
+	int i = indexOf(name);
+	if(i < 0) {
+		operator[](name) = value;
+		return true;
+	}
+
+	if(!getFlags(name)[Flag::Multi]) {
+		debug_w("[HTTP] Append not supported for header field '%s'", toString(name).c_str());
+		return false;
+	}
+
+	valueAt(i) += '\0' + value;
+
+	return true;
+}
+
+void HttpHeaders::setMultiple(const HttpHeaders& headers)
+{
+	for(unsigned i = 0; i < headers.count(); i++) {
+		HttpHeaderFieldName fieldName = headers.keyAt(i);
+		auto fieldNameString = headers.toString(fieldName);
+		operator[](fieldNameString) = headers.valueAt(i);
+	}
+}

--- a/Sming/Core/Network/Http/HttpHeaders.h
+++ b/Sming/Core/Network/Http/HttpHeaders.h
@@ -86,6 +86,22 @@ public:
 
 	using HashMap::remove;
 
+	bool append(const HttpHeaderFieldName& name, const String& value)
+	{
+		if(!isMultiHeader(name)) {
+			return false;
+		}
+
+		int i = indexOf(name);
+		if(i < 0) {
+			operator[](name) = value;
+		} else {
+			operator[](name) += '\0' + value;
+		}
+
+		return true;
+	}
+
 	void remove(const String& name)
 	{
 		remove(fromString(name));

--- a/Sming/Core/Network/Http/HttpHeaders.h
+++ b/Sming/Core/Network/Http/HttpHeaders.h
@@ -48,14 +48,7 @@ public:
 	 *  @retval const String& Reference to value
 	 *  @note if the field doesn't exist a null String reference is returned
 	 */
-	const String& operator[](const String& name) const
-	{
-		auto field = fromString(name);
-		if(field == HTTP_HEADER_UNKNOWN) {
-			return nil;
-		}
-		return operator[](field);
-	}
+	const String& operator[](const String& name) const;
 
 	/** @brief Fetch a reference to the header field value by name
 	 *  @param name
@@ -86,35 +79,20 @@ public:
 
 	using HashMap::remove;
 
-	bool append(const HttpHeaderFieldName& name, const String& value)
-	{
-		if(!isMultiHeader(name)) {
-			return false;
-		}
-
-		int i = indexOf(name);
-		if(i < 0) {
-			operator[](name) = value;
-		} else {
-			operator[](name) += '\0' + value;
-		}
-
-		return true;
-	}
+	/**
+	 * @brief Append value to multi-value field
+	 * @param name
+	 * @param value
+	 * @retval bool false if value exists and field does not permit multiple values
+	 */
+	bool append(const HttpHeaderFieldName& name, const String& value);
 
 	void remove(const String& name)
 	{
 		remove(fromString(name));
 	}
 
-	void setMultiple(const HttpHeaders& headers)
-	{
-		for(unsigned i = 0; i < headers.count(); i++) {
-			HttpHeaderFieldName fieldName = headers.keyAt(i);
-			auto fieldNameString = headers.toString(fieldName);
-			operator[](fieldNameString) = headers.valueAt(i);
-		}
-	}
+	void setMultiple(const HttpHeaders& headers);
 
 	HttpHeaders& operator=(const HttpHeaders& headers)
 	{

--- a/Sming/Core/Network/Http/HttpResponse.cpp
+++ b/Sming/Core/Network/Http/HttpResponse.cpp
@@ -20,10 +20,10 @@ HttpResponse* HttpResponse::setCookie(const String& name, const String& value, b
 	String s = name;
 	s += '=';
 	s += value;
-	if(!append) {
-		headers[HTTP_HEADER_SET_COOKIE] = s;
-	} else {
+	if(append) {
 		headers.append(HTTP_HEADER_SET_COOKIE, s);
+	} else {
+		headers[HTTP_HEADER_SET_COOKIE] = s;
 	}
 
 	return this;

--- a/Sming/Core/Network/Http/HttpResponse.cpp
+++ b/Sming/Core/Network/Http/HttpResponse.cpp
@@ -15,12 +15,17 @@
 #include "Data/Stream/MemoryDataStream.h"
 #include "Data/Stream/FileStream.h"
 
-HttpResponse* HttpResponse::setCookie(const String& name, const String& value)
+HttpResponse* HttpResponse::setCookie(const String& name, const String& value, bool append)
 {
 	String s = name;
 	s += '=';
 	s += value;
-	headers[HTTP_HEADER_SET_COOKIE] = s;
+	if(!append) {
+		headers[HTTP_HEADER_SET_COOKIE] = s;
+	} else {
+		headers.append(HTTP_HEADER_SET_COOKIE, s);
+	}
+
 	return this;
 }
 

--- a/Sming/Core/Network/Http/HttpResponse.h
+++ b/Sming/Core/Network/Http/HttpResponse.h
@@ -77,7 +77,7 @@ public:
 		return setContentType(::toString(type));
 	}
 
-	HttpResponse* setCookie(const String& name, const String& value);
+	HttpResponse* setCookie(const String& name, const String& value, bool append = false);
 
 	HttpResponse* setHeader(const String& name, const String& value)
 	{

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -28,6 +28,11 @@ void onIndex(HttpRequest& request, HttpResponse& response)
 void onHello(HttpRequest& request, HttpResponse& response)
 {
 	response.setContentType(MIME_HTML);
+
+	// Below is an example how to send multiple cookies
+	response.setCookie("cookie1", "value1");
+	response.setCookie("cookie2", "value", true);
+
 	// Use direct strings output only for small amount of data (huge memory allocation)
 	response.sendString("Sming. Let's do smart things.");
 }

--- a/tests/HostTests/modules/Http.cpp
+++ b/tests/HostTests/modules/Http.cpp
@@ -35,11 +35,12 @@ public:
 		TEST_CASE("http lookups")
 		{
 			auto s = toString(HPE_UNKNOWN);
-			REQUIRE(s == F("HPE_UNKNOWN"));
+			REQUIRE(s == "HPE_UNKNOWN");
 			s = httpGetErrorDescription(HPE_INVALID_URL);
-			REQUIRE(s == F("invalid URL"));
+			REQUIRE(s == "invalid URL");
 			s = toString(HTTP_STATUS_TOO_MANY_REQUESTS);
-			REQUIRE(s.equalsIgnoreCase(F("too many requests")));
+			DEFINE_FSTR_LOCAL(too_many_requests, "too many requests");
+			REQUIRE(s.equalsIgnoreCase(too_many_requests));
 		}
 	}
 
@@ -204,9 +205,14 @@ public:
 			HttpHeaders headers2;
 			headers2.append(HTTP_HEADER_SET_COOKIE, "name1=value1");
 			headers2.append(HTTP_HEADER_SET_COOKIE, "name2=value2");
+			printHeaders(headers2);
 			REQUIRE(headers2.count() == 1);
 			REQUIRE(serialize(headers2) == FS_cookies);
-			printHeaders(headers2);
+
+			// Append should work if field not already set
+			REQUIRE(headers2.append(HTTP_HEADER_CONTENT_LENGTH, "0") == true);
+			// But fail on actual append
+			REQUIRE(headers2.append(HTTP_HEADER_CONTENT_LENGTH, "1234") == false);
 		}
 	}
 };

--- a/tests/HostTests/modules/Http.cpp
+++ b/tests/HostTests/modules/Http.cpp
@@ -195,6 +195,19 @@ public:
 			REQUIRE(serialize(headers2) == FS_serialized);
 			printHeaders(headers2);
 		}
+
+		DEFINE_FSTR_LOCAL(FS_cookies, "Set-Cookie: name1=value1\r\n"
+									  "Set-Cookie: name2=value2\r\n");
+
+		TEST_CASE("appendHeaders")
+		{
+			HttpHeaders headers2;
+			headers2.append(HTTP_HEADER_SET_COOKIE, "name1=value1");
+			headers2.append(HTTP_HEADER_SET_COOKIE, "name2=value2");
+			REQUIRE(headers2.count() == 1);
+			REQUIRE(serialize(headers2) == FS_cookies);
+			printHeaders(headers2);
+		}
 	}
 };
 


### PR DESCRIPTION
Some fields can appear multiple times in one HTTP response or request.

The following headers are supported:
- Set-Cookie
- WWW-Authenticate
- Proxy-Authenticate

Updated HttpResponse::setCookie to support adding multiple cookies in one response.