### PR TITLE
Fix IFS error handling issues

### DIFF
--- a/Sming/Core/Data/Stream/IFS/FileStream.h
+++ b/Sming/Core/Data/Stream/IFS/FileStream.h
@@ -71,7 +71,7 @@ public:
 	bool isFinished() override
 	{
 		auto fs = getFileSystem();
-		return fs == nullptr || fs->eof(handle) != 0;
+		return fs == nullptr || lastError != FS_OK || fs->eof(handle) != 0;
 	}
 
 	/** @brief Filename of file stream is attached to


### PR DESCRIPTION
Fix `IFS::FileStream::isFinished()` so it returns true on file error.
lastError was incorrectly reset in `FsBase` which masked errors and could cause recursion issues with `HostFileStream`.
File error messages not handled correctly; fixed, test added and verified on Esp8266, Esp32, Host/Linux and Host/Win32 targets.