### PR TITLE
Fix base64 encode length calculation to account for padding

### DIFF
--- a/Sming/Core/Network/WebHelpers/base64.cpp
+++ b/Sming/Core/Network/WebHelpers/base64.cpp
@@ -14,9 +14,27 @@
 #include "libb64/cencode.h"
 #include "libb64/cdecode.h"
 
-// Base-64 encodes 6 bits into one character (4 output chars for every 3 input bytes)
-#define MIN_ENCODE_LEN(_in_len) (((_in_len)*4 + 2) / 3)
-#define MIN_DECODE_LEN(_in_len) (((_in_len)*3 + 3) / 4)
+namespace
+{
+/*
+ * Base-64 encodes 6 bits into one character (4 output chars for every 3 input bytes).
+ * However, it also requires padding such that the output size is a multiple of 4 characters.
+ */
+size_t MIN_ENCODE_LEN(size_t in_len)
+{
+	int groups = 1 + ((int(in_len) - 1) / 3);
+	return groups * 4;
+}
+
+/*
+ * For decoding, do not assume that input is padded.
+ */
+size_t MIN_DECODE_LEN(size_t in_len)
+{
+	return ((in_len * 3) + 3) / 4;
+}
+
+} // namespace
 
 int base64_encode(size_t in_len, const unsigned char* in, size_t out_len, char* out)
 {

--- a/Sming/Core/Network/WebHelpers/base64.cpp
+++ b/Sming/Core/Network/WebHelpers/base64.cpp
@@ -14,32 +14,21 @@
 #include "libb64/cencode.h"
 #include "libb64/cdecode.h"
 
-namespace
-{
-/*
- * Base-64 encodes 6 bits into one character (4 output chars for every 3 input bytes).
- * However, it also requires padding such that the output size is a multiple of 4 characters.
- */
-size_t MIN_ENCODE_LEN(size_t in_len)
+size_t base64_min_encode_len(size_t in_len)
 {
 	int groups = 1 + ((int(in_len) - 1) / 3);
 	return groups * 4;
 }
 
-/*
- * For decoding, do not assume that input is padded.
- */
-size_t MIN_DECODE_LEN(size_t in_len)
+size_t base64_min_decode_len(size_t in_len)
 {
 	return ((in_len * 3) + 3) / 4;
 }
 
-} // namespace
-
 int base64_encode(size_t in_len, const unsigned char* in, size_t out_len, char* out)
 {
 	// Base-64 encoding produces 3 output bytes for every 2 input bytes
-	unsigned min_out_len = MIN_ENCODE_LEN(in_len);
+	unsigned min_out_len = base64_min_encode_len(in_len);
 	if(out_len < min_out_len) {
 		return -1;
 	}
@@ -54,7 +43,7 @@ int base64_encode(size_t in_len, const unsigned char* in, size_t out_len, char* 
 String base64_encode(const unsigned char* in, size_t in_len)
 {
 	String s;
-	if(!s.setLength(MIN_ENCODE_LEN(in_len))) {
+	if(!s.setLength(base64_min_encode_len(in_len))) {
 		return nullptr;
 	}
 
@@ -70,7 +59,7 @@ String base64_encode(const unsigned char* in, size_t in_len)
 /* decode a base64 string in one shot */
 int base64_decode(size_t in_len, const char* in, size_t out_len, unsigned char* out)
 {
-	if(out_len < MIN_DECODE_LEN(in_len)) {
+	if(out_len < base64_min_decode_len(in_len)) {
 		return -1;
 	}
 
@@ -82,7 +71,7 @@ int base64_decode(size_t in_len, const char* in, size_t out_len, unsigned char* 
 String base64_decode(const char* in, size_t in_len)
 {
 	String s;
-	if(!s.setLength(MIN_DECODE_LEN(in_len))) {
+	if(!s.setLength(base64_min_decode_len(in_len))) {
 		return nullptr;
 	}
 

--- a/Sming/Core/Network/WebHelpers/base64.h
+++ b/Sming/Core/Network/WebHelpers/base64.h
@@ -15,6 +15,25 @@
 
 #include "WString.h"
 
+/**
+ * @brief Get minimum output buffer size required to encode message of given length.
+ * @param in_len Length of input message in bytes
+ * @retval size_t Number of bytes required in output buffer
+ * 
+ * Base-64 encodes 6 bits into one character (4 output chars for every 3 input bytes).
+ * However, it also requires padding such that the output size is a multiple of 4 characters.
+ */
+size_t base64_min_encode_len(size_t in_len);
+
+/**
+ * @brief Get minimum output buffer size required to decode message of given length.
+ * @param in_len Length of base64-encoded input message in characters
+ * @retval size_t Number of characters required in output buffer
+ * 
+ * For decoding, do not assume that input is padded.
+ */
+size_t base64_min_decode_len(size_t in_len);
+
 /** @brief encode binary data into base64 digits with MIME style === pads
  *  @param in_len quantity of characters to encode
  *  @param in data to encode

--- a/tests/HostTests/modules/Base64.cpp
+++ b/tests/HostTests/modules/Base64.cpp
@@ -30,6 +30,44 @@ public:
 			debug_hex(INFO, "decode output", clear.c_str(), clear.length() + 1);
 			REQUIRE(clear == token);
 		}
+
+		TEST_CASE("Encode lengths")
+		{
+			// Verify that actual encoded size is no larger than estimated size
+			constexpr size_t inputSize{1024};
+			constexpr size_t outputSize{2048};
+			auto inbuf = new uint8_t[inputSize];
+			auto outbuf = new char[outputSize];
+			os_get_random(inbuf, inputSize);
+			for(unsigned i = 0; i < inputSize; ++i) {
+				auto minEncodeLen = base64_min_encode_len(i);
+				int len = base64_encode(i, inbuf, outputSize, outbuf);
+				CHECK(len >= int(i));
+				CHECK(size_t(len) <= minEncodeLen);
+			}
+			delete[] outbuf;
+			delete[] inbuf;
+		}
+
+		TEST_CASE("Decode lengths")
+		{
+			// Verify that actual decoded size is no larger than estimated size
+			constexpr size_t inputSize{2048};
+			constexpr size_t outputSize{1020};
+			auto inbuf = new char[inputSize];
+			auto outbuf = new uint8_t[outputSize];
+			os_get_random(reinterpret_cast<uint8_t*>(outbuf), outputSize);
+			size_t maxLen = base64_encode(outputSize, outbuf, inputSize, inbuf);
+			CHECK(maxLen < inputSize);
+			for(unsigned i = 0; i < maxLen; ++i) {
+				auto minDecodeLen = base64_min_decode_len(i);
+				int len = base64_decode(i, inbuf, outputSize, outbuf);
+				CHECK(len <= int(i));
+				CHECK(size_t(len) <= minDecodeLen);
+			}
+			delete[] outbuf;
+			delete[] inbuf;
+		}
 	}
 };
 


### PR DESCRIPTION
Some input lengths cause buffer overruns - @vesley thanks for spotting this. I've reviewed https://en.wikipedia.org/wiki/Base64 and verified behaviour using tabulated values below. The core `base64_encode()` and `base64_decode()` routines return the values in the 'expected' column.

For example, `base64_encode("abc:def")` input is of length 7 which the current calculation allocates 10 bytes for the output, but 2 additional padding characters are written which causes the problem.

| Input length | Expected output<br>with padding | ORIGINAL<br>#e3adc6ae<br>14/9/2018 | FIX<br>#300fb8c6<br>24/3/21 | THIS PR |
| ------------ | ------------------------------- | ---------------------------------- | --------------------------- | ------- |
| 0            | 0                               | 0                                  | 0                           | 4       |
| 1            | 4                               | **2**                              | **2**                       | 4       |
| 2            | 4                               | **3**                              | **3**                       | 4       |
| 3            | 4                               | 5                                  | 4                           | 4       |
| 4            | 8                               | **6**                              | **6**                       | 8       |
| 5            | 8                               | 8                                  | **7**                       | 8       |
| 6            | 8                               | 9                                  | 8                           | 8       |
| 7            | 12                              | **11**                             | **10**                      | 12      |
| 8            | 12                              | 12                                 | **11**                      | 12      |
| 9            | 12                              | 14                                 | 12                          | 12      |
| 10           | 16                              | **15**                             | **14**                      | 16      |
| 11           | 16                              | 17                                 | **15**                      | 16      |
| 12           | 16                              | 18                                 | 16                          | 16      |
| 13           | 20                              | 20                                 | **18**                      | 20      |
| 14           | 20                              | 21                                 | **19**                      | 20      |
| 15           | 20                              | 23                                 | 20                          | 20      |
| 16           | 24                              | 24                                 | **22**                      | 24      |

No change to decoding:

| Input length | Expected<br>output | ORIGINAL<br>DECODE<br>#e3adc6ae | FIX<br>#300fb8c6<br>24/3/21 |
| ------------ | ------------------ | ------------------------------- | --------------------------- |
| 0            | 0                  | 0                               | 0                           |
| 1            | 0                  | 1                               | 1                           |
| 2            | 1                  | 2                               | 2                           |
| 3            | 2                  | 2                               | 3                           |
| 4            | 3                  | 3                               | 3                           |
| 5            | 3                  | 4                               | 4                           |
| 6            | 4                  | 4                               | 5                           |
| 7            | 5                  | 5                               | 6                           |
| 8            | 6                  | 6                               | 6                           |
| 9            | 6                  | 6                               | 7                           |
| 10           | 7                  | 7                               | 8                           |
| 11           | 8                  | 8                               | 9                           |
| 12           | 9                  | **8**                           | 9                           |
| 13           | 9                  | 9                               | 10                          |
| 14           | 10                 | 10                              | 11                          |
| 15           | 11                 | **10**                          | 12                          |
| 16           | 12                 | **11**                          | 12                          |

NB. The above tables were converted from spreadsheets at https://tabletomarkdown.com/convert-spreadsheet-to-markdown/