### PR TITLE
Read the docs is missing npm and npx. Try to use python only.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -66,6 +66,8 @@ templates_path = ['_templates']
 offline_skin_js_path = '_static/WaveSkin.js'
 offline_wavedrom_js_path = '_static/WaveDrom.js'
 
+render_using_wavedrompy = True
+
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.


### PR DESCRIPTION
Fixes:

```python
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinx/cmd/build.py", line 276, in build_main
    app.build(args.force_all, filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinx/application.py", line 349, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 294, in build_update
    self.build(['__all__'], to_build)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 361, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinx/builders/singlehtml.py", line 165, in write
    self.write_doc(self.config.master_doc, doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinx/builders/html.py", line 612, in write_doc
    self.docwriter.write(doctree, destination)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/docutils/writers/__init__.py", line 78, in write
    self.translate()
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinx/writers/html.py", line 58, in translate
    self.document.walkabout(visitor)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/docutils/nodes.py", line 227, in walkabout
    if child.walkabout(visitor):
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/docutils/nodes.py", line 227, in walkabout
    if child.walkabout(visitor):
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/docutils/nodes.py", line 227, in walkabout
    if child.walkabout(visitor):
  [Previous line repeated 7 more times]
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/docutils/nodes.py", line 219, in walkabout
    visitor.dispatch_visit(self)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinx/util/docutils.py", line 484, in dispatch_visit
    return method(node)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinxcontrib/wavedrom.py", line 182, in visit_wavedrom
    render_wavedrom_image(sphinx, node)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinxcontrib/wavedrom_render_image.py", line 85, in render_wavedrom_image
    imgname = render_wavedrom_cli(sphinx, node, outpath, bname, image_format)
  File "/home/docs/checkouts/readthedocs.org/user_builds/sming/envs/latest/lib/python3.7/site-packages/sphinxcontrib/wavedrom_render_image.py", line 181, in render_wavedrom_cli
    raise SphinxError('wavedrom command %r cannot be run' % sphinx.builder.config.wavedrom_cli)
sphinx.errors.SphinxError: wavedrom command 'npx wavedrom-cli' cannot be run

Sphinx error:
wavedrom command 'npx wavedrom-cli' cannot be run
```