### PR TITLE
Arch/Esp8266/Core/Digital.cpp: fixed pulseIn() for pins >= 8

### DIFF
--- a/Sming/Arch/Esp8266/Core/Digital.cpp
+++ b/Sming/Arch/Esp8266/Core/Digital.cpp
@@ -141,9 +141,9 @@ unsigned long pulseIn(uint16_t pin, uint8_t state, unsigned long timeout)
 	// cache the port and bit of the pin in order to speed up the
 	// pulse width measuring loop and achieve finer resolution.  calling
 	// digitalRead() instead yields much coarser resolution.
-	uint8_t bit = digitalPinToBitMask(pin);
+	uint32_t bit = digitalPinToBitMask(pin);
 	// uint8_t port = digitalPinToPort(pin); // Does nothing in Sming, comment-out to prevent compiler warning
-	uint8_t stateMask = (state ? bit : 0);
+	uint32_t stateMask = (state ? bit : 0);
 	unsigned long width = 0; // keep initialization out of time critical area
 
 	// convert the timeout from microseconds to a number of times through


### PR DESCRIPTION
Fix for: #2336