### PR TITLE
Add `Stream::readBytes(uint8_t*, size_t)` overload

### DIFF
--- a/Sming/Core/Data/Stream/DataSourceStream.h
+++ b/Sming/Core/Data/Stream/DataSourceStream.h
@@ -62,6 +62,8 @@ public:
 		return getStreamType() != eSST_Invalid;
 	}
 
+	using Stream::readBytes;
+
 	size_t readBytes(char* buffer, size_t length) override;
 
 	/** @brief  Read a block of memory

--- a/Sming/Core/Data/Stream/IFS/FileStream.h
+++ b/Sming/Core/Data/Stream/IFS/FileStream.h
@@ -69,6 +69,8 @@ public:
 		return readBytes(&c, 1) ? static_cast<unsigned char>(c) : -1;
 	}
 
+	using ReadWriteStream::readBytes;
+
 	size_t readBytes(char* buffer, size_t length) override;
 
 	uint16_t readMemoryBlock(char* data, int bufSize) override;

--- a/Sming/Wiring/Stream.h
+++ b/Sming/Wiring/Stream.h
@@ -105,6 +105,11 @@ public:
      */
 	virtual size_t readBytes(char* buffer, size_t length);
 
+	size_t readBytes(uint8_t* buffer, size_t length)
+	{
+		return readBytes(reinterpret_cast<char*>(buffer), length);
+	}
+
 	/**
      * @brief As `readBytes()` with terminator character
      *


### PR DESCRIPTION
Consistent with arduino