### PR TITLE
Minor host updates

### DIFF
--- a/Sming/Arch/Host/Components/gdbstub/gdbcmds
+++ b/Sming/Arch/Host/Components/gdbstub/gdbcmds
@@ -1,3 +1,5 @@
+handle SIGUSR1 nostop noprint
+
 # Enable this if you want to log all traffic between GDB and the stub
 #set remotelogfile gdb_rsp_logfile.txt
 

--- a/Sming/Arch/Host/Components/gdbstub/gdbinit
+++ b/Sming/Arch/Host/Components/gdbstub/gdbinit
@@ -1,1 +1,0 @@
-handle SIGUSR1 nostop noprint

--- a/Sming/Arch/Host/Components/hostlib/threads.h
+++ b/Sming/Arch/Host/Components/hostlib/threads.h
@@ -70,6 +70,11 @@ public:
 		HOST_THREAD_DEBUG("Thread '%s' complete", name);
 	}
 
+	bool isCurrent() const
+	{
+		return pthread_equal(pthread_self(), m_thread) != 0;
+	}
+
 	/*
 	 * Called at the start of any code which affects framework variables.
 	 * Will block if any another thread is running in interrupt context.

--- a/Sming/Components/malloc_count/malloc_count.cpp
+++ b/Sming/Components/malloc_count/malloc_count.cpp
@@ -275,7 +275,7 @@ extern "C" void mc_free(void* ptr)
 		dec_count(size);
 
 		if(size >= logThreshold) {
-			log("free(%p) -> %u (cur %u)", ptr, size, stats.current);
+			log("free(%p) -> %u (cur %u)", (char*)ptr + alignment, size, stats.current);
 		}
 	}
 
@@ -328,9 +328,10 @@ extern "C" void* mc_realloc(void* ptr, size_t size)
 
 	if(size >= logThreshold) {
 		if(newptr == ptr) {
-			log("realloc(%u -> %u) = %p (cur %u)", oldsize, size, newptr, stats.current);
+			log("realloc(%u -> %u) = %p (cur %u)", oldsize, size, (char*)newptr + alignment, stats.current);
 		} else {
-			log("realloc(%u -> %u) = %p -> %p (cur %u)", oldsize, size, ptr, newptr, stats.current);
+			log("realloc(%u -> %u) = %p -> %p (cur %u)", oldsize, size, (char*)ptr + alignment,
+				(char*)newptr + alignment, stats.current);
 		}
 	}
 


### PR DESCRIPTION
Add CThread::isCurrent() method.
Merge host gdbinit into gdbcmds - fix for SIGUSR1 should be the default.
Fix malloc_count logging so pointer values are displayed consistently.