### PR TITLE
No-WiFi flash fixes

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp_no_wifi/README.rst
+++ b/Sming/Arch/Esp8266/Components/esp_no_wifi/README.rst
@@ -74,10 +74,6 @@ If you want to disassemble other SDK libraries, do this::
 Known issues
 ------------
 
--  Call to `spi_flash_get_id()` hangs in application code
--  ROMs must be located below 1M
-   SDK implementation of `Cache_Read_Enable_New()` has internal flag which doesn't get initialised (default is 0xff, must be 1 or the function does nothing).
-
 Further work is required to implement the following (list incomplete):
 
 -  Sleep/power saving modes

--- a/Sming/Arch/Esp8266/Components/esp_no_wifi/app_main.c
+++ b/Sming/Arch/Esp8266/Components/esp_no_wifi/app_main.c
@@ -36,11 +36,23 @@ void set_pll(void)
 	}
 }
 
+static void init_flash_code()
+{
+	spi_flash_set_read_func(NULL);
+	// Variable resets to 0xff, must be 0 or Cache_Read_Enable_New hangs
+	uint32_t addr = (uint32_t)&Cache_Read_Enable_New;
+	addr -= 8;
+	uint32_t** varptr = (uint32_t**)addr;
+	**varptr = 0;
+}
+
 static void user_start(void)
 {
 	ets_isr_mask(0x3FE);			  // disable interrupts 1..9
 	sleep_reset_analog_rtcreg_8266(); // spoils the PLL!
 	set_pll();
+
+	init_flash_code();
 
 	memset(&_bss_start, 0, &_bss_end - &_bss_start);
 

--- a/Sming/Arch/Esp8266/Components/esp_no_wifi/user_interface.c
+++ b/Sming/Arch/Esp8266/Components/esp_no_wifi/user_interface.c
@@ -34,7 +34,7 @@ void system_print_meminfo(void)
 #undef ADDR
 }
 
-bool system_os_post(uint8_t prio, os_signal_t sig, os_param_t par)
+bool IRAM_ATTR system_os_post(uint8_t prio, os_signal_t sig, os_param_t par)
 {
 	if(prio >= USER_TASK_PRIO_MAX) {
 		os_printf("err: post prio >= %u\n", USER_TASK_PRIO_MAX);

--- a/samples/Basic_Storage/app/application.cpp
+++ b/samples/Basic_Storage/app/application.cpp
@@ -16,11 +16,8 @@ void listDevices()
 		Serial.print(toString(dev.getType()));
 		Serial.print(_F(", size = 0x"));
 		Serial.print(dev.getSize(), HEX);
-#ifndef DISABLE_WIFI
-		// KNOWN ISSUE: Call to `spi_flash_get_id()` hangs in application code
 		Serial.print(_F(", ID = 0x"));
 		Serial.print(dev.getId(), HEX);
-#endif
 		Serial.println();
 	}
 	Serial.println();


### PR DESCRIPTION
Fixes the following issues:

- Call to `spi_flash_get_id()` hangs in application code
- ROMs must be located below 1M

Both due to SDK implementation of `Cache_Read_Enable_New()` which requires a variable to be set to 0 at startup.
This variable is always located at offset -8 from the function address so it can be reliably patched during init code.

Also, `system_os_post` must be in IRAM.