### PR TITLE
Fix ArduinoJson6 serialisation bug and update from v6.13 to v6.15.2

### DIFF
--- a/Sming/Arch/Host/Tools/ci/install.cmd
+++ b/Sming/Arch/Host/Tools/ci/install.cmd
@@ -3,7 +3,7 @@ REM Host install.cmd
 call :install "c:\tools\doxygen" doxygen-1.9.1.windows.bin.zip
 call :install "c:\tools" stable_windows_10_msbuild_Release_Win32_graphviz-2.46.1-win32.zip
 
-python -m pip install --upgrade pip setuptools wheel
+python -m pip install --upgrade pip wheel
 
 python -m pip install -r %SMING_HOME%/../docs/requirements.txt
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ sphinxcontrib-wavedrom
 sphinx-copybutton
 sphinxcontrib-seqdiag>=0.8.5
 jinja2>=2.11.3
+setuptools==57.5.0

--- a/tests/HostTests/modules/ArduinoJson6.cpp
+++ b/tests/HostTests/modules/ArduinoJson6.cpp
@@ -84,8 +84,13 @@ public:
 
 		TEST_CASE("Json::serialize(doc, String), then save to file")
 		{
+			DEFINE_FSTR_LOCAL(expectedOutput,
+							  "{\"string1\":\"string value "
+							  "1\",\"number2\":12345,\"arr\":[\"FlashString-1\"],\"FlashString-2\":\"FlashString-1\"}")
 			String s;
-			REQUIRE(Json::serialize(doc, s) == 95);
+			auto sz = Json::serialize(doc, s);
+			REQUIRE_EQ(sz, 100U);
+			REQUIRE(expectedOutput == s);
 			REQUIRE(fileSetContent(test_json, s) == int(s.length()));
 		}
 


### PR DESCRIPTION
Contains bugfix where serializing to String returns wrong length.
https://github.com/bblanchon/ArduinoJson/commit/3aebef6d0a94d0bc84829bf7aa36995fe3791263

Example:

```
String s;
size_t length = Json::serialize(doc, s);
send(s.c_str(), length); ///< Problem: Returned length likely less than actual length
send(s); ///< OK, string is correct
```

Framework code not affected. Picked up by HostTests when running against bug-fixed version where returned length is correct.

Note: Releases after 6.15.2 require rework to FlashStringRefAdapter.