### PR TITLE
Add `flashid` build target

### DIFF
--- a/Sming/Arch/Host/Components/vflash/component.mk
+++ b/Sming/Arch/Host/Components/vflash/component.mk
@@ -30,6 +30,11 @@ define VerifyFlash
 	@echo VerifyFlash not implemented for Host
 endef
 
+# Read flash manufacturer ID and determine actual size
+define ReadFlashID
+	$(info ReadFlashID: Flash backing file "$(FLASH_BIN)", size $(SPI_SIZE))
+endef
+
 # Read flash memory into file
 # $1 -> `Offset,Size` chunk
 # $2 -> Output filename

--- a/Sming/Components/esptool/component.mk
+++ b/Sming/Components/esptool/component.mk
@@ -43,6 +43,12 @@ endif
 
 comma := ,
 
+# Read flash manufacturer ID and determine actual size
+define ReadFlashID
+	$(info Reading Flash ID)
+	$(call ESPTOOL_EXECUTE,flash_id)
+endef
+
 # Write file contents to Flash
 # $1 -> List of `Offset=File` chunks
 define WriteFlash

--- a/Sming/component.mk
+++ b/Sming/component.mk
@@ -156,3 +156,7 @@ endif
 verifyflash: ##Read all flash sections and verify against source
 	$(Q) $(call CheckPartitionChunks,$(FLASH_PARTITION_CHUNKS))
 	$(call VerifyFlash,$(FLASH_BOOT_CHUNKS) $(FLASH_MAP_CHUNK) $(FLASH_PARTITION_CHUNKS))
+
+.PHONY: flashid
+flashid: ##Read flash identifier and determine actual size
+	$(call ReadFlashID)

--- a/docs/source/troubleshooting/random-restart.rst
+++ b/docs/source/troubleshooting/random-restart.rst
@@ -15,6 +15,10 @@ To achieve this do the following:
 
 1) Check the :ref:`hardware_config` especially ``flash_size`` setting.
 
+.. note::
+
+   If you're not sure what size the flash memory is on your device, run `make flashid` to check.
+
 2) Run ``flashinit``::
 
       cd $SMING_HOME/../samples/Basic_Blink

--- a/samples/Basic_Storage/basic_storage_2m.hw
+++ b/samples/Basic_Storage/basic_storage_2m.hw
@@ -1,0 +1,28 @@
+{
+    "name": "Basic Storage sample (2M)",
+    "base_config": "basic_storage",
+    "devices": {
+        "spiFlash": {
+            "size": "2M"
+        }
+    },
+    "partitions": {
+        "user0": {
+            "address": "0x000fa000"
+        },
+        "user1": {
+            "address": "0x000fe000"
+        },
+        "spiffs0": {
+            "address": "0x00102000"
+        },
+        "spiffs1": {
+            "address": "0x00182000",
+            "size": "240K"
+        },
+        "spiffs2": {
+            "address": "0x001be000",
+            "size": "216K"
+        }
+    }
+}


### PR DESCRIPTION
Run `make flashid` to read flash manufacturer ID and infer actual size.

Also adds config for `Basic_Storage` sample to support 2M flash.
