### PR TITLE
Fix hwconfig option handling, add 1m, 2m hwconfig options and spiffs-2m.hw

### DIFF
--- a/Sming/Arch/Host/standard.hw
+++ b/Sming/Arch/Host/standard.hw
@@ -3,12 +3,7 @@
 	"arch": "Host",
 	"bootloader_size": "0x2000",
 	"partition_table_offset": "0x2000",
-	"devices": {
-		"spiFlash": {
-			"type": "flash",
-			"size": "4M"
-		}
-	},
+	"options": ["4m"],
 	"partitions": {
 		"rom0": {
 			"address": "0x008000",

--- a/Sming/Components/Storage/Tools/hwconfig/config.py
+++ b/Sming/Components/Storage/Tools/hwconfig/config.py
@@ -122,11 +122,11 @@ class Config(object):
         self.parse_dict(data)
 
     def parse_options(self, options):
-        """Apply any specified options, each option is applied only once
+        """Apply any specified options
+        
+        Each option can be applied more than once to ensure overrides work as expected
         """
         for option in options:
-            if option in self.options:
-                continue
             self.options.append(option)
             data = self.option_library.get(option)
             if data is None:

--- a/Sming/options.json
+++ b/Sming/options.json
@@ -1,4 +1,20 @@
 {
+    "1m": {
+        "description": "Set Flash size to 1MByte",
+        "devices": {
+            "spiFlash": {
+                "size": "1M"
+            }
+        }
+    },
+    "2m": {
+        "description": "Set Flash size to 2MByte",
+        "devices": {
+            "spiFlash": {
+                "size": "2M"
+            }
+        }
+    },
     "4m": {
         "description": "Set Flash size to 4MByte",
         "devices": {

--- a/Sming/spiffs-2m.hw
+++ b/Sming/spiffs-2m.hw
@@ -1,0 +1,12 @@
+{
+	"name": "Single SPIFFS partition (2M flash)",
+	"base_config": "spiffs",
+	"options": [
+		"2m"
+	],
+	"partitions": {
+		"spiffs0": {
+			"address": "0x100000"
+		}
+	}
+}


### PR DESCRIPTION
Fix allows inherited configurations to re-apply options.

Current behaviour is to apply options only once, but expected behaviour is that the most recent application takes effect.

For example, 2m - 4m - 2m. Otherwise the second 2m is ignored and uses 4m instead.