### PR TITLE
Fix bugs in si2c twi_status() timeout and host uart/timer.

### DIFF
--- a/Sming/Arch/Host/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Host/Components/driver/hw_timer.cpp
@@ -44,7 +44,7 @@ public:
 	void attach_interrupt(hw_timer_source_type_t source_type, hw_timer_callback_t callback, void* arg)
 	{
 		stop();
-		source_type = source_type;
+		this->source_type = source_type;
 		this->callback.func = callback;
 		this->callback.arg = arg;
 	}

--- a/Sming/Arch/Host/Components/driver/uart_server.cpp
+++ b/Sming/Arch/Host/Components/driver/uart_server.cpp
@@ -209,7 +209,7 @@ void CUart::onNotify(smg_uart_t* uart, smg_uart_notify_code_t code)
 		break;
 
 	case UART_NOTIFY_AFTER_WRITE: {
-		if(uart != nullptr) {
+		if(this->uart != nullptr) {
 			// Kick the thread to send now
 			txsem.post();
 		} else {

--- a/Sming/Core/si2c.cpp
+++ b/Sming/Core/si2c.cpp
@@ -249,7 +249,7 @@ uint8_t twi_status()
 
 	int clockCount = 20;
 
-	while(SDA_READ() == 0 && clockCount > 0) { //if SDA low, read the bits slaves have to sent to a max
+	while(SDA_READ() == 0 && clockCount-- > 0) { //if SDA low, read the bits slaves have to sent to a max
 		twi_read_bit();
 		if(SCL_READ() == 0) {
 			return I2C_SCL_HELD_LOW_AFTER_READ; //I2C bus error. SCL held low beyond slave clock stretch time


### PR DESCRIPTION
Tallies with esp8266 arduino core code

(alerted to presence by codacy.)