### PR TITLE
Bugfix: Edge case in  String::replace

### DIFF
--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -883,7 +883,7 @@ bool String::replace(const char* find_buf, size_t find_len, const char* replace_
 		}
 		buf = buffer();
 		int index = len - 1;
-		while((index = lastIndexOf(find_buf, index, find_len)) >= 0) {
+		while(index >= 0 && (index = lastIndexOf(find_buf, index, find_len)) >= 0) {
 			readFrom = buf + index + find_len;
 			memmove(readFrom + diff, readFrom, len - (readFrom - buf));
 			len += diff;

--- a/tests/HostTests/modules/String.cpp
+++ b/tests/HostTests/modules/String.cpp
@@ -102,6 +102,13 @@ public:
 			REQUIRE(FS_Text4 == text);
 		}
 
+		TEST_CASE("replace, increase length with first char (Bug 24/10/2021)")
+		{
+			String s = F("abcdefa");
+			s.replace("a", "aa");
+			REQUIRE(F("aabcdefaa") == s);
+		}
+
 		TEST_CASE("content check (manual inspection)")
 		{
 			DEFINE_FSTR_LOCAL(test, "This is a some test data \1\2\3 Not all ASCII\0"


### PR DESCRIPTION
If replacement increases string size and includes first character goes pop because search index goes negative. e.g.

```
String s = F("abcdefa");
s.replace("a", "aa"); // bang!
```
