### PR TITLE
Fix problem with `make flash` in Windows

### DIFF
--- a/Sming/Components/Storage/Tools/hwconfig/hwconfig.py
+++ b/Sming/Components/Storage/Tools/hwconfig/hwconfig.py
@@ -49,7 +49,7 @@ def handle_flashcheck(args, config, part):
             raise InputError("No partition contains address 0x%08x" % addr)
         if part.address != addr:
             raise InputError("Address 0x%08x is within partition '%s', not at start (0x%08x)" % (addr, part.name, part.address))
-        filesize = os.path.getsize(filename)
+        filesize = os.path.getsize(fixpath(filename))
         if filesize > part.size:
             raise InputError("File '%s' is 0x%08x bytes, too big for partition '%s' (0x%08x bytes)" % (os.path.basename(filename), filesize, part.name, part.size))
 


### PR DESCRIPTION
Python hwtool missing call to `fixpath` in `flashcheck`.

Problem typically looks like this when running `make flash`:

```
...
ESPTOOL2 out/Esp8266/debug/firmware/rom0.bin
SSL support disabled
make[1]: Nothing to be done for `application'.
make[1]: Leaving directory `/c/tools/Sming/samples/Basic_Blink'
Killing Terminal to free COM5
/bin/sh: : command not found
make: [kill_term] Error 127 (ignored)
WriteFlash 0x00000=out/Esp8266/debug/firmware/rboot.bin 0x000fa000=out/Esp8266/debug/firmware/partitions.bin 0x00002000=out/Esp8266/debug/firmware/rom0.bin  0x000fc000=/C/tools/Sming/Sming/Arch/Esp8266/Components/esp8266/ESP8266_NONOS_SDK/bin/esp_init_data_default.bin
Traceback (most recent call last):
  File "c:\tools\Sming\Sming\Components\Storage\Tools\hwconfig\hwconfig.py", line 114, in <module>
    main()
  File "c:\tools\Sming\Sming\Components\Storage\Tools\hwconfig\hwconfig.py", line 106, in main
    output = globals()['handle_' + args.command](args, config, part)
  File "c:\tools\Sming\Sming\Components\Storage\Tools\hwconfig\hwconfig.py", line 52, in handle_flashcheck
    filesize = os.path.getsize(filename)
  File "c:\Python310\lib\genericpath.py", line 50, in getsize
    return os.stat(filename).st_size
FileNotFoundError: [WinError 3] The system cannot find the path specified: '/C/tools/Sming/Sming/Arch/Esp8266/Components/esp8266/ESP8266_NONOS_SDK/bin/esp_init_data_default.bin'
make: *** [flash] Error 1
```

The `/C/tools/Sming/Sming/Arch/Esp8266/Components/esp8266/ESP8266_NONOS_SDK/bin/esp_init_data_default.bin` path from make is gets translated into 'C:/tools/Sming/Sming/Arch/Esp8266/Components/esp8266/ESP8266_NONOS_SDK/bin/esp_init_data_default.bin' which python can interpret correctly.

Note that this issue does not appear when running in WSL2 because although flashing is run using Windows python, the pre-check script is executed within Linux.