### PR TITLE
Fix minor warnings

### DIFF
--- a/Sming/Arch/Esp32/Core/Digital.cpp
+++ b/Sming/Arch/Esp32/Core/Digital.cpp
@@ -58,7 +58,8 @@ void pinMode(uint16_t pin, uint8_t mode)
 	}
 #endif
 
-	gpio_set_level(gpio, 0);
+	gpio_ll_set_level(&GPIO, gpio, 0);
+
 	gpio_ll_input_enable(&GPIO, gpio);
 	gpio_ll_pulldown_dis(&GPIO, gpio);
 

--- a/Sming/Core/Data/LinkedObjectList.h
+++ b/Sming/Core/Data/LinkedObjectList.h
@@ -171,6 +171,7 @@ public:
 	OwnedLinkedObjectListTemplate() = default;
 
 	OwnedLinkedObjectListTemplate(const OwnedLinkedObjectListTemplate& other) = delete;
+	OwnedLinkedObjectListTemplate& operator=(const OwnedLinkedObjectListTemplate& other) = delete;
 
 	~OwnedLinkedObjectListTemplate()
 	{

--- a/Sming/Libraries/OtaUpgradeMqtt/samples/Upgrade/app/application.cpp
+++ b/Sming/Libraries/OtaUpgradeMqtt/samples/Upgrade/app/application.cpp
@@ -99,9 +99,8 @@ void showInfo()
 
 	int total = 0;
 	for(auto it = OtaManager.getBootPartitions(); it; ++it) {
-		auto part = *it;
-		debug_d("ROM %s: 0x%08x, SubType: %s", part.name().c_str(), part.address(),
-				toLongString(part.type(), part.subType()).c_str());
+		debug_d("ROM %s: 0x%08x, SubType: %s", it->name().c_str(), it->address(),
+				toLongString(it->type(), it->subType()).c_str());
 		total++;
 	}
 	debug_d("=======================");

--- a/Sming/Libraries/OtaUpgradeMqtt/src/StandardPayloadParser.cpp
+++ b/Sming/Libraries/OtaUpgradeMqtt/src/StandardPayloadParser.cpp
@@ -20,7 +20,9 @@ namespace Mqtt
 {
 bool StandardPayloadParser::switchRom(const UpdateState& updateState)
 {
+#if DEBUG_VERBOSE_LEVEL >= DBG
 	auto before = OtaManager.getBootPartition();
+#endif
 	auto after = OtaManager.getNextBootPartition();
 
 	debug_d("Swapping from %s @ 0x%08x to %s @ 0x%08x.\r\n", before.name().c_str(), before.address(),

--- a/Sming/Libraries/OtaUpgradeMqtt/src/StandardPayloadParser.cpp
+++ b/Sming/Libraries/OtaUpgradeMqtt/src/StandardPayloadParser.cpp
@@ -20,13 +20,12 @@ namespace Mqtt
 {
 bool StandardPayloadParser::switchRom(const UpdateState& updateState)
 {
+	auto after = OtaManager.getNextBootPartition();
 #if DEBUG_VERBOSE_LEVEL >= DBG
 	auto before = OtaManager.getBootPartition();
-#endif
-	auto after = OtaManager.getNextBootPartition();
-
 	debug_d("Swapping from %s @ 0x%08x to %s @ 0x%08x.\r\n", before.name().c_str(), before.address(),
 			after.name().c_str(), after.address());
+#endif
 
 	return OtaManager.setBootPartition(after);
 }


### PR DESCRIPTION
- Fix Esp32 runtime warning calling `pinMode(INPUT)` where GPIO is input-only
- Fix build warnings
- Delete `OwnedLinkedObjectListTemplate` assignment operator (as for constructor)
