### PR TITLE
Feature: rbpf containers

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -273,6 +273,10 @@
 	path = Sming/Libraries/RapidXML
 	url = https://github.com/mikee47/Sming-RapidXML
 	ignore = dirty
+[submodule "Libraries.rbpf"]
+	path = Sming/Libraries/rbpf
+	url = https://github.com/slaff/Sming-rbpf.git
+	ignore = dirty
 [submodule "Libraries.RingBufCPP"]
 	path = Sming/Libraries/RingBufCPP
 	url = https://github.com/wizard97/Embedded_RingBuf_CPP.git
@@ -297,7 +301,7 @@
 	path = Sming/Libraries/SolarCalculator
 	url = https://github.com/mikee47/SolarCalculator
 	ignore = dirty
-[submodule "spiffs"]
+[submodule "Libraries.spiffs"]
 	path = Sming/Libraries/Spiffs/spiffs
 	url = https://github.com/pellepl/spiffs.git
 	ignore = dirty

--- a/Sming/util.mk
+++ b/Sming/util.mk
@@ -77,7 +77,7 @@ endef
 # $1 -> Directories to scan
 # $2 -> Filename filter
 define ListAllFiles
-$(wildcard $(foreach d,$(call ListAllSubDirs,$1),$d/$2))
+$(foreach d,$1 $(call ListAllSubDirs,$1),$(wildcard $(foreach f,$2,$d/$f)))
 endef
 
 


### PR DESCRIPTION
This PR adds support for rBPF in Sming.
rBPF provides a minimal virtual machine for microcontrollers.
rBPF is a virtual machine based on the popular Linux BPF virtual machine.
It is small and fast enough to host multiple instances on architectures targeted by Sming.

Related to #2419.