### PR TITLE
Drop support for old esp8266 toolchain (UDK / esp-open-sdk)

### DIFF
--- a/Sming/Arch/Esp8266/Tools/ci/build.run.sh
+++ b/Sming/Arch/Esp8266/Tools/ci/build.run.sh
@@ -7,7 +7,4 @@ make clean samples-clean
 $MAKE_PARALLEL Basic_Blink ENABLE_CUSTOM_HEAP=1 DEBUG_VERBOSE_LEVEL=3
 $MAKE_PARALLEL HttpServer_ConfigNetwork ENABLE_CUSTOM_LWIP=2 STRICT=1
 
-# Some samples (UPnP, for example) require more recent compiler
-if [ "$BUILD_COMPILER" == "eqt" ]; then
-    $MAKE_PARALLEL component-samples
-fi
+$MAKE_PARALLEL component-samples

--- a/Sming/Arch/Esp8266/Tools/ci/install.cmd
+++ b/Sming/Arch/Esp8266/Tools/ci/install.cmd
@@ -1,11 +1,9 @@
 REM Esp8266 install.cmd
 
-call :install "%UDK_ROOT%" esp-udk-win32.7z
-call :install "%EQT_ROOT%" x86_64-w64-mingw32.xtensa-lx106-elf-e6a192b.201211.zip
+call :install "%ESP_HOME%" x86_64-w64-mingw32.xtensa-lx106-elf-e6a192b.201211.zip
 goto :EOF
 
 :install
-if "%1"=="" goto :EOF
 mkdir %1
 curl -LO %SMINGTOOLS%/%2
 7z -o%1 x %2

--- a/Sming/Arch/Esp8266/Tools/install.sh
+++ b/Sming/Arch/Esp8266/Tools/install.sh
@@ -2,28 +2,11 @@
 #
 # Esp8266 install.sh
 
-# Old toolchain
-if [ -n "$UDK_ROOT" ]; then
-    if [ -d "$UDK_ROOT" ]; then
-        printf "\n\n** Skipping Esp8266 tools installation: '$UDK_ROOT' exists\n\n"
-    else
-        TOOLCHAIN=esp-open-sdk-linux-x86_64.tar.gz
-        $WGET "$SMINGTOOLS/$TOOLCHAIN" -O "$DOWNLOADS/$TOOLCHAIN"
-        mkdir -p "$UDK_ROOT"
-        tar -zxf "$DOWNLOADS/$TOOLCHAIN" -C "$UDK_ROOT" --totals
-        mv "$UDK_ROOT/esp-open-sdk/"* "$UDK_ROOT"
-        rmdir "$UDK_ROOT/esp-open-sdk"
-    fi
-fi
-
-# New toolchain
-if [ -n "$EQT_ROOT" ]; then
-    if [ -d "$EQT_ROOT" ]; then
-        printf "\n\n** Skipping Esp8266 tools installation: '$EQT_ROOT' exists\n\n"
-    else
-        TOOLCHAIN=x86_64-linux-gnu.xtensa-lx106-elf-e6a192b.201211.tar.gz
-        $WGET "$SMINGTOOLS/$TOOLCHAIN" -O "$DOWNLOADS/$TOOLCHAIN"
-        mkdir -p "$EQT_ROOT"
-        tar -zxf "$DOWNLOADS/$TOOLCHAIN" -C "$EQT_ROOT" --totals
-    fi
+if [ -d "$ESP_HOME" ]; then
+    printf "\n\n** Skipping Esp8266 tools installation: '$ESP_HOME' exists\n\n"
+else
+    TOOLCHAIN=x86_64-linux-gnu.xtensa-lx106-elf-e6a192b.201211.tar.gz
+    $WGET "$SMINGTOOLS/$TOOLCHAIN" -O "$DOWNLOADS/$TOOLCHAIN"
+    mkdir -p "$ESP_HOME"
+    tar -zxf "$DOWNLOADS/$TOOLCHAIN" -C "$ESP_HOME" --totals
 fi

--- a/Tools/Docker/cli/Dockerfile
+++ b/Tools/Docker/cli/Dockerfile
@@ -9,9 +9,7 @@ ENV SMING_HOME /opt/Sming/Sming
 ENV PYTHON /usr/bin/python3
 
 # Esp8266
-#ENV UDK_ROOT /opt/esp-open-sdk
-ENV EQT_ROOT /opt/esp-quick-toolchain
-ENV ESP_HOME $EQT_ROOT
+ENV ESP_HOME /opt/esp-quick-toolchain
 
 # Esp32
 ENV IDF_PATH /opt/esp-idf

--- a/Tools/ci/build.cmd
+++ b/Tools/ci/build.cmd
@@ -28,11 +28,7 @@ make help
 make list-config
 
 REM HostTests should build and run on all architectures
-if "%BUILD_COMPILER%" == "udk" ( 
-    REM Skip old toolchain - there are issues
-) else (
-    %MAKE_PARALLEL% -C "%SMING_PROJECTS_DIR%/tests/HostTests"
-)
+%MAKE_PARALLEL% -C "%SMING_PROJECTS_DIR%/tests/HostTests"
 
 REM Start Arch-specific tests
 cd /d %SMING_HOME%

--- a/Tools/ci/setenv.ps1
+++ b/Tools/ci/setenv.ps1
@@ -1,12 +1,6 @@
 
 # Esp8266 
-$env:UDK_ROOT = Join-Path $env:CI_BUILD_DIR "opt/esp-alt-sdk"
-$env:EQT_ROOT = Join-Path $env:CI_BUILD_DIR "opt/esp-quick-toolchain"
-if ($env:BUILD_COMPILER -eq "udk") {
-$env:ESP_HOME = $env:UDK_ROOT
-} else {
-$env:ESP_HOME = $env:EQT_ROOT
-}
+$env:ESP_HOME = Join-Path $env:CI_BUILD_DIR "opt/esp-quick-toolchain"
 
 # Esp32
 $env:IDF_PATH = Join-Path $env:CI_BUILD_DIR "opt/esp-idf"

--- a/Tools/export.sh
+++ b/Tools/export.sh
@@ -31,9 +31,7 @@ fi
 export PYTHON=${PYTHON:=/usr/bin/python3}
 
 # Esp8266
-#export UDK_ROOT=${UDK_ROOT:=/opt/esp-open-sdk}
-export EQT_ROOT=${EQT_ROOT:=/opt/esp-quick-toolchain}
-export ESP_HOME=${ESP_HOME:=$EQT_ROOT}
+export ESP_HOME=${ESP_HOME:=/opt/esp-quick-toolchain}
 
 # Esp32
 export IDF_PATH=${IDF_PATH:=/opt/esp-idf}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,11 +14,6 @@ environment:
 
     - SMING_ARCH: Esp8266
       INSTALL_OPTS: esp8266
-      BUILD_COMPILER: udk
-
-    - SMING_ARCH: Esp8266
-      INSTALL_OPTS: esp8266
-      BUILD_COMPILER: eqt
 
     - SMING_ARCH: Esp32
       SMING_SOC: esp32

--- a/docs/source/upgrading/4.4-4.5.rst
+++ b/docs/source/upgrading/4.4-4.5.rst
@@ -22,3 +22,12 @@ Eclipse Project Files
 Starting with version 4.5.x we don't provide Eclipse meta files in our samples. 
 These can be generated using the ``ide-eclipse`` makefile target.
 For more information read the updated :doc:`/tools/eclipse`.
+
+
+Esp8266 toolchain
+-----------------
+
+Sming now requires the :doc:`/arch/esp8266/eqt` for building.
+Support for the old legacy toolchains (ESP open SDK, UDK) have been dropped.
+
+They may still work but are no longer tested.


### PR DESCRIPTION
The old toolchains have been deprecated since #2155. Removing support simplifies implementation of new features and reduces testing load.