### PR TITLE
Feature: JavaScript VM

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -225,6 +225,10 @@
 	path = Sming/Libraries/HueEmulator
 	url = https://github.com/mikee47/HueEmulator
 	ignore = dirty
+[submodule "Libraries.jerryscript"]
+	path = Sming/Libraries/jerryscript
+	url = https://github.com/slaff/Sming-jerryscript.git
+	ignore = dirty
 [submodule "Libraries.IR"]
 	path = Sming/Libraries/IR
 	url = https://github.com/markszabo/IRremoteESP8266.git


### PR DESCRIPTION
These libraries allow running JavaScript in a sandbox on all architectures supported by Sming. The actual JavaScript engine is [JerryScript](https://github.com/jerryscript-project/jerryscript).

This is port from the initial work done for the [U:Kit project](https://github.com/attachix/ukit).

Tasks:
--------
- [x] Copyright headers
- [x] Add documentation
- [x] Move to submodule
