### PR TITLE
Add library CI support

### DIFF
--- a/Sming/Arch/Rp2040/Components/rp2040/component.mk
+++ b/Sming/Arch/Rp2040/Components/rp2040/component.mk
@@ -86,7 +86,8 @@ LIBDIRS += \
 	$(PICO_BUILD_DIR)
 
 EXTRA_LIBS += \
-	pico
+	pico \
+	m
 
 ifdef NINJA
 NINJA := $(call FixPath,$(NINJA))

--- a/Sming/Arch/Rp2040/build.mk
+++ b/Sming/Arch/Rp2040/build.mk
@@ -11,7 +11,6 @@ CPPFLAGS += \
 	-mthumb
 
 CXXFLAGS += \
-	-fno-exceptions \
 	-fno-threadsafe-statics \
 	-fno-use-cxa-atexit
 

--- a/Tools/ci/library/Makefile
+++ b/Tools/ci/library/Makefile
@@ -28,18 +28,13 @@ apps: $(APP_NAMES)
 
 .PHONY: $(APP_NAMES)
 $(APP_NAMES):
-	$(info )
-	$(info )
-	$(info ===================== )
-	$(info Building $@ for $(SMING_SOC))
-	$(info ===================== )
-	$(info )
+	@printf "\n\n** Building $@ for $(SMING_SOC) **\n\n"
 	$(Q) $(MAKE) --no-print-directory -C $@ PIP_ARGS=-q python-requirements sample
 
 .PHONY: run-test
 run-test:
 ifeq (,$(wildcard test))
-	$(info No test directory found)
+	@printf "\n\n** No test directory found - skipping **\n\n"
 else ifeq ($(SMING_ARCH),Host)
 	$(Q) $(MAKE) --no-print-directory -C test execute
 endif

--- a/Tools/ci/library/Makefile
+++ b/Tools/ci/library/Makefile
@@ -34,14 +34,14 @@ $(APP_NAMES):
 	$(info Building $@ for $(SMING_SOC))
 	$(info ===================== )
 	$(info )
-	$(Q) $(MAKE) -C $@ -r -R --no-print-directory sample
+	$(Q) $(MAKE) --no-print-directory -C $@ PIP_ARGS=-q python-requirements sample
 
 .PHONY: run-test
 run-test:
 ifeq (,$(wildcard test))
 	$(info No test directory found)
 else ifeq ($(SMING_ARCH),Host)
-	$(Q) $(MAKE) -C test -r -R --no-print-directory execute
+	$(Q) $(MAKE) --no-print-directory -C test execute
 endif
 
 clean:

--- a/Tools/ci/library/Makefile
+++ b/Tools/ci/library/Makefile
@@ -1,0 +1,48 @@
+# Don't bother with implicit checks
+.SUFFIXES:
+
+.NOTPARALLEL:
+
+ifeq (,$(SMING_HOME))
+$(error SMING_HOME not set)
+endif
+
+ifeq (,$(SMING_ARCH))
+$(error SMING_ARCH not set)
+endif
+
+include $(SMING_HOME)/util.mk
+
+APP_NAMES := $(patsubst $(CURDIR)/%,%,$(call ListSubDirs,samples) $(wildcard test))
+
+ARCH_SOC := $(ARCH_$(SMING_ARCH)_SOC)
+
+all: $(ARCH_SOC)
+
+.PHONY: $(ARCH_SOC)
+$(ARCH_SOC):
+	$(Q) $(MAKE) --no-print-directory -f $(firstword $(MAKEFILE_LIST)) SMING_SOC=$@ STRICT=1 apps run-test
+
+.PHONY: apps
+apps: $(APP_NAMES)
+
+.PHONY: $(APP_NAMES)
+$(APP_NAMES):
+	$(info )
+	$(info )
+	$(info ===================== )
+	$(info Building $@ for $(SMING_SOC))
+	$(info ===================== )
+	$(info )
+	$(Q) $(MAKE) -C $@ -r -R --no-print-directory sample
+
+.PHONY: run-test
+run-test:
+ifeq (,$(wildcard test))
+	$(info No test directory found)
+else ifeq ($(SMING_ARCH),Host)
+	$(Q) $(MAKE) -C test -r -R --no-print-directory execute
+endif
+
+clean:
+	$(Q) rm -rf $(addsuffix /out,$(APP_NAMES))

--- a/Tools/ci/library/README.rst
+++ b/Tools/ci/library/README.rst
@@ -1,0 +1,32 @@
+Library CI support
+==================
+
+Appveyor
+--------
+
+Steps to enable:
+
+Add project to appveyor account
+    ``Projects`` -> ``New Project`` and select from list
+
+Set ``Custom Configuration``
+    to ``https://raw.githubusercontent.com/SmingHub/Sming/develop/Tools/ci/library/appveyor.txt``
+
+Set ``Project URL slug``
+    If library exists as Sming submodule then set this to the same name so it overrides current Sming version.
+
+    For example, a library called ``Sming-jerryscript`` will get a default slug of ``sming-jerryscript``,
+    but this must be changed to ``jerryscript``.
+
+Set sming fork/branch
+    By default builds use the main Sming ``develop`` branch.
+    To change this add ``SMING_REPO`` and/or ``SMING_BRANCH`` environment variables.
+
+
+Makefile
+--------
+
+The provided default makefile builds all applications within the library's ``samples`` directory
+for all architectures.
+
+If a ``test`` directory is found then that too is built for all architectures, and executed for Host.

--- a/Tools/ci/library/appveyor.txt
+++ b/Tools/ci/library/appveyor.txt
@@ -8,16 +8,9 @@ environment:
 
   matrix:
     - SMING_ARCH: Host
-      INSTALL_OPTS: host
-
     - SMING_ARCH: Esp8266
-      INSTALL_OPTS: esp8266
-
     - SMING_ARCH: Esp32
-      INSTALL_OPTS: esp32
-
     - SMING_ARCH: Rp2040
-      INSTALL_OPTS: rp2040
 
 install:
   - ps: |
@@ -29,10 +22,10 @@ install:
       env
 
   - cmd: |
-      sming/Tools/ci/install.cmd %INSTALL_OPTS%
+      sming/Tools/ci/install.cmd %SMING_ARCH%
 
   - sh: |
-      . sming/Tools/ci/install.sh $INSTALL_OPTS
+      . sming/Tools/ci/install.sh ${SMING_ARCH,,}
 
 build_script:
   - sh: make -j$(nproc) -f $SMING_HOME/../Tools/ci/library/Makefile

--- a/Tools/ci/library/appveyor.txt
+++ b/Tools/ci/library/appveyor.txt
@@ -1,0 +1,39 @@
+image:
+- Ubuntu2004
+- Visual Studio 2019
+
+environment:
+  SMING_REPO: https://github.com/SmingHub/Sming
+  SMING_BRANCH: develop
+
+  matrix:
+    - SMING_ARCH: Host
+      INSTALL_OPTS: host
+
+    - SMING_ARCH: Esp8266
+      INSTALL_OPTS: esp8266
+
+    - SMING_ARCH: Esp32
+      INSTALL_OPTS: esp32
+
+    - SMING_ARCH: Rp2040
+      INSTALL_OPTS: rp2040
+
+install:
+  - ps: |
+      git clone -b $env:SMING_BRANCH --single-branch --depth 1 $env:SMING_REPO sming
+      $env:CI_BUILD_DIR = $pwd.path
+      $env:COMPONENT_SEARCH_DIRS = (resolve-path "$pwd/..").path
+      $env:SMING_HOME = (resolve-path "$pwd/sming/Sming").path
+      sming/Tools/ci/setenv.ps1
+      env
+
+  - cmd: |
+      sming/Tools/ci/install.cmd %INSTALL_OPTS%
+
+  - sh: |
+      . sming/Tools/ci/install.sh $INSTALL_OPTS
+
+build_script:
+  - sh: make -j$(nproc) -f $SMING_HOME/../Tools/ci/library/Makefile
+  - cmd: make -j%NUMBER_OF_PROCESSORS% -f %SMING_HOME%/../Tools/ci/library/Makefile

--- a/Tools/ci/library/appveyor.txt
+++ b/Tools/ci/library/appveyor.txt
@@ -21,7 +21,7 @@ environment:
 
 install:
   - ps: |
-      git clone -b $env:SMING_BRANCH --single-branch --depth 1 $env:SMING_REPO sming
+      Start-Process -FilePath git -ArgumentList "clone -b $env:SMING_BRANCH --single-branch --depth 1 $env:SMING_REPO sming" -Wait -NoNewWindow
       $env:CI_BUILD_DIR = $pwd.path
       $env:COMPONENT_SEARCH_DIRS = (resolve-path "$pwd/..").path
       $env:SMING_HOME = (resolve-path "$pwd/sming/Sming").path

--- a/Tools/ci/setenv.ps1
+++ b/Tools/ci/setenv.ps1
@@ -5,7 +5,7 @@ $env:ESP_HOME = Join-Path $env:CI_BUILD_DIR "opt/esp-quick-toolchain"
 # Esp32
 $env:IDF_PATH = Join-Path $env:CI_BUILD_DIR "opt/esp-idf"
 $env:IDF_TOOLS_PATH = Join-Path $env:CI_BUILD_DIR "opt/tools/esp32"
-$env:IDF_BRANCH = "sming/dev/v4.3"
+$env:IDF_BRANCH = "sming/release/v4.3"
 
 # Rp2040
 $env:PICO_TOOLCHAIN_PATH = Join-Path $env:CI_BUILD_DIR "opt/rp2040"


### PR DESCRIPTION
This PR provides an appveyor script and makefile to support standalone integration testing for libraries.

It builds all samples and tests against the Sming `develop` branch from the source repository.
This takes considerably less time and consumes less CI resource than a full Sming CI build, which may not be necessary.

See `Tools/ci/library/README.rst` for details.

Example run https://ci.appveyor.com/project/mikee47/FlashString/history