### PR TITLE
Fix bit-length bugs in Esp32 SPIClass

### DIFF
--- a/Sming/Arch/Esp32/Core/SPI.cpp
+++ b/Sming/Arch/Esp32/Core/SPI.cpp
@@ -272,6 +272,10 @@ bool SPIClass::begin()
 	spi_ll_enable_miso(&dev, true);
 	spi_ll_set_half_duplex(&dev, false);
 
+	spi_ll_set_dummy(&dev, 0);
+	spi_ll_set_command_bitlen(&dev, 0);
+	spi_ll_set_addr_bitlen(&dev, 0);
+
 	// Not using any auto. chip selects
 	spi_ll_master_select_cs(&dev, -1);
 


### PR DESCRIPTION
These functions are added:
```
	spi_ll_set_dummy(&dev, 0);
	spi_ll_set_command_bitlen(&dev, 0);
	spi_ll_set_addr_bitlen(&dev, 0);
```

The PR should NOT be merged yet due ```SPI.read8()``` not working properly yet.  https://github.com/SmingHub/Sming/issues/2437#issuecomment-986206399

The text below is for my reference.
```
In Sming/Arch/Esp32/SPI.cpp the main `object` is the SPI device.
This object is spi_signal_conn_t (see esp-idf/components/soc/include/soc/spi_periph.h).
The hardware access is realised through the *hw member of this struct, that is of type
spi_dev_t (see esp-idf/components/soc/esp32/include/soc/spi_struct.h)
The Sming's SPI class uses the esp-idf's initialization functions declarations
in eps-idf/components/hal/esp32/include/hal/spi_ll.h
```