### PR TITLE
Fix CI library build issues

### DIFF
--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -13,7 +13,7 @@ ifeq (,$(SMING_ARCH))
     SMING_ARCH := Esp8266
     SMING_SOC := esp8266
   else
-    SMING_ARCH := $(notdir $(call dirx,$(filter %/$(SMING_SOC)-soc.json,$(SOC_CONFIG_FILES))))
+    override SMING_ARCH := $(notdir $(call dirx,$(filter %/$(SMING_SOC)-soc.json,$(SOC_CONFIG_FILES))))
     ifeq (,$(SMING_ARCH))
       $(error SOC '$(SMING_SOC)' not found)
     endif

--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -736,7 +736,7 @@ menuconfig: checksoc ##Run option editor
 list-soc: ##List supported and available SOCs
 	@echo "Available SoCs: $(AVAILABLE_SOCS)"
 	@echo "Project support:"
-	@$(foreach s,$(AVAILABLE_SOCS),$(MAKE) --no-print-directory --silent MAKE_CLEAN=1 SMING_SOC=$s checksoc-print; )
+	@$(foreach s,$(AVAILABLE_SOCS),$(MAKE) --no-print-directory --silent MAKE_CLEAN=1 SMING_ARCH= SMING_SOC=$s checksoc-print; )
 
 .PHONY: list-soc-check
 checksoc-print:

--- a/Tools/ci/library/appveyor.txt
+++ b/Tools/ci/library/appveyor.txt
@@ -27,6 +27,7 @@ install:
       Start-Process -FilePath git -ArgumentList "clone $env:SMING_REPO -b $env:SMING_BRANCH --depth 1 sming" -Wait -NoNewWindow
       $env:COMPONENT_SEARCH_DIRS = (resolve-path "$pwd/..").path
       sming/Tools/ci/setenv.ps1
+      make -C "$env:SMING_HOME" "fetch-$env:APPVEYOR_PROJECT_SLUG"
 
   - cmd: |
       if "%APPVEYOR_BUILD_WORKER_CLOUD%"=="" sming\Tools\ci\install.cmd %SMING_ARCH% %INSTALL_OPTS%


### PR DESCRIPTION
Building UPnP fails because when `make python-requirements` is run it doesn't pick up lxml requirement for UPnP-Schema, a dependent library.
Running `make fetch-UPnP` here mimics how users would do things, and this also fetches any dependent submodules.

IFS test application fails for esp8266 claiming 'only host supported'.

Also, fix 'make list-soc` build target.