### PR TITLE
Fix esp32 hardware timer performance

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/hw_timer.h
@@ -12,7 +12,11 @@
 
 #include <esp_attr.h>
 #include <sming_attr.h>
-#include <cstdint>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define HW_TIMER_BASE_CLK APB_CLK_FREQ
 
@@ -117,9 +121,9 @@ uint32_t hw_timer1_read(void);
  *
  *************************************/
 
-constexpr uint32_t HW_TIMER2_CLK = 1000000;
+#define HW_TIMER2_CLK 1000000U
 
-extern "C" int64_t esp_timer_get_time(void);
+int64_t esp_timer_get_time(void);
 
 /**
  * @brief Read current timer2 value
@@ -139,3 +143,7 @@ __forceinline uint32_t hw_timer2_read(void)
 void hw_timer_init(void);
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif

--- a/Sming/Arch/Esp32/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/hw_timer.h
@@ -14,6 +14,12 @@
 #include <sming_attr.h>
 #include <stdint.h>
 
+#ifdef CONFIG_ESP_TIMER_IMPL_TG0_LAC
+#include <soc/timer_group_reg.h>
+#else
+#include <hal/systimer_ll.h>
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -121,17 +127,34 @@ uint32_t hw_timer1_read(void);
  *
  *************************************/
 
-#define HW_TIMER2_CLK 1000000U
-
-int64_t esp_timer_get_time(void);
+#if CONFIG_ESP_TIMER_IMPL_TG0_LAC
+#define HW_TIMER2_CLK 2000000U
+#define HW_TIMER2_INDEX 0
+#elif defined(CONFIG_IDF_TARGET_ESP32S2)
+#define HW_TIMER2_CLK 80000000U
+#define HW_TIMER2_INDEX
+#elif defined(CONFIG_IDF_TARGET_ESP32C3)
+#define HW_TIMER2_CLK 16000000U
+#define HW_TIMER2_INDEX 0
+#elif defined(CONFIG_IDF_TARGET_ESP32S3)
+#define HW_TIMER2_CLK 16000000U
+#define HW_TIMER2_INDEX 0
+#else
+_Static_assert(false, "ESP32 Unsupported timer");
+#endif
 
 /**
  * @brief Read current timer2 value
  * @retval uint32_t
  */
-__forceinline uint32_t hw_timer2_read(void)
+__forceinline static uint32_t hw_timer2_read(void)
 {
-	return esp_timer_get_time();
+#if CONFIG_ESP_TIMER_IMPL_TG0_LAC
+	return REG_READ(TIMG_LACTLO_REG(HW_TIMER2_INDEX));
+#else
+	systimer_ll_counter_snapshot(HW_TIMER2_INDEX);
+	return systimer_ll_get_counter_value_low(HW_TIMER2_INDEX);
+#endif
 }
 
 #define NOW() hw_timer2_read()

--- a/Sming/Arch/Esp8266/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Esp8266/Components/driver/include/driver/hw_timer.h
@@ -84,8 +84,8 @@ void IRAM_ATTR hw_timer1_attach_interrupt(hw_timer_source_type_t source_type, hw
  */
 inline void IRAM_ATTR hw_timer1_enable(hw_timer_clkdiv_t div, hw_timer_intr_type_t intr_type, bool auto_load)
 {
-	constexpr uint32_t FRC1_ENABLE_TIMER = BIT7;
-	constexpr uint32_t FRC1_AUTO_LOAD = BIT6;
+#define FRC1_ENABLE_TIMER BIT7
+#define FRC1_AUTO_LOAD BIT6
 
 	uint32_t ctrl = (div & 0x0C) | (intr_type & 0x01) | FRC1_ENABLE_TIMER;
 	if(auto_load) {
@@ -143,12 +143,12 @@ __forceinline uint32_t hw_timer1_read(void)
  *************************************/
 
 #ifdef USE_US_TIMER
-constexpr uint32_t HW_TIMER2_CLKDIV = TIMER_CLKDIV_16;
+#define HW_TIMER2_CLKDIV TIMER_CLKDIV_16
 #else
-constexpr uint32_t HW_TIMER2_CLKDIV = TIMER_CLKDIV_256;
+#define HW_TIMER2_CLKDIV TIMER_CLKDIV_256
 #endif
 
-constexpr uint32_t HW_TIMER2_CLK = HW_TIMER_BASE_CLK >> HW_TIMER2_CLKDIV;
+#define HW_TIMER2_CLK (HW_TIMER_BASE_CLK >> HW_TIMER2_CLKDIV)
 
 /**
  * @brief Read current timer2 value

--- a/Sming/Arch/Host/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Host/Components/driver/include/driver/hw_timer.h
@@ -14,13 +14,13 @@
 #include <esp_attr.h>
 #include <sming_attr.h>
 
-#define APB_CLK_FREQ 80000000U
-
-#define HW_TIMER_BASE_CLK APB_CLK_FREQ
-
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define APB_CLK_FREQ 80000000U
+
+#define HW_TIMER_BASE_CLK APB_CLK_FREQ
 
 /*************************************
  *
@@ -67,9 +67,9 @@ uint32_t hw_timer1_read(void);
  *************************************/
 
 #ifdef USE_US_TIMER
-constexpr uint32_t HW_TIMER2_CLK = HW_TIMER_BASE_CLK / 16;
+#define HW_TIMER2_CLK (HW_TIMER_BASE_CLK / 16)
 #else
-constexpr uint32_t HW_TIMER2_CLK = HW_TIMER_BASE_CLK / 256;
+#define HW_TIMER2_CLK (HW_TIMER_BASE_CLK / 256)
 #endif
 
 uint32_t hw_timer2_read(void);

--- a/Sming/Arch/Rp2040/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Rp2040/Components/driver/include/driver/hw_timer.h
@@ -13,6 +13,10 @@
 #include <esp_systemapi.h>
 #include <hardware/structs/timer.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define HW_TIMER_BASE_CLK 1000000U
 
 /**
@@ -44,7 +48,7 @@ __forceinline uint32_t IRAM_ATTR hw_timer_ticks()
 /**
  * @brief Maximum timer interval in ticks
  */
-#define MAX_HW_TIMER1_INTERVAL 0x7fffffff
+#define MAX_HW_TIMER1_INTERVAL 0x7fffffffU
 
 /**
  * @brief Minimum hardware interval in microseconds
@@ -81,7 +85,7 @@ struct hw_timer_private_t {
 	void* timer1_arg;
 };
 
-extern hw_timer_private_t hw_timer_private;
+extern struct hw_timer_private_t hw_timer_private;
 
 /**
  * @brief Attach an interrupt for the timer
@@ -142,7 +146,7 @@ __forceinline uint32_t hw_timer1_read()
  *
  *************************************/
 
-constexpr uint32_t HW_TIMER2_CLK = HW_TIMER_BASE_CLK;
+#define HW_TIMER2_CLK HW_TIMER_BASE_CLK
 
 /**
  * @brief Read current timer2 value
@@ -154,3 +158,7 @@ __forceinline uint32_t hw_timer2_read()
 }
 
 /** @} */
+
+#ifdef __cplusplus
+}
+#endif

--- a/tests/HostTests/component.mk
+++ b/tests/HostTests/component.mk
@@ -1,6 +1,8 @@
 ifeq ($(SMING_ARCH),Rp2040)
 HWCONFIG = host-tests-1m
 DISABLE_NETWORK := 1
+else ifeq ($(SMING_ARCH),Esp32)
+HWCONFIG = host-tests-esp32
 else
 HWCONFIG = host-tests
 endif

--- a/tests/HostTests/host-tests-esp32.hw
+++ b/tests/HostTests/host-tests-esp32.hw
@@ -1,0 +1,9 @@
+{
+    "name": "Host Tests for Esp32",
+    "base_config": "host-tests",
+    "partitions": {
+        "factory": {
+            "size": "1M"
+        }
+    }
+}


### PR DESCRIPTION
This PR fix poor performance of hwtimer2 on ESP32 by using hardware directly.
It also fixes code so it can be used from C.

How many loop iterations can we achieve in 100 ms ?

**ESP32**

Using millis(), managed 105418 iterations, average loop time = 949ns (152 CPU cycles)
Using micros(), managed 102942 iterations, average loop time = 971ns (155 CPU cycles)

Using PolledTimer:
  BEFORE: managed 135827 iterations, average loop time = 736ns (118 CPU cycles)
  AFTER: managed 921085 iterations, average loop time = 109ns (17 CPU cycles)

**ESP32C3**

Using millis(), managed 98837 iterations, average loop time = 1012ns (162 CPU cycles)
Using micros(), managed 123863 iterations, average loop time = 807ns (129 CPU cycles)

Using PolledTimer:
  BEFORE: managed 136670 iterations, average loop time = 732ns (117 CPU cycles)
  AFTER: managed 551882 iterations, average loop time = 181ns (29 CPU cycles)

**ESP32S2**

Using millis(), managed 68260 iterations, average loop time = 1465ns (234 CPU cycles)
Using micros(), managed 68921 iterations, average loop time = 1451ns (232 CPU cycles)
Using PolledTimer:
  AFTER: managed 528409 iterations, average loop time = 189ns (30 CPU cycles)