### PR TITLE
Fix esp32 clock definitions

### DIFF
--- a/Sming/Arch/Esp32/Platform/Clocks.h
+++ b/Sming/Arch/Esp32/Platform/Clocks.h
@@ -16,9 +16,8 @@
 
 /**
  * @brief Clock implementation for os_timer API
- * @see See IDF components/esp_common/src/ets_timer_legacy.c
  */
-struct OsTimerClock : public NanoTime::Clock<OsTimerClock, HW_TIMER2_CLK, uint32_t, 0xFFFFFFFFU> {
+struct OsTimerClock : public NanoTime::Clock<OsTimerClock, 1000000U, uint32_t, 0xFFFFFFFFU> {
 	static constexpr const char* typeName()
 	{
 		return "OsTimerClock";
@@ -26,7 +25,7 @@ struct OsTimerClock : public NanoTime::Clock<OsTimerClock, HW_TIMER2_CLK, uint32
 
 	static uint32_t __forceinline ticks()
 	{
-		return hw_timer2_read();
+		return system_get_time();
 	}
 };
 
@@ -34,7 +33,7 @@ struct OsTimerClock : public NanoTime::Clock<OsTimerClock, HW_TIMER2_CLK, uint32
  * @brief Clock implementation for polled timers
  * @note The Esp32 timer is actually 64-bit but for now stick with 32-bits for more efficient code.
  */
-using PolledTimerClock = OsTimerClock;
+using PolledTimerClock = Timer2Clock;
 
 using CpuCycleClockSlow = CpuCycleClock<eCF_80MHz>;
 using CpuCycleClockNormal = CpuCycleClock<eCF_160MHz>;

--- a/Sming/Arch/Rp2040/Components/rp2040/src/clk.c
+++ b/Sming/Arch/Rp2040/Components/rp2040/src/clk.c
@@ -17,12 +17,12 @@ static void IRAM_ATTR systick_overflow_isr()
 
 uint32_t IRAM_ATTR esp_get_ccount()
 {
-	extern volatile uint32_t systick_overflow;
 	uint32_t ovf = systick_overflow;
 	if(ovf != systick_overflow) {
 		ovf = systick_overflow;
 	}
-	return systick_hw->cvr | (ovf << 24);
+	// CVR is a down-counter
+	return ((1 + ovf) << 24) - systick_hw->cvr;
 }
 
 /*! \brief Check if a given system clock frequency is valid/attainable

--- a/tests/HostTests/app/application.cpp
+++ b/tests/HostTests/app/application.cpp
@@ -54,6 +54,7 @@ void init()
 	debug_e("WELCOME to SMING! Host Tests application running.");
 
 	spiffs_mount();
+	fileSystemFormat();
 
 	registerTests();
 

--- a/tests/HostTests/modules/Clocks.cpp
+++ b/tests/HostTests/modules/Clocks.cpp
@@ -6,6 +6,7 @@
 
 #include <HostTests.h>
 #include <Platform/Timers.h>
+#include <HardwareTimer.h>
 
 template <class Clock, typename TimeType> class ClockTestTemplate : public TestGroup
 {
@@ -241,6 +242,20 @@ private:
 	bool verbose = false;
 	CpuCycleTimes refCycles;
 	CpuCycleTimes calcCycles;
+};
+
+template <hw_timer_clkdiv_t clkdiv>
+class Timer1ClockTestTemplate : public ClockTestTemplate<Timer1Clock<clkdiv>, uint32_t>
+{
+public:
+	void execute() override
+	{
+		// Configure the hardware to match selected clock divider
+		Timer1Api<clkdiv, eHWT_Maskable> timer;
+		timer.arm(false);
+
+		ClockTestTemplate<Timer1Clock<clkdiv>, uint32_t>::execute();
+	}
 };
 
 template <class Clock, typename TimeType> class CpuClockTestTemplate : public ClockTestTemplate<Clock, TimeType>
@@ -479,8 +494,8 @@ void REGISTER_TEST(Clocks)
 
 	registerGroup<TimerCalcTest>();
 
-	registerGroup<ClockTestTemplate<Timer1Clock<TIMER_CLKDIV_16>, uint32_t>>();
-	registerGroup<ClockTestTemplate<Timer1Clock<TIMER_CLKDIV_256>, uint32_t>>();
+	registerGroup<Timer1ClockTestTemplate<TIMER_CLKDIV_16>>();
+	registerGroup<Timer1ClockTestTemplate<TIMER_CLKDIV_256>>();
 
 	registerGroup<ClockTestTemplate<Timer2Clock, uint32_t>>();
 

--- a/tests/HostTests/modules/Timers.cpp
+++ b/tests/HostTests/modules/Timers.cpp
@@ -82,7 +82,10 @@ public:
 			}
 
 			auto mem = MallocCount::getCurrent();
-			String s = statusTimer;
+			String s;
+			s += system_get_time();
+			s += " ";
+			s += statusTimer;
 			s += " fired, timercount = ";
 			s += activeTimerCount;
 			s += ", mem = ";


### PR DESCRIPTION
#2455 changed the timer2 timebase so it no longer corresponds with the microsecond system clock used for OsTimer.

Added check in HostTests to catch this.
Also improve Host CPU clock emulation to accurately reflect selected frequency.

Also fix rp2040 esp_get_ccount return value, now passes tests.