### PR TITLE
Fix CI library python requirements

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -116,8 +116,9 @@ SAMPLE_NAMES		= $(notdir $(SAMPLE_PATHS))
 samples: $(SAMPLES_BUILT) ##Build all sample applications
 
 # Build any samples which haven't yet been marked
-$(SAMPLES_BUILT):
-	@printf "\n\n** Building $(notdir $(call dirx,$@)) **\n\n"
+%.built:
+	@printf "\n\n** Building $(@D) **\n\n"
+	$(Q) $(MAKE) --no-print-directory -C $(@D) submodules
 	$(Q) $(MAKE) --no-print-directory -C $(@D) PIP_ARGS=-q python-requirements sample
 	$(Q) touch $@
 
@@ -143,10 +144,6 @@ COMPONENT_SAMPLES_BUILT = $(addsuffix $(BUILT_SUFFIX),$(COMPONENT_SAMPLE_PATHS))
 .PHONY: build-component-samples
 build-component-samples: $(COMPONENT_SAMPLES_BUILT)
 
-$(COMPONENT_SAMPLES_BUILT):
-	@printf "\n\n** Building $(@D) **\n\n"
-	$(Q) $(MAKE) --no-print-directory -C $(@D) PIP_ARGS=-q python-requirements sample
-	$(Q) touch $@
 
 # This file is generated on failure during test phase
 export TEST_FAILURE_FILE := $(SMING_HOME)/.test-failure

--- a/Tools/ci/library/Makefile
+++ b/Tools/ci/library/Makefile
@@ -36,6 +36,7 @@ apps: $(APP_NAMES)
 .PHONY: $(APP_NAMES)
 $(APP_NAMES):
 	@printf "\n\n** Building $@ for $(SMING_SOC) **\n\n"
+	$(Q) $(MAKE) --no-print-directory -C $@ submodules
 	$(Q) $(MAKE) --no-print-directory -C $@ PIP_ARGS=-q python-requirements sample
 
 .PHONY: run-test

--- a/Tools/ci/library/appveyor.txt
+++ b/Tools/ci/library/appveyor.txt
@@ -37,10 +37,6 @@ install:
         . sming/Tools/ci/install.sh ${SMING_ARCH,,}
       fi
 
-  - ps: |
-      Start-Process -FilePath make -ArgumentList "-C $env:SMING_HOME fetch-$env:APPVEYOR_PROJECT_SLUG" -Wait -NoNewWindow
-
-
 build_script:
   - sh: make -j$(nproc) -f $CI_MAKEFILE
   - cmd: make -j%NUMBER_OF_PROCESSORS% -f %CI_MAKEFILE%


### PR DESCRIPTION
Building HueEmulator library fails because of missing `lxml` python requirement.

This is defined in UPnP-Schemas but `make fetch` doesn't recurse dependencies.

However, running `make submodules` from the project directory does fix the problem.
Should have gone with that to start with!

**Revise samples + component-samples build targets**

Add `make submodules` as things could break there too.
Merge make targets using %.built

* [x] Library test builds complete