### PR TITLE
Revise `FixPath` build function

### DIFF
--- a/Sming/util.mk
+++ b/Sming/util.mk
@@ -9,7 +9,7 @@
 ifeq ($(OS),Windows_NT)
 # Powershell does weird things to this variable, revert to default
 override MAKE	:= make
-FixPath			= $(subst //,/,$(subst \,/,/$(subst :,,$1)))
+FixPath			= $(if $(findstring :,$1),$(subst //,/,$(subst \,/,/$(subst :,,$1))),$(abspath $1))
 else
 FixPath			= $1
 endif

--- a/Tools/ci/build.cmd
+++ b/Tools/ci/build.cmd
@@ -33,8 +33,8 @@ cd /d %SMING_PROJECTS_DIR%/samples/Basic_Blink
 make help
 make list-config
 
-REM HostTests should build and run on all architectures
-%MAKE_PARALLEL% -C "%SMING_PROJECTS_DIR%/tests/HostTests"
+REM HostTests must build for all architectures
+%MAKE_PARALLEL% -C "%SMING_PROJECTS_DIR%/tests/HostTests" || goto :error
 
 REM Start Arch-specific tests
 cd /d %SMING_HOME%


### PR DESCRIPTION
Translates "" into "/" which is not only wrong but can do weird things in Windows.

Let's just check various path permutations to make sure they're handled correctly.
Test script:

```
define Check
$(info FixPath "$1": "$(call FixPath,$1)")
endef

$(call Check,)
$(call Check,C:\test)
$(call Check,test)
$(call Check,./test)
$(call Check,/c/test)
$(call Check,c:/test)
$(call Check,c:/path with spaces)
```

Run from `Basic_Blink` sample directory, we previously get this:

```
FixPath "": "/"
FixPath "C:\test": "/C/test"
FixPath "test": "/test"
FixPath "./test": "/./test"
FixPath "/c/test": "/c/test"
FixPath "c:/test": "/c/test"
FixPath "c:/path with spaces": "/c/path with spaces"
```

With this commit:

```
FixPath "": ""
FixPath "C:\test": "/C/test"
FixPath "test": "/s/sandboxes/sming-tmp/samples/Basic_Blink/test"
FixPath "./test": "/s/sandboxes/sming-tmp/samples/Basic_Blink/test"
FixPath "/c/test": "/c/test"
FixPath "c:/test": "/c/test"
FixPath "c:/path with spaces": "/c/path with spaces"
```