### PR TITLE
Fix `FixPath`

### DIFF
--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -52,7 +52,7 @@ endif
 # Convert Windows paths to POSIX paths
 DEBUG_VARS		+= OS
 ifeq ($(OS),Windows_NT)
-FixPath			= $(subst //,/,$(subst \,/,$(addprefix /,$(subst :,,$1))))
+FixPath			= $(if $(findstring :,$1),$(subst //,/,$(subst \,/,/$(subst :,,$1))),$(abspath $1))
 else
 FixPath			= $1
 endif


### PR DESCRIPTION
Translates "" into "/" which is not only wrong but can do weird things in Windows.

Let's just check various path permutations to make sure they're handled correctly.
Test script:

```
define Check
$(info FixPath "$1": "$(call FixPath,$1)")
endef

$(call Check,)
$(call Check,C:\test)
$(call Check,test)
$(call Check,./test)
$(call Check,/c/test)
$(call Check,c:/test)
$(call Check,c:/path with spaces)
```

Run from `Basic_Blink` sample directory, we previously get this:

```
FixPath "": "/"
FixPath "C:\test": "/C/test"
FixPath "test": "/test"
FixPath "./test": "/./test"
FixPath "/c/test": "/c/test"
FixPath "c:/test": "/c/test"
FixPath "c:/path with spaces": "/c/path with spaces"
```

With this commit:

```
FixPath "": ""
FixPath "C:\test": "/C/test"
FixPath "test": "/s/sandboxes/sming-tmp/samples/Basic_Blink/test"
FixPath "./test": "/s/sandboxes/sming-tmp/samples/Basic_Blink/test"
FixPath "/c/test": "/c/test"
FixPath "c:/test": "/c/test"
FixPath "c:/path with spaces": "/c/path with spaces"
```

Backported from #2459

Co-authored-by: Mike <mike@sillyhouse.net>