### PR TITLE
Fix issue with coding style fixer failing when list of files is too long

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -215,7 +215,7 @@ CS_SEARCH_DIRS	?= $(call ListAllSubDirs,$(CS_ROOT_DIRS))
 # Resultant set of directories whose contents to apply coding style to
 CS_DIRS			?= $(patsubst %/.cs,%,$(wildcard $(foreach d,$(CS_SEARCH_DIRS),$d/.cs)))
 # Files to apply coding style to
-CS_FILES		= $(if $(CS_DIRS),$(call rwildcard,$(CS_DIRS:=/*),%.cpp %.hpp %.h %.c),)
+CS_FILES		= $(if $(CS_DIRS),$(sort $(call rwildcard,$(CS_DIRS:=/*),%.cpp %.hpp %.h %.c)))
 
 .PHONY: cs
 cs: ##Apply coding style to all core files

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -281,9 +281,7 @@ endef
 # $1 -> List of files
 define ClangFormat
 	$(if $(V),$(info Applying coding style to $(words $1) files ...))
-	@for FILE in $1; do \
-		$(CLANG_FORMAT) -i -style=file $$FILE; \
-	done
+	$(foreach FILE,$1, $(shell clang-format -i -style=file $(FILE)))
 endef
 
 define ListSubmodules

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -281,7 +281,12 @@ endef
 # $1 -> List of files
 define ClangFormat
 	$(if $(V),$(info Applying coding style to $(words $1) files ...))
-	$(foreach FILE,$1, $(shell clang-format -i -style=file $(FILE)))
+	$(call ClangFormatBatch,$(sort $1))
+endef
+
+define ClangFormatBatch
+	@$(CLANG_FORMAT) -i -style=file $(wordlist 1,20,$1)
+	$(if $(word 20,$1),$(call ClangFormatBatch,$(wordlist 20,1000000,$1)))
 endef
 
 define ListSubmodules

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -281,12 +281,12 @@ endef
 # $1 -> List of files
 define ClangFormat
 	$(if $(V),$(info Applying coding style to $(words $1) files ...))
-	$(call ClangFormatBatch,$(sort $1))
+	$(call ClangFormatBatch,$1)
 endef
 
 define ClangFormatBatch
 	@$(CLANG_FORMAT) -i -style=file $(wordlist 1,20,$1)
-	$(if $(word 20,$1),$(call ClangFormatBatch,$(wordlist 20,1000000,$1)))
+	$(if $(word 21,$1),$(call ClangFormatBatch,$(wordlist 21,1000000,$1)))
 endef
 
 define ListSubmodules


### PR DESCRIPTION
At least fails for me on a stock Linux system. 

Excerpt from `xargs --show-limits`
```
POSIX upper limit on argument length (this system): 16772719
POSIX smallest allowable upper limit on argument length (all systems): 4096
Maximum length of command we could actually use: 16770270
```
