### PR TITLE
String::remove() should use memmove

### DIFF
--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -909,7 +909,7 @@ void String::remove(size_t index, size_t count)
 	}
 	char* writeTo = buffer() + index;
 	len -= count;
-	memcpy(writeTo, writeTo + count, len - index);
+	memmove(writeTo, writeTo + count, len - index);
 	setlen(len);
 }
 


### PR DESCRIPTION
Memory areas overlap, memcpy is unsafe