### PR TITLE
Host fixes (RTC clock setting, UART restrictions, thread race condition)

### DIFF
--- a/Sming/Arch/Host/Components/driver/component.mk
+++ b/Sming/Arch/Host/Components/driver/component.mk
@@ -23,7 +23,7 @@ ENABLE_HOST_UARTID	?=
 # Options to add when running emulator
 CACHE_VARS			+= HOST_UART_OPTIONS
 HOST_UART_OPTIONS	?= $(addprefix --uart=,$(ENABLE_HOST_UARTID))
-CLI_TARGET_OPTIONS += $(HOST_UART_OPTIONS)
+override CLI_TARGET_OPTIONS += $(HOST_UART_OPTIONS)
 
 # $1 -> Uart ID
 define RunHostTerminal

--- a/Sming/Arch/Host/Components/driver/uart.rst
+++ b/Sming/Arch/Host/Components/driver/uart.rst
@@ -9,8 +9,7 @@ Introduction
 Implements a UART driver to connect via TCP socket, allowing terminal emulation using telnet,
 or directly to local host serial device (e.g. /dev/ttyUSB0, COM4, etc.)
 
-By default, output to UART0 is sent to the console and keyboard input is written to the UART0 receive queue.
-If emulation is enabled on any ports then this behaviour is disabled.
+If not otherwise reassigned, UART0 output is sent to the console and keyboard input is written to the UART0 receive queue.
 
 
 Build variables
@@ -101,3 +100,7 @@ For Windows, substitute the appropriate device name, e.g. ``COM4`` instead of ``
 .. note::
 
    If necessary, add ``ENABLE_HOST_UARTID=`` to prevent telnet windows from being created.
+
+Console I/O may be assigned to a different port like this::
+
+   make run HOST_UART_OPTIONS="--uart=1 --device=console"

--- a/Sming/Arch/Host/Components/esp_wifi/component.mk
+++ b/Sming/Arch/Host/Components/esp_wifi/component.mk
@@ -5,7 +5,7 @@ COMPONENT_DEPENDS	:= lwip
 # Options to add for configuring host network behaviour
 CACHE_VARS				+= HOST_NETWORK_OPTIONS
 HOST_NETWORK_OPTIONS	?=
-CLI_TARGET_OPTIONS		+= $(HOST_NETWORK_OPTIONS)
+override CLI_TARGET_OPTIONS += $(HOST_NETWORK_OPTIONS)
 
 App-build: esp-wifi-check
 

--- a/Sming/Arch/Host/Components/hostlib/options.h
+++ b/Sming/Arch/Host/Components/hostlib/options.h
@@ -31,8 +31,10 @@
 	XX(help, no_argument, "Show help", nullptr, nullptr, nullptr)                                                      \
 	XX(uart, required_argument, "Enable UART server", "PORT", "Which UART number to enable",                           \
 	   "e.g. --uart=0 --uart=1 enable servers for UART0, UART1\0")                                                     \
-	XX(device, required_argument, "Set device for uart", "DEVICE", "Optionally map uart to device",                    \
-	   "e.g. --uart=0 --device=/dev/ttyUSB0\0")                                                                        \
+	XX(device, required_argument, "Set device for uart", "DEVICE",                                                     \
+	   "Optionally map uart to device. Use `console` to change printf target.",                                        \
+	   "e.g. --uart=0 --device=/dev/ttyUSB0\0"                                                                         \
+	   "     --uart=1 --device=console\0")                                                                             \
 	XX(baud, required_argument, "Set baud rate for UART", "BAUD", "Requires --device argument",                        \
 	   "e.g. --uart=0 --device=/dev/ttyUSB0 --baud=115200\0")                                                          \
 	XX(portbase, required_argument, "Specify base port number for UART socket servers", "PORT", "IP port number",      \

--- a/Sming/Arch/Host/Components/hostlib/threads.cpp
+++ b/Sming/Arch/Host/Components/hostlib/threads.cpp
@@ -223,13 +223,18 @@ void CThread::interrupt_begin()
 	assert(interrupt_level > interrupt_mask);
 
 	// Are we suspended by another thread?
-	suspendMutex.lock();
-	while(suspended != 0) {
-		suspendMutex.wait(resumeCond);
-	}
-	suspendMutex.unlock();
-
 	interrupt->lock();
+	while(suspended != 0) {
+		interrupt->unlock();
+
+		suspendMutex.lock();
+		while(suspended != 0) {
+			suspendMutex.wait(resumeCond);
+		}
+		suspendMutex.unlock();
+
+		interrupt->lock();
+	}
 
 	if(interrupt_mask == 0) {
 		suspend_main_thread();

--- a/Sming/Arch/Host/Components/vflash/component.mk
+++ b/Sming/Arch/Host/Components/vflash/component.mk
@@ -13,7 +13,7 @@ SPI_SIZE			= $(STORAGE_DEVICE_spiFlash_SIZE)
 # Options to add when running emulator
 CACHE_VARS			+= HOST_FLASH_OPTIONS
 HOST_FLASH_OPTIONS	?= --flashfile=$(FLASH_BIN) --flashsize=$(SPI_SIZE)
-CLI_TARGET_OPTIONS += $(HOST_FLASH_OPTIONS)
+override CLI_TARGET_OPTIONS += $(HOST_FLASH_OPTIONS)
 
 # Virtual flasher tool
 VFLASH := $(PYTHON) $(COMPONENT_PATH)/vflash.py $(FLASH_BIN) $(STORAGE_DEVICE_spiFlash_SIZE_BYTES)

--- a/Sming/Arch/Host/Platform/RTC.cpp
+++ b/Sming/Arch/Host/Platform/RTC.cpp
@@ -14,6 +14,11 @@
 
 RtcClass RTC;
 
+namespace
+{
+int timeDiff; // Difference between set time and system time
+}
+
 RtcClass::RtcClass()
 {
 }
@@ -30,7 +35,7 @@ uint32_t RtcClass::getRtcSeconds()
 {
 	struct timeval tv;
 	gettimeofday(&tv, nullptr);
-	return tv.tv_sec;
+	return tv.tv_sec + timeDiff;
 }
 
 bool RtcClass::setRtcNanoseconds(uint64_t nanoseconds)
@@ -40,5 +45,7 @@ bool RtcClass::setRtcNanoseconds(uint64_t nanoseconds)
 
 bool RtcClass::setRtcSeconds(uint32_t seconds)
 {
-	return false;
+	timeDiff = 0;
+	timeDiff = seconds - getRtcSeconds();
+	return true;
 }


### PR DESCRIPTION
**Allow setting Host RTC clock**

Calling `setRtcSeconds()` fails which can break applications.
Instead, note difference between set time and system time.

**UART improvements**

Remove Host UART1 TX-only restriction. (Originally included to mirror ESP8266 behaviour.)

Fix race condition in Host threads. Manifests with assertion failure running two telnet ports.

Allow console to be directed to alternative UART. Also default UART0 to console, even if other ports are redirected

**CLI_TARGET_OPTIONS**

We need a way to more miscellaneous settings from the command line. e.g. `make run CLI_TARGET_OPTIONS=--cpulimit=1`.
However, currently this means options from `HOST_NETWORK_OPTIONS` and `HOST_UART_OPTIONS` are ignored.
This might be considered a bug, so behaviour has been fixed so this works as expected.
