### PR TITLE
Add CStringArray push/pop methods

### DIFF
--- a/Sming/Core/Data/CStringArray.cpp
+++ b/Sming/Core/Data/CStringArray.cpp
@@ -81,6 +81,65 @@ const char* CStringArray::getValue(unsigned index) const
 	return nullptr;
 }
 
+bool CStringArray::pushFront(const char* str)
+{
+	if(str == nullptr) {
+		// Nothing to insert
+		return true;
+	}
+
+	auto str_len = strlen(str) + 1;
+	auto len = length();
+	if(!setLength(len + str_len)) {
+		return false;
+	}
+	char* ptr = String::begin();
+	memmove(ptr + str_len, ptr, str_len);
+	memcpy(ptr, str, str_len);
+	if(stringCount != 0) {
+		++stringCount;
+	}
+	return true;
+}
+
+String CStringArray::popFront()
+{
+	if(length() == 0) {
+		return nullptr;
+	}
+	auto p = c_str();
+	auto len = strlen(p);
+	String s(p, len);
+	remove(0, len + 1);
+	if(stringCount != 0) {
+		--stringCount;
+	}
+	return s;
+}
+
+const char* CStringArray::back() const
+{
+	size_t len = length();
+	if(len == 0) {
+		return nullptr;
+	}
+	return cbuffer() + lastIndexOf('\0', len - 2) + 1;
+}
+
+String CStringArray::popBack()
+{
+	auto backPtr = back();
+	if(backPtr == nullptr) {
+		return nullptr;
+	}
+	String s = backPtr;
+	setLength(backPtr - cbuffer());
+	if(stringCount != 0) {
+		--stringCount;
+	}
+	return s;
+}
+
 // Called when a string array is constructed or assigned
 void CStringArray::init()
 {

--- a/Sming/Core/Data/CStringArray.h
+++ b/Sming/Core/Data/CStringArray.h
@@ -191,6 +191,48 @@ public:
 		return getValue(index);
 	}
 
+	/**
+	 * @brief Get first value in array, null if empty
+	 */
+	const char* front() const
+	{
+		return cbuffer();
+	}
+
+	/**
+	 * @brief Insert item at start of array
+	 * @param str Item to insert
+	 * @retval bool false on memory error
+	 */
+	bool pushFront(const char* str);
+
+	/**
+	 * @brief Pop first item from array (at index 0)
+	 * @retval String null if array is empty
+	 */
+	String popFront();
+
+	/**
+	 * @brief Get last item in array, null if empty
+	 */
+	const char* back() const;
+
+	/**
+	 * @brief Add item to end of array
+	 * @param str Item to add
+	 * @retval bool false on memory error
+	 */
+	bool pushBack(const char* str)
+	{
+		return add(str);
+	}
+
+	/**
+	 * @brief Pop last item from array
+	 * @retval String null if array is empty
+	 */
+	String popBack();
+
 	/** @brief Empty the array
 	 */
 	void clear()

--- a/Sming/Core/Data/CStringArray.h
+++ b/Sming/Core/Data/CStringArray.h
@@ -215,13 +215,13 @@ public:
 		Iterator(const Iterator&) = default;
 
 		Iterator(const CStringArray* array, uint16_t offset, uint16_t index)
-			: array_(array), offset_(offset), index_(index)
+			: mArray(array), mOffset(offset), mIndex(index)
 		{
 		}
 
 		operator bool() const
 		{
-			return array_ != nullptr && offset_ < array_->length();
+			return mArray != nullptr && mOffset < mArray->length();
 		}
 
 		bool equals(const char* rhs) const
@@ -238,7 +238,7 @@ public:
 
 		bool operator==(const Iterator& rhs) const
 		{
-			return array_ == rhs.array_ && offset_ == rhs.offset_;
+			return mArray == rhs.mArray && mOffset == rhs.mOffset;
 		}
 
 		bool operator!=(const Iterator& rhs) const
@@ -278,11 +278,11 @@ public:
 
 		const char* str() const
 		{
-			if(array_ == nullptr) {
+			if(mArray == nullptr) {
 				return "";
 			}
 
-			return array_->c_str() + offset_;
+			return mArray->c_str() + mOffset;
 		}
 
 		const char* operator*() const
@@ -292,12 +292,12 @@ public:
 
 		uint16_t index() const
 		{
-			return index_;
+			return mIndex;
 		}
 
 		uint16_t offset() const
 		{
-			return offset_;
+			return mOffset;
 		}
 
 		Iterator& operator++()
@@ -316,17 +316,17 @@ public:
 		void next()
 		{
 			if(*this) {
-				offset_ += strlen(str()) + 1;
-				++index_;
+				mOffset += strlen(str()) + 1;
+				++mIndex;
 			}
 		}
 
 		using const_iterator = Iterator;
 
 	private:
-		const CStringArray* array_ = nullptr;
-		uint16_t offset_ = 0;
-		uint16_t index_ = 0;
+		const CStringArray* mArray = nullptr;
+		uint16_t mOffset = 0;
+		uint16_t mIndex = 0;
 	};
 
 	Iterator begin() const

--- a/docs/source/framework/core/data/cstringarray.rst
+++ b/docs/source/framework/core/data/cstringarray.rst
@@ -132,6 +132,29 @@ For more complex operations::
    }
 
 
+Pushing and popping
+-------------------
+
+CStringArray can be used as a simple FIFO or stack using push/pop methods.
+Behaviour is similar to STL deque, except pop methods also return a value.
+
+STACK::
+
+   CStringArray csa;
+   csa.pushBack("first value");
+   csa.pushBack("second value");
+   String popStack = csa.popBack(); // "second value"
+
+FIFO::
+
+   CStringArray csa;
+   csa.pushBack("first value");
+   csa.pushBack("second value");
+   String deque = csa.popFront(); // "first value"
+
+Note that popping values does not perform any memory de-allocation.
+
+
 Comparison with Vector<String>
 ------------------------------
 

--- a/tests/HostTests/modules/CStringArray.cpp
+++ b/tests/HostTests/modules/CStringArray.cpp
@@ -180,6 +180,39 @@ public:
 				std::swap(it1, it2);
 			}
 		}
+
+		TEST_CASE("push front")
+		{
+			CStringArray csa;
+			REQUIRE(csa.front() == nullptr);
+			REQUIRE(csa.pushFront("abc"));
+			REQUIRE_EQ(String(csa.front()), "abc");
+			REQUIRE(csa.pushFront("def"));
+			REQUIRE_EQ(String(csa.front()), "def");
+			REQUIRE_EQ(csa.count(), 2);
+			REQUIRE_EQ(csa.popFront(), "def");
+			REQUIRE_EQ(csa.count(), 1);
+			REQUIRE_EQ(csa.popFront(), "abc");
+			REQUIRE_EQ(csa.count(), 0);
+			REQUIRE(!csa.popFront());
+		}
+
+		TEST_CASE("push back")
+		{
+			CStringArray csa;
+			REQUIRE(csa.back() == nullptr);
+			REQUIRE(csa.pushBack("abc"));
+			REQUIRE(csa.pushBack("def"));
+			REQUIRE_EQ(csa.count(), 2);
+			REQUIRE_EQ(String(csa.back()), "def");
+			REQUIRE_EQ(csa.popBack(), "def");
+			REQUIRE_EQ(String(csa.back()), "abc");
+			REQUIRE_EQ(csa.count(), 1);
+			REQUIRE_EQ(csa.popBack(), "abc");
+			REQUIRE_EQ(csa.count(), 0);
+			REQUIRE(csa.back() == nullptr);
+			REQUIRE(!csa.popBack());
+		}
 	}
 };
 


### PR DESCRIPTION
This PR extends CStringArray so it can be used as a FIFO or stack:

```
const char* front() const;
bool pushFront(const char* str);
String popFront();
const char* back() const;
bool pushBack(const char* str);
String popBack();
```

Method names and behaviour consistent with STL.
