### PR TITLE
Add `*` and `->` operators to Hashmap iterator

### DIFF
--- a/Sming/Wiring/WHashMap.h
+++ b/Sming/Wiring/WHashMap.h
@@ -70,6 +70,26 @@ public:
 			return *this;
 		}
 
+		Value& operator*()
+		{
+			return v;
+		}
+
+		const Value& operator*() const
+		{
+			return v;
+		}
+
+		Value* operator->()
+		{
+			return &v;
+		}
+
+		const Value* operator->() const
+		{
+			return &v;
+		}
+
 	private:
 		const K& k;
 		Value& v;

--- a/tests/HostTests/modules/Wiring.cpp
+++ b/tests/HostTests/modules/Wiring.cpp
@@ -14,7 +14,7 @@ public:
 	{
 		Serial.print(e.key());
 		Serial.print(" = ");
-		Serial.println(e.value());
+		Serial.println(*e);
 	}
 
 	template <typename Map> void print(const Map& map) const
@@ -37,8 +37,15 @@ public:
 			print(map);
 
 			for(auto e : map) {
-				e.value() += ": gobbed";
+				String s = *e;
+				e->length();
 			}
+
+			for(auto e : map) {
+				*e += ": gobbed";
+			}
+
+			REQUIRE_EQ(map["b"], "value(b): gobbed");
 
 			print(map);
 		}


### PR DESCRIPTION
This PR enables more natural use of iteration:

```
HashMap<int, String> map;
map[0] = "abc";'
map[2] = "def";
for(auto entry: map) {
  Serial.println(*entry); // Previously had to use entry->value()
  Serial.println(entry->length()); // entry->value().length();
}
```