### PR TITLE
Fix incorrect use of assert - breaks release builds

### DIFF
--- a/Sming/Arch/Esp32/Components/esp32/src/startup.cpp
+++ b/Sming/Arch/Esp32/Components/esp32/src/startup.cpp
@@ -27,9 +27,13 @@ namespace
 {
 void main(void*)
 {
-	assert(esp_task_wdt_init(CONFIG_ESP_TASK_WDT_TIMEOUT_S, true) == ESP_OK);
-	assert(esp_task_wdt_add(NULL) == ESP_OK);
-	assert(esp_task_wdt_status(NULL) == ESP_OK);
+	auto err = esp_task_wdt_init(CONFIG_ESP_TASK_WDT_TIMEOUT_S, true);
+	(void)err;
+	assert(err == ESP_OK);
+	err = esp_task_wdt_add(nullptr);
+	assert(err == ESP_OK);
+	err = esp_task_wdt_status(nullptr);
+	assert(err == ESP_OK);
 
 	hw_timer_init();
 

--- a/Sming/Arch/Host/Components/hostlib/threads.cpp
+++ b/Sming/Arch/Host/Components/hostlib/threads.cpp
@@ -94,7 +94,9 @@ void suspend_main_thread()
 #else
 
 	assert(!mainThreadSignalled);
-	assert(pthread_kill(mainThread, pauseSignal) == 0);
+	int err = pthread_kill(mainThread, pauseSignal);
+	(void)err;
+	assert(err == 0);
 	while(!mainThreadSignalled) {
 		sched_yield();
 	}
@@ -109,7 +111,9 @@ void resume_main_thread()
 	ResumeThread(pthread_getw32threadhandle_np(mainThread));
 #else
 	assert(mainThreadSignalled);
-	assert(pthread_kill(mainThread, resumeSignal) == 0);
+	int err = pthread_kill(mainThread, resumeSignal);
+	(void)err;
+	assert(err == 0);
 	while(mainThreadSignalled) {
 		sched_yield();
 	}

--- a/Sming/Core/Data/Stream/LimitedMemoryStream.cpp
+++ b/Sming/Core/Data/Stream/LimitedMemoryStream.cpp
@@ -82,7 +82,9 @@ bool LimitedMemoryStream::moveString(String& s)
 		sizeOk = false;
 	}
 
-	assert(s.setBuffer({buffer, capacity, size - 1}));
+	bool res = s.setBuffer({buffer, capacity, size - 1});
+	(void)res;
+	assert(res);
 
 	owned = false;
 	buffer = nullptr;

--- a/Sming/Core/Data/Stream/MemoryDataStream.cpp
+++ b/Sming/Core/Data/Stream/MemoryDataStream.cpp
@@ -103,7 +103,9 @@ bool MemoryDataStream::moveString(String& s)
 	bool sizeOk = ensureCapacity(size + 1);
 
 	// If we couldn't reallocate for the NUL terminator, drop the last character
-	assert(s.setBuffer({buffer, capacity, sizeOk ? size : size - 1}));
+	bool res = s.setBuffer({buffer, capacity, sizeOk ? size : size - 1});
+	(void)res;
+	assert(res);
 
 	buffer = nullptr;
 	readPos = 0;


### PR DESCRIPTION
Occasionally I forget that `assert()` calls are completely omitted in NDEBUG (release) builds. This is bad:

```
assert(esp_task_wdt_init(CONFIG_ESP_TASK_WDT_TIMEOUT_S, true) == ESP_OK);
```
