### PR TITLE
Fix `ListSubDirs` build function

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -61,7 +61,7 @@ submodules: $(ALL_SUBMODULES:=/.submodule) ##Fetch all third-party submodules (b
 
 # Build a list of available Components
 COMPONENT_SEARCH_DIRS	+= $(ARCH_COMPONENTS) Components Libraries
-ALL_COMPONENT_DIRS := $(sort $(foreach d,$(COMPONENT_SEARCH_DIRS),$(call ListSubDirs,$d)))
+ALL_COMPONENT_DIRS := $(sort $(call ListSubDirs,$(COMPONENT_SEARCH_DIRS)))
 
 # Generates a rule to fetch all submodules for a Component
 # $1 Component name

--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -227,7 +227,7 @@ endif # PROJECT_SOC
 endef # ParseComponent
 
 # Build a list of all available Components
-ALL_COMPONENT_DIRS = $(foreach d,$(ALL_SEARCH_DIRS),$(call ListSubDirs,$d))
+ALL_COMPONENT_DIRS = $(call ListSubDirs,$(ALL_SEARCH_DIRS))
 
 # Lookup Component directory from a name
 # $1 -> Component name

--- a/Sming/util.mk
+++ b/Sming/util.mk
@@ -46,7 +46,7 @@ endef
 # Results are sorted and without trailing path separator
 # $1 -> Root paths
 define ListSubDirs
-$(foreach d,$(dir $(wildcard $1/*/.)),$(d:/=))
+$(foreach d,$(dir $(wildcard $(addsuffix /*/.,$1))),$(d:/=))
 endef
 
 # Check that $2 is a valid sub-directory of $1. Return empty string if not.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -108,7 +108,7 @@ COMPONENT_ROOT_DIRS := \
 	$(SMINGDIR)/samples
 
 # All directories where a README file should/must exist, and where a component.mk file could exist
-COMPONENT_DIRS := $(SMING_HOME) $(foreach d,$(COMPONENT_ROOT_DIRS),$(call ListSubDirs,$d))
+COMPONENT_DIRS := $(SMING_HOME) $(call ListSubDirs,$(COMPONENT_ROOT_DIRS))
 COMPONENT_SAMPLES := $(wildcard $(addsuffix /samples/*/component.mk,$(COMPONENT_DIRS)))
 COMPONENT_DIRS += $(COMPONENT_SAMPLES:/component.mk=)
 


### PR DESCRIPTION
Calling with no/empty parameters should produce no results, but instead get a list of root directories.
It should also handle multiple parameters.