### PR TITLE
Add `MacAddress` constructor to create from String

### DIFF
--- a/Sming/Wiring/MacAddress.cpp
+++ b/Sming/Wiring/MacAddress.cpp
@@ -50,15 +50,6 @@ MacAddress::MacAddress(const String& s)
 	memcpy(octets, res, sizeof(res));
 }
 
-uint8_t MacAddress::operator[](unsigned index) const
-{
-	if(index >= sizeof(octets)) {
-		abort();
-	}
-
-	return octets[index];
-}
-
 uint8_t& MacAddress::operator[](unsigned index)
 {
 	if(index >= sizeof(octets)) {

--- a/Sming/Wiring/MacAddress.cpp
+++ b/Sming/Wiring/MacAddress.cpp
@@ -23,6 +23,33 @@
 #include "MacAddress.h"
 #include <Data/HexString.h>
 
+MacAddress::MacAddress(const String& s)
+{
+	// Maximum length with 2 hex digits per octet plus optional separator
+	bool sep;
+	if(s.length() == 12) {
+		sep = false;
+	} else if(s.length() == 17) {
+		sep = true;
+	} else {
+		return;
+	}
+	auto str = s.c_str();
+	unsigned pos{0};
+	Octets res{};
+	for(unsigned i = 0; i < 6; ++i) {
+		if(sep && i != 5 && strchr(_F(":-.,/ "), str[2]) == nullptr) {
+			return;
+		}
+		if(!isxdigit(str[0]) || !isxdigit(str[1])) {
+			return;
+		}
+		res[i] = (unhex(str[0]) << 4) | unhex(str[1]);
+		str += 2 + unsigned(sep);
+	}
+	memcpy(octets, res, sizeof(res));
+}
+
 uint8_t MacAddress::operator[](unsigned index) const
 {
 	if(index >= sizeof(octets)) {

--- a/Sming/Wiring/MacAddress.h
+++ b/Sming/Wiring/MacAddress.h
@@ -54,6 +54,13 @@ public:
 	}
 
 	/**
+	 * @brief Create a MAC address from valid string.
+	 * e.g. 01:02:03:04:05:06
+	 * Separators are optional.
+	 */
+	MacAddress(const String& s);
+
+	/**
 	 * @brief Get the octets of the MAC address.
 	 */
 	void getOctets(Octets& octets) const

--- a/Sming/Wiring/MacAddress.h
+++ b/Sming/Wiring/MacAddress.h
@@ -79,14 +79,17 @@ public:
 	/**
 	 * @brief Get the octet at the given index in the MAC address.
 	 * @param index The index.
-	 * @return The octet at the given index.
+	 * @retval const uint8_t& Read-only reference to the octet at the given index.
 	 */
-	uint8_t operator[](unsigned index) const;
+	const uint8_t& operator[](unsigned index) const
+	{
+		return const_cast<MacAddress*>(this)->operator[](index);
+	}
 
 	/**
 	 * @brief Get a reference to the octet at the given index in the MAC address.
 	 * @param index The index.
-	 * @return A reference to the octet at the given index.
+	 * @retval uint8_t& A writeable reference to the octet at the given index.
 	 */
 	uint8_t& operator[](unsigned index);
 

--- a/tests/HostTests/modules/Wiring.cpp
+++ b/tests/HostTests/modules/Wiring.cpp
@@ -2,6 +2,7 @@
 
 #include <WHashMap.h>
 #include <WVector.h>
+#include <MacAddress.h>
 
 class WiringTest : public TestGroup
 {

--- a/tests/HostTests/modules/Wiring.cpp
+++ b/tests/HostTests/modules/Wiring.cpp
@@ -70,6 +70,21 @@ public:
 				Serial.println(e);
 			}
 		}
+
+		TEST_CASE("MacAddress")
+		{
+			const uint8_t refOctets[]{0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc};
+			const MacAddress ref{refOctets};
+			REQUIRE(memcmp(&ref[0], refOctets, 6) == 0);
+			REQUIRE(MacAddress("123456789abc") == ref);
+			REQUIRE(MacAddress("12:34:56:78:9A:bc") == ref);
+			REQUIRE(MacAddress("12.34:56:78:9a:Bc") == ref);
+			REQUIRE(MacAddress("12 34 56 78 9a bC") == ref);
+			REQUIRE(MacAddress("ffffffffffff") == MacAddress({0xff, 0xff, 0xff, 0xff, 0xff, 0xff}));
+			REQUIRE(!MacAddress("123456789abc."));
+			REQUIRE(!MacAddress(""));
+			REQUIRE(!MacAddress("fffffffgfffff"));
+		}
 	}
 };
 


### PR DESCRIPTION
Add `MacAddress(const String&)` constructor

Works with both `aa:bb:cc:dd:ee:ff` and `aabbccddeeff` forms.
Add tests, change const operator[] to return constant reference to octets