### PR TITLE
Add uart interrupt config and format control

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp32/Components/driver/uart.cpp
@@ -655,7 +655,7 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 	uart_ll_set_tx_idle_num(dev, 0);
 
 	// Bottom 8 bits identical to esp8266
-	dev->conf0.val = (dev->conf0.val & 0xFFFFFF00) | cfg.config;
+	dev->conf0.val = (dev->conf0.val & 0xFFFFFF00) | cfg.format;
 
 	smg_uart_set_baudrate(uart, cfg.baudrate);
 	smg_uart_flush(uart);
@@ -690,13 +690,13 @@ void smg_uart_uninit(smg_uart_t* uart)
 	delete uart;
 }
 
-void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)
+void smg_uart_set_format(smg_uart_t* uart, smg_uart_format_t format)
 {
 	uart = get_physical(uart);
 	if(uart == nullptr) {
 		return;
 	}
-	smg_uart_config_format_t fmt{.val = config};
+	smg_uart_config_format_t fmt{.val = format};
 	auto dev = getDevice(uart->uart_nr);
 	uart_ll_set_data_bit_num(dev, uart_word_length_t(fmt.bits));
 	uart_ll_set_parity(dev, uart_parity_t(fmt.parity));

--- a/Sming/Arch/Esp32/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp32/Components/driver/uart.cpp
@@ -152,36 +152,6 @@ smg_uart_t* get_physical(smg_uart_t* uart)
 	return uart;
 }
 
-bool realloc_buffer(SerialBuffer*& buffer, size_t new_size)
-{
-	if(buffer != nullptr) {
-		if(new_size == 0) {
-			smg_uart_disable_interrupts();
-			delete buffer;
-			buffer = nullptr;
-			smg_uart_restore_interrupts();
-			return true;
-		}
-
-		return buffer->resize(new_size) == new_size;
-	}
-
-	if(new_size == 0) {
-		return true;
-	}
-
-	// Avoid allocating in SPIRAM
-	auto mem = heap_caps_malloc(sizeof(SerialBuffer), MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
-	auto new_buf = new(mem) SerialBuffer;
-	if(new_buf != nullptr && new_buf->resize(new_size) == new_size) {
-		buffer = new_buf;
-		return true;
-	}
-
-	delete new_buf;
-	return false;
-}
-
 /** @brief UART interrupt service routine
  *  @note both UARTS share the same ISR, although UART1 only supports transmit
  */
@@ -314,51 +284,6 @@ void smg_uart_set_callback(smg_uart_t* uart, smg_uart_callback_t callback, void*
 		uart->param = param;
 		uart->callback = callback;
 	}
-}
-
-size_t smg_uart_resize_rx_buffer(smg_uart_t* uart, size_t new_size)
-{
-	if(smg_uart_rx_enabled(uart)) {
-		realloc_buffer(uart->rx_buffer, new_size);
-	}
-	return smg_uart_rx_buffer_size(uart);
-}
-
-size_t smg_uart_rx_buffer_size(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->rx_buffer != nullptr ? uart->rx_buffer->getSize() : 0;
-}
-
-size_t smg_uart_resize_tx_buffer(smg_uart_t* uart, size_t new_size)
-{
-	if(smg_uart_tx_enabled(uart)) {
-		realloc_buffer(uart->tx_buffer, new_size);
-	}
-	return smg_uart_tx_buffer_size(uart);
-}
-
-size_t smg_uart_tx_buffer_size(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->tx_buffer != nullptr ? uart->tx_buffer->getSize() : 0;
-}
-
-int smg_uart_peek_char(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->rx_buffer ? uart->rx_buffer->peekChar() : -1;
-}
-
-int smg_uart_rx_find(smg_uart_t* uart, char c)
-{
-	if(uart == nullptr || uart->rx_buffer == nullptr) {
-		return -1;
-	}
-
-	return uart->rx_buffer->find(c);
-}
-
-int smg_uart_peek_last_char(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->rx_buffer != nullptr ? uart->rx_buffer->peekLastChar() : -1;
 }
 
 size_t smg_uart_read(smg_uart_t* uart, void* buffer, size_t size)
@@ -687,7 +612,7 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 	auto txBufferSize = cfg.tx_size;
 
 	if(smg_uart_rx_enabled(uart)) {
-		if(!realloc_buffer(uart->rx_buffer, rxBufferSize)) {
+		if(!smg_uart_realloc_buffer(uart->rx_buffer, rxBufferSize)) {
 			delete uart;
 			return nullptr;
 		}
@@ -697,7 +622,7 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 	}
 
 	if(smg_uart_tx_enabled(uart)) {
-		if(!realloc_buffer(uart->tx_buffer, txBufferSize)) {
+		if(!smg_uart_realloc_buffer(uart->tx_buffer, txBufferSize)) {
 			delete uart->rx_buffer;
 			delete uart;
 			return nullptr;
@@ -763,21 +688,6 @@ void smg_uart_uninit(smg_uart_t* uart)
 	delete uart->rx_buffer;
 	delete uart->tx_buffer;
 	delete uart;
-}
-
-smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, uint32_t config, smg_uart_mode_t mode, uint8_t tx_pin,
-						  size_t rx_size, size_t tx_size)
-{
-	smg_uart_config_t cfg = {.uart_nr = uart_nr,
-							 .tx_pin = tx_pin,
-							 .rx_pin = UART_PIN_DEFAULT,
-							 .mode = mode,
-							 .options = _BV(UART_OPT_TXWAIT),
-							 .baudrate = baudrate,
-							 .config = config,
-							 .rx_size = rx_size,
-							 .tx_size = tx_size};
-	return smg_uart_init_ex(cfg);
 }
 
 void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)

--- a/Sming/Arch/Esp8266/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp8266/Components/driver/uart.cpp
@@ -144,36 +144,6 @@ smg_uart_t* get_physical(smg_uart_t* uart)
 	return uart;
 }
 
-bool realloc_buffer(SerialBuffer*& buffer, size_t new_size)
-{
-	if(buffer != nullptr) {
-		size_t res = 0;
-		smg_uart_disable_interrupts();
-		if(new_size == 0) {
-			delete buffer;
-			buffer = nullptr;
-		} else {
-			res = buffer->resize(new_size);
-		}
-		smg_uart_restore_interrupts();
-
-		return res == new_size;
-	}
-
-	if(new_size == 0) {
-		return true;
-	}
-
-	auto new_buf = new SerialBuffer;
-	if(new_buf != nullptr && new_buf->resize(new_size) == new_size) {
-		buffer = new_buf;
-		return true;
-	}
-
-	delete new_buf;
-	return false;
-}
-
 /**
  * @brief service interrupts for a UART
  * @param uart_nr identifies which UART to check
@@ -380,51 +350,6 @@ void smg_uart_set_callback(smg_uart_t* uart, smg_uart_callback_t callback, void*
 		uart->param = param;
 		uart->callback = callback;
 	}
-}
-
-size_t smg_uart_resize_rx_buffer(smg_uart_t* uart, size_t new_size)
-{
-	if(smg_uart_rx_enabled(uart)) {
-		realloc_buffer(uart->rx_buffer, new_size);
-	}
-	return smg_uart_rx_buffer_size(uart);
-}
-
-size_t smg_uart_rx_buffer_size(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->rx_buffer != nullptr ? uart->rx_buffer->getSize() : 0;
-}
-
-size_t smg_uart_resize_tx_buffer(smg_uart_t* uart, size_t new_size)
-{
-	if(smg_uart_tx_enabled(uart)) {
-		realloc_buffer(uart->tx_buffer, new_size);
-	}
-	return smg_uart_tx_buffer_size(uart);
-}
-
-size_t smg_uart_tx_buffer_size(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->tx_buffer != nullptr ? uart->tx_buffer->getSize() : 0;
-}
-
-int smg_uart_peek_char(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->rx_buffer ? uart->rx_buffer->peekChar() : -1;
-}
-
-int smg_uart_rx_find(smg_uart_t* uart, char c)
-{
-	if(uart == nullptr || uart->rx_buffer == nullptr) {
-		return -1;
-	}
-
-	return uart->rx_buffer->find(c);
-}
-
-int smg_uart_peek_last_char(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->rx_buffer != nullptr ? uart->rx_buffer->peekLastChar() : -1;
 }
 
 size_t smg_uart_read(smg_uart_t* uart, void* buffer, size_t size)
@@ -753,12 +678,12 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 			txBufferSize += UART_TX_FIFO_SIZE;
 		}
 
-		if(smg_uart_rx_enabled(uart) && !realloc_buffer(uart->rx_buffer, rxBufferSize)) {
+		if(smg_uart_rx_enabled(uart) && !smg_uart_realloc_buffer(uart->rx_buffer, rxBufferSize)) {
 			delete uart;
 			return nullptr;
 		}
 
-		if(smg_uart_tx_enabled(uart) && !realloc_buffer(uart->tx_buffer, txBufferSize)) {
+		if(smg_uart_tx_enabled(uart) && !smg_uart_realloc_buffer(uart->tx_buffer, txBufferSize)) {
 			delete uart->rx_buffer;
 			delete uart;
 			return nullptr;
@@ -795,7 +720,7 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 		uart->mode = UART_TX_ONLY;
 
 		// Transmit buffer optional
-		if(!realloc_buffer(uart->tx_buffer, txBufferSize)) {
+		if(!smg_uart_realloc_buffer(uart->tx_buffer, txBufferSize)) {
 			delete uart;
 			return nullptr;
 		}
@@ -850,23 +775,6 @@ void smg_uart_uninit(smg_uart_t* uart)
 	delete uart->rx_buffer;
 	delete uart->tx_buffer;
 	delete uart;
-}
-
-smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, uint32_t config, smg_uart_mode_t mode, uint8_t tx_pin,
-						  size_t rx_size, size_t tx_size)
-{
-	smg_uart_config_t cfg = {
-		.uart_nr = uart_nr,
-		.tx_pin = tx_pin,
-		.rx_pin = UART_PIN_DEFAULT,
-		.mode = mode,
-		.options = _BV(UART_OPT_TXWAIT),
-		.baudrate = baudrate,
-		.config = config,
-		.rx_size = rx_size,
-		.tx_size = tx_size,
-	};
-	return smg_uart_init_ex(cfg);
 }
 
 void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)

--- a/Sming/Arch/Esp8266/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp8266/Components/driver/uart.cpp
@@ -146,15 +146,17 @@ smg_uart_t* get_physical(smg_uart_t* uart)
 bool realloc_buffer(SerialBuffer*& buffer, size_t new_size)
 {
 	if(buffer != nullptr) {
+		size_t res = 0;
+		smg_uart_disable_interrupts();
 		if(new_size == 0) {
-			smg_uart_disable_interrupts();
 			delete buffer;
 			buffer = nullptr;
-			smg_uart_restore_interrupts();
-			return true;
+		} else {
+			res = buffer->resize(new_size);
 		}
+		smg_uart_restore_interrupts();
 
-		return buffer->resize(new_size) == new_size;
+		return res == new_size;
 	}
 
 	if(new_size == 0) {

--- a/Sming/Arch/Esp8266/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp8266/Components/driver/uart.cpp
@@ -708,7 +708,7 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 
 		CLEAR_PERI_REG_MASK(UART_SWAP_REG, UART_SWAP0);
 
-		WRITE_PERI_REG(UART_CONF0(UART0), cfg.config);
+		WRITE_PERI_REG(UART_CONF0(UART0), cfg.format);
 		break;
 
 	case UART1:
@@ -729,7 +729,7 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 		smg_uart_detach(cfg.uart_nr);
 		uart->tx_pin = 2;
 		uart1_pin_select(uart->tx_pin);
-		WRITE_PERI_REG(UART_CONF0(UART1), cfg.config);
+		WRITE_PERI_REG(UART_CONF0(UART1), cfg.format);
 		break;
 
 	default:
@@ -777,11 +777,11 @@ void smg_uart_uninit(smg_uart_t* uart)
 	delete uart;
 }
 
-void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)
+void smg_uart_set_format(smg_uart_t* uart, smg_uart_format_t format)
 {
 	uart = get_physical(uart);
 	if(uart != nullptr) {
-		SET_PERI_REG_BITS(UART_CONF0(uart->uart_nr), 0xff, config, 0);
+		SET_PERI_REG_BITS(UART_CONF0(uart->uart_nr), 0xff, format, 0);
 	}
 }
 

--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbuart.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbuart.cpp
@@ -382,7 +382,7 @@ bool ATTR_GDBINIT gdb_uart_init()
 		.mode = UART_FULL,
 		.options = _BV(UART_OPT_TXWAIT) | _BV(UART_OPT_CALLBACK_RAW),
 		.baudrate = SERIAL_BAUD_RATE,
-		.config = UART_8N1,
+		.format = UART_8N1,
 		.rx_size = 0,
 		.tx_size = 0,
 	};

--- a/Sming/Arch/Host/Components/driver/uart.cpp
+++ b/Sming/Arch/Host/Components/driver/uart.cpp
@@ -78,34 +78,6 @@ __forceinline bool smg_uart_isr_enabled(uint8_t nr)
 	return bitRead(isrMask, nr);
 }
 
-bool realloc_buffer(SerialBuffer*& buffer, size_t new_size)
-{
-	if(buffer != nullptr) {
-		if(new_size == 0) {
-			(void)smg_uart_disable_interrupts();
-			delete buffer;
-			buffer = nullptr;
-			smg_uart_restore_interrupts();
-			return true;
-		}
-
-		return buffer->resize(new_size) == new_size;
-	}
-
-	if(new_size == 0) {
-		return true;
-	}
-
-	auto new_buf = new SerialBuffer;
-	if(new_buf != nullptr && new_buf->resize(new_size) == new_size) {
-		buffer = new_buf;
-		return true;
-	}
-
-	delete new_buf;
-	return false;
-}
-
 } // namespace
 
 smg_uart_t* smg_uart_get_uart(uint8_t uart_nr)
@@ -139,51 +111,6 @@ void smg_uart_set_callback(smg_uart_t* uart, smg_uart_callback_t callback, void*
 		uart->param = param;
 		uart->callback = callback;
 	}
-}
-
-size_t smg_uart_resize_rx_buffer(smg_uart_t* uart, size_t new_size)
-{
-	if(smg_uart_rx_enabled(uart)) {
-		realloc_buffer(uart->rx_buffer, new_size);
-	}
-	return smg_uart_rx_buffer_size(uart);
-}
-
-size_t smg_uart_rx_buffer_size(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->rx_buffer != nullptr ? uart->rx_buffer->getSize() : 0;
-}
-
-size_t smg_uart_resize_tx_buffer(smg_uart_t* uart, size_t new_size)
-{
-	if(smg_uart_tx_enabled(uart)) {
-		realloc_buffer(uart->tx_buffer, new_size);
-	}
-	return smg_uart_tx_buffer_size(uart);
-}
-
-size_t smg_uart_tx_buffer_size(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->tx_buffer != nullptr ? uart->tx_buffer->getSize() : 0;
-}
-
-int smg_uart_peek_char(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->rx_buffer ? uart->rx_buffer->peekChar() : -1;
-}
-
-int smg_uart_rx_find(smg_uart_t* uart, char c)
-{
-	if(uart == nullptr || uart->rx_buffer == nullptr) {
-		return -1;
-	}
-
-	return uart->rx_buffer->find(c);
-}
-
-int smg_uart_peek_last_char(smg_uart_t* uart)
-{
-	return uart != nullptr && uart->rx_buffer != nullptr ? uart->rx_buffer->peekLastChar() : -1;
 }
 
 size_t smg_uart_read(smg_uart_t* uart, void* buffer, size_t size)
@@ -381,12 +308,12 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 	rxBufferSize += UART_RX_FIFO_SIZE;
 	txBufferSize += UART_TX_FIFO_SIZE;
 
-	if(smg_uart_rx_enabled(uart) && !realloc_buffer(uart->rx_buffer, rxBufferSize)) {
+	if(smg_uart_rx_enabled(uart) && !smg_uart_realloc_buffer(uart->rx_buffer, rxBufferSize)) {
 		delete uart;
 		return nullptr;
 	}
 
-	if(smg_uart_tx_enabled(uart) && !realloc_buffer(uart->tx_buffer, txBufferSize)) {
+	if(smg_uart_tx_enabled(uart) && !smg_uart_realloc_buffer(uart->tx_buffer, txBufferSize)) {
 		delete uart->rx_buffer;
 		delete uart;
 		return nullptr;
@@ -423,23 +350,6 @@ void smg_uart_uninit(smg_uart_t* uart)
 	delete uart->rx_buffer;
 	delete uart->tx_buffer;
 	delete uart;
-}
-
-smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, smg_uart_format_t config, smg_uart_mode_t mode,
-						  uint8_t tx_pin, size_t rx_size, size_t tx_size)
-{
-	smg_uart_config_t cfg = {
-		.uart_nr = uart_nr,
-		.tx_pin = tx_pin,
-		.rx_pin = UART_PIN_DEFAULT,
-		.mode = mode,
-		.options = _BV(UART_OPT_TXWAIT),
-		.baudrate = baudrate,
-		.config = config,
-		.rx_size = rx_size,
-		.tx_size = tx_size,
-	};
-	return smg_uart_init_ex(cfg);
 }
 
 void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)

--- a/Sming/Arch/Host/Components/driver/uart.cpp
+++ b/Sming/Arch/Host/Components/driver/uart.cpp
@@ -425,8 +425,8 @@ void smg_uart_uninit(smg_uart_t* uart)
 	delete uart;
 }
 
-smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, uint32_t config, smg_uart_mode_t mode, uint8_t tx_pin,
-						  size_t rx_size, size_t tx_size)
+smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, smg_uart_format_t config, smg_uart_mode_t mode,
+						  uint8_t tx_pin, size_t rx_size, size_t tx_size)
 {
 	smg_uart_config_t cfg = {
 		.uart_nr = uart_nr,

--- a/Sming/Arch/Host/Components/driver/uart.cpp
+++ b/Sming/Arch/Host/Components/driver/uart.cpp
@@ -396,6 +396,7 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 	smg_uart_detach(cfg.uart_nr);
 
 	smg_uart_set_baudrate(uart, cfg.baudrate);
+	smg_uart_set_config(uart, cfg.config);
 	smg_uart_flush(uart);
 	uartInstances[cfg.uart_nr] = uart;
 	smg_uart_start_isr(uart);
@@ -439,6 +440,21 @@ smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, uint32_t config, s
 		.tx_size = tx_size,
 	};
 	return smg_uart_init_ex(cfg);
+}
+
+void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)
+{
+	// Not implemented
+	(void)uart;
+	(void)config;
+}
+
+bool smg_uart_intr_config(smg_uart_t* uart, const smg_uart_intr_config_t* config)
+{
+	// Not implemented
+	(void)uart;
+	(void)config;
+	return false;
 }
 
 void smg_uart_swap(smg_uart_t* uart, int tx_pin)

--- a/Sming/Arch/Host/Components/driver/uart.cpp
+++ b/Sming/Arch/Host/Components/driver/uart.cpp
@@ -323,7 +323,7 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 	smg_uart_detach(cfg.uart_nr);
 
 	smg_uart_set_baudrate(uart, cfg.baudrate);
-	smg_uart_set_config(uart, cfg.config);
+	smg_uart_set_format(uart, cfg.format);
 	smg_uart_flush(uart);
 	uartInstances[cfg.uart_nr] = uart;
 	smg_uart_start_isr(uart);
@@ -352,11 +352,11 @@ void smg_uart_uninit(smg_uart_t* uart)
 	delete uart;
 }
 
-void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)
+void smg_uart_set_format(smg_uart_t* uart, smg_uart_format_t format)
 {
 	// Not implemented
 	(void)uart;
-	(void)config;
+	(void)format;
 }
 
 bool smg_uart_intr_config(smg_uart_t* uart, const smg_uart_intr_config_t* config)

--- a/Sming/Arch/Host/Components/hostlib/threads.cpp
+++ b/Sming/Arch/Host/Components/hostlib/threads.cpp
@@ -23,7 +23,6 @@
 #include <signal.h>
 #include <sys/time.h>
 
-CThread::List CThread::list;
 unsigned CThread::interrupt_mask;
 
 namespace
@@ -178,17 +177,11 @@ void CThread::startup(unsigned cpulimit)
 CThread::CThread(const char* name, unsigned interrupt_level) : name(name), interrupt_level(interrupt_level)
 {
 	assert(interrupt_level > 0);
-	interrupt->lock();
-	list.add(this);
-	interrupt->unlock();
 }
 
 CThread::~CThread()
 {
 	HOST_THREAD_DEBUG("Thread '%s' destroyed", name);
-	interrupt->lock();
-	list.remove(this);
-	interrupt->unlock();
 }
 
 void CThread::interrupt_lock()
@@ -238,18 +231,6 @@ void CThread::interrupt_end()
 	}
 
 	interrupt->unlock();
-}
-
-const char* CThread::getCurrentName()
-{
-	auto cur = pthread_self();
-	for(auto& t : list) {
-		if(t == cur) {
-			return t.name;
-		}
-	}
-
-	return "";
 }
 
 void host_thread_wait(int ms)

--- a/Sming/Arch/Host/Components/hostlib/threads.h
+++ b/Sming/Arch/Host/Components/hostlib/threads.h
@@ -209,16 +209,6 @@ public:
 	 */
 	static void interrupt_unlock();
 
-	/**
-	 * @brief Suspend interrupts for this thread.
-	 */
-	void suspend();
-
-	/**
-	 * @brief Resume interrupts for this thread.
-	 */
-	void resume();
-
 	bool operator==(pthread_t other) const
 	{
 		return pthread_equal(other, m_thread);
@@ -248,9 +238,6 @@ private:
 	const char* name;		   ///< Helps to identify purpose for debugging
 	unsigned interrupt_level;  ///< Interrupt level associated with this thread
 	unsigned previous_mask{0}; ///< Used to restore previous interrupt mask when interrupt ends
-	unsigned suspended{0};	 ///< Non-zero when thread interrupts are suspended
-	CBasicMutex suspendMutex;  ///< Synchronises suspend
-	pthread_cond_t resumeCond = PTHREAD_COND_INITIALIZER; ///< Synchronnises resume
 	static List list;									  ///< All running threads
 	static unsigned interrupt_mask;						  ///< Current interrupt level
 };

--- a/Sming/Arch/Host/Components/hostlib/threads.h
+++ b/Sming/Arch/Host/Components/hostlib/threads.h
@@ -21,7 +21,6 @@
 
 #include "include/hostlib/hostlib.h"
 #include <hostlib/hostmsg.h>
-#include <Data/LinkedObjectList.h>
 #include <pthread.h>
 #include <semaphore.h>
 #include <cassert>
@@ -140,12 +139,9 @@ private:
 /**
  * @brief Class to manage separate execution thread for simulating hardware and interrupts.
  */
-class CThread : public LinkedObjectTemplate<CThread>
+class CThread
 {
 public:
-	using List = LinkedObjectListTemplate<CThread>;
-	using OwnedList = OwnedLinkedObjectListTemplate<CThread>;
-
 	static void startup(unsigned cpulimit = 0);
 
 	/**
@@ -235,11 +231,10 @@ private:
 
 private:
 	pthread_t m_thread = {0};
-	const char* name;		   ///< Helps to identify purpose for debugging
-	unsigned interrupt_level;  ///< Interrupt level associated with this thread
-	unsigned previous_mask{0}; ///< Used to restore previous interrupt mask when interrupt ends
-	static List list;									  ///< All running threads
-	static unsigned interrupt_mask;						  ///< Current interrupt level
+	const char* name;				///< Helps to identify purpose for debugging
+	unsigned interrupt_level;		///< Interrupt level associated with this thread
+	unsigned previous_mask{0};		///< Used to restore previous interrupt mask when interrupt ends
+	static unsigned interrupt_mask; ///< Current interrupt level
 };
 
 /*

--- a/Sming/Arch/Rp2040/Components/driver/uart.cpp
+++ b/Sming/Arch/Rp2040/Components/driver/uart.cpp
@@ -612,7 +612,7 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 	smg_uart_detach(cfg.uart_nr);
 	smg_uart_set_baudrate(uart, cfg.baudrate);
 
-	smg_uart_set_config(uart, cfg.config);
+	smg_uart_set_format(uart, cfg.format);
 
 	auto dev = getDevice(cfg.uart_nr);
 
@@ -662,7 +662,7 @@ void smg_uart_uninit(smg_uart_t* uart)
 	delete uart;
 }
 
-void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)
+void smg_uart_set_format(smg_uart_t* uart, smg_uart_format_t format)
 {
 	if(uart == nullptr) {
 		return;
@@ -671,7 +671,7 @@ void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)
 	auto dev = getDevice(uart->uart_nr);
 
 	// Setup line control register
-	smg_uart_config_format_t fmt{.val = config};
+	smg_uart_config_format_t fmt{.val = format};
 	uint32_t lcr{0};
 	lcr |= fmt.bits << UART_UARTLCR_H_WLEN_LSB; // data bits
 	if(fmt.stop_bits != UART_NB_STOP_BIT_1) {   // stop bits

--- a/Sming/Arch/Rp2040/Components/driver/uart.cpp
+++ b/Sming/Arch/Rp2040/Components/driver/uart.cpp
@@ -737,8 +737,8 @@ void smg_uart_uninit(smg_uart_t* uart)
 	delete uart;
 }
 
-smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, uint32_t config, smg_uart_mode_t mode, uint8_t tx_pin,
-						  size_t rx_size, size_t tx_size)
+smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, smg_uart_format_t config, smg_uart_mode_t mode,
+						  uint8_t tx_pin, size_t rx_size, size_t tx_size)
 {
 	smg_uart_config_t cfg = {.uart_nr = uart_nr,
 							 .tx_pin = tx_pin,

--- a/Sming/Arch/Rp2040/Components/driver/uart.cpp
+++ b/Sming/Arch/Rp2040/Components/driver/uart.cpp
@@ -687,19 +687,9 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg)
 	smg_uart_detach(cfg.uart_nr);
 	smg_uart_set_baudrate(uart, cfg.baudrate);
 
-	auto dev = getDevice(cfg.uart_nr);
+	smg_uart_set_config(uart, cfg.config);
 
-	// Setup line control register
-	smg_uart_config_format_t fmt;
-	fmt.val = cfg.config;
-	uint32_t lcr{0};
-	lcr |= fmt.bits << UART_UARTLCR_H_WLEN_LSB; // data bits
-	if(fmt.stop_bits != UART_NB_STOP_BIT_1) {   // stop bits
-		lcr |= UART_UARTLCR_H_STP2_BITS;
-	}
-	lcr |= fmt.parity << UART_UARTLCR_H_PEN_LSB; // parity
-	lcr |= UART_UARTLCR_H_FEN_BITS;				 // Enable FIFOs
-	dev->lcr_h = lcr;
+	auto dev = getDevice(cfg.uart_nr);
 
 	// Enable the UART
 	if(uart->mode == UART_TX_ONLY) {
@@ -760,6 +750,34 @@ smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, uint32_t config, s
 							 .rx_size = rx_size,
 							 .tx_size = tx_size};
 	return smg_uart_init_ex(cfg);
+}
+
+void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config)
+{
+	if(uart == nullptr) {
+		return;
+	}
+
+	auto dev = getDevice(uart->uart_nr);
+
+	// Setup line control register
+	smg_uart_config_format_t fmt{.val = config};
+	uint32_t lcr{0};
+	lcr |= fmt.bits << UART_UARTLCR_H_WLEN_LSB; // data bits
+	if(fmt.stop_bits != UART_NB_STOP_BIT_1) {   // stop bits
+		lcr |= UART_UARTLCR_H_STP2_BITS;
+	}
+	lcr |= fmt.parity << UART_UARTLCR_H_PEN_LSB; // parity
+	lcr |= UART_UARTLCR_H_FEN_BITS;				 // Enable FIFOs
+	dev->lcr_h = lcr;
+}
+
+bool smg_uart_intr_config(smg_uart_t* uart, const smg_uart_intr_config_t* config)
+{
+	// Not supported
+	(void)uart;
+	(void)config;
+	return false;
 }
 
 void smg_uart_swap(smg_uart_t* uart, int tx_pin)

--- a/Sming/Components/arch_driver/src/include/driver/uart.h
+++ b/Sming/Components/arch_driver/src/include/driver/uart.h
@@ -268,6 +268,32 @@ smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg);
 
 void smg_uart_uninit(smg_uart_t* uart);
 
+/**
+ * @brief Set the UART config
+ * @param uart
+ * @param config UART CONF0 register bits
+ */
+void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config);
+
+/**
+ * @brief UART interrupt configuration parameters for smg_uart_intr_config function
+ *
+ * Threshold values are expressed in character times
+ */
+typedef struct {
+	uint8_t rx_timeout_thresh;
+	uint8_t txfifo_empty_intr_thresh;
+	uint8_t rxfifo_full_thresh; ///< Ignored if additional buffers are allocated
+} smg_uart_intr_config_t;
+
+/**
+  * @brief Configure interrupt thresholds
+  * @param uart
+  * @param config
+  * @retval bool true on success, false on error (bad parameter or unsupported)
+  */
+bool smg_uart_intr_config(smg_uart_t* uart, const smg_uart_intr_config_t* config);
+
 __forceinline int smg_uart_get_nr(smg_uart_t* uart)
 {
 	return uart ? uart->uart_nr : -1;

--- a/Sming/Components/arch_driver/src/include/driver/uart.h
+++ b/Sming/Components/arch_driver/src/include/driver/uart.h
@@ -104,9 +104,9 @@ static inline constexpr uint8_t SMG_UART_FORMAT(smg_uart_bits_t databits, smg_ua
 }
 
 /**
- * @brief Structure for easier decomposing of `config` value
+ * @brief Structure for easier decomposing of `format` value
  * 
- * Used by drivers to read config values
+ * Used by drivers to read format values
  */
 union smg_uart_config_format_t {
 	struct {
@@ -255,25 +255,25 @@ struct smg_uart_config_t {
 	smg_uart_mode_t mode; ///< Whether to enable receive, transmit or both
 	uart_options_t options;
 	uint32_t baudrate;		  ///< Requested baudrate; actual baudrate may differ
-	smg_uart_format_t config; ///< UART CONF0 register bits
+	smg_uart_format_t format; ///< UART CONF0 register bits
 	size_t rx_size;
 	size_t tx_size;
 };
 
 // @deprecated Use `smg_uart_init_ex()` instead
-smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, uint32_t config, smg_uart_mode_t mode, uint8_t tx_pin,
-						  size_t rx_size, size_t tx_size = 0);
+smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, smg_uart_format_t format, smg_uart_mode_t mode,
+						  uint8_t tx_pin, size_t rx_size, size_t tx_size = 0);
 
 smg_uart_t* smg_uart_init_ex(const smg_uart_config_t& cfg);
 
 void smg_uart_uninit(smg_uart_t* uart);
 
 /**
- * @brief Set the UART config
+ * @brief Set the UART data format
  * @param uart
- * @param config UART CONF0 register bits
+ * @param format UART CONF0 register bits
  */
-void smg_uart_set_config(smg_uart_t* uart, smg_uart_format_t config);
+void smg_uart_set_format(smg_uart_t* uart, smg_uart_format_t format);
 
 /**
  * @brief UART interrupt configuration parameters for smg_uart_intr_config function

--- a/Sming/Components/arch_driver/src/include/driver/uart.h
+++ b/Sming/Components/arch_driver/src/include/driver/uart.h
@@ -514,6 +514,9 @@ void smg_uart_restore_interrupts();
 
 /** @} */
 
+// Internal routine
+bool smg_uart_realloc_buffer(SerialBuffer*& buffer, size_t new_size);
+
 #if defined(__cplusplus)
 } // extern "C"
 #endif

--- a/Sming/Components/arch_driver/src/include/driver/uart.h
+++ b/Sming/Components/arch_driver/src/include/driver/uart.h
@@ -254,8 +254,8 @@ struct smg_uart_config_t {
 	uint8_t rx_pin;
 	smg_uart_mode_t mode; ///< Whether to enable receive, transmit or both
 	uart_options_t options;
-	uint32_t baudrate; ///< Requested baudrate; actual baudrate may differ
-	uint32_t config;   ///< UART CONF0 register bits
+	uint32_t baudrate;		  ///< Requested baudrate; actual baudrate may differ
+	smg_uart_format_t config; ///< UART CONF0 register bits
 	size_t rx_size;
 	size_t tx_size;
 };

--- a/Sming/Components/arch_driver/src/uart.cpp
+++ b/Sming/Components/arch_driver/src/uart.cpp
@@ -39,7 +39,7 @@ bool smg_uart_realloc_buffer(SerialBuffer*& buffer, size_t new_size)
 	return false;
 }
 
-smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, smg_uart_format_t config, smg_uart_mode_t mode,
+smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, smg_uart_format_t format, smg_uart_mode_t mode,
 						  uint8_t tx_pin, size_t rx_size, size_t tx_size)
 {
 	smg_uart_config_t cfg = {
@@ -49,7 +49,7 @@ smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, smg_uart_format_t 
 		.mode = mode,
 		.options = _BV(UART_OPT_TXWAIT),
 		.baudrate = baudrate,
-		.config = config,
+		.format = format,
 		.rx_size = rx_size,
 		.tx_size = tx_size,
 	};

--- a/Sming/Components/arch_driver/src/uart.cpp
+++ b/Sming/Components/arch_driver/src/uart.cpp
@@ -1,0 +1,102 @@
+#include "include/driver/uart.h"
+#include "include/driver/SerialBuffer.h"
+#include <BitManipulations.h>
+#include <esp_systemapi.h>
+
+bool smg_uart_realloc_buffer(SerialBuffer*& buffer, size_t new_size)
+{
+	if(buffer != nullptr) {
+		size_t res = 0;
+		smg_uart_disable_interrupts();
+		if(new_size == 0) {
+			delete buffer;
+			buffer = nullptr;
+		} else {
+			res = buffer->resize(new_size);
+		}
+		smg_uart_restore_interrupts();
+
+		return res == new_size;
+	}
+
+	if(new_size == 0) {
+		return true;
+	}
+
+#ifdef ARCH_ESP32
+	// Avoid allocating in SPIRAM
+	auto mem = heap_caps_malloc(sizeof(SerialBuffer), MALLOC_CAP_DEFAULT | MALLOC_CAP_INTERNAL);
+	auto new_buf = new(mem) SerialBuffer;
+#else
+	auto new_buf = new SerialBuffer;
+#endif
+	if(new_buf != nullptr && new_buf->resize(new_size) == new_size) {
+		buffer = new_buf;
+		return true;
+	}
+
+	delete new_buf;
+	return false;
+}
+
+smg_uart_t* smg_uart_init(uint8_t uart_nr, uint32_t baudrate, smg_uart_format_t config, smg_uart_mode_t mode,
+						  uint8_t tx_pin, size_t rx_size, size_t tx_size)
+{
+	smg_uart_config_t cfg = {
+		.uart_nr = uart_nr,
+		.tx_pin = tx_pin,
+		.rx_pin = UART_PIN_DEFAULT,
+		.mode = mode,
+		.options = _BV(UART_OPT_TXWAIT),
+		.baudrate = baudrate,
+		.config = config,
+		.rx_size = rx_size,
+		.tx_size = tx_size,
+	};
+	return smg_uart_init_ex(cfg);
+}
+
+size_t smg_uart_resize_rx_buffer(smg_uart_t* uart, size_t new_size)
+{
+	if(smg_uart_rx_enabled(uart)) {
+		smg_uart_realloc_buffer(uart->rx_buffer, new_size);
+	}
+	return smg_uart_rx_buffer_size(uart);
+}
+
+size_t smg_uart_rx_buffer_size(smg_uart_t* uart)
+{
+	return uart != nullptr && uart->rx_buffer != nullptr ? uart->rx_buffer->getSize() : 0;
+}
+
+size_t smg_uart_resize_tx_buffer(smg_uart_t* uart, size_t new_size)
+{
+	if(smg_uart_tx_enabled(uart)) {
+		smg_uart_realloc_buffer(uart->tx_buffer, new_size);
+	}
+	return smg_uart_tx_buffer_size(uart);
+}
+
+size_t smg_uart_tx_buffer_size(smg_uart_t* uart)
+{
+	return uart != nullptr && uart->tx_buffer != nullptr ? uart->tx_buffer->getSize() : 0;
+}
+
+int smg_uart_peek_char(smg_uart_t* uart)
+{
+	return uart != nullptr && uart->rx_buffer ? uart->rx_buffer->peekChar() : -1;
+}
+
+int smg_uart_rx_find(smg_uart_t* uart, char c)
+{
+	if(uart == nullptr || uart->rx_buffer == nullptr) {
+		return -1;
+	}
+
+	return uart->rx_buffer->find(c);
+}
+
+int smg_uart_peek_last_char(smg_uart_t* uart)
+{
+	return uart != nullptr && uart->rx_buffer != nullptr ? uart->rx_buffer->peekLastChar() : -1;
+}

--- a/Sming/Core/HardwareSerial.cpp
+++ b/Sming/Core/HardwareSerial.cpp
@@ -28,7 +28,7 @@ HardwareSerial::~HardwareSerial()
 #endif
 }
 
-void HardwareSerial::begin(uint32_t baud, SerialConfig config, SerialMode mode, uint8_t txPin, uint8_t rxPin)
+void HardwareSerial::begin(uint32_t baud, SerialFormat format, SerialMode mode, uint8_t txPin, uint8_t rxPin)
 {
 	end();
 
@@ -42,7 +42,7 @@ void HardwareSerial::begin(uint32_t baud, SerialConfig config, SerialMode mode, 
 		.mode = smg_uart_mode_t(mode),
 		.options = options,
 		.baudrate = baud,
-		.config = smg_uart_format_t(config),
+		.format = smg_uart_format_t(format),
 		.rx_size = rxSize,
 		.tx_size = txSize,
 	};

--- a/Sming/Core/HardwareSerial.cpp
+++ b/Sming/Core/HardwareSerial.cpp
@@ -42,7 +42,7 @@ void HardwareSerial::begin(uint32_t baud, SerialConfig config, SerialMode mode, 
 		.mode = smg_uart_mode_t(mode),
 		.options = options,
 		.baudrate = baud,
-		.config = uint32_t(config),
+		.config = smg_uart_format_t(config),
 		.rx_size = rxSize,
 		.tx_size = txSize,
 	};

--- a/Sming/Core/HardwareSerial.h
+++ b/Sming/Core/HardwareSerial.h
@@ -58,13 +58,13 @@ class CommandExecutor;
 	XX(5E2) XX(6E2) XX(7E2) XX(8E2) XX(5O1) XX(6O1) XX(7O1) XX(8O1) XX(5O2) XX(6O2) XX(7O2) XX(8O2)
 // clang-format on
 
-enum class SerialConfig {
-#define XX(x) Cfg##x = UART_##x,
+enum class SerialFormat {
+#define XX(x) Fmt##x = UART_##x,
 	SERIAL_CONFIG_MAP(XX)
 #undef XX
 };
 
-#define XX(x) static constexpr SerialConfig SERIAL_##x{SerialConfig::Cfg##x};
+#define XX(x) static constexpr SerialFormat SERIAL_##x{SerialFormat::Fmt##x};
 SERIAL_CONFIG_MAP(XX)
 #undef XX
 
@@ -140,39 +140,39 @@ public:
 	/**
 	 * @brief Initialise and set its configuration.
 	 * @param baud Baud rate to use
-	 * @param config can be 5, 6, 7, 8 data bits, odd (O),
+	 * @param format can be 5, 6, 7, 8 data bits, odd (O),
 	 * 				 even (E), and no (N) parity, and 1 or 2 stop bits.
 	 * 		  		 To set the desired mode, call  Serial.begin(baudrate, SERIAL_8N1),
 	 * 		  		 Serial.begin(baudrate, SERIAL_6E2), etc.
 	 */
-	void begin(uint32_t baud, SerialConfig config)
+	void begin(uint32_t baud, SerialFormat format)
 	{
-		begin(baud, config, SERIAL_FULL, SERIAL_PIN_DEFAULT);
+		begin(baud, format, SERIAL_FULL, SERIAL_PIN_DEFAULT);
 	}
 
 	/**
 	 * @brief Initialise, set its configuration and mode.
 	 * @param baud Baud rate to use
-	 * @param config can be 5, 6, 7, 8 data bits, odd (O),
+	 * @param format can be 5, 6, 7, 8 data bits, odd (O),
 	 * 				 even (E), and no (N) parity, and 1 or 2 stop bits.
 	 * 		  		 To set the desired mode, call  Serial.begin(baudrate, SERIAL_8N1),
 	 * 		  		 Serial.begin(baudrate, SERIAL_6E2), etc.
 	 * @param mode specifies if the UART supports receiving (RX), transmitting (TX) or both (FULL) operations
 	 */
-	void begin(uint32_t baud, SerialConfig config, SerialMode mode)
+	void begin(uint32_t baud, SerialFormat format, SerialMode mode)
 	{
-		begin(baud, config, mode, 1);
+		begin(baud, format, mode, 1);
 	}
 
 	/**
 	 * @brief Initialise, set its configuration and mode.
 	 * @param baud Baud rate to use
-	 * @param config
+	 * @param format
 	 * @param mode
 	 * @param txPin Can specify alternate pin for TX
 	 * @param rxPin
 	 */
-	void begin(uint32_t baud, SerialConfig config, SerialMode mode, uint8_t txPin, uint8_t rxPin = SERIAL_PIN_DEFAULT);
+	void begin(uint32_t baud, SerialFormat format, SerialMode mode, uint8_t txPin, uint8_t rxPin = SERIAL_PIN_DEFAULT);
 
 	/**
 	 * @brief De-inits the current UART if it is already used


### PR DESCRIPTION
- Add `smg_uart_intr_config` function for controlling rx/tx buffer threshold values. (I use this for RS485.)
- Add `smg_uart_set_format` function to allow parity, etc. to be changed dynamically (e.g. multiple devices on same wire.)
- Move common code into arch_driver Component
- Fix race condition in host threads (and simplify)