### PR TITLE
Add IOControl library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -245,6 +245,10 @@
 	path = Sming/Libraries/jerryscript
 	url = https://github.com/slaff/Sming-jerryscript.git
 	ignore = dirty
+[submodule "Libraries.IOControl"]
+	path = Sming/Libraries/IOControl
+	url = https://github.com/mikee47/IOControl
+	ignore = dirty
 [submodule "Libraries.IR"]
 	path = Sming/Libraries/IR
 	url = https://github.com/markszabo/IRremoteESP8266.git


### PR DESCRIPTION
The IO Control library is an asynchronous Input/Output device stack for embedded devices such as the ESP8266.
The main reason for building this was to provide a mechanism for serialising modbus requests along with commands to other types of device such as DMX512 dimmers and 433MHz light switches.

This PR is related to #1991.

todo:

* [x] Thorough test with real hardware