### PR TITLE
[WIP] Add websocket failure debug messages

### DIFF
--- a/Sming/Components/Network/src/Network/WebsocketClient.cpp
+++ b/Sming/Components/Network/src/Network/WebsocketClient.cpp
@@ -77,6 +77,7 @@ bool WebsocketClient::connect(const Url& url)
 int WebsocketClient::verifyKey(HttpConnection& connection, HttpResponse& response)
 {
 	if(!response.headers.contains(HTTP_HEADER_SEC_WEBSOCKET_ACCEPT)) {
+		debug_e("[WS] Websocket Accept missing from headers");
 		state = eWSCS_Closed;
 		return -2; // we don't have response.
 	}


### PR DESCRIPTION
If a remote server sends a normal HTTP response without appropriate websocket headers then websocket open requests fail with `HPE_CB_headers_complete` error. This PR is intended to look at this, initially by adding an additional debug message at the point of failure to clarify what's happened.

How applications should handle this situation is perhaps more complicated.

See #2494 for discussion.