### PR TITLE
Revise station configuration to support BSSID

### DIFF
--- a/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
@@ -165,27 +165,34 @@ bool StationImpl::isEnabled() const
 	return (mode == WIFI_MODE_STA) || (mode == WIFI_MODE_APSTA);
 }
 
-bool StationImpl::config(const String& ssid, const String& password, bool autoConnectOnStartup, bool save)
+bool StationImpl::config(const Config& cfg)
 {
 	wifi_config_t config{};
 
-	if(ssid.length() >= sizeof(config.sta.ssid)) {
+	if(cfg.ssid.length() >= sizeof(config.sta.ssid)) {
 		return false;
 	}
-	if(password.length() >= sizeof(config.sta.password)) {
+	if(cfg.password.length() >= sizeof(config.sta.password)) {
 		return false;
 	}
 
-	memcpy(config.sta.ssid, ssid.c_str(), ssid.length());
-	memcpy(config.sta.password, password.c_str(), password.length());
+	memcpy(config.sta.ssid, cfg.ssid.c_str(), cfg.ssid.length());
+	memcpy(config.sta.password, cfg.password.c_str(), cfg.password.length());
 
-	enable(true, save);
-
-	if(save) {
-		setAutoConnect(autoConnectOnStartup);
+	if(cfg.bssid) {
+		config.sta.bssid_set = true;
+		cfg.bssid.getOctets(config.sta.bssid);
+	} else {
+		config.sta.bssid_set = false;
 	}
 
-	ESP_ERROR_CHECK(esp_wifi_set_storage(save ? WIFI_STORAGE_FLASH : WIFI_STORAGE_RAM));
+	enable(true, cfg.save);
+
+	if(cfg.save) {
+		setAutoConnect(cfg.autoConnectOnStartup);
+	}
+
+	ESP_ERROR_CHECK(esp_wifi_set_storage(cfg.save ? WIFI_STORAGE_FLASH : WIFI_STORAGE_RAM));
 	ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_STA, &config));
 
 	return connect();
@@ -326,6 +333,16 @@ String StationImpl::getSSID() const
 	auto ssid = reinterpret_cast<const char*>(config.sta.ssid);
 	debug_d("SSID: '%s'", ssid);
 	return ssid;
+}
+
+MacAddress StationImpl::getBSSID() const
+{
+	wifi_config_t config{};
+	if(esp_wifi_get_config(WIFI_IF_STA, &config) != ESP_OK) {
+		debug_e("Can't read station configuration!");
+		return MacAddress{};
+	}
+	return config.sta.bssid;
 }
 
 int8_t StationImpl::getRssi() const

--- a/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
@@ -489,7 +489,7 @@ void StationImpl::internalSmartConfig(smartconfig_event_t event_id, void* pdata)
 
 	switch(event_id) {
 	case SC_EVENT_GOT_SSID_PSWD:
-		config(evt.ssid, evt.password, true, true);
+		StationClass::config(evt.ssid, evt.password, true, true);
 		connect();
 		break;
 	case SC_EVENT_SEND_ACK_DONE:

--- a/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.h
+++ b/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.h
@@ -35,7 +35,7 @@ public:
 
 	void enable(bool enabled, bool save) override;
 	bool isEnabled() const override;
-	bool config(const String& ssid, const String& password, bool autoConnectOnStartup, bool save) override;
+	bool config(const Config& cfg) override;
 	bool connect() override;
 	bool disconnect() override;
 	StationConnectionStatus getConnectionStatus() const override;
@@ -51,6 +51,7 @@ public:
 	IpAddress getNetworkBroadcast() const override;
 	bool setIP(IpAddress address, IpAddress netmask, IpAddress gateway) override;
 	String getSSID() const override;
+	MacAddress getBSSID() const override;
 	String getPassword() const override;
 	int8_t getRssi() const override;
 	uint8_t getChannel() const override;

--- a/Sming/Components/Network/Arch/Esp8266/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp8266/Platform/StationImpl.cpp
@@ -380,7 +380,7 @@ void StationImpl::internalSmartConfig(sc_status status, void* pdata)
 		case SC_STATUS_GETTING_SSID_PSWD:
 			break;
 		case SC_STATUS_LINK:
-			config(evt.ssid, evt.password, true, true);
+			StationClass::config(evt.ssid, evt.password, true, true);
 			connect();
 			break;
 		case SC_STATUS_LINK_OVER:

--- a/Sming/Components/Network/Arch/Esp8266/Platform/StationImpl.h
+++ b/Sming/Components/Network/Arch/Esp8266/Platform/StationImpl.h
@@ -28,7 +28,7 @@ public:
 
 	void enable(bool enabled, bool save) override;
 	bool isEnabled() const override;
-	bool config(const String& ssid, const String& password, bool autoConnectOnStartup, bool save) override;
+	bool config(const Config& cfg) override;
 	bool connect() override;
 	bool disconnect() override;
 	StationConnectionStatus getConnectionStatus() const override;
@@ -44,6 +44,7 @@ public:
 	IpAddress getNetworkBroadcast() const override;
 	bool setIP(IpAddress address, IpAddress netmask, IpAddress gateway) override;
 	String getSSID() const override;
+	MacAddress getBSSID() const override;
 	String getPassword() const override;
 	int8_t getRssi() const override;
 	uint8_t getChannel() const override;

--- a/Sming/Components/Network/Arch/Host/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Host/Platform/StationImpl.cpp
@@ -164,7 +164,7 @@ bool StationImpl::config(const Config& cfg)
 		if(cfg.ssid == ap.ssid) {
 			if(ap.authMode != AUTH_OPEN) {
 				if(cfg.password != ap.pwd) {
-					debug_w("Bad password for '%s'", ssid.c_str());
+					debug_w("Bad password for '%s'", cfg.ssid.c_str());
 					return false;
 				}
 			}
@@ -295,7 +295,7 @@ String StationImpl::getSSID() const
 
 MacAddress StationImpl::getBSSID() const
 {
-	return MacAddress{0xff, 0xff, 0xff, 0x00, 0x01};
+	return MacAddress({0xff, 0xff, 0xff, 0x00, 0x01});
 }
 
 int8_t StationImpl::getRssi() const

--- a/Sming/Components/Network/Arch/Host/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Host/Platform/StationImpl.cpp
@@ -158,30 +158,30 @@ bool StationImpl::isEnabled() const
 	return currentConfig.enabled;
 }
 
-bool StationImpl::config(const String& ssid, const String& password, bool autoConnectOnStartup, bool save)
+bool StationImpl::config(const Config& cfg)
 {
 	for(auto& ap : apInfoList) {
-		if(ssid == ap.ssid) {
+		if(cfg.ssid == ap.ssid) {
 			if(ap.authMode != AUTH_OPEN) {
-				if(password != ap.pwd) {
+				if(cfg.password != ap.pwd) {
 					debug_w("Bad password for '%s'", ssid.c_str());
 					return false;
 				}
 			}
 
 			currentAp = &ap;
-			if(save) {
+			if(cfg.save) {
 				savedAp = &ap;
 			}
 
-			debug_i("Connected to SSID '%s'", ssid.c_str());
+			debug_i("Connected to SSID '%s'", cfg.ssid.c_str());
 
-			autoConnect = autoConnectOnStartup;
+			autoConnect = cfg.autoConnectOnStartup;
 			return true;
 		}
 	}
 
-	debug_w("SSID '%s' not found", ssid.c_str());
+	debug_w("SSID '%s' not found", cfg.ssid.c_str());
 	return false;
 }
 
@@ -291,6 +291,11 @@ bool StationImpl::setIP(IpAddress address, IpAddress netmask, IpAddress gateway)
 String StationImpl::getSSID() const
 {
 	return currentAp ? currentAp->ssid : nullptr;
+}
+
+MacAddress StationImpl::getBSSID() const
+{
+	return MacAddress{0xff, 0xff, 0xff, 0x00, 0x01};
 }
 
 int8_t StationImpl::getRssi() const

--- a/Sming/Components/Network/Arch/Host/Platform/StationImpl.h
+++ b/Sming/Components/Network/Arch/Host/Platform/StationImpl.h
@@ -36,7 +36,7 @@ public:
 	// StationClass
 	void enable(bool enabled, bool save) override;
 	bool isEnabled() const override;
-	bool config(const String& ssid, const String& password, bool autoConnectOnStartup, bool save) override;
+	bool config(const Config& cfg) override;
 	bool connect() override;
 	bool disconnect() override;
 	StationConnectionStatus getConnectionStatus() const override;
@@ -52,6 +52,7 @@ public:
 	IpAddress getNetworkBroadcast() const override;
 	bool setIP(IpAddress address, IpAddress netmask, IpAddress gateway) override;
 	String getSSID() const override;
+	MacAddress getBSSID() const override;
 	String getPassword() const override;
 	int8_t getRssi() const override;
 	uint8_t getChannel() const override;

--- a/Sming/Components/Network/Arch/Rp2040/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Rp2040/Platform/StationImpl.cpp
@@ -23,7 +23,7 @@ bool StationImpl::isEnabled() const
 	return false;
 }
 
-bool StationImpl::config(const String& ssid, const String& password, bool autoConnectOnStartup, bool save)
+bool StationImpl::config(const Config& cfg)
 {
 	return false;
 }
@@ -94,6 +94,11 @@ bool StationImpl::setIP(IpAddress address, IpAddress netmask, IpAddress gateway)
 String StationImpl::getSSID() const
 {
 	return nullptr;
+}
+
+MacAddress StationImpl::getBSSID() const
+{
+	return {};
 }
 
 int8_t StationImpl::getRssi() const

--- a/Sming/Components/Network/Arch/Rp2040/Platform/StationImpl.h
+++ b/Sming/Components/Network/Arch/Rp2040/Platform/StationImpl.h
@@ -23,7 +23,7 @@ public:
 
 	void enable(bool enabled, bool save) override;
 	bool isEnabled() const override;
-	bool config(const String& ssid, const String& password, bool autoConnectOnStartup, bool save) override;
+	bool config(const Config& cfg) override;
 	bool connect() override;
 	bool disconnect() override;
 	StationConnectionStatus getConnectionStatus() const override;
@@ -39,6 +39,7 @@ public:
 	IpAddress getNetworkBroadcast() const override;
 	bool setIP(IpAddress address, IpAddress netmask, IpAddress gateway) override;
 	String getSSID() const override;
+	MacAddress getBSSID() const override;
 	String getPassword() const override;
 	int8_t getRssi() const override;
 	uint8_t getChannel() const override;

--- a/Sming/Components/Network/src/Platform/Station.h
+++ b/Sming/Components/Network/src/Platform/Station.h
@@ -108,6 +108,17 @@ using WPSConfigDelegate = Delegate<bool(WpsStatus status)>;
 class StationClass
 {
 public:
+	/**
+	 * @brief Station configuration passed to config method
+	 */
+	struct Config {
+		String ssid;					  ///< Service Set to connect to (may be advertised by multiple access points)
+		String password;				  ///< Password (if required)
+		MacAddress bssid;				  ///< Set this to connect to a specific access point
+		bool autoConnectOnStartup = true; ///< Auto connect to this AP on system restart
+		bool save = true;				  ///< Store new settings in NV memory
+	};
+
 	virtual ~StationClass()
 	{
 	}
@@ -130,8 +141,24 @@ public:
 	 *	@param	autoConnectOnStartup True to auto connect. False for manual. (Default: True)
 	 *	@param  save True to save the SSID and password in Flash. False otherwise. (Default: True)
 	 */
-	virtual bool config(const String& ssid, const String& password, bool autoConnectOnStartup = true,
-						bool save = true) = 0;
+	virtual bool config(const Config& config) = 0;
+
+	/**	@brief	Configure WiFi station
+	 *	@param	ssid WiFi SSID
+	 *	@param	password WiFi password
+	 *	@param	autoConnectOnStartup True to auto connect. False for manual. (Default: True)
+	 *	@param  save True to save the SSID and password in Flash. False otherwise. (Default: True)
+	 */
+	bool config(const String& ssid, const String& password, bool autoConnectOnStartup = true, bool save = true)
+	{
+		Config cfg{
+			.ssid = ssid,
+			.password = password,
+			.autoConnectOnStartup = autoConnectOnStartup,
+			.save = save,
+		};
+		return config(cfg);
+	}
 
 	/**	@brief	Connect WiFi station to network
 	 */
@@ -250,10 +277,15 @@ public:
 	 */
 	virtual bool setIP(IpAddress address, IpAddress netmask, IpAddress gateway) = 0;
 
-	/**	@brief	Get WiFi station SSID
+	/**	@brief	Get WiFi station SSID (Service Set Identifier)
 	 *	@retval	String WiFi station SSID
 	 */
 	virtual String getSSID() const = 0;
+
+	/**	@brief	Get BSSID (Basic Service Set Identifier) for connected AP
+	 *	@retval	MacAddress Identifier of connected Access Point
+	 */
+	virtual MacAddress getBSSID() const = 0;
 
 	/**	@brief	Get WiFi station password
 	 *	@retval	String WiFi station password


### PR DESCRIPTION
This PR overloads the `StationClass::config` method to allow connection to a specific access point. This may be necessary where multiple access points share the same SSID.