### PR TITLE
Implement basic ESP32 deep sleep

### DIFF
--- a/Sming/Arch/Esp32/Components/esp32/src/include/esp_sleep.h
+++ b/Sming/Arch/Esp32/Components/esp32/src/include/esp_sleep.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include <driver/gpio.h>
+#include_next <esp_sleep.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/Sming/Arch/Esp32/Components/esp32/src/include/esp_sleep.h
+++ b/Sming/Arch/Esp32/Components/esp32/src/include/esp_sleep.h
@@ -13,7 +13,7 @@ enum sleep_type {
 	MODEM_SLEEP_T,
 };
 
-void system_deep_sleep(uint32_t time_in_us);
+bool system_deep_sleep(uint32_t time_in_us);
 bool system_deep_sleep_set_option(uint8_t option);
 
 /* These aren't defined in the RTOS SDK */

--- a/Sming/Arch/Esp32/Components/esp32/src/sleep.c
+++ b/Sming/Arch/Esp32/Components/esp32/src/sleep.c
@@ -1,14 +1,16 @@
-#include "include/esp_sleep.h"
+#include <esp_sleep.h>
 #include <rom/gpio.h>
 
 bool system_deep_sleep(uint32_t time_in_us)
 {
+	esp_deep_sleep(time_in_us);
 	return true;
 }
 
 bool system_deep_sleep_set_option(uint8_t option)
 {
-	return false;
+	(void)option; // Ignore
+	return true;
 }
 
 /* GPIO */

--- a/Sming/Arch/Esp32/Components/esp32/src/sleep.c
+++ b/Sming/Arch/Esp32/Components/esp32/src/sleep.c
@@ -1,8 +1,9 @@
 #include "include/esp_sleep.h"
 #include <rom/gpio.h>
 
-void system_deep_sleep(uint32_t time_in_us)
+bool system_deep_sleep(uint32_t time_in_us)
 {
+	return true;
 }
 
 bool system_deep_sleep_set_option(uint8_t option)

--- a/Sming/Arch/Esp32/Components/esp32/src/system.cpp
+++ b/Sming/Arch/Esp32/Components/esp32/src/system.cpp
@@ -13,20 +13,32 @@ uint32_t system_get_time(void)
 struct rst_info* system_get_rst_info(void)
 {
 	static rst_info info{};
-	auto reason = esp_reset_reason();
-	switch(reason) {
-	case ESP_RST_INT_WDT:
-		info.reason = REASON_SOFT_WDT_RST;
-		break;
-	case ESP_RST_BROWNOUT:
-		info.reason = REASON_WDT_RST;
-		break;
-	case ESP_RST_SDIO:
-		info.reason = REASON_SOFT_RESTART;
-		break;
-	default:
-		info.reason = reason;
-	}
+
+	auto translateReason = [](uint8_t reason) -> uint8_t {
+		switch(reason) {
+		case ESP_RST_EXT:
+		case ESP_RST_BROWNOUT:
+			return REASON_EXT_SYS_RST;
+		case ESP_RST_PANIC:
+			return REASON_EXCEPTION_RST;
+		case ESP_RST_INT_WDT:
+			return REASON_SOFT_WDT_RST;
+		case ESP_RST_TASK_WDT:
+		case ESP_RST_WDT:
+			return REASON_WDT_RST;
+		case ESP_RST_DEEPSLEEP:
+			return REASON_DEEP_SLEEP_AWAKE;
+		case ESP_RST_SW:
+		case ESP_RST_SDIO:
+			return REASON_SOFT_RESTART;
+		case ESP_RST_UNKNOWN:
+		case ESP_RST_POWERON:
+		default:
+			return REASON_DEFAULT_RST;
+		}
+	};
+
+	info.reason = translateReason(esp_reset_reason());
 
 	return &info;
 }

--- a/Sming/Arch/Host/Components/esp_hal/include/esp_sleep.h
+++ b/Sming/Arch/Host/Components/esp_hal/include/esp_sleep.h
@@ -15,7 +15,7 @@ enum sleep_type {
 
 typedef void (*fpm_wakeup_cb)(void);
 
-void system_deep_sleep(uint32_t time_in_us);
+bool system_deep_sleep(uint32_t time_in_us);
 bool system_deep_sleep_set_option(uint8_t option);
 
 /* Forced sleep */

--- a/Sming/Arch/Host/Components/esp_hal/sleep.c
+++ b/Sming/Arch/Host/Components/esp_hal/sleep.c
@@ -1,7 +1,8 @@
 #include "include/esp_sleep.h"
 
-void system_deep_sleep(uint32_t time_in_us)
+bool system_deep_sleep(uint32_t time_in_us)
 {
+	return false;
 }
 
 bool system_deep_sleep_set_option(uint8_t option)

--- a/Sming/Arch/Rp2040/Components/rp2040/src/include/esp_sleep.h
+++ b/Sming/Arch/Rp2040/Components/rp2040/src/include/esp_sleep.h
@@ -12,7 +12,7 @@ enum sleep_type {
 	MODEM_SLEEP_T,
 };
 
-void system_deep_sleep(uint32_t time_in_us);
+bool system_deep_sleep(uint32_t time_in_us);
 bool system_deep_sleep_set_option(uint8_t option);
 
 #ifdef __cplusplus

--- a/Sming/Arch/Rp2040/Components/rp2040/src/sleep.c
+++ b/Sming/Arch/Rp2040/Components/rp2040/src/sleep.c
@@ -1,7 +1,8 @@
 #include "include/esp_sleep.h"
 
-void system_deep_sleep(uint32_t time_in_us)
+bool system_deep_sleep(uint32_t time_in_us)
 {
+	return false;
 }
 
 bool system_deep_sleep_set_option(uint8_t option)

--- a/Sming/Platform/System.cpp
+++ b/Sming/Platform/System.cpp
@@ -135,6 +135,5 @@ bool SystemClass::deepSleep(uint32_t timeMilliseconds, DeepSleepOptions options)
 		return false;
 	}
 	// Note: In SDK Version 3+ system_deep_sleep() returns bool but it's void before that
-	system_deep_sleep(timeMilliseconds * 1000);
-	return true;
+	return system_deep_sleep(timeMilliseconds * 1000ULL);
 }


### PR DESCRIPTION
ESP32 has many more sleep options but this should allow use of the basic (timed) option.

Also propagate return value from `system_deep_sleep` calls.