### PR TITLE
Esp32 fixes

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
@@ -9,6 +9,7 @@
  ****/
 
 #include <driver/hw_timer.h>
+#include <driver/periph_ctrl.h>
 #include <hal/timer_hal.h>
 #include <esp_intr_alloc.h>
 
@@ -36,11 +37,11 @@ void IRAM_ATTR timerIsr(void* arg)
 
 	timer_hal_clear_intr_status(&timer.hal);
 
-	if(timer.autoload) {
-		timer_hal_set_alarm_enable(&timer.hal, true);
-	} else {
+	if(!timer.autoload) {
 		timer_hal_set_counter_enable(&timer.hal, false);
 	}
+
+	timer_hal_set_alarm_enable(&timer.hal, true);
 }
 
 } // namespace
@@ -102,6 +103,7 @@ void hw_timer_init(void)
 {
 	timer.group = HW_TIMER1_GROUP;
 	timer.index = HW_TIMER1_INDEX;
+	periph_module_enable(timer_group_periph_signals.groups[timer.group].module);
 	timer_hal_init(&timer.hal, timer.group, timer.index);
 	timer_hal_set_counter_enable(&timer.hal, false);
 	timer_hal_set_alarm_enable(&timer.hal, true);

--- a/Sming/Arch/Esp32/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp32/Components/driver/uart.cpp
@@ -20,6 +20,7 @@
 #include <BitManipulations.h>
 #include <Data/Range.h>
 #include <esp_systemapi.h>
+#include <hal/gpio_ll.h>
 
 namespace
 {
@@ -757,14 +758,14 @@ bool smg_uart_set_pins(smg_uart_t* uart, int tx_pin, int rx_pin)
 	auto& conn = uart_periph_signal[uart->uart_nr];
 
 	if(tx_pin != UART_PIN_NO_CHANGE) {
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[tx_pin], PIN_FUNC_GPIO);
+		gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[tx_pin], PIN_FUNC_GPIO);
 		gpio_set_level(gpio_num_t(tx_pin), true);
 		gpio_matrix_out(tx_pin, conn.tx_sig, false, false);
 		uart->tx_pin = tx_pin;
 	}
 
 	if(rx_pin != UART_PIN_NO_CHANGE) {
-		PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[rx_pin], PIN_FUNC_GPIO);
+		gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[rx_pin], PIN_FUNC_GPIO);
 		gpio_set_pull_mode(gpio_num_t(rx_pin), GPIO_PULLUP_ONLY);
 		gpio_set_direction(gpio_num_t(rx_pin), GPIO_MODE_INPUT);
 		gpio_matrix_in(rx_pin, conn.rx_sig, false);

--- a/Sming/Arch/Esp32/Core/Digital.cpp
+++ b/Sming/Arch/Esp32/Core/Digital.cpp
@@ -82,7 +82,7 @@ void pinMode(uint16_t pin, uint8_t mode)
 		gpio_ll_pullup_dis(&GPIO, gpio);
 	}
 
-	PIN_FUNC_SELECT(GPIO_PIN_MUX_REG[pin], PIN_FUNC_GPIO);
+	gpio_ll_iomux_func_sel(GPIO_PIN_MUX_REG[pin], PIN_FUNC_GPIO);
 }
 
 //Detect if pin is input

--- a/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
@@ -186,6 +186,10 @@ bool StationImpl::config(const Config& cfg)
 		config.sta.bssid_set = false;
 	}
 
+	// Find *all* APs for the requested SSID and pick the best one
+	config.sta.scan_method = WIFI_ALL_CHANNEL_SCAN;
+	config.sta.sort_method = WIFI_CONNECT_AP_BY_SIGNAL;
+
 	enable(true, cfg.save);
 
 	if(cfg.save) {


### PR DESCRIPTION
Use HAL to control IO MUX as, for example, GPIO18/19 on ESP32-C3 require additional steps.
Fix hardware timer on ESP32
Use WiFi full channel scan. Where multiple APs exist for an SSID fast scan will pick the first one which could be a borderline signal.