### PR TITLE
Allow use of static and global File, Directory objects

### DIFF
--- a/Sming/Core/Data/Stream/FileStream.h
+++ b/Sming/Core/Data/Stream/FileStream.h
@@ -20,9 +20,7 @@
 class FileStream : public IFS::FileStream
 {
 public:
-	FileStream() : IFS::FileStream(::getFileSystem())
-	{
-	}
+	using IFS::FileStream::FileStream;
 
 	/** @brief  Create a file stream
      *  @param  fileName Name of file to open

--- a/Sming/Core/FileSystem.cpp
+++ b/Sming/Core/FileSystem.cpp
@@ -17,6 +17,15 @@ namespace SmingInternal
 IFS::FileSystem* activeFileSystem;
 }
 
+namespace IFS
+{
+FileSystem* getDefaultFileSystem()
+{
+	return SmingInternal::activeFileSystem;
+}
+
+} // namespace IFS
+
 void fileSetFileSystem(IFS::IFileSystem* fileSystem)
 {
 	if(SmingInternal::activeFileSystem != fileSystem) {

--- a/Sming/Core/FileSystem.h
+++ b/Sming/Core/FileSystem.h
@@ -29,6 +29,8 @@ using FileAttribute = IFS::FileAttribute;
 using FileAttributes = IFS::FileAttributes;
 using FileStat = IFS::Stat;
 using FileNameStat = IFS::NameStat;
+using File = IFS::File;
+using Directory = IFS::Directory;
 constexpr int FS_OK = IFS::FS_OK;
 
 namespace SmingInternal
@@ -44,26 +46,6 @@ namespace SmingInternal
 extern IFS::FileSystem* activeFileSystem;
 
 } // namespace SmingInternal
-
-class File : public IFS::File
-{
-public:
-	File() : IFS::File(SmingInternal::activeFileSystem)
-	{
-	}
-};
-
-/**
-  * @brief      Directory stream class
-  * @ingroup    stream data
- */
-class Directory : public IFS::Directory
-{
-public:
-	Directory() : IFS::Directory(SmingInternal::activeFileSystem)
-	{
-	}
-};
 
 /*
  * Boilerplate check for file function wrappers to catch undefined filesystem.


### PR DESCRIPTION
Using global or static `File` objects doesn't work because the filesystem has not yet been constructed.

This PR adds a default filesystem mechanism for `FsBase` objects. File system is passed to constructor, but null is now interpreted as 'default file system'. 

Sming implements the `IFS::getDefaultFileSystem()` function which is called for such objects.