### PR TITLE
Add support for TX_DONE interrupt for ESP32 in IOControl modbus

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp32/Components/driver/uart.cpp
@@ -728,6 +728,9 @@ bool smg_uart_intr_config(smg_uart_t* uart, const smg_uart_intr_config_t* config
 		uart_ll_set_txfifo_empty_thr(dev, TRange(0, UART_TXFIFO_EMPTY_THRHD).clip(config->txfifo_empty_intr_thresh));
 	}
 
+	dev->int_clr.val = config->intr_mask;
+	dev->int_ena.val = (dev->int_ena.val & ~config->intr_mask) | config->intr_enable;
+
 	return true;
 }
 

--- a/Sming/Components/arch_driver/src/include/driver/uart.h
+++ b/Sming/Components/arch_driver/src/include/driver/uart.h
@@ -149,6 +149,7 @@ enum smg_uart_format_t {
 
 // Status values
 enum smg_uart_status_t {
+	UART_STATUS_TX_DONE = BIT(14), ///< All data transmitted (ESP32 only)
 	UART_STATUS_RXFIFO_TOUT = BIT(8),
 	UART_STATUS_BRK_DET = BIT(7),
 	UART_STATUS_CTS_CHG = BIT(6),
@@ -284,6 +285,9 @@ typedef struct {
 	uint8_t rx_timeout_thresh;
 	uint8_t txfifo_empty_intr_thresh;
 	uint8_t rxfifo_full_thresh; ///< Ignored if additional buffers are allocated
+	uint8_t reserved;
+	uint32_t intr_mask;   ///< Mask of smg_uart_status_t indicating which interrupt bits to change
+	uint32_t intr_enable; ///< State of interrupt bits
 } smg_uart_intr_config_t;
 
 /**


### PR DESCRIPTION
Allow enabling of TX_DONE for ESP32 UART.
Add interrupt mask control to smg_uart_intr_config_t
Update IOControl library with fixes for modbus on esp32c3, and use TX_DONE interrupt.