### PR TITLE
Add basic C++ output streaming support

### DIFF
--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -271,13 +271,6 @@ String DateTime::format(const char* sFormat)
 
 	String sReturn;
 
-	// Append a number to the return buffer, padding to a fixed number of digits
-	auto appendNumber = [&sReturn](unsigned number, unsigned digits, char padChar = '0') {
-		char buf[8];
-		ultoa_wp(number, buf, 10, digits, padChar);
-		sReturn.concat(buf, digits);
-	};
-
 	char c;
 	while((c = *sFormat++) != '\0') {
 		if(c != '%') {
@@ -298,10 +291,10 @@ String DateTime::format(const char* sFormat)
 			sReturn += Year;
 			break;
 		case 'y': // Year, last 2 digits as a decimal number [00..99]
-			appendNumber(Year % 100, 2);
+			sReturn.concat(Year % 100, DEC, 2);
 			break;
 		case 'C': // Year, first 2 digits as a decimal number [00..99]
-			appendNumber(Year / 100, 2);
+			sReturn.concat(Year / 100, DEC, 2);
 			break;
 		// Month (not implemented: Om)
 		case 'b': // Abbreviated month name, e.g. Oct (always English)
@@ -312,18 +305,18 @@ String DateTime::format(const char* sFormat)
 			sReturn += CStringArray(flashMonthNames)[Month];
 			break;
 		case 'm': // Month as a decimal number [01..12]
-			appendNumber(Month + 1, 2);
+			sReturn.concat(Month + 1, DEC, 2);
 			break;
 		// Week (not implemented: OU, OW, OV)
 		case 'U': // Week of the year as a decimal number (Sunday is the first day of the week) [00..53]
-			appendNumber(calcWeek(0), 2);
+			sReturn.concat(calcWeek(0), DEC, 2);
 			break;
 		case 'V': // ISO 8601 week number (01-53)
 			// !@todo Calculation of ISO 8601 week number is crude and frankly wrong but does anyone care?
-			appendNumber(calcWeek(1) + 1, 2);
+			sReturn.concat(calcWeek(1) + 1, DEC, 2);
 			break;
 		case 'W': // Week of the year as a decimal number (Monday is the first day of the week) [00..53]
-			appendNumber(calcWeek(1), 2);
+			sReturn.concat(calcWeek(1), DEC, 2);
 			break;
 		case 'x': // Locale preferred date format
 			sReturn += format(_F(LOCALE_DATE));
@@ -333,13 +326,13 @@ String DateTime::format(const char* sFormat)
 			break;
 		// Day of year/month (Not implemented: Od, Oe)
 		case 'j': // Day of the year as a decimal number [001..366]
-			appendNumber(DayofYear, 3);
+			sReturn.concat(DayofYear, DEC, 3);
 			break;
 		case 'd': // Day of the month as a decimal number [01..31]
-			appendNumber(Day, 2);
+			sReturn.concat(Day, DEC, 2);
 			break;
 		case 'e': // Day of the month as a decimal number [ 1,31]
-			appendNumber(Day, 2, ' ');
+			sReturn.concat(Day, DEC, 2, ' ');
 			break;
 		// Day of week (Not implemented: Ow, Ou)
 		case 'w': // Weekday as a decimal number with Sunday as 0 [0..6]
@@ -356,16 +349,16 @@ String DateTime::format(const char* sFormat)
 			break;
 		// Time (not implemented: OH, OI, OM, OS)
 		case 'H': // Hour as a decimal number, 24 hour clock [00..23]
-			appendNumber(Hour, 2);
+			sReturn.concat(Hour, DEC, 2);
 			break;
 		case 'I': // Hour as a decimal number, 12 hour clock [0..12]
-			appendNumber(Hour ? ((Hour > 12) ? Hour - 12 : Hour) : 12, 2);
+			sReturn.concat(Hour ? ((Hour > 12) ? Hour - 12 : Hour) : 12, DEC, 2);
 			break;
 		case 'M': // Minute as a decimal number [00..59]
-			appendNumber(Minute, 2);
+			sReturn.concat(Minute, DEC, 2);
 			break;
 		case 'S': // Second as a decimal number [00..61]
-			appendNumber(Second, 2);
+			sReturn.concat(Second, DEC, 2);
 			break;
 		// Other (not implemented: Ec, Ex, EX, z, Z)
 		case 'c': // Locale preferred date and time format, e.g. Tue Dec 11 08:48:32 2018

--- a/Sming/Wiring/Print.cpp
+++ b/Sming/Wiring/Print.cpp
@@ -38,29 +38,6 @@ size_t Print::write(const uint8_t* buffer, size_t size)
 	return n;
 }
 
-size_t Print::print(long num, int base)
-{
-	if(base == 0) {
-		return write(num);
-	}
-
-	if(base == 10 && num < 0) {
-		return print('-') + printNumber(static_cast<unsigned long>(-num), base);
-	}
-
-	return printNumber(static_cast<unsigned long>(num), base);
-}
-
-// Overload (signed long long)
-size_t Print::print(const long long& num, int base)
-{
-	if(base == 10 && num < 0) {
-		return print('-') + printNumber(static_cast<unsigned long long>(-num), base);
-	}
-
-	return printNumber(static_cast<unsigned long long>(num), base);
-}
-
 size_t Print::printf(const char* fmt, ...)
 {
 	size_t buffSize = INITIAL_PRINTF_BUFFSIZE;
@@ -83,17 +60,31 @@ size_t Print::printf(const char* fmt, ...)
 	}
 }
 
-size_t Print::printNumber(unsigned long num, uint8_t base)
+size_t Print::printNumber(unsigned long num, uint8_t base, uint8_t width, char pad)
 {
 	char buf[8 * sizeof(num) + 1]; // Assumes 8-bit chars plus zero byte.
-	ultoa(num, buf, base);
+	ultoa_wp(num, buf, base, width, pad);
 	return write(buf);
 }
 
-size_t Print::printNumber(const unsigned long long& num, uint8_t base)
+size_t Print::printNumber(const unsigned long long& num, uint8_t base, uint8_t width, char pad)
 {
 	char buf[8 * sizeof(num) + 1]; // Assumes 8-bit chars plus zero byte.
-	ulltoa(num, buf, base);
+	ulltoa_wp(num, buf, base, width, pad);
+	return write(buf);
+}
+
+size_t Print::printNumber(long num, uint8_t base, uint8_t width, char pad)
+{
+	char buf[8 * sizeof(num) + 1]; // Assumes 8-bit chars plus zero byte.
+	ltoa_wp(num, buf, base, width, pad);
+	return write(buf);
+}
+
+size_t Print::printNumber(const long long& num, uint8_t base, uint8_t width, char pad)
+{
+	char buf[8 * sizeof(num) + 1]; // Assumes 8-bit chars plus zero byte.
+	lltoa_wp(num, buf, base, width, pad);
 	return write(buf);
 }
 

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -197,6 +197,16 @@ public:
 		return write(s.c_str(), s.length());
 	}
 
+	/**
+	 * @brief enums can be printed as strings provided they have a `toString(E)` implementation.
+	 */
+	template <typename E>
+	typename std::enable_if<std::is_enum<E>::value && !std::is_convertible<E, int>::value, size_t>::type print(E value)
+	{
+		extern String toString(E e);
+		return print(toString(value));
+	}
+
 	/** @brief  Prints a newline to output stream
 	  * @retval size_t Quantity of characters written to stream
 	  */

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -246,6 +246,23 @@ protected:
 	}
 };
 
+template <typename T> Print& operator<<(Print& p, T value)
+{
+	p.print(value);
+	return p;
+}
+
+// Thanks to Arduino forum user Paul V. who suggested this
+// clever technique to allow for expressions like
+//   Serial << "Hello!" << endl;
+enum EndLineCode { endl };
+
+inline Print& operator<<(Print& p, EndLineCode)
+{
+	p.println();
+	return p;
+}
+
 /** @} */
 
 #endif // __cplusplus

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -246,7 +246,7 @@ protected:
 	}
 };
 
-template <typename T> Print& operator<<(Print& p, T value)
+template <typename T> Print& operator<<(Print& p, const T& value)
 {
 	p.print(value);
 	return p;

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -115,7 +115,7 @@ public:
 	  *
 	  * @{
 	  */
-	size_t print(unsigned long num, int base = DEC)
+	size_t print(unsigned long num, uint8_t base = DEC)
 	{
 		if(base == 0) {
 			return write(num);
@@ -124,28 +124,48 @@ public:
 		}
 	}
 
-	size_t print(const unsigned long long& num, int base = DEC)
+	template <typename... Args> size_t print(unsigned long num, Args... args)
 	{
-		return printNumber(num, base);
+		return printNumber(num, args...);
 	}
 
-	size_t print(long, int base = DEC);
-
-	size_t print(const long long&, int base = DEC);
-
-	size_t print(unsigned int num, int base = DEC)
+	template <typename... Args> size_t print(const unsigned long long& num, Args... args)
 	{
-		return print((unsigned long)num, base);
+		return printNumber(num, args...);
 	}
 
-	size_t print(unsigned char num, int base = DEC)
+	size_t print(long num, uint8_t base = DEC)
 	{
-		return print((unsigned long)num, base);
+		if(base == 0) {
+			return write(num);
+		} else {
+			return printNumber(num, base);
+		}
 	}
 
-	size_t print(int num, int base = DEC)
+	template <typename... Args> size_t print(long num, Args... args)
 	{
-		return print((long)num, base);
+		return printNumber(num, args...);
+	}
+
+	template <typename... Args> size_t print(const long long& num, Args... args)
+	{
+		return printNumber(num, args...);
+	}
+
+	template <typename... Args> size_t print(unsigned int num, Args... args)
+	{
+		return print((unsigned long)num, args...);
+	}
+
+	template <typename... Args> size_t print(unsigned char num, Args... args)
+	{
+		return print((unsigned long)num, args...);
+	}
+
+	template <typename... Args> size_t print(int num, Args... args)
+	{
+		return printNumber((long)num, args...);
 	}
 	/** @} */
 
@@ -203,8 +223,10 @@ public:
 
 private:
 	int write_error = 0;
-	size_t printNumber(unsigned long num, uint8_t base);
-	size_t printNumber(const unsigned long long& num, uint8_t base);
+	size_t printNumber(unsigned long num, uint8_t base = DEC, uint8_t width = 0, char pad = '0');
+	size_t printNumber(const unsigned long long& num, uint8_t base = DEC, uint8_t width = 0, char pad = '0');
+	size_t printNumber(long num, uint8_t base = DEC, uint8_t width = 0, char pad = '0');
+	size_t printNumber(const long long& num, uint8_t base = DEC, uint8_t width = 0, char pad = '0');
 	size_t printFloat(double num, uint8_t digits);
 
 protected:

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -185,93 +185,12 @@ public:
 		return print("\r\n");
 	}
 
-	/** @brief  Prints a c-string to output stream, appending newline
-	  * @param  str c-string to print
+	/** @brief Print value plus newline to output stream
 	  * @retval size_t Quantity of characters written to stream
 	  */
-	size_t println(const char str[])
+	template <typename... Args> size_t println(const Args&... args)
 	{
-		return print(str) + println();
-	}
-
-	/** @brief  Prints a single character to output stream, appending newline
-	  * @param  c Character to print
-	  * @retval size_t Quantity of characters written to stream
-	  */
-	size_t println(char c)
-	{
-		return print(c) + println();
-	}
-
-	/** @name   Print an integral number to output stream, appending newline
-	  * @param  num Number to print
-	  * @param  base The base for output (Default: Decimal (base 10))
-	  * @retval size_t Quantity of characters written to stream
-	  *
-	  * @{
-	  */
-	size_t println(unsigned char num, int base = DEC)
-	{
-		return print(num, base) + println();
-	}
-
-	size_t println(unsigned int num, int base = DEC)
-	{
-		return print(num, base) + println();
-	}
-
-	size_t println(unsigned long num, int base = DEC)
-	{
-		return print(num, base) + println();
-	}
-
-	size_t println(const unsigned long long& num, int base = DEC)
-	{
-		return print(num, base) + println();
-	}
-
-	size_t println(int num, int base = DEC)
-	{
-		return print(num, base) + println();
-	}
-
-	size_t println(long num, int base = DEC)
-	{
-		return print(num, base) + println();
-	}
-
-	size_t println(const long long& num, int base = DEC)
-	{
-		return print(num, base) + println();
-	}
-	/** @} */
-
-	/** @brief  Print a floating-point number to output stream, appending newline
-	  * @param  num Number to print
-	  * @param  digits The decimal places to print (Default: 2, e.g. 21.35)
-	  * @retval size_t Quantity of characters written to stream
-	  */
-	size_t println(double num, int digits = 2)
-	{
-		return print(num, digits) + println();
-	}
-
-	/** @brief  Prints a Printable object to output stream, appending newline
-	  * @param  p Object to print
-	  * @retval size_t Quantity of characters written to stream
-	  */
-	size_t println(const Printable& p)
-	{
-		return print(p) + println();
-	}
-
-	/** @brief  Prints a String to output stream, appending newline
-	  * @param  s String to print
-	  * @retval size_t Quantity of characters written to stream
-	  */
-	size_t println(const String& s)
-	{
-		return print(s) + println();
+		return print(args...) + println();
 	}
 
 	/** @brief  Prints a formatted c-string to output stream

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -923,6 +923,32 @@ void String::trim(const char* set)
 	setlen(len);
 }
 
+String& String::pad(int16_t minWidth, char c)
+{
+	size_t w = (minWidth < 0) ? -minWidth : minWidth;
+	auto len = length();
+	if(w <= len) {
+		return *this;
+	}
+
+	if(!reserve(std::max(w, len))) {
+		return *this;
+	}
+
+	setLength(w);
+	auto buf = buffer();
+	if(minWidth < 0) {
+		// Left-pad
+		memmove(buf + w - len, buf, len);
+		memset(buf, c, w - len);
+	} else {
+		// Right-pad
+		memset(buf + len, c, w - len);
+	}
+
+	return *this;
+}
+
 /*********************************************/
 /*  Parsing / Conversion                     */
 /*********************************************/

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -48,52 +48,38 @@ String::String(char c) : String()
 		buffer()[0] = c;
 }
 
-String::String(unsigned char value, unsigned char base) : String()
+String::String(unsigned char value, unsigned char base, unsigned char width, char pad) : String()
 {
 	char buf[8 + 8 * sizeof(value)];
 	ultoa(value, buf, base);
 	*this = buf;
 }
 
-String::String(int value, unsigned char base) : String()
+String::String(long value, unsigned char base, unsigned char width, char pad) : String()
 {
 	char buf[8 + 8 * sizeof(value)];
-	itoa(value, buf, base);
+	ltoa_wp(value, buf, base, width, pad);
 	*this = buf;
 }
 
-String::String(unsigned int value, unsigned char base) : String()
+String::String(long long value, unsigned char base, unsigned char width, char pad) : String()
 {
 	char buf[8 + 8 * sizeof(value)];
-	ultoa(value, buf, base);
+	lltoa_wp(value, buf, base, width, pad);
 	*this = buf;
 }
 
-String::String(long value, unsigned char base) : String()
+String::String(unsigned long value, unsigned char base, unsigned char width, char pad) : String()
 {
 	char buf[8 + 8 * sizeof(value)];
-	ltoa(value, buf, base);
+	ultoa_wp(value, buf, base, width, pad);
 	*this = buf;
 }
 
-String::String(long long value, unsigned char base) : String()
+String::String(unsigned long long value, unsigned char base, unsigned char width, char pad) : String()
 {
 	char buf[8 + 8 * sizeof(value)];
-	lltoa(value, buf, base);
-	*this = buf;
-}
-
-String::String(unsigned long value, unsigned char base) : String()
-{
-	char buf[8 + 8 * sizeof(value)];
-	ultoa(value, buf, base);
-	*this = buf;
-}
-
-String::String(unsigned long long value, unsigned char base) : String()
-{
-	char buf[8 + 8 * sizeof(value)];
-	ulltoa(value, buf, base);
+	ulltoa_wp(value, buf, base, width, pad);
 	*this = buf;
 }
 

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -394,52 +394,38 @@ bool String::concat(const char* cstr)
 	return concat(cstr, strlen(cstr));
 }
 
-bool String::concat(unsigned char num)
+bool String::concat(unsigned char num, unsigned char base, unsigned char width, char pad)
 {
 	char buf[1 + 3 * sizeof(num)];
-	itoa(num, buf, 10);
+	ultoa_wp(num, buf, base, width, pad);
 	return concat(buf, strlen(buf));
 }
 
-bool String::concat(int num)
+bool String::concat(long num, unsigned char base, unsigned char width, char pad)
 {
 	char buf[8 + 3 * sizeof(num)];
-	itoa(num, buf, 10);
+	ltoa_wp(num, buf, base, width, pad);
 	return concat(buf, strlen(buf));
 }
 
-bool String::concat(unsigned int num)
+bool String::concat(long long num, unsigned char base, unsigned char width, char pad)
 {
 	char buf[8 + 3 * sizeof(num)];
-	ultoa(num, buf, 10);
+	lltoa_wp(num, buf, base, width, pad);
 	return concat(buf, strlen(buf));
 }
 
-bool String::concat(long num)
+bool String::concat(unsigned long num, unsigned char base, unsigned char width, char pad)
 {
 	char buf[8 + 3 * sizeof(num)];
-	ltoa(num, buf, 10);
+	ultoa_wp(num, buf, base, width, pad);
 	return concat(buf, strlen(buf));
 }
 
-bool String::concat(long long num)
+bool String::concat(unsigned long long num, unsigned char base, unsigned char width, char pad)
 {
 	char buf[8 + 3 * sizeof(num)];
-	lltoa(num, buf, 10);
-	return concat(buf, strlen(buf));
-}
-
-bool String::concat(unsigned long num)
-{
-	char buf[8 + 3 * sizeof(num)];
-	ultoa(num, buf, 10);
-	return concat(buf, strlen(buf));
-}
-
-bool String::concat(unsigned long long num)
-{
-	char buf[8 + 3 * sizeof(num)];
-	ulltoa(num, buf, 10);
+	ulltoa_wp(num, buf, base, width, pad);
 	return concat(buf, strlen(buf));
 }
 

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -331,13 +331,19 @@ public:
 	{
 		return concat(&c, 1);
 	}
-	bool concat(unsigned char num);
-	bool concat(int num);
-	bool concat(unsigned int num);
-	bool concat(long num);
-	bool concat(long long num);
-	bool concat(unsigned long num);
-	bool concat(unsigned long long num);
+	bool concat(unsigned char num, unsigned char base = 10, unsigned char width = 0, char pad = '0');
+	bool concat(int num, unsigned char base = 10, unsigned char width = 0, char pad = '0')
+	{
+		return concat(long(num), base, width, pad);
+	}
+	bool concat(unsigned int num, unsigned char base = 10, unsigned char width = 0, char pad = '0')
+	{
+		return concat((unsigned long)(num), base, width, pad);
+	}
+	bool concat(long num, unsigned char base = 10, unsigned char width = 0, char pad = '0');
+	bool concat(long long num, unsigned char base = 10, unsigned char width = 0, char pad = '0');
+	bool concat(unsigned long num, unsigned char base = 10, unsigned char width = 0, char pad = '0');
+	bool concat(unsigned long long num, unsigned char base = 10, unsigned char width = 0, char pad = '0');
 	bool concat(float num);
 	bool concat(double num);
 	/** @} */

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -806,6 +806,43 @@ public:
      */
 	void trim(const char* set = " \t\n\v\f\r");
 
+	/**
+	 * @name Pad string to a minimum length
+	 *
+	 * This is used, for example, when outputting tabular data.
+	 * The string is modified in-situ to minimise memory reallocations.
+	 *
+	 * Methods may be chained like this::
+	 *
+	 * 		Serial << String(value).padLeft(10, '.') << endl;
+	 *
+	 * @{
+	 */
+
+	/**
+	 * @brief Insert padding at start of string if length is less than given width
+	 */
+	String& padLeft(uint16_t minWidth, char c = ' ')
+	{
+		return pad(-minWidth, c);
+	}
+
+	/**
+	 * @brief Insert padding at end of string if length is less than given width
+	 */
+	String& padRight(uint16_t minWidth, char c = ' ')
+	{
+		return pad(minWidth, c);
+	}
+
+	/**
+	 * @brief Pad string if length is less than given width
+	 * @param width Left-padded if < 0, right-padded if > 0.
+	 */
+	String& pad(int16_t minWidth, char c = ' ');
+
+	/** @} */
+
 	// parsing/conversion
 	long toInt(void) const;
 	float toFloat(void) const;

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -191,13 +191,19 @@ public:
 	String(StringSumHelper&& rval) noexcept;
 #endif
 	explicit String(char c);
-	explicit String(unsigned char, unsigned char base = 10);
-	explicit String(int, unsigned char base = 10);
-	explicit String(unsigned int, unsigned char base = 10);
-	explicit String(long, unsigned char base = 10);
-	explicit String(long long, unsigned char base = 10);
-	explicit String(unsigned long, unsigned char base = 10);
-	explicit String(unsigned long long, unsigned char base = 10);
+	explicit String(unsigned char, unsigned char base = 10, unsigned char width = 0, char pad = '0');
+	explicit String(int num, unsigned char base = 10, unsigned char width = 0, char pad = '0')
+		: String(long(num), base, width, pad)
+	{
+	}
+	explicit String(unsigned int num, unsigned char base = 10, unsigned char width = 0, char pad = '0')
+		: String((unsigned long)(num), base, width, pad)
+	{
+	}
+	explicit String(long, unsigned char base = 10, unsigned char width = 0, char pad = '0');
+	explicit String(long long, unsigned char base = 10, unsigned char width = 0, char pad = '0');
+	explicit String(unsigned long, unsigned char base = 10, unsigned char width = 0, char pad = '0');
+	explicit String(unsigned long long, unsigned char base = 10, unsigned char width = 0, char pad = '0');
 	explicit String(float, unsigned char decimalPlaces = 2);
 	explicit String(double, unsigned char decimalPlaces = 2);
 	/** @} */

--- a/docs/source/framework/core/data/streams/index.rst
+++ b/docs/source/framework/core/data/streams/index.rst
@@ -1,6 +1,8 @@
 Streams
 =======
 
+.. highlight:: c++
+
 Sming provides a set of Stream class which extend :cpp:class:`Stream` methods.
 
 :cpp:class:`IDataSourceStream` is used where read-only access is required.
@@ -10,6 +12,69 @@ This allows optimistic reading and re-sending, but cannot be handled by some str
 types and should be used with care.
 
 :cpp:class:`ReadWriteStream` is used where read/write operation is required.
+
+Printing
+--------
+
+The arduino :cpp:class:`Print` class provides the basic output streaming mechanism.
+Sming has some enhancements:
+
+C++ streaming operation <<
+   Building output is commonly done like this::
+
+      Serial.print("Temperature: ");
+      Serial.print(temperature);
+      Serial.print(" °C, humidity: ");
+      Serial.print(humidity);
+      Serial.println("%");
+
+   In Sming, this will produce exactly the same result::
+
+      Serial << "Temperature" << temperature << " °C, humidity: " << humidity << "%" << endl;
+
+   .. note::
+
+      Sming does NOT support the C++ STL streaming classes, such as ``iostream``, etc.
+
+
+Number Printing
+   Examples::
+
+      Serial.print(12, HEX);         // "c"
+      Serial.print(12, HEX, 4);      // "000c"
+      Serial.print(12, HEX, 4, '.'); // "...c"
+      Serial.print(12);              // "12"
+      Serial.print(12, DEC, 4);      // "0012"
+
+   Similar extensions are provided for :cpp:class:`String` construction::
+
+      Serial << "0x" << String(12, HEX, 8);       // "0x0000000c"
+      Serial << String(12, DEC, 4, '.');          // "..12"
+
+
+Field-width control
+   Supported via String methods::
+
+      Serial << String(12).padLeft(4);          // "  12"
+      Serial << String(12).padLeft(4, '0');     // "0012"
+      Serial << String(12).padRight(4);         // "12  "
+      Serial << String(12).pad(-4, '0');        // "0012"
+      Serial << String(12).pad(4);              // "12  "
+
+
+Strongly-typed enumerations
+   Use of ``enum class`` is good practice as it produces strongly-typed and scoped values.
+   Most of these are also provided with a standard ``toString(E)`` function overload.
+
+   This allows string equivalents to be printed very easily::
+
+      auto status = HTTP_STATUS_HTTP_VERSION_NOT_SUPPORTED;
+      auto type = MIME_HTML;
+      Serial.print(type); // "text/html"
+      // "Status: HTTP Version Not Supported, type: text/html"
+      Serial << "Status: " << status << ", type: " << type << endl;
+      // Status: 505, type: 0
+      Serial << "Status: " << int(status) << ", type: " << int(type) << endl;
 
 
 API Documentation

--- a/samples/Accelerometer_MMA7455/app/application.cpp
+++ b/samples/Accelerometer_MMA7455/app/application.cpp
@@ -12,12 +12,7 @@ void readSensor()
 	int8_t x = accel.readAxis('x');
 	int8_t y = accel.readAxis('y');
 	int8_t z = accel.readAxis('z');
-	Serial.print("Accelerometer data: ");
-	Serial.print(x);
-	Serial.print(", ");
-	Serial.print(y);
-	Serial.print(", ");
-	Serial.println(z);
+	Serial << _F("Accelerometer data: ") << x << ", " << y << ", " << z << endl;
 }
 
 void init()

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -78,9 +78,10 @@ void initCam()
 	myCAM.rdSensorReg8_8(OV2640_CHIPID_LOW, &pid);
 	if((vid != 0x26) || (pid != 0x42)) {
 		Serial.println("Can't find OV2640 module!");
-		Serial.printf("vid = [%X]  pid = [%X]\n", vid, pid);
-	} else
+		Serial << "vid = [" << String(vid, HEX) << "], pid = [" << String(pid, HEX) << "]" << endl;
+	} else {
 		Serial.println("OV2640 detected");
+	}
 
 	// initialize SPI:
 	pinMode(CAM_CS, OUTPUT);
@@ -167,7 +168,7 @@ void onCapture(HttpRequest& request, HttpResponse& response)
 	// get the picture
 	OneShotFastMs timer;
 	startCapture();
-	Serial.printf("onCapture() startCapture() %s\r\n", timer.elapsedTime().toString().c_str());
+	Serial << _F("onCapture() startCapture() ") << timer.elapsedTime() << endl;
 
 	ArduCAMStream* stream = new ArduCAMStream(&myCAM);
 
@@ -178,7 +179,7 @@ void onCapture(HttpRequest& request, HttpResponse& response)
 		response.sendDataStream(stream, contentType);
 	}
 
-	Serial.printf("onCapture() process Stream %s\r\n", timer.elapsedTime().toString().c_str());
+	Serial << _F("onCapture() process Stream ") << timer.elapsedTime() << endl;
 }
 
 MultipartStream::BodyPart snapshotProducer()
@@ -190,22 +191,22 @@ MultipartStream::BodyPart snapshotProducer()
 	result.stream = camStream;
 
 	result.headers = new HttpHeaders();
-	(*result.headers)[HTTP_HEADER_CONTENT_TYPE] = "image/jpeg";
+	(*result.headers)[HTTP_HEADER_CONTENT_TYPE] = toString(MIME_JPEG);
 
 	return result;
 }
 
 void onStream(HttpRequest& request, HttpResponse& response)
 {
-	Serial.printf("perform onCapture()\r\n");
+	Serial.println(_F("perform onCapture()"));
 
 	// TODO: use request parameters to overwrite camera settings
 	// setupCamera(camSettings);
 	myCAM.clear_fifo_flag();
 	myCAM.write_reg(ARDUCHIP_FRAMES, 0x00);
 
-	MultipartStream* stream = new MultipartStream(snapshotProducer);
-	response.sendDataStream(stream, String("multipart/x-mixed-replace; boundary=") + stream->getBoundary());
+	auto stream = new MultipartStream(snapshotProducer);
+	response.sendDataStream(stream, F("multipart/x-mixed-replace; boundary=") + stream->getBoundary());
 }
 
 void onFavicon(HttpRequest& request, HttpResponse& response)
@@ -228,15 +229,15 @@ void StartServers()
 	server.paths.set("/favicon.ico", onFavicon);
 	server.paths.setDefault(onFile);
 
-	Serial.println("\r\n=== WEB SERVER STARTED ===");
+	Serial.println(_F("\r\n=== WEB SERVER STARTED ==="));
 	Serial.println(WifiStation.getIP());
-	Serial.println("==============================\r\n");
+	Serial.println(_F("==============================\r\n"));
 
 	telnet.listen(23);
 	telnet.enableDebug(true);
 
-	Serial.println("\r\n=== TelnetServer SERVER STARTED ===");
-	Serial.println("==============================\r\n");
+	Serial.println(_F("\r\n=== TelnetServer SERVER STARTED ==="));
+	Serial.println(_F("==============================\r\n"));
 }
 
 // Will be called when station is fully operational

--- a/samples/Basic_APA102/app/application.cpp
+++ b/samples/Basic_APA102/app/application.cpp
@@ -107,8 +107,7 @@ static void updateLED()
 			cnt = 0;
 		}
 
-		Serial.print("ping ");
-		Serial.println(cnt);
+		Serial << "ping " << cnt << endl;
 		LED.show(cnt); // show shifted LED buffer
 		break;
 	}

--- a/samples/Basic_AWS/app/application.cpp
+++ b/samples/Basic_AWS/app/application.cpp
@@ -48,36 +48,31 @@ void publishMessage()
 // Callback for messages, arrived from MQTT server
 int onMessagePublish(MqttClient& client, mqtt_message_t* message)
 {
-	Serial.print("Publish: ");
-	Serial.print(MqttBuffer(message->publish.topic_name));
-	Serial.print(":\r\n\t"); // Pretify alignment for printing
-	Serial.println(MqttBuffer(message->publish.content));
+	Serial << _F("Publish: ") << MqttBuffer(message->publish.topic_name) << ':' << endl;
+	Serial << '\t' << MqttBuffer(message->publish.content) << endl;
 	return 0;
 }
 
 int onMessageConnect(MqttClient& client, mqtt_message_t* message)
 {
-	Serial.print("Connect: ");
-	Serial.print(MqttBuffer(message->connect.protocol_name));
-	Serial.print(", client: ");
-	Serial.println(MqttBuffer(message->connect.client_id));
+	Serial << _F("Connect: ") << MqttBuffer(message->connect.protocol_name) << _F(", client: ")
+		   << MqttBuffer(message->connect.client_id) << endl;
 	return 0;
 }
 
 int onMessageDisconnect(MqttClient& client, mqtt_message_t* message)
 {
-	Serial.println("Disconnect");
+	Serial.println(_F("Disconnect"));
 	return 0;
 }
 
 void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
-	Serial.print("Connected: ");
-	Serial.println(ip);
+	Serial << _F("Connected: ") << ip << endl;
 	startMqttClient();
 	publishMessage(); // run once publishMessage
 
-	mqtt.subscribe("$aws/things/Basic_AWS/shadow/get");
+	mqtt.subscribe(F("$aws/things/Basic_AWS/shadow/get"));
 }
 
 } // namespace
@@ -87,7 +82,7 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true);
 
-	Serial.println("Hello");
+	Serial.println(_F("Hello"));
 
 	// initialization config
 	mqtt.setEventHandler(MQTT_TYPE_PUBLISH, onMessagePublish);

--- a/samples/Basic_Audio/app/application.cpp
+++ b/samples/Basic_Audio/app/application.cpp
@@ -54,11 +54,8 @@ static struct {
 		// Modify frequency to fit in exact number of samples
 		frequency = sampleRate / sampleCount;
 
-		Serial.print("Generating sine wave table @ ");
-		Serial.print(frequency);
-		Serial.print(" Hz, ");
-		Serial.print(sampleCount);
-		Serial.println(" samples");
+		Serial << _F("Generating sine wave table @ ") << frequency << _F(" Hz, ") << sampleCount << _F(" samples")
+			   << endl;
 
 		samples = new uint16_t[sampleCount];
 		if(samples == nullptr) {
@@ -202,8 +199,7 @@ static void initialiseI2S()
 #endif
 
 	auto realSampleRate = i2s_get_real_rate();
-	Serial.print(_F("I2S initialised, rate = "));
-	Serial.println(realSampleRate);
+	Serial << _F("I2S initialised, rate = ") << realSampleRate << endl;
 
 #ifndef GENERATE_FIXED_VALUES
 	/*

--- a/samples/Basic_Capsense/app/application.cpp
+++ b/samples/Basic_Capsense/app/application.cpp
@@ -13,9 +13,8 @@ Timer procTimer;
 
 void capsense()
 {
-	long total = cs_0_2.capacitiveSensor(30); //Read sensor with 30 samples
-	Serial.print("Sense Value: ");
-	Serial.println(total); // print sensor output
+	long total = cs_0_2.capacitiveSensor(30);		//Read sensor with 30 samples
+	Serial << _F("Sense Value: ") << total << endl; // print sensor output
 }
 
 void init()

--- a/samples/Basic_DateTime/app/application.cpp
+++ b/samples/Basic_DateTime/app/application.cpp
@@ -57,20 +57,14 @@ void showTime(time_t timestamp)
 	Serial.println(dt.format("%%x Locale date: %x"));
 	Serial.println(dt.format("%%X Locale time: %X"));
 	//HTTP date
-	Serial.print("toHTTPDate: ");
-	Serial.println(dt.toHTTPDate());
+	Serial << "toHTTPDate: " << dt.toHTTPDate() << endl;
 	DateTime dt2;
 	dt2.fromHttpDate(dt.toHTTPDate());
-	Serial.print("fromHTTPDate: ");
-	Serial.println(dt2.toHTTPDate());
-	Serial.print("toFullDateTimeString: ");
-	Serial.println(dt.toFullDateTimeString());
-	Serial.print("toISO8601: ");
-	Serial.println(dt.toISO8601());
-	Serial.print("toShortDateString: ");
-	Serial.println(dt.toShortDateString());
-	Serial.print("toShortTimeString: ");
-	Serial.println(dt.toShortTimeString());
+	Serial << "fromHTTPDate: " << dt2.toHTTPDate() << endl;
+	Serial << "toFullDateTimeString: " << dt.toFullDateTimeString() << endl;
+	Serial << "toISO8601: " << dt.toISO8601() << endl;
+	Serial << "toShortDateString: " << dt.toShortDateString() << endl;
+	Serial << "toShortTimeString: " << dt.toShortTimeString() << endl;
 }
 
 void onRx(Stream& source, char arrivedChar, unsigned short availableCharsCount)
@@ -79,8 +73,7 @@ void onRx(Stream& source, char arrivedChar, unsigned short availableCharsCount)
 	case '\n':
 		Serial.println();
 		Serial.println();
-		Serial.print(_F("****Showing DateTime formatting options for Unix timestamp: "));
-		Serial.println(timestamp);
+		Serial << _F("****Showing DateTime formatting options for Unix timestamp: ") << timestamp << endl;
 		showTime(timestamp);
 		Serial.print(commandPrompt);
 		timestamp = 0;

--- a/samples/Basic_Delegates/app/speed.cpp
+++ b/samples/Basic_Delegates/app/speed.cpp
@@ -19,7 +19,7 @@ static CpuCycleTimer timer;
 
 static void printTime(const char* name, unsigned ticks)
 {
-	Serial.printf("%s: %u cycles, %s\r\n", name, ticks, timer.ticksToTime(ticks).toString().c_str());
+	Serial << name << ": " << ticks << " cycles, " << timer.ticksToTime(ticks).toString() << endl;
 }
 
 static void __noinline evaluateCallback(const char* name, TestCallback callback, int testParam)
@@ -46,7 +46,7 @@ void evaluateSpeed()
 {
 	Serial.println();
 	Serial.println();
-	Serial.printf("Timings are in CPU cycles per loop, averaged over %u iterations\r\n", ITERATIONS);
+	Serial << _F("Timings are in CPU cycles per loop, averaged over ") << ITERATIONS << _F(" iterations") << endl;
 
 	int testParam = 123;
 

--- a/samples/Basic_Ethernet/app/application.cpp
+++ b/samples/Basic_Ethernet/app/application.cpp
@@ -30,19 +30,12 @@ Ethernet::W5500Service ethernet;
 
 static void ethernetEventHandler(Ethernet::Event event)
 {
-	Serial.print(toString(event));
-	Serial.print(_F(", MAC = "));
-	Serial.println(ethernet.getMacAddress().toString());
+	Serial << event << _F(", MAC = ") << ethernet.getMacAddress() << endl;
 }
 
 static void ethernetGotIp(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
-	Serial.print(_F("Connected! Ethernet IP "));
-	Serial.print(ip.toString());
-	Serial.print(_F(", netmask "));
-	Serial.print(netmask.toString());
-	Serial.print(_F(", gateway "));
-	Serial.println(gateway.toString());
+	Serial << _F("Connected! Ethernet IP ") << ip << _F(", netmask ") << netmask << _F(", gateway ") << gateway << endl;
 }
 
 void init()

--- a/samples/Basic_Interrupts/app/application.cpp
+++ b/samples/Basic_Interrupts/app/application.cpp
@@ -7,22 +7,13 @@
 #define INT_PIN_B 4  // GPIO4
 #define TOGGLE_PIN 5 // GPIO5
 
-#define say(a) (Serial.print(a))
-#define newline() (Serial.println())
-
 static unsigned interruptToggleCount;
 
 void showInterruptToggleCount(uint32_t toggleCount)
 {
-	say("Toggle count hit ");
-	say(toggleCount);
-	say(", current value is ");
-	say(interruptToggleCount);
-	say("!");
-	newline();
-	say("Max tasks queued: ");
-	say(System.getMaxTaskCount());
-	newline();
+	Serial << _F("Toggle count hit ") << toggleCount << _F(", current value is ") << interruptToggleCount << '!'
+		   << endl;
+	Serial << _F("Max tasks queued: ") << System.getMaxTaskCount() << endl;
 }
 
 /** @brief Low-level interrupt handler
@@ -74,15 +65,10 @@ void IRAM_ATTR interruptHandler()
 void interruptDelegate()
 {
 	// For this example, we write some stuff out of the serial port.
-	say(micros());
-	say("   Pin changed, now   ");
-	say(digitalRead(INT_PIN_B));
-	newline();
+	Serial << micros() << _F("   Pin changed, now   ") << digitalRead(INT_PIN_B) << endl;
 
 	// Interrupt delegates work by queueing your callback routine, so let's just show you how many requests got queued
-	say("Max tasks queued: ");
-	say(System.getMaxTaskCount());
-	newline();
+	Serial << _F("Max tasks queued: ") << System.getMaxTaskCount() << endl;
 
 	/* OK, so you probably got a number which hit 255 pretty quickly! It stays there to indicate the task queue
 	 * overflowed, which happens because we're getting way more interrupts than we can process in a timely manner, so
@@ -95,21 +81,16 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 or 9600 by default
 
 	delay(3000);
-	say("======= Bring GPIO");
-	say(INT_PIN_A);
-	say(" low to trigger interrupt(s) =======");
-	newline();
+	Serial << _F("======= Bring GPIO") << INT_PIN_A << _F(" low to trigger interrupt(s) =======") << endl;
 
 	// Note we enable pullup on our test pin so it will stay high when not connected
 	attachInterrupt(INT_PIN_A, interruptHandler, CHANGE);
 	pinMode(INT_PIN_A, INPUT_PULLUP);
-	say("Interrupt A attached");
-	newline();
+	Serial.println(_F("Interrupt A attached"));
 
 	// For an interrupt delegate callback, we simply cast our function or method using InterruptDelegate()
 	pinMode(TOGGLE_PIN, OUTPUT);
 	attachInterrupt(INT_PIN_B, InterruptDelegate(interruptDelegate), CHANGE);
 	pinMode(INT_PIN_B, INPUT_PULLUP);
-	say("Interrupt B attached");
-	newline();
+	Serial.println(_F("Interrupt B attached"));
 }

--- a/samples/Basic_Neopixel/app/application.cpp
+++ b/samples/Basic_Neopixel/app/application.cpp
@@ -87,8 +87,7 @@ void TheaterChase()
 
 void StartDemo()
 {
-	Serial.print("NeoPixel Demo type: ");
-	Serial.println(StripDemoType);
+	Serial << _F("NeoPixel Demo type: ") << StripDemoType << endl;
 
 	StripDemoTimer.stop(); // next demo wait until this demo ends
 
@@ -142,15 +141,14 @@ void StartDemo()
 
 void got_IP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
-	Serial.print("IP: ");
-	Serial.println(ip);
-	//You can put here other job like web,tcp etc.
+	Serial << "IP: " << ip << endl;
+	// You can put here other job like web,tcp etc.
 }
 
 // Will be called when WiFi station loses connection
 void connect_Fail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
-	Serial.println("I'm NOT CONNECTED!");
+	Serial.println(_F("I'm NOT CONNECTED!"));
 }
 
 void init()
@@ -158,7 +156,7 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE);  // 115200 by default
 	Serial.systemDebugOutput(false); // Disable debug output to serial
 
-	Serial.print("NeoPixel demo .. start");
+	Serial.print(_F("NeoPixel demo .. start"));
 
 #ifndef DISABLE_WIFI
 	// Wifi could be used eg. for switching Neopixel from internet.

--- a/samples/Basic_ProgMem/app/application.cpp
+++ b/samples/Basic_ProgMem/app/application.cpp
@@ -27,50 +27,35 @@ const PROGMEM float floats[] = {13, 130, 1300, 13000, 130000, 1300000, 13000000,
 void assertEquals8(uint8_t expected, uint8_t actual)
 {
 	if(expected != actual) {
-		Serial.print("assertEquals8: ");
-		Serial.print(expected);
-		Serial.print(" != ");
-		Serial.println(actual);
+		Serial << "assertEquals8: " << expected << " != " << actual << endl;
 	}
 }
 
 void assertEquals16(uint16_t expected, uint16_t actual)
 {
 	if(expected != actual) {
-		Serial.print("assertEquals16: ");
-		Serial.print(expected);
-		Serial.print(" != ");
-		Serial.println(actual);
+		Serial << "assertEquals16: " << expected << " != " << actual << endl;
 	}
 }
 
 void assertEquals32(uint32_t expected, uint32_t actual)
 {
 	if(expected != actual) {
-		Serial.print("assertEquals32: ");
-		Serial.print(expected);
-		Serial.print(" != ");
-		Serial.println(actual);
+		Serial << "assertEquals32: " << expected << " != " << actual << endl;
 	}
 }
 
 void assertEqualsFloat(float expected, float actual)
 {
 	if(expected != actual) {
-		Serial.print("assertEqualsFloat: ");
-		Serial.print(expected);
-		Serial.print(" != ");
-		Serial.println(actual);
+		Serial << "assertEqualsFloat: " << expected << " != " << actual << endl;
 	}
 }
 
 void assertEqualsString(String expected, String actual)
 {
 	if(expected != actual) {
-		Serial.print("assertEqualsString: ");
-		Serial.print(expected);
-		Serial.print(" != ");
-		Serial.println(actual);
+		Serial << "assertEqualsString: " << expected << " != " << actual << endl;
 	}
 }
 
@@ -80,10 +65,9 @@ void testPgm()
 	for(uint8_t i = 0, b = 1; i < 8; i++, b++) {
 		uint8_t d = pgm_read_byte(bytes + i);
 		assertEquals8(b, d);
-		Serial.print(d);
-		Serial.print(" ");
+		Serial << d << ' ';
 	}
-	Serial.println("");
+	Serial.println();
 
 	for(uint16_t i = 0, w = 11; i < 8; i++, w += 10) {
 		assertEquals16(w, pgm_read_word(words + i));
@@ -120,10 +104,9 @@ void testPgm()
 	memcpy_P(buf, demoPgm, sizeof(demoPgm));
 	for(uint8_t i = 0; i < sizeof(demoPgm); i++) {
 		assertEquals8(demoRam[i], buf[i]);
-		Serial.print((unsigned char)buf[i]);
-		Serial.print(" ");
+		Serial << (unsigned char)buf[i] << ' ';
 	}
-	Serial.println("");
+	Serial.println();
 }
 
 void init()
@@ -137,11 +120,6 @@ void init()
 	Serial.println("> 0x3FFE8000 ~ 0x3FFFBFFF - User data RAM, 80kb. Available to applications.");
 	Serial.println("> 0x40200000 ~ ...        - SPI Flash.");
 
-	Serial.print("> demoRam array address: 0x");
-	Serial.print((uint32_t)demoRam, HEX);
-	Serial.println(" is in the RAM");
-
-	Serial.print("> demoPgm array address: 0x");
-	Serial.print((uint32_t)demoPgm, HEX);
-	Serial.println(" is in the Flash");
+	Serial << "> demoRam array address: 0x" << String(uint32_t(demoRam), HEX) << " is in the RAM" << endl;
+	Serial << "> demoPgm array address: 0x" << String(uint32_t(demoPgm), HEX) << " is in the Flash" << endl;
 }

--- a/samples/Basic_ScannerI2C/app/application.cpp
+++ b/samples/Basic_ScannerI2C/app/application.cpp
@@ -49,24 +49,17 @@ void scanBus()
 		WDT.alive(); // Second option: notify Watch Dog what you are alive (feed it)
 
 		if(error == 0) {
-			Serial.print("I2C device found at address 0x");
-			if(address < 16)
-				Serial.print("0");
-			Serial.print(address, HEX);
-			Serial.println("  !");
-
+			Serial << _F("I2C device found at address 0x") << String(address, HEX, 2) << "  !" << endl;
 			nDevices++;
 		} else if(error == 4) {
-			Serial.print("Unknown error at address 0x");
-			if(address < 16)
-				Serial.print("0");
-			Serial.println(address, HEX);
+			Serial << _F("Unknown error at address 0x") << String(address, HEX, 2) << endl;
 		}
 	}
-	if(nDevices == 0)
+	if(nDevices == 0) {
 		Serial.println("No I2C devices found\n");
-	else
+	} else {
 		Serial.println("done\n");
+	}
 }
 
 void init()

--- a/samples/Basic_Serial/app/SerialReadingDelegateDemo.cpp
+++ b/samples/Basic_Serial/app/SerialReadingDelegateDemo.cpp
@@ -8,7 +8,7 @@
 void onDataCallback(Stream& stream, char arrivedChar, unsigned short availableCharsCount)
 {
 	// Note: we're using the global Serial here, but it may not be the same port as stream
-	Serial.printf(_F("Char: %d, Count: %d\r\n"), (uint8_t)arrivedChar, availableCharsCount);
+	Serial << "Char: " << uint8_t(arrivedChar) << ", Count: " << availableCharsCount << endl;
 }
 
 void echoCallback(Stream& stream, char arrivedChar, unsigned short availableCharsCount)
@@ -25,12 +25,8 @@ void SerialReadingDelegateDemo::begin(HardwareSerial& serial)
 
 void SerialReadingDelegateDemo::onData(Stream& stream, char arrivedChar, unsigned short availableCharsCount)
 {
-	serial->print(_F("Class Delegate Demo Time = "));
-	serial->print(micros());
-	serial->print(_F(" char = 0x"));
-	serial->print(arrivedChar, HEX); // char hex code
-	serial->print(_F(" available = "));
-	serial->println(availableCharsCount);
+	Serial << _F("Class Delegate Demo Time = ") << micros() << _F(" char = 0x") << String(arrivedChar, HEX, 2)
+		   << _F(" available = ") << availableCharsCount << endl;
 
 	// Error detection
 	unsigned status = serial->getStatus();

--- a/samples/Basic_Serial/app/application.cpp
+++ b/samples/Basic_Serial/app/application.cpp
@@ -149,19 +149,15 @@ HardwareSerial Serial1(UART_ID_1);
 
 void sayHello()
 {
-	Serial.print(_F("Hello Sming! Let's do smart things."));
-	Serial.print(_F(" Time : "));
-	Serial.println(micros());
-	Serial.println();
-
-	Serial.printf(_F("This is Hello message %d \r\r\n"), ++helloCounter);
+	Serial << _F("Hello Sming! Let's do smart things. Time: ") << micros() << endl;
+	Serial << _F("This is Hello message ") << ++helloCounter << endl;
 }
 
 void testPrintf()
 {
-	Serial.print(_F("\r\n== PRINTF TEST START ==\r\n"));
+	Serial.println(_F("\r\n== PRINTF TEST START =="));
 
-	Serial.print(_F("\r\nFloat numbers display test: \r\n"));
+	Serial.println(_F("\r\nFloat numbers display test:"));
 
 	Serial.printf("Pi with 2 decimals: %.2f and with 4 decimals: %.4f \r\n", PI, PI);
 	Serial.printf("Pi without specifying precision(default 9): %f\r\n", PI);
@@ -217,19 +213,19 @@ void handleCommand(const String& command)
 		String filename = F("README.md");
 		FileStream* fileStream = new FileStream;
 		if(fileStream && fileStream->open(filename, File::ReadOnly)) {
-			Serial.printf(_F("Sending \"%s\" (%u bytes)\r\n"), filename.c_str(), fileStream->available());
+			Serial << _F("Sending \"") << filename << "\" (" << fileStream->available() << " bytes)" << endl;
 			auto demo = new SerialTransmitDemo(Serial1, fileStream);
 			demo->begin();
 		} else {
-			Serial.printf(_F("Failed to open file \"%s\"\r\n"), filename.c_str());
+			Serial << _F("Failed to open file \"") << filename << '"' << endl;
 			delete fileStream;
 		}
 	} else if(command.equalsIgnoreCase(_F("text"))) {
-		Serial.printf(_F("Sending flash data, %u bytes\r\n"), testFlashData.length());
+		Serial << _F("Sending flash data, ") << testFlashData.length() << " bytes" << endl;
 		auto demo = new SerialTransmitDemo(Serial, new FlashMemoryStream(testFlashData));
 		demo->begin();
 	} else {
-		Serial.printf(_F("I don't know what \"%s\" means! Try typing: cat\r\n"), command.c_str());
+		Serial << _F("I don't know what \"") << command << _F("\" means! Try typing: cat") << endl;
 	}
 }
 

--- a/samples/Basic_Servo/app/application.cpp
+++ b/samples/Basic_Servo/app/application.cpp
@@ -44,8 +44,7 @@ void MyServoChannel::calcValue()
 
 	auto pin = getPin();
 	Serial.write(indent, pin);
-	Serial.print("GPIO");
-	Serial.print(pin);
+	Serial << "GPIO" << pin;
 
 #ifdef UPDATE_RAW
 
@@ -64,13 +63,10 @@ void MyServoChannel::calcValue()
 		value = 0; // overflow and restart linear ramp
 	}
 
-	Serial.print(" value = ");
-	Serial.print(value);
+	Serial << " value = " << value;
 
 	if(!setValue(value)) {
-		Serial.print(": setValue(");
-		Serial.print(value);
-		Serial.print(") failed!");
+		Serial << ": setValue(" << value << ") failed!";
 	}
 
 #else
@@ -81,13 +77,10 @@ void MyServoChannel::calcValue()
 		++degree;
 	}
 
-	Serial.print(" degree = ");
-	Serial.print(degree);
+	Serial << " degree = " << degree;
 
 	if(!setDegree(degree)) {
-		Serial.print(": setDegree(");
-		Serial.print(degree);
-		Serial.print(") failed!");
+		Serial << ": setDegree(" << degree << ") failed!";
 	}
 
 #endif

--- a/samples/Basic_SmartConfig/app/application.cpp
+++ b/samples/Basic_SmartConfig/app/application.cpp
@@ -29,8 +29,7 @@ bool smartConfigCallback(SmartConfigEvent event, const SmartConfigEventInfo& inf
 
 void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
-	Serial.print("Connected: ");
-	Serial.println(ip);
+	Serial << "Connected: " << ip << endl;
 }
 
 void init()

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -18,17 +18,12 @@ OneShotFastMs connectTimer;
 void printHeap()
 {
 	Serial.println(_F("Heap statistics"));
-	Serial.print(_F("  Free bytes:  "));
-	Serial.println(system_get_free_heap_size());
+	Serial << _F("  Free bytes:  ") << system_get_free_heap_size() << endl;
 #ifdef ENABLE_MALLOC_COUNT
-	Serial.print(_F("  Used:        "));
-	Serial.println(MallocCount::getCurrent());
-	Serial.print(_F("  Peak used:   "));
-	Serial.println(MallocCount::getPeak());
-	Serial.print(_F("  Allocations: "));
-	Serial.println(MallocCount::getAllocCount());
-	Serial.print(_F("  Total used:  "));
-	Serial.println(MallocCount::getTotal());
+	Serial << _F("  Used:        ") << MallocCount::getCurrent() << endl;
+	Serial << _F("  Peak used:   ") << MallocCount::getPeak() << endl;
+	Serial << _F("  Allocations: ") << MallocCount::getAllocCount() << endl;
+	Serial << _F("  Total used:  ") << MallocCount::getTotal() << endl;
 #endif
 }
 
@@ -36,20 +31,13 @@ int onDownload(HttpConnection& connection, bool success)
 {
 	auto elapsed = connectTimer.elapsedTime();
 
-	Serial.print(_F("Got response code: "));
 	auto status = connection.getResponse()->code;
-	Serial.print(unsigned(status));
-	Serial.print(" (");
-	Serial.print(toString(status));
-	Serial.print(_F("), success: "));
-	Serial.print(success);
+	Serial << _F("Got response code: ") << unsigned(status) << " (" << status << _F("), success: ") << success;
 
 	auto stream = connection.getResponse()->stream;
 	assert(stream != nullptr);
 
-	Serial.print(_F(", received "));
-	Serial.print(stream->available());
-	Serial.println(_F(" bytes"));
+	Serial << _F(", received ") << stream->available() << _F(" bytes") << endl;
 
 	auto& headers = connection.getResponse()->headers;
 	for(unsigned i = 0; i < headers.count(); ++i) {
@@ -61,8 +49,7 @@ int onDownload(HttpConnection& connection, bool success)
 		ssl->printTo(Serial);
 	}
 
-	Serial.print(_F("Time to connect and download page: "));
-	Serial.println(elapsed.toString());
+	Serial << _F("Time to connect and download page: ") << elapsed.toString() << endl;
 
 	return 0; // return 0 on success in your callbacks
 }
@@ -76,13 +63,13 @@ void grcSslInit(Ssl::Session& session, HttpRequest& request)
 
 	// Use the Gibson Research fingerprints web page as an example. Unlike Google, these fingerprints change very infrequently.
 	static const Ssl::Fingerprint::Cert::Sha1 sha1Fingerprint PROGMEM = {
-		0x7A, 0x85, 0x1C, 0xF0, 0xF6, 0x9F, 0xD0, 0xCC, 0xEA, 0xEA,
-		0x9A, 0x88, 0x01, 0x96, 0xBF, 0x79, 0x8C, 0xE1, 0xA8, 0x33,
+		0xC3, 0xFB, 0x91, 0x85, 0xCC, 0x6B, 0x4C, 0x7D, 0xE7, 0x18,
+		0xED, 0xD8, 0x00, 0xD2, 0x84, 0xE7, 0x6E, 0x97, 0x06, 0x07,
 	};
 
 	static const Ssl::Fingerprint::Cert::Sha256 certSha256Fingerprint PROGMEM = {
-		0xEC, 0xB2, 0x21, 0x7E, 0x43, 0xCC, 0x83, 0xE5, 0x5B, 0x35, 0x7F, 0x1A, 0xC2, 0x06, 0xE8, 0xBF,
-		0xB1, 0x5F, 0x5B, 0xC8, 0x13, 0x9F, 0x93, 0x37, 0x3C, 0xF4, 0x8E, 0x82, 0xEC, 0x81, 0x28, 0xDF,
+		0xC3, 0xFB, 0x91, 0x85, 0xCC, 0x6B, 0x4C, 0x7D, 0xE7, 0x18,
+		0xED, 0xD8, 0x00, 0xD2, 0x84, 0xE7, 0x6E, 0x97, 0x06, 0x07,
 	};
 
 	static const Ssl::Fingerprint::Pki::Sha256 publicKeyFingerprint PROGMEM = {

--- a/samples/Basic_Tasks/app/application.cpp
+++ b/samples/Basic_Tasks/app/application.cpp
@@ -43,17 +43,9 @@ void hwTimerDelegate(uint32_t count)
 	static ElapseTimer timer;
 	auto elapsed = timer.elapsedTime();
 
-	Serial.print(F("count = "));
-	Serial.print(count);
-	Serial.print(F(", hwTimerCount = "));
-	Serial.print(hwTimerCount);
-	Serial.print(F(", av. interval = "));
-	Serial.print(diff ? (elapsed / diff) : 0);
-	Serial.print(F(", maxTasks = "));
-	Serial.print(System.getMaxTaskCount());
-	Serial.print(F(", CPU usage = "));
-	Serial.print(cpuUsage.getUtilisation() / 100.0);
-	Serial.println(F("%%"));
+	Serial << _F("count = ") << count << _F(", hwTimerCount = ") << hwTimerCount << _F(", av. interval = ")
+		   << (diff ? (elapsed / diff) : 0) << _F(", maxTasks = ") << System.getMaxTaskCount() << _F(", CPU usage = ")
+		   << cpuUsage.getUtilisation() / 100.0 << '%' << endl;
 
 	cpuUsage.reset();
 
@@ -87,12 +79,7 @@ void onReady()
 		WifiStation.enable(true);
 		WifiAccessPoint.enable(false);
 		WifiEvents.onStationGotIP([](IpAddress ip, IpAddress netmask, IpAddress gateway) {
-			Serial.print(F("GOTIP - IP: "));
-			Serial.print(ip);
-			Serial.print(F(", mask: "));
-			Serial.print(netmask);
-			Serial.print(F(", gateway: "));
-			Serial.println(gateway);
+			Serial << _F("GOTIP - IP: ") << ip << _F(", mask: ") << netmask << _F(", gateway: ") << gateway << endl;
 		});
 
 #endif

--- a/samples/Basic_Tasks/include/AnalogueReader.h
+++ b/samples/Basic_Tasks/include/AnalogueReader.h
@@ -91,9 +91,7 @@ ANALOGUE_READER(void)::processSamples()
 		}
 		Serial.print(bands[i]);
 	}
-	Serial.print(" - ");
-	Serial.print(missedSamples);
-	Serial.println(" missed");
+	Serial << " - " << missedSamples << " missed" << endl;
 }
 
 ANALOGUE_READER(void)::loop()
@@ -115,12 +113,8 @@ ANALOGUE_READER(void)::loop()
 		missedSamples = 0;
 		restartSampler = false;
 
-		//		Serial.print("groupStartTicks = ");
-		//		Serial.print(groupStartTicks);
-		//		Serial.print(", now = ");
-		//		Serial.print(now);
-		//		Serial.print(", diff = ");
-		//		Serial.println(int(now - groupStartTicks));
+		// Serial << "groupStartTicks = " << groupStartTicks,
+		// 	" <<  now = " << now << ", diff = " << int(now - groupStartTicks) << endl;
 
 	} else if(int(nextSampleTicks - now) <= 0) {
 		unsigned index = (now - groupStartTicks) / sampleIntervalTicks;
@@ -163,8 +157,7 @@ ANALOGUE_READER(void)::onNotify(Notify code)
 		groupStartTicks = sampleTimer.ticks();
 		restartSampler = true;
 
-		Serial.print(_F("sampleIntervalTicks = "));
-		Serial.println(sampleIntervalTicks);
+		Serial << _F("sampleIntervalTicks = ") << sampleIntervalTicks << endl;
 		break;
 	default:;
 	}

--- a/samples/Basic_Tasks/include/AnalogueReader.h
+++ b/samples/Basic_Tasks/include/AnalogueReader.h
@@ -157,7 +157,7 @@ ANALOGUE_READER(void)::onNotify(Notify code)
 		groupStartTicks = sampleTimer.ticks();
 		restartSampler = true;
 
-		Serial << _F("sampleIntervalTicks = ") << sampleIntervalTicks << endl;
+		Serial << F("sampleIntervalTicks = ") << sampleIntervalTicks << endl;
 		break;
 	default:;
 	}

--- a/samples/Basic_WiFi/app/application.cpp
+++ b/samples/Basic_WiFi/app/application.cpp
@@ -15,12 +15,9 @@ void listNetworks(bool succeeded, BssList& list)
 	}
 
 	for(unsigned i = 0; i < list.count(); i++) {
-		Serial.print(_F("\tWiFi: "));
-		Serial.print(list[i].ssid);
-		Serial.print(", ");
-		Serial.print(list[i].getAuthorizationMethodName());
+		Serial << _F("\tWiFi: ") << list[i].ssid << ", " << list[i].getAuthorizationMethodName();
 		if(list[i].hidden) {
-			Serial.print(_F(" (hidden)"));
+			Serial << _F(" (hidden)");
 		}
 		Serial.println();
 	}
@@ -29,18 +26,15 @@ void listNetworks(bool succeeded, BssList& list)
 // Will be called when WiFi station was connected to AP
 void connectOk(IpAddress ip, IpAddress mask, IpAddress gateway)
 {
-	Serial.print(_F("I'm CONNECTED to "));
-	Serial.println(ip);
+	Serial << _F("I'm CONNECTED to ") << ip << endl;
 }
 
 // Will be called when WiFi station was disconnected
 void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
 	// The different reason codes can be found in user_interface.h. in your SDK.
-	Serial.print(_F("Disconnected from \""));
-	Serial.print(ssid);
-	Serial.print(_F("\", reason: "));
-	Serial.println(WifiEvents.getDisconnectReasonDesc(reason));
+	Serial << _F("Disconnected from \"") << ssid << _F("\", reason: ") << WifiEvents.getDisconnectReasonDesc(reason)
+		   << endl;
 
 	/*
 	 * Print available access points
@@ -62,10 +56,7 @@ void ready()
 	Serial.println(_F("READY!"));
 
 	if(WifiAccessPoint.isEnabled()) {
-		Serial.print(_F("AP. ip: "));
-		Serial.print(WifiAccessPoint.getIP());
-		Serial.print(_F(" mac: "));
-		Serial.println(WifiAccessPoint.getMacAddress());
+		Serial << _F("AP. ip: ") << WifiAccessPoint.getIP() << _F(" mac: ") << WifiAccessPoint.getMacAddress() << endl;
 	}
 }
 
@@ -92,10 +83,7 @@ void init()
 
 	// Optional: Print details of any incoming probe requests
 	WifiEvents.onAccessPointProbeReqRecved([](int rssi, MacAddress mac) {
-		Serial.print(_F("Probe request: RSSI = "));
-		Serial.print(rssi);
-		Serial.print(_F(", mac = "));
-		Serial.println(mac);
+		Serial << _F("Probe request: RSSI = ") << rssi << _F(", mac = ") << mac << endl;
 	});
 
 	// Set callback that should be triggered when we have assigned IP

--- a/samples/CanBus/app/application.cpp
+++ b/samples/CanBus/app/application.cpp
@@ -35,18 +35,18 @@ void init()
 
 	// init CAN0 bus, baudrate: 250k@16MHz
 	if(canBus0.begin(MCP_EXT, CAN_250KBPS, MCP_16MHZ) == CAN_OK) {
-		Serial.print("CAN0: Init OK!\r\n");
+		Serial.println(_F("CAN0: Init OK!"));
 		canBus0.setMode(MCP_NORMAL);
 	} else {
-		Serial.print("CAN0: Init Fail!!!\r\n");
+		Serial.println(_F("CAN0: Init Fail!!!"));
 	}
 
 	// init CAN1 bus, baudrate: 250k@16MHz
 	if(canBus1.begin(MCP_EXT, CAN_250KBPS, MCP_16MHZ) == CAN_OK) {
-		Serial.print("CAN1: Init OK!\r\n");
+		Serial.println(_F("CAN1: Init OK!"));
 		canBus1.setMode(MCP_NORMAL);
 	} else {
-		Serial.print("CAN1: Init Fail!!!\r\n");
+		Serial.println(_F("CAN1: Init Fail!!!"));
 	}
 
 	// Set SPI to run at 8MHz (16MHz / 2 = 8 MHz)

--- a/samples/CommandProcessing_Debug/app/application.cpp
+++ b/samples/CommandProcessing_Debug/app/application.cpp
@@ -42,29 +42,30 @@ int msgCount = 0;
 
 void wsConnected(WebsocketConnection& socket)
 {
-	Serial.printf("Socket connected\r\n");
+	Serial.println(_F("Socket connected"));
 }
 
 void wsMessageReceived(WebsocketConnection& socket, const String& message)
 {
-	Serial.printf("WebsocketConnection message received:\r\n%s\r\n", message.c_str());
+	Serial.println(_F("WebsocketConnection message received:"));
+	Serial.println(message);
 	String response = "Echo: " + message;
 	socket.sendString(response);
 }
 
 void wsBinaryReceived(WebsocketConnection& socket, uint8_t* data, size_t size)
 {
-	Serial.printf("Websocket binary data received, size: %d\r\n", size);
+	Serial << _F("Websocket binary data received, size: ") << size << endl;
 }
 
 void wsDisconnected(WebsocketConnection& socket)
 {
-	Serial.printf("Socket disconnected");
+	Serial.println(_F("Socket disconnected"));
 }
 
 void processApplicationCommands(String commandLine, CommandOutput* commandOutput)
 {
-	commandOutput->printf("This command is handle by the application\r\n");
+	commandOutput->println(_F("This command is handle by the application"));
 }
 
 void StartServers()
@@ -82,29 +83,29 @@ void StartServers()
 
 	server.paths.set("/ws", wsResource);
 
-	Serial.println("\r\n=== WEB SERVER STARTED ===");
+	Serial.println(_F("\r\n=== WEB SERVER STARTED ==="));
 	Serial.println(WifiStation.getIP());
-	Serial.println("==============================\r\n");
+	Serial.println(_F("==============================\r\n"));
 
 	// Start FTP server
 	ftp.listen(21);
 	ftp.addUser("me", "123"); // FTP account
 
-	Serial.println("\r\n=== FTP SERVER STARTED ===");
-	Serial.println("==============================\r\n");
+	Serial.println(_F("\r\n=== FTP SERVER STARTED ==="));
+	Serial.println(_F("==============================\r\n"));
 
 	telnet.listen(23);
 	telnet.enableDebug(true);
 
-	Serial.println("\r\n=== TelnetServer SERVER STARTED ===");
-	Serial.println("==============================\r\n");
+	Serial.println(_F("\r\n=== TelnetServer SERVER STARTED ==="));
+	Serial.println(_F("==============================\r\n"));
 }
 
 void startExampleApplicationCommand()
 {
 	exampleCommand.initCommand();
 	commandHandler.registerCommand(
-		CommandDelegate("example", "Example Command from Class", "Application", processApplicationCommands));
+		CommandDelegate(F("example"), F("Example Command from Class"), F("Application"), processApplicationCommands));
 }
 
 void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)

--- a/samples/Compass_HMC5883L/app/application.cpp
+++ b/samples/Compass_HMC5883L/app/application.cpp
@@ -21,10 +21,11 @@ void init()
 
 	mag.initialize();
 
-	if(mag.testConnection())
-		Serial.println("[Compass] Magnetometer found");
-	else
-		Serial.println("Can't connect to Magnetometer");
+	if(mag.testConnection()) {
+		Serial.println(_F("[Compass] Magnetometer found"));
+	} else {
+		Serial.println(_F("Can't connect to Magnetometer"));
+	}
 
 	// Start reading loop
 	procTimer.initializeMs(100, readCompass).start();
@@ -35,21 +36,14 @@ void readCompass()
 	// read raw heading measurements from device
 	mag.getHeading(&mx, &my, &mz);
 
-	// display tab-separated gyro x/y/z values
-	Serial.print("mag:\t");
-	Serial.print(mx);
-	Serial.print("\t");
-	Serial.print(my);
-	Serial.print("\t");
-	Serial.print(mz);
-	Serial.print("\t");
-
 	// To calculate heading in degrees. 0 degree indicates North
 	float heading = atan2(my, mx);
-	if(heading < 0)
+	if(heading < 0) {
 		heading += 2 * PI;
-	if(heading > 2 * PI)
+	} else if(heading > 2 * PI) {
 		heading -= 2 * PI;
-	Serial.print("heading:\t");
-	Serial.println(heading * RAD_TO_DEG);
+	}
+
+	// display tab-separated gyro x/y/z values and heading
+	Serial << "mag:\t" << mx << '\t' << my << '\t' << mz << "\theading:\t" << heading * RAD_TO_DEG << endl;
 }

--- a/samples/DS3232RTC_NTP_Setter/app/application.cpp
+++ b/samples/DS3232RTC_NTP_Setter/app/application.cpp
@@ -23,20 +23,16 @@ void onPrintSystemTime()
 {
 	DateTime rtcNow = DSRTC.get();
 	Serial.println(_F("Current time"));
-	Serial.print(_F("  System(LOCAL TZ): "));
-	Serial.println(SystemClock.getSystemTimeString());
-	Serial.print(_F("  UTC(UTC TZ): "));
-	Serial.println(SystemClock.getSystemTimeString(eTZ_UTC));
-	Serial.print(_F("  DSRTC(UTC TZ): "));
-	Serial.println(rtcNow.toFullDateTimeString());
+	Serial << _F("  System(LOCAL TZ): ") << SystemClock.getSystemTimeString() << endl;
+	Serial << _F("  UTC(UTC TZ): ") << SystemClock.getSystemTimeString(eTZ_UTC) << endl;
+	Serial << _F("  DSRTC(UTC TZ): ") << rtcNow.toFullDateTimeString() << endl;
 }
 
 void onNtpReceive(NtpClient& client, time_t timestamp)
 {
 	SystemClock.setTime(timestamp, eTZ_UTC); //System timezone is LOCAL so to set it from UTC we specify TZ
 	DSRTC.set(timestamp);					 //DSRTC timezone is UTC so we need TZ-correct DSRTC.get()
-	Serial.print(_F("Time synchronized: "));
-	Serial.println(SystemClock.getSystemTimeString());
+	Serial << _F("Time synchronized: ") << SystemClock.getSystemTimeString() << endl;
 }
 
 void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
@@ -50,7 +46,7 @@ void init()
 {
 	Serial.begin(SERIAL_BAUD_RATE);
 	Serial.systemDebugOutput(true); // Allow debug print to serial
-	Serial.println("Sming DSRTC_NTP_SETTER started!");
+	Serial.println(_F("Sming DSRTC_NTP_SETTER started!"));
 	Wire.pins(SDA_PIN, SCL_PIN);
 	Wire.begin();
 

--- a/samples/Distance_Vl53l0x/app/application.cpp
+++ b/samples/Distance_Vl53l0x/app/application.cpp
@@ -15,14 +15,13 @@ void loop()
 {
 	VL53L0X_RangingMeasurementData_t measure;
 
-	Serial.print("Reading a measurement... ");
+	Serial.print(_F("Reading a measurement... "));
 	lox.rangingTest(&measure, false); // pass in 'true' to get debug data printout!
 
 	if(measure.RangeStatus != 4) { // phase failures have incorrect data
-		Serial.print("Distance (mm): ");
-		Serial.println(measure.RangeMilliMeter);
+		Serial << _F("Distance: ") << measure.RangeMilliMeter << " mm" << endl;
 	} else {
-		Serial.println(" out of range ");
+		Serial.println(_F("Out of range"));
 	}
 }
 
@@ -34,11 +33,10 @@ void init()
 	Wire.begin(SDA, SCL);
 
 	if(!lox.begin(VL53L0X_I2C_ADDR, false, &Wire, Adafruit_VL53L0X::VL53L0X_SENSE_LONG_RANGE)) {
-		Serial.println(F("Failed to boot VL53L0X"));
-		while(1) {
-		}
+		Serial.println(_F("Failed to boot VL53L0X"));
+		return;
 	}
 
-	Serial.println(F("VL53L0X API Simple Ranging example\n\n"));
+	Serial.println(_F("VL53L0X API Simple Ranging example\n\n"));
 	loopTimer.initializeMs<100>(loop).start();
 }

--- a/samples/FtpServer_Files/app/application.cpp
+++ b/samples/FtpServer_Files/app/application.cpp
@@ -10,8 +10,7 @@ FtpServer ftp;
 
 void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
-	Serial.print("IP: ");
-	Serial.println(ip);
+	Serial << "IP: " << ip << endl;
 	// Start FTP server
 	ftp.listen(21);
 	// Add user accounts
@@ -24,7 +23,7 @@ void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 // Will be called when WiFi station timeout was reached
 void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
-	Serial.println("I'm NOT CONNECTED. Need help!!! :(");
+	Serial.println(_F("I'm NOT CONNECTED. Need help!!! :("));
 }
 
 void init()

--- a/samples/Gesture_APDS-9960/app/application.cpp
+++ b/samples/Gesture_APDS-9960/app/application.cpp
@@ -14,25 +14,25 @@ void handleGesture()
 	if(apds.isGestureAvailable()) {
 		switch(apds.readGesture()) {
 		case DIR_UP:
-			Serial.println("UP");
+			Serial.println(_F("UP"));
 			break;
 		case DIR_DOWN:
-			Serial.println("DOWN");
+			Serial.println(_F("DOWN"));
 			break;
 		case DIR_LEFT:
-			Serial.println("LEFT");
+			Serial.println(_F("LEFT"));
 			break;
 		case DIR_RIGHT:
-			Serial.println("RIGHT");
+			Serial.println(_F("RIGHT"));
 			break;
 		case DIR_NEAR:
-			Serial.println("NEAR");
+			Serial.println(_F("NEAR"));
 			break;
 		case DIR_FAR:
-			Serial.println("FAR");
+			Serial.println(_F("FAR"));
 			break;
 		default:
-			Serial.println("NONE");
+			Serial.println(_F("NONE"));
 		}
 	}
 }
@@ -55,23 +55,23 @@ void init()
 	WifiAccessPoint.enable(false);
 #endif
 
-	Serial.println();
-	Serial.println("--------------------------------");
-	Serial.println("SparkFun APDS-9960 - GestureTest");
-	Serial.println("--------------------------------");
+	Serial.print(_F("\r\n"
+					"--------------------------------\r\n"
+					"SparkFun APDS-9960 - GestureTest\r\n"
+					"--------------------------------\r\n"));
 
 	// Initialize APDS-9960 (configure I2C and initial values)
 	if(apds.init()) {
-		Serial.println("APDS-9960 initialization complete");
+		Serial.println(_F("APDS-9960 initialization complete"));
 	} else {
-		Serial.println("Something went wrong during APDS-9960 init!");
+		Serial.println(_F("Something went wrong during APDS-9960 init!"));
 	}
 
 	// Start running the APDS-9960 gesture sensor engine
 	if(apds.enableGestureSensor(true)) {
-		Serial.println("Gesture sensor is now running");
+		Serial.println(_F("Gesture sensor is now running"));
 	} else {
-		Serial.println("Something went wrong during gesture sensor init!");
+		Serial.println(_F("Something went wrong during gesture sensor init!"));
 	}
 
 	// Initialize interrupt service routine

--- a/samples/HttpClient/app/application.cpp
+++ b/samples/HttpClient/app/application.cpp
@@ -78,8 +78,7 @@ void sslRequestInit(Ssl::Session& session, HttpRequest& request)
 
 void connectOk(IpAddress ip, IpAddress mask, IpAddress gateway)
 {
-	Serial.print(F("Connected. Got IP: "));
-	Serial.println(ip);
+	Serial << _F("Connected. Got IP: ") << ip << endl;
 
 	// [ GET request: The example below shows how to make HTTP requests ]
 

--- a/samples/HttpClient_Instapush/app/application.cpp
+++ b/samples/HttpClient_Instapush/app/application.cpp
@@ -82,20 +82,20 @@ InstapushApplication pusher(APP_ID, APP_SECRET);
 // Publish our message
 void publishMessage()
 {
-	Serial.println("Push message now!");
+	Serial.println(_F("Push message now!"));
 	InstapushTrackers trackers;
-	trackers["title"] = "Sming Framework";
-	trackers["text"] = "New test was successfully launched";
+	trackers["title"] = F("Sming Framework");
+	trackers["text"] = F("New test was successfully launched");
 	pusher.notify("notify", trackers); // event name, trackers
 }
 
 // Will be called when WiFi station was connected to AP
 void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
-	Serial.println("I'm CONNECTED");
+	Serial << _F("I'm CONNECTED to ") << ip << endl;
 
 	// Start publishing loop
-	procTimer.initializeMs(10 * 1000, publishMessage).start(true); // every 20 seconds
+	procTimer.initializeMs<10 * 1000>(publishMessage).start();
 }
 
 void init()

--- a/samples/HttpClient_ThingSpeak/app/application.cpp
+++ b/samples/HttpClient_ThingSpeak/app/application.cpp
@@ -15,14 +15,12 @@ int onDataSent(HttpConnection& client, bool successful)
 	Serial.println(successful ? _F("Success sent") : _F("Failed"));
 
 	String response = client.getResponse()->getBody();
-	Serial.print(_F("Server response: '"));
-	Serial.print(response);
-	Serial.println('\'');
+	Serial << _F("Server response: '") << response << '\'' << endl;
 	if(response.length() > 0) {
 		int intVal = response.toInt();
 
 		if(intVal == 0) {
-			Serial.println("Sensor value wasn't accepted. May be we need to wait a little?");
+			Serial.println(_F("Sensor value wasn't accepted. May be we need to wait a little?"));
 		}
 	}
 

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -78,16 +78,17 @@ void startWebServer()
 	server.paths.set("/ajax/frequency", onAjaxFrequency);
 	server.paths.setDefault(onFile);
 
-	Serial.println("\r\n=== WEB SERVER STARTED ===");
+	Serial.println(_F("\r\n"
+					  "=== WEB SERVER STARTED ==="));
 	Serial.println(WifiStation.getIP());
-	Serial.println("==============================\r\n");
+	Serial.println(_F("==========================\r\n"));
 }
 
 void startFTP()
 {
 	if(!fileExist("index.html"))
 		fileSetContent("index.html",
-					   "<h3>Please connect to FTP and upload files from folder 'web/build' (details in code)</h3>");
+					   F("<h3>Please connect to FTP and upload files from folder 'web/build' (details in code)</h3>"));
 
 	// Start FTP server
 	ftp.listen(21);

--- a/samples/HttpServer_Bootstrap/app/application.cpp
+++ b/samples/HttpServer_Bootstrap/app/application.cpp
@@ -56,9 +56,10 @@ void startWebServer()
 	server.paths.set("/hello", onHello);
 	server.paths.setDefault(onFile);
 
-	Serial.println("\r\n=== WEB SERVER STARTED ===");
+	Serial.println(_F("\r\n"
+					  "=== WEB SERVER STARTED ==="));
 	Serial.println(WifiStation.getIP());
-	Serial.println("==============================\r\n");
+	Serial.println(_F("==========================\r\n"));
 }
 
 Timer downloadTimer;
@@ -66,9 +67,9 @@ HttpClient downloadClient;
 int dowfid = 0;
 void downloadContentFiles()
 {
-	downloadClient.downloadFile("http://simple.anakod.ru/templates/index.html");
-	downloadClient.downloadFile("http://simple.anakod.ru/templates/bootstrap.css.gz");
-	downloadClient.downloadFile("http://simple.anakod.ru/templates/jquery.js.gz",
+	downloadClient.downloadFile(F("http://simple.anakod.ru/templates/index.html"));
+	downloadClient.downloadFile(F("http://simple.anakod.ru/templates/bootstrap.css.gz"));
+	downloadClient.downloadFile(F("http://simple.anakod.ru/templates/jquery.js.gz"),
 								(RequestCompletedDelegate)([](HttpConnection& connection, bool success) -> int {
 									if(success) {
 										startWebServer();
@@ -105,6 +106,5 @@ void init()
 
 	// Max. out CPU frequency
 	System.setCpuFrequency(CpuCycleClockFast::cpuFrequency());
-	Serial.print("New CPU frequency is:");
-	Serial.println(int(System.getCpuFrequency()));
+	Serial << _F("New CPU frequency is ") << System.getCpuFrequency() << " MHz" << endl;
 }

--- a/samples/HttpServer_WebSockets/app/CUserData.cpp
+++ b/samples/HttpServer_WebSockets/app/CUserData.cpp
@@ -30,10 +30,7 @@ void CUserData::printMessage(WebsocketConnection& connection, const String& msg)
 	}
 
 	if(i < activeWebSockets.count()) {
-		Serial.print(F("Received msg on connection "));
-		Serial.print(i);
-		Serial.print(" :");
-		Serial.print(msg);
+		Serial << _F("Received msg on connection ") << i << ": " << msg;
 	}
 }
 

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -47,7 +47,8 @@ void wsConnected(WebsocketConnection& socket)
 
 void wsMessageReceived(WebsocketConnection& socket, const String& message)
 {
-	Serial.printf("WebSocket message received:\r\n%s\r\n", message.c_str());
+	Serial.println(_F("WebSocket message received:"));
+	Serial.println(message);
 
 	if(message == _F("shutdown")) {
 		String message(F("The server is shutting down..."));
@@ -77,7 +78,7 @@ void wsMessageReceived(WebsocketConnection& socket, const String& message)
 
 void wsBinaryReceived(WebsocketConnection& socket, uint8_t* data, size_t size)
 {
-	Serial.printf(_F("Websocket binary data received, size: %d\r\n"), size);
+	Serial << _F("Websocket binary data received, size: ") << size << endl;
 }
 
 void wsDisconnected(WebsocketConnection& socket)
@@ -110,9 +111,10 @@ void startWebServer()
 
 	server.paths.set("/ws", wsResource);
 
-	Serial.println(F("\r\n=== WEB SERVER STARTED ==="));
+	Serial.println(_F("\r\n"
+					  "=== WEB SERVER STARTED ==="));
 	Serial.println(WifiStation.getIP());
-	Serial.println(F("==============================\r\n"));
+	Serial.println(_F("==========================\r\n"));
 }
 
 // Will be called when WiFi station becomes fully operational

--- a/samples/Humidity_AM2321/app/application.cpp
+++ b/samples/Humidity_AM2321/app/application.cpp
@@ -12,11 +12,7 @@ const int SDA = 4;
 
 void read()
 {
-	Serial.print(am2321.read());
-	Serial.print(",");
-	Serial.print(am2321.temperature / 10.0);
-	Serial.print(",");
-	Serial.println(am2321.humidity / 10.0);
+	Serial << am2321.read() << ',' << am2321.temperature / 10.0 << ',' << am2321.humidity / 10.0 << endl;
 }
 
 void init()

--- a/samples/Humidity_BME280/app/application.cpp
+++ b/samples/Humidity_BME280/app/application.cpp
@@ -33,23 +33,10 @@ Timer procTimer;
 
 void printValues()
 {
-	Serial.print(F("Temperature = "));
-	Serial.print(bme.readTemperature());
-	Serial.println(" °C");
-
-	Serial.print(F("Pressure = "));
-
-	Serial.print(bme.readPressure() / 100.0F);
-	Serial.println(" hPa");
-
-	Serial.print(F("Approx. Altitude = "));
-	Serial.print(bme.readAltitude(SEALEVELPRESSURE_HPA));
-	Serial.println(" m");
-
-	Serial.print(F("Humidity = "));
-	Serial.print(bme.readHumidity());
-	Serial.println(" %");
-
+	Serial << _F("Temperature = ") << bme.readTemperature() << " °C" << endl;
+	Serial << _F("Pressure = ") << bme.readPressure() / 100.0F << " hPa" << endl;
+	Serial << _F("Approx. Altitude = ") << bme.readAltitude(SEALEVELPRESSURE_HPA) << " m" << endl;
+	Serial << _F("Humidity = ") << bme.readHumidity() << " %" << endl;
 	Serial.println();
 }
 
@@ -58,26 +45,25 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Enable/disable debug output
 
-	Serial.println(F("BME280 test"));
+	Serial.println(_F("BME280 test"));
 
 #ifdef SDA
 	Wire.pins(SDA, SCL);
 #endif
 
 	if(!bme.begin()) { // if(!bme.begin(0x76, &Wire)) { if you need a specific address
-		Serial.println(F("Could not find a valid BME280 sensor, check wiring, address, sensor ID!"));
-		Serial.print(F("SensorID was: 0x"));
-		Serial.println(bme.sensorID(), 16);
-		Serial.println(F("  ID of 0xFF probably means a bad address, a BMP 180 or BMP 085"));
-		Serial.println(F("  ID of 0x56-0x58 represents a BMP 280,"));
-		Serial.println(F("  ID of 0x60 represents a BME 280."));
-		Serial.println(F("  ID of 0x61 represents a BME 680."));
+		Serial.println(_F("Could not find a valid BME280 sensor, check wiring, address, sensor ID!"));
+		Serial << _F("SensorID was: 0x") << String(bme.sensorID(), HEX) << endl;
+		Serial << _F("  ID of 0xFF probably means a bad address, a BMP 180 or BMP 085\r\n"
+					 "  ID of 0x56-0x58 represents a BMP 280,\r\n"
+					 "  ID of 0x60 represents a BME 280.\r\n"
+					 "  ID of 0x61 represents a BME 680.\r\n");
 		return;
 	}
 
-	Serial.println(F("-- Default Test --"));
+	Serial.println(_F("-- Default Test --"));
 
 	Serial.println();
 
-	procTimer.initializeMs(3000, printValues).start();
+	procTimer.initializeMs<3000>(printValues).start();
 }

--- a/samples/Humidity_DHT22/app/application.cpp
+++ b/samples/Humidity_DHT22/app/application.cpp
@@ -17,10 +17,10 @@ void init()
 	dht.setup(WORK_PIN, DHTesp::DHT22);
 	readTemperatureProcTimer.initializeMs(5 * 1000, onTimer_readTemperatures).start(); // every so often.
 
-	Serial.println("\nDHT improved lib");
-	Serial.print("TickCount=");
-	Serial.print((int)(RTC.getRtcNanoseconds() / 1000000));
-	Serial.println("Need to wait 1 second for the sensor to boot up");
+	Serial.println(_F("\r\n"
+					  "DHT improved lib"));
+	Serial << _F("TickCount=") << RTC.getRtcNanoseconds() / 1000000
+		   << _F("; Need to wait 1 second for the sensor to boot up") << endl;
 }
 
 void onTimer_readTemperatures()
@@ -30,41 +30,30 @@ void onTimer_readTemperatures()
 	toggle = !toggle;
 	float humidity = 0;
 	float temperature = 0;
-	Serial.print("TickCount=");
-	Serial.print((int)(RTC.getRtcNanoseconds() / 1000000));
+	Serial << _F("TickCount=") << RTC.getRtcNanoseconds() / 1000000 << endl;
 	if(toggle) {
-		Serial.print("Read using Adafruit API methods\n");
+		Serial.println(_F("Read using Adafruit API methods"));
 		humidity = dht.getHumidity();
 		temperature = dht.getTemperature();
 
 		// check if returns are valid, if they are NaN (not a number) then something went wrong!
 		if(dht.getStatus() == DHTesp::ERROR_NONE) {
-			Serial.print("\tHumidity: ");
-			Serial.print(humidity);
-			Serial.print("% Temperature: ");
-			Serial.print(temperature);
-			Serial.print(" *C\n");
+			Serial << _F("\tHumidity: ") << humidity << _F("% Temperature: ") << temperature << " °C" << endl;
 		} else {
-			Serial.print("Failed to read from DHT: ");
-			Serial.println((int)dht.getStatus());
+			Serial << _F("Failed to read from DHT: ") << dht.getStatus() << endl;
 		}
 	} else {
 		//* improved reading method
-		Serial.print("\nRead using new API methods\n");
-		TempAndHumidity th;
-		th = dht.getTempAndHumidity();
+		Serial.println(_F("\r\n"
+						  "Read using new API methods"));
+		TempAndHumidity th = dht.getTempAndHumidity();
 		humidity = th.humidity;
 		temperature = th.temperature;
 
 		if(dht.getStatus() == DHTesp::ERROR_NONE) {
-			Serial.print("\tHumidity: ");
-			Serial.print(th.humidity);
-			Serial.print("% Temperature: ");
-			Serial.print(th.temperature);
-			Serial.print(" *C\n");
+			Serial << _F("\tHumidity: ") << th.humidity << _F("% Temperature: ") << th.temperature << " °C" << endl;
 		} else {
-			Serial.print("Failed to read from DHT: ");
-			Serial.print(dht.getStatus());
+			Serial << _F("Failed to read from DHT: ") << dht.getStatus() << endl;
 		}
 	}
 
@@ -73,61 +62,55 @@ void onTimer_readTemperatures()
 	//  Heatindex is the perceived temperature taking humidity into account
 	//  More: https://en.wikipedia.org/wiki/Heat_index
 	//
-	Serial.print("Heatindex: ");
-	Serial.print(dht.computeHeatIndex(temperature, humidity));
-	Serial.print("*C\n");
+	Serial << _F("Heatindex: ") << dht.computeHeatIndex(temperature, humidity) << " °C" << endl;
 
 	//
 	//  Dewpoint is the temperature where condensation starts.
 	//  Water vapors will start condensing on an object having this temperature or below.
 	//  More: https://en.wikipedia.org/wiki/Dew_point
 	//
-	Serial.printf("Dewpoint: ");
-	Serial.print(dht.computeDewPoint(temperature, humidity));
-	Serial.print("*C\n");
+	Serial << _F("Dewpoint: ") << dht.computeDewPoint(temperature, humidity) << " °C" << endl;
 
 	//
 	// Determine thermal comfort according to http://epb.apogee.net/res/refcomf.asp
 	//
 	ComfortState cf;
 
-	Serial.print("Comfort is at ");
-	Serial.print(dht.getComfortRatio(cf, temperature, humidity));
-	Serial.print(" percent, (");
+	Serial << _F("Comfort is at ") << dht.getComfortRatio(cf, temperature, humidity) << " %, (";
 
 	switch(cf) {
 	case Comfort_OK:
-		Serial.print("OK");
+		Serial.print(_F("OK"));
 		break;
 	case Comfort_TooHot:
-		Serial.print("Too Hot");
+		Serial.print(_F("Too Hot"));
 		break;
 	case Comfort_TooCold:
-		Serial.print("Too Cold");
+		Serial.print(_F("Too Cold"));
 		break;
 	case Comfort_TooDry:
-		Serial.print("Too Dry");
+		Serial.print(_F("Too Dry"));
 		break;
 	case Comfort_TooHumid:
-		Serial.print("Too Humid");
+		Serial.print(_F("Too Humid"));
 		break;
 	case Comfort_HotAndHumid:
-		Serial.print("Hot And Humid");
+		Serial.print(_F("Hot And Humid"));
 		break;
 	case Comfort_HotAndDry:
-		Serial.print("Hot And Dry");
+		Serial.print(_F("Hot And Dry"));
 		break;
 	case Comfort_ColdAndHumid:
-		Serial.print("Cold And Humid");
+		Serial.print(_F("Cold And Humid"));
 		break;
 	case Comfort_ColdAndDry:
-		Serial.print("Cold And Dry");
+		Serial.print(_F("Cold And Dry"));
 		break;
 	default:
-		Serial.print("Unknown:");
+		Serial.print(_F("Unknown:"));
 		Serial.print(cf);
 		break;
 	}
 
-	Serial.print(")\n");
+	Serial.println(')');
 }

--- a/samples/Humidity_SI7021/app/application.cpp
+++ b/samples/Humidity_SI7021/app/application.cpp
@@ -19,55 +19,35 @@ double getDewPoint(unsigned int humidity, int temperature)
 
 void si_read_ht()
 {
-	if(!hydrometer.begin())
-		Serial.println("Could not connect to SI7021.");
-	Serial.print("Start reading Humidity and Temperature");
-	Serial.println(); // Start a new line.
+	if(!hydrometer.begin()) {
+		Serial.println(_F("Could not connect to SI7021."));
+	}
+	Serial.println(_F("Start reading Humidity and Temperature"));
 
 	si7021_env env_data = hydrometer.getHumidityAndTemperature();
 
 	if(env_data.error_crc == 1) {
-		Serial.print("\tCRC ERROR: ");
-		Serial.println(); // Start a new line.
+		Serial.println(_F("\tCRC ERROR: "));
 	} else {
-		// Print out the Temperature
-		Serial.print("\tTemperature: ");
-		float tprint = env_data.temperature;
-		Serial.print(tprint / 100);
-		Serial.print("C");
-		Serial.println(); // Start a new line.
-		// Print out the Humidity Percent
-		Serial.print("\tHumidity: ");
-		Serial.print(env_data.humidityPercent);
-		Serial.print("%");
-		Serial.println(); // Start a new line.
-		// Print out the Dew Point
-		Serial.print("\tDew Point: ");
-		Serial.print(getDewPoint(env_data.humidityPercent, env_data.temperature));
-		Serial.print("C");
-		Serial.println();
+		Serial << _F("\tTemperature: ") << env_data.temperature / 100.0 << " °C" << endl;
+		Serial << _F("\tHumidity: ") << env_data.humidityPercent << '%' << endl;
+		Serial << _F("\tDew Point: ") << getDewPoint(env_data.humidityPercent, env_data.temperature) << " °C" << endl;
 	}
 }
 
 void si_read_olt()
 {
-	if(!hydrometer.begin())
-		Serial.println("Could not connect to SI7021.");
-	Serial.print("Start reading Temperature");
-	Serial.println(); // Start a new line.
+	if(!hydrometer.begin()) {
+		Serial.println(_F("Could not connect to SI7021."));
+	}
+	Serial.println(_F("Start reading Temperature"));
 
 	si7021_olt olt_data = hydrometer.getTemperatureOlt();
 
 	if(olt_data.error_crc == 1) {
-		Serial.print("\tCRC ERROR: ");
-		Serial.println(); // Start a new line.
+		Serial.println(_F("\tCRC ERROR: "));
 	} else {
-		// Print out the Temperature
-		Serial.print("\tTemperature: ");
-		float tprint = olt_data.temperature;
-		Serial.print(tprint / 100);
-		Serial.print("C");
-		Serial.println(); // Start a new line.
+		Serial << _F("\tTemperature: ") << olt_data.temperature / 100.0 << " °C" << endl;
 	}
 }
 
@@ -75,7 +55,7 @@ void init()
 {
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Allow debug output to serial
-	Serial.print("Start I2c");
+	Serial.print(_F("Start I2c"));
 	Wire.pins(I2C_SDA, I2C_SCL); // SDA, SCL
 	Wire.begin();
 	procTimer_ht.initializeMs(10000, si_read_ht).start();

--- a/samples/Light_BH1750/app/application.cpp
+++ b/samples/Light_BH1750/app/application.cpp
@@ -25,9 +25,9 @@ void init()
 	Serial.systemDebugOutput(false); // Disable debug output to serial
 
 	if(LightSensor.begin() == 0)
-		Serial.println("LightSensor initialized");
+		Serial.println(_F("LightSensor initialized"));
 	else
-		Serial.println("LightSensor not available. May be wrong I2C address?");
+		Serial.println(_F("LightSensor not available. May be wrong I2C address?"));
 
 	/*
 	Set the Working Mode for this sensor

--- a/samples/LiquidCrystal_44780/app/application.cpp
+++ b/samples/LiquidCrystal_44780/app/application.cpp
@@ -16,7 +16,7 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
-	Serial.println("Initializing lcd via I2C (IIC/TWI) interface");
+	Serial.println(_F("Initializing lcd via I2C (IIC/TWI) interface"));
 
 	lcd.begin(16, 2); // initialize the lcd for 16 chars 2 lines, turn on backlight
 
@@ -32,7 +32,7 @@ void init()
 	//-------- Write characters on the display ------------------
 	// NOTE: Cursor Position: (CHAR, LINE) start at 0
 	lcd.setCursor(0, 0);
-	lcd.print("SMING: Let's do");
+	lcd.print(_F("SMING: Let's do"));
 	lcd.setCursor(0, 1);
-	lcd.print("smart things!");
+	lcd.print(_F("smart things!"));
 }

--- a/samples/MeteoControl_mqtt/app/application.cpp
+++ b/samples/MeteoControl_mqtt/app/application.cpp
@@ -14,17 +14,15 @@ void publishMessage() // uncomment timer in connectOk() if need publishMessage()
 	if(mqtt.getConnectionState() != eTCS_Connected)
 		startMqttClient(); // Auto reconnect
 
-	Serial.println("publish message");
+	Serial.println(_F("publish message"));
 	mqtt.publish(VER_TOPIC, "ver.1.2"); // or publishWithQoS
 }
 
 // Callback for messages, arrived from MQTT server
 int onMessageReceived(MqttClient& client, mqtt_message_t* message)
 {
-	Serial.print("Received: ");
-	Serial.print(MqttBuffer(message->publish.topic_name));
-	Serial.print(":\r\n\t"); // Pretify alignment for printing
-	Serial.println(MqttBuffer(message->publish.content));
+	Serial << _F("Received: ") << MqttBuffer(message->publish.topic_name) << ':' << endl;
+	Serial << '\t' << MqttBuffer(message->publish.content) << endl;
 	return 0;
 }
 
@@ -33,14 +31,13 @@ void startMqttClient()
 {
 	Url url(URI_SCHEME_MQTT, F(LOG), F(PASS), F(MQTT_SERVER), MQTT_PORT);
 	mqtt.connect(url, CLIENT);
-	Serial.println("Connected to MQTT server");
+	Serial.println(_F("Connected to MQTT server"));
 	mqtt.subscribe(SUB_TOPIC);
 }
 
 void gotIP(IpAddress ip, IpAddress netmask, IpAddress gateway)
 {
-	Serial.print("Connected: ");
-	Serial.println(ip);
+	Serial << _F("Connected: ") << ip << endl;
 	startMqttClient();
 	publishMessage(); // run once publishMessage
 }

--- a/samples/MeteoControl_mqtt/app/bmp180.cpp
+++ b/samples/MeteoControl_mqtt/app/bmp180.cpp
@@ -18,10 +18,10 @@ void publishBMP()
 	if(mqtt.getConnectionState() != eTCS_Connected)
 		startMqttClient(); // Auto reconnect
 
-	Serial.print("*********************************************");
-	Serial.println("Start reading BMP180 sensor");
+	Serial.print(_F("*********************************************"));
+	Serial.println(_F("Start reading BMP180 sensor"));
 	if(!barometer.EnsureConnected()) {
-		Serial.println("Could not connect to BMP180");
+		Serial.println(_F("Could not connect to BMP180"));
 	} else {
 		// Retrieve the current pressure in Pascals
 		long currentPressure = barometer.GetPressure();
@@ -29,21 +29,17 @@ void publishBMP()
 		float BMPPress = currentPressure / 133.322;
 
 		// Print out the Pressure
-		Serial.print("Pressure: ");
-		Serial.print(BMPPress);
-		Serial.println(" mmHg");
+		Serial << _F("Pressure: ") << BMPPress << _F(" mmHg") << endl;
 		mqtt.publish(BMP_P, String(BMPPress));
 
 		// Retrieve the current temperature in degrees celsius
 		float BMPTemp = barometer.GetTemperature();
 
 		// Print out the Temperature
-		Serial.print("Temperature: ");
-		Serial.print(BMPTemp);
-		Serial.println(" *C");
+		Serial << _F("Temperature: ") << BMPTemp << " °C" << endl;
 		mqtt.publish(BMP_T, String(BMPTemp));
-		Serial.println("BMP180 sensor read and transmitted to server");
-		Serial.println("*********************************************");
+		Serial.println(_F("BMP180 sensor read and transmitted to server\r\n"
+						  "********************************************"));
 	}
 }
 

--- a/samples/MeteoControl_mqtt/app/si7021.cpp
+++ b/samples/MeteoControl_mqtt/app/si7021.cpp
@@ -12,33 +12,30 @@ Timer publishSITimer;
 
 void publishSI()
 {
-	if(mqtt.getConnectionState() != eTCS_Connected)
+	if(mqtt.getConnectionState() != eTCS_Connected) {
 		startMqttClient(); // Auto reconnect
+	}
 
-	Serial.print("*********************************************");
-	Serial.println("Start reading SI7021 sensor");
+	Serial.println(_F("*********************************************\r\n"
+					  "Start reading SI7021 sensor"));
 
 	if(!hydrometer.begin()) {
-		Serial.println("Could not connect to SI7021");
+		Serial.println(_F("Could not connect to SI7021"));
 	} else {
 		si7021_env data = hydrometer.getHumidityAndTemperature();
 		if(data.error_crc == 1) {
-			Serial.println("\tCRC ERROR");
+			Serial.println(_F("\tCRC ERROR"));
 		} else {
 			float SIhum = data.humidityPercent;
 			// Print out the humidity
-			Serial.print("Humidity: ");
-			Serial.print(SIhum);
-			Serial.println("%");
+			Serial << _F("Humidity: ") << SIhum << '%' << endl;
 			mqtt.publish(SI_H, String(SIhum));
 			float SITemp = data.temperature;
 			// Print out the Temperature
-			Serial.print("Temperature: ");
-			Serial.print(SITemp / 100);
-			Serial.println(" *C");
+			Serial << _F("Temperature: ") << SITemp / 100 << " °C" << endl;
 			mqtt.publish(SI_T, String(SITemp / 100));
-			Serial.println("SI sensor read and transmitted to server");
-			Serial.println("*********************************************");
+			Serial.println(_F("SI sensor read and transmitted to server\r\n"
+							  "*********************************************"));
 		}
 	}
 }

--- a/samples/MqttClient_Hello/app/application.cpp
+++ b/samples/MqttClient_Hello/app/application.cpp
@@ -42,8 +42,8 @@ void checkMQTTDisconnect(TcpClient& client, bool flag)
 
 int onMessageDelivered(MqttClient& client, mqtt_message_t* message)
 {
-	Serial.printf(_F("Message with id %d and QoS %d was delivered successfully.\n"), message->puback.message_id,
-				  message->puback.qos);
+	Serial << _F("Message with id ") << message->puback.message_id << _F(" and QoS ") << message->puback.qos
+		   << _F(" was delivered successfully.") << endl;
 	return 0;
 }
 
@@ -54,8 +54,7 @@ void publishMessage()
 		startMqttClient(); // Auto reconnect
 	}
 
-	Serial.print(_F("Let's publish message now. Memory free="));
-	Serial.println(system_get_free_heap_size());
+	Serial << _F("Let's publish message now. Memory free=") << system_get_free_heap_size() << endl;
 	mqtt.publish(F("main/frameworks/sming"), F("Hello friends, from Internet of things :)"));
 
 	mqtt.publish(F("important/frameworks/sming"), F("Request Return Delivery"),
@@ -65,10 +64,8 @@ void publishMessage()
 // Callback for messages, arrived from MQTT server
 int onMessageReceived(MqttClient& client, mqtt_message_t* message)
 {
-	Serial.print("Received: ");
-	Serial.print(MqttBuffer(message->publish.topic_name));
-	Serial.print(":\r\n\t"); // Pretify alignment for printing
-	Serial.println(MqttBuffer(message->publish.content));
+	Serial << _F("Received: ") << MqttBuffer(message->publish.topic_name) << ':' << endl;
+	Serial << '\t' << MqttBuffer(message->publish.content) << endl;
 	return 0;
 }
 
@@ -86,8 +83,7 @@ void startMqttClient()
 	mqtt.setEventHandler(MQTT_TYPE_PUBACK, onMessageDelivered);
 
 	mqtt.setConnectedHandler([](MqttClient& client, mqtt_message_t* message) {
-		Serial.print(_F("Connected to "));
-		Serial.println(client.getRemoteIp());
+		Serial << _F("Connected to ") << client.getRemoteIp() << endl;
 
 		// Start publishing message now
 		publishMessage();
@@ -109,8 +105,7 @@ void startMqttClient()
 
 	// 2. [Connect]
 	Url url(MQTT_URL);
-	Serial.print(_F("Connecting to "));
-	Serial.println(url);
+	Serial << _F("Connecting to ") << url << endl;
 	mqtt.connect(url, F("esp8266"));
 	mqtt.subscribe(F("main/status/#"));
 }

--- a/samples/Network_Ping/app/application.cpp
+++ b/samples/Network_Ping/app/application.cpp
@@ -36,7 +36,7 @@ void onSent(void* arg, void* pdata)
 		return;
 	}
 
-	Serial.printf("Ping sent. Total failed attempts: %d.\n", failedAttempts);
+	Serial << _F("Ping sent. Total failed attempts: ") << failedAttempts << endl;
 	if(failedAttempts / response->total_count > MAX_FAILED_ATTEMTPS) {
 		debug_d("Scheduling system restart in %d seconds.", RESTART_DELAY_SECONDS);
 		// schedule restart
@@ -56,9 +56,8 @@ void onReceived(void* arg, void* pdata)
 		return;
 	}
 
-	Serial.printf("Ping received. Sequence: %d, Success: %d, Elapsed time: %d", response->seqno,
-				  response->ping_err == 0, response->total_time);
-	Serial.println();
+	Serial << _F("Ping received. Sequence: ") << response->seqno << _F(", Success: ") << (response->ping_err == 0)
+		   << _F(", Elapsed time: ") << response->total_time << endl;
 
 	if(response->ping_err) {
 		failedAttempts++;

--- a/samples/PortExpander_MCP23S17/app/application.cpp
+++ b/samples/PortExpander_MCP23S17/app/application.cpp
@@ -16,7 +16,7 @@ void init()
 {
 	Serial.begin(SERIAL_BAUD_RATE);  // 115200 by default
 	Serial.systemDebugOutput(false); // Allow debug output to serial
-	Serial.println("<-= Sming start =->");
+	Serial.println(_F("<-= Sming start =->"));
 
 	// Set higher CPU freq & disable wifi sleep
 	System.setCpuFrequency(CpuCycleClockFast::cpuFrequency());

--- a/samples/Pressure_BMP180/app/application.cpp
+++ b/samples/Pressure_BMP180/app/application.cpp
@@ -10,7 +10,7 @@ void init()
 	Wire.begin();
 
 	if(!barometer.EnsureConnected())
-		Serial.println("Could not connect to BMP180.");
+		Serial.println(_F("Could not connect to BMP180."));
 
 	// When we have connected, we reset the device to ensure a clean start.
 	//barometer.SoftReset();
@@ -18,24 +18,8 @@ void init()
 	barometer.Initialize();
 	barometer.PrintCalibrationData();
 
-	Serial.print("Start reading");
+	Serial.print(_F("Start reading"));
 
-	// Retrieve the current pressure in Pascals.
-	long currentPressure = barometer.GetPressure();
-
-	// Print out the Pressure.
-	Serial.print("Pressure: ");
-	Serial.print(currentPressure);
-	Serial.print(" Pa");
-
-	// Retrieve the current temperature in degrees celsius.
-	float currentTemperature = barometer.GetTemperature();
-
-	// Print out the Temperature
-	Serial.print("\tTemperature: ");
-	Serial.print(currentTemperature);
-	Serial.write(176);
-	Serial.print("C");
-
-	Serial.println(); // Start a new line.
+	Serial << _F("Pressure: ") << barometer.GetPressure() << " Pa" << _F("\tTemperature: ")
+		   << barometer.GetTemperature() << " °C" << endl;
 }

--- a/samples/Radio_RCSwitch/app/application.cpp
+++ b/samples/Radio_RCSwitch/app/application.cpp
@@ -11,22 +11,17 @@ RCSwitch mySwitch = RCSwitch();
 void sendRF()
 {
 	mySwitch.send(5393, 24);
-	Serial.println("RF command successful sent");
+	Serial.println(_F("RF command successful sent"));
 }
 
 void receiveRF()
 {
 	if(mySwitch.available()) {
 		if(mySwitch.getReceivedValue() == 0) {
-			Serial.print("Unknown encoding");
+			Serial.print(_F("Unknown encoding"));
 		} else {
-			Serial.print("Received ");
-			Serial.print(mySwitch.getReceivedValue());
-			Serial.print(" / ");
-			Serial.print(mySwitch.getReceivedBitlength());
-			Serial.print("bit ");
-			Serial.print("Protocol: ");
-			Serial.println(mySwitch.getReceivedProtocol());
+			Serial << _F("Received ") << mySwitch.getReceivedValue() << " / " << mySwitch.getReceivedBitlength()
+				   << " bit, Protocol: " << mySwitch.getReceivedProtocol() << endl;
 		}
 
 		mySwitch.resetAvailable();

--- a/samples/Radio_nRF24L01/app/application.cpp
+++ b/samples/Radio_nRF24L01/app/application.cpp
@@ -41,7 +41,7 @@ void loopListen()
 			done = radio.read(&got_time, sizeof(unsigned long));
 
 			// Spew it
-			Serial.printf("Got payload %lu...", got_time);
+			Serial << _F("Got payload ") << got_time << "...";
 
 			// Forward this data packet to UDP/HTTP/MQTT here.
 			// Example:
@@ -58,7 +58,7 @@ void loopListen()
 
 		// Send the final one back.
 		radio.write(&got_time, sizeof(unsigned long));
-		Serial.println("Sent response.");
+		Serial.println(_F("Sent response."));
 
 		// Now, resume listening so we catch the next packets.
 		radio.startListening();
@@ -70,7 +70,7 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
-	Serial.println("start");
+	Serial.println(_F("start"));
 
 	//
 	// Setup and configure rf radio
@@ -105,8 +105,8 @@ void init()
 	// Dump the configuration of the rf unit for debugging
 	//
 	radio.printDetails();
-	Serial.println("Initialization completed.");
+	Serial.println(_F("Initialization completed."));
 
 	procTimer.initializeMs(10, loopListen).start();
-	Serial.println("Listening...");
+	Serial.println(_F("Listening..."));
 }

--- a/samples/SDCard/app/application.cpp
+++ b/samples/SDCard/app/application.cpp
@@ -30,11 +30,12 @@ void writeToFile(const String& filename, uint32_t totalBytes, uint32_t bytesPerR
 {
 	char* buf = new char[totalBytes];
 	if(buf == nullptr) {
-		Serial.println("Failed to allocate heap");
+		Serial.println(_F("Failed to allocate heap"));
 		return;
 	}
 
-	Serial.printf(_F("Write %u kBytes in %u Bytes increment:\r\n"), totalBytes / 1024, bytesPerRound);
+	Serial << _F("Write ") << totalBytes / 1024 << _F(" kBytes in ") << bytesPerRound << _F(" Bytes increment:")
+		   << endl;
 	for(unsigned i = 0; i < totalBytes; i++) {
 		buf[i] = (i % 10) + '0';
 	}
@@ -51,7 +52,7 @@ void writeToFile(const String& filename, uint32_t totalBytes, uint32_t bytesPerR
 			uint32_t bytesWritten = 0;
 			f_write(&file, buf + i, remainingBytes, &bytesWritten);
 			if(bytesWritten != remainingBytes) {
-				Serial.printf(_F("Only written %u bytes\r\n"), i + bytesWritten);
+				Serial << _F("Only written ") << i + bytesWritten << " bytes" << endl;
 				break;
 			}
 			i += bytesWritten;
@@ -62,10 +63,9 @@ void writeToFile(const String& filename, uint32_t totalBytes, uint32_t bytesPerR
 		//get the time at test end
 		unsigned elapsed = timer.elapsedTime();
 
-		Serial.print((i / 1024.0f) * 1000000.0f / elapsed);
-		Serial.println(_F(" kB/s"));
+		Serial << (i / 1024.0f) * 1000000.0f / elapsed << _F(" kB/s") << endl;
 	} else {
-		Serial.printf(_F("fopen FAIL: %u\r\n"), (unsigned int)fRes);
+		Serial << _F("fopen FAIL: ") << fRes << endl;
 	}
 
 	delete[] buf;
@@ -77,8 +77,7 @@ void stat_file(char* fname)
 	FRESULT fr = f_stat(fname, &fno);
 	switch(fr) {
 	case FR_OK: {
-		Serial.print(fno.fsize);
-		Serial.print('\t');
+		Serial << fno.fsize << '\t';
 
 		uint8_t size = 0;
 		if(fno.fattrib & AM_DIR) {
@@ -96,11 +95,11 @@ void stat_file(char* fname)
 			Serial.print('\t');
 		}
 
-		Serial.printf(_F("%u/%02u/%02u, %02u:%02u\t"), (fno.fdate >> 9) + 1980, (fno.fdate >> 5) & 15, fno.fdate & 31,
-					  fno.ftime >> 11, (fno.ftime >> 5) & 63);
-		Serial.printf(_F("%c%c%c%c%c\r\n"), (fno.fattrib & AM_DIR) ? 'D' : '-', (fno.fattrib & AM_RDO) ? 'R' : '-',
-					  (fno.fattrib & AM_HID) ? 'H' : '-', (fno.fattrib & AM_SYS) ? 'S' : '-',
-					  (fno.fattrib & AM_ARC) ? 'A' : '-');
+		Serial << (fno.fdate >> 9) + 1980 << '/' << String((fno.fdate >> 5) & 15, DEC, 2) << '/'
+			   << String(fno.fdate & 31, DEC, 2) << ", " << String(fno.ftime >> 11, DEC, 2) << ':'
+			   << String((fno.ftime >> 5) & 63, DEC, 2) << '\t' << ((fno.fattrib & AM_DIR) ? 'D' : '-')
+			   << ((fno.fattrib & AM_RDO) ? 'R' : '-') << ((fno.fattrib & AM_HID) ? 'H' : '-')
+			   << ((fno.fattrib & AM_SYS) ? 'S' : '-') << ((fno.fattrib & AM_ARC) ? 'A' : '-') << endl;
 		break;
 	}
 

--- a/samples/ScreenOLED_SSD1306/app/application.cpp
+++ b/samples/ScreenOLED_SSD1306/app/application.cpp
@@ -29,19 +29,19 @@ Timer DemoTimer;
 
 void Demo2()
 {
-	Serial.println("Display: some text");
+	Serial.println(_F("Display: some text"));
 	display.clearDisplay();
 	// text display tests
 	display.setTextSize(1);
 	display.setTextColor(WHITE);
 	display.setCursor(0, 0);
-	display.println("Sming Framework");
+	display.println(_F("Sming Framework"));
 	display.setTextColor(BLACK, WHITE); // 'inverted' text
 	display.setCursor(104, 7);
-	display.println("v1.0");
+	display.println(_F("v1.0"));
 	//----
 	display.setTextColor(WHITE);
-	display.println("Let's do smart things");
+	display.println(_F("Let's do smart things"));
 	display.setTextSize(3);
 	display.print("IoT");
 	display.display();
@@ -50,7 +50,7 @@ void Demo2()
 
 void Demo1()
 {
-	Serial.println("Display: circle");
+	Serial.println(_F("Display: circle"));
 	// Clear the buffer.
 	display.clearDisplay();
 	// draw a circle, 10 pixel radius
@@ -63,7 +63,7 @@ void Demo1()
 void init()
 {
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
-	Serial.println("Display: start");
+	Serial.println(_F("Display: start"));
 
 	// by default, we'll generate the high voltage from the 3.3v line internally! (neat!)
 	// initialize with the I2C addr 0x3c (for the 128x64)

--- a/samples/ScreenTFT_ILI9163C/app/application.cpp
+++ b/samples/ScreenTFT_ILI9163C/app/application.cpp
@@ -18,7 +18,7 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Allow debug output to serial
 
-	Serial.println("Display start");
+	Serial.println(_F("Display start"));
 	tft.begin();
 	tft.setRotation(2); // try yourself
 	tft.fillScreen();
@@ -30,12 +30,12 @@ void init()
 	tft.setTextSize(1);
 	tft.setTextColor(GREEN);
 	tft.setCursor(0, 0);
-	tft.println("Sming Framework");
+	tft.println(_F("Sming Framework"));
 	tft.setTextColor(BLACK, WHITE); // 'inverted' text
 	tft.setCursor(104, 7);
 	tft.println("v1.0");
 	tft.setTextColor(WHITE);
-	tft.println("Let's do smart things");
+	tft.println(_F("Let's do smart things"));
 	tft.setTextSize(3);
 	tft.setTextColor(BLUE);
 	tft.print("IoT");

--- a/samples/ScreenTFT_ILI9340-ILI9341/app/application.cpp
+++ b/samples/ScreenTFT_ILI9340-ILI9341/app/application.cpp
@@ -76,10 +76,10 @@ void init()
 #endif
 
 	spiffs_mount();
-	Serial.println("FileSystem mounted.");
+	Serial.println(_F("FileSystem mounted."));
 
 	//	delay(2000);
-	Serial.println("Display start");
+	Serial.println(_F("Display start"));
 
 	// text display tests
 	tft.begin();
@@ -90,15 +90,15 @@ void init()
 	tft.setTextColor(ILI9341_GREEN);
 	tft.setCursor(0, 0);
 	tft.setCursor(60, 60);
-	tft.println("Sming  Framework");
+	tft.println(_F("Sming  Framework"));
 	tft.setTextColor(ILI9341_WHITE, ILI9341_BLACK); // text
 	tft.setCursor(60, 75);
 	tft.println("              v1.1");
 	tft.setTextColor(ILI9341_CYAN);
 	tft.setCursor(60, 90);
-	tft.println("ili9340-40C-41 ");
+	tft.println(_F("ili9340-40C-41 "));
 	tft.setCursor(60, 125);
-	tft.println("M.Bozkurt");
+	tft.println(_F("M.Bozkurt"));
 	delay(2000);
 	tft.fillScreen(0);
 	guiTimer.initializeMs<1000>(basicGui).start(false);


### PR DESCRIPTION
Add some improvements to the `Print` class, with support from new `String` methods.

A full STL stream implementation would require considerable work, with iostream wrappers, etc.

This PR adds basic support to the `Print` classs for the `<<` insertion streaming operator. Avoiding `printf` is generally a good idea, and strong C++ types can do a much better job.

I've started going updating the sample projects using this capability to improve code flow and readability,  but not yet complete. Let's see what people think before going any further!

## C++ streaming operation <<
   Building output is commonly done like this::

      Serial.print("Temperature: ");
      Serial.print(temperature);
      Serial.print(" °C, humidity: ");
      Serial.print(humidity);
      Serial.println("%");

   We can now do this::

      Serial << "Temperature" << temperature << " °C, humidity: " << humidity << "%" << endl;


## Number Printing
   Examples::

      Serial.print(12, HEX);         // "c"
      Serial.print(12, HEX, 4);      // "000c"
      Serial.print(12, HEX, 4, '.'); // "...c"
      Serial.print(12);              // "12"
      Serial.print(12, DEC, 4);      // "0012"

   Similar extensions are provided for `String` construction::

      Serial << "0x" << String(12, HEX, 8);       // "0x0000000c"
      Serial << String(12, DEC, 4, '.');          // "..12"


## Field-width control
   Supported via String methods::

      Serial << String(12).padLeft(4);          // "  12"
      Serial << String(12).padLeft(4, '0');     // "0012"
      Serial << String(12).padRight(4);         // "12  "
      Serial << String(12).pad(-4, '0');        // "0012"
      Serial << String(12).pad(4);              // "12  "


## Strongly-typed enumerations
   Use of ``enum class`` is good practice as it produces strongly-typed and scoped values.
   Most of these are also provided with a standard ``toString(E)`` function overload.

   This allows string equivalents to be printed very easily::

      auto status = HTTP_STATUS_HTTP_VERSION_NOT_SUPPORTED;
      auto type = MIME_HTML;
      Serial.print(type); // "text/html"
      // "Status: HTTP Version Not Supported, type: text/html"
      Serial << "Status: " << status << ", type: " << type << endl;
      // Status: 505, type: 0
      Serial << "Status: " << int(status) << ", type: " << int(type) << endl;


