### PR TITLE
Apply printing improvements to remaining samples

### DIFF
--- a/Sming/Components/Network/Arch/Esp8266/Platform/WifiSniffer.cpp
+++ b/Sming/Components/Network/Arch/Esp8266/Platform/WifiSniffer.cpp
@@ -68,9 +68,9 @@ static void parseClientInfo(ClientInfo& ci, uint8_t* frame, uint16_t framelen, i
 		break;
 	}
 
-	memcpy(ci.station, station, ETH_MAC_LEN);
-	memcpy(ci.bssid, bssid, ETH_MAC_LEN);
-	memcpy(ci.ap, ap, ETH_MAC_LEN);
+	memcpy(&ci.station[0], station, ETH_MAC_LEN);
+	memcpy(&ci.bssid[0], bssid, ETH_MAC_LEN);
+	memcpy(&ci.ap[0], ap, ETH_MAC_LEN);
 
 	ci.seq_n = (frame[23] * 0xFF) + (frame[22] & 0xF0);
 }
@@ -121,7 +121,7 @@ static void parseBeaconInfo(BeaconInfo& bi, uint8_t* frame, uint16_t framelen, i
 
 	bi.capa[0] = frame[34];
 	bi.capa[1] = frame[35];
-	memcpy(bi.bssid, frame + 10, ETH_MAC_LEN);
+	memcpy(&bi.bssid[0], frame + 10, ETH_MAC_LEN);
 }
 
 void WifiSniffer::parseData(uint8_t* buf, uint16_t len)
@@ -147,7 +147,7 @@ void WifiSniffer::parseData(uint8_t* buf, uint16_t len)
 				ClientInfo ci;
 				parseClientInfo(ci, data->buf, 36, data->rx_ctrl.rssi, data->rx_ctrl.channel);
 				// Check BSSID and station don't match (why ?)
-				if(memcmp(ci.bssid, ci.station, ETH_MAC_LEN) != 0) {
+				if(ci.bssid != ci.station) {
 					clientCallback(ci);
 				}
 			}

--- a/Sming/Components/Network/src/Platform/WifiSniffer.h
+++ b/Sming/Components/Network/src/Platform/WifiSniffer.h
@@ -54,16 +54,13 @@ struct ClientInfo {
 	uint16_t seq_n;
 };
 
-/**
- * @brief For applications to use to manage list of unique beacons
- */
-class BeaconInfoList : public Vector<BeaconInfo>
+template <class T> class BeaconOrClientListTemplate : public Vector<T>
 {
 public:
 	int indexOf(const MacAddress& bssid)
 	{
-		for(unsigned i = 0; i < count(); ++i) {
-			if(elementAt(i).bssid == bssid) {
+		for(unsigned i = 0; i < this->count(); ++i) {
+			if(this->elementAt(i).bssid == bssid) {
 				return i;
 			}
 		}
@@ -73,22 +70,14 @@ public:
 };
 
 /**
+ * @brief For applications to use to manage list of unique beacons
+ */
+using BeaconInfoList = BeaconOrClientListTemplate<BeaconInfo>;
+
+/**
  * @brief For applications to use to manage list of unique clients
  */
-class ClientInfoList : public Vector<ClientInfo>
-{
-public:
-	int indexOf(const MacAddress& station)
-	{
-		for(unsigned i = 0; i < count(); ++i) {
-			if(elementAt(i).station == station) {
-				return i;
-			}
-		}
-
-		return -1;
-	}
-};
+using ClientInfoList = BeaconOrClientListTemplate<ClientInfo>;
 
 using WifiSnifferCallback = Delegate<void(uint8_t* data, uint16_t length)>;
 using WifiBeaconCallback = Delegate<void(const BeaconInfo& beacon)>;

--- a/Sming/Components/Network/src/Platform/WifiSniffer.h
+++ b/Sming/Components/Network/src/Platform/WifiSniffer.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <Platform/System.h>
+#include <MacAddress.h>
 #include "WVector.h"
 
 /**	@defgroup wifi_sniffer WiFi Sniffer
@@ -31,7 +32,7 @@
  * @brief Decoded Wifi beacon (Access Point) information
  */
 struct BeaconInfo {
-	uint8_t bssid[ETH_MAC_LEN];
+	MacAddress bssid;
 	uint8_t ssid[33];
 	uint8_t ssid_len;
 	uint8_t channel;
@@ -44,9 +45,9 @@ struct BeaconInfo {
  * @brief Decoded Wifi client information
  */
 struct ClientInfo {
-	uint8_t bssid[ETH_MAC_LEN];
-	uint8_t station[ETH_MAC_LEN];
-	uint8_t ap[ETH_MAC_LEN];
+	MacAddress bssid;
+	MacAddress station;
+	MacAddress ap;
 	uint8_t channel;
 	int8_t err;
 	int8_t rssi;
@@ -59,10 +60,10 @@ struct ClientInfo {
 class BeaconInfoList : public Vector<BeaconInfo>
 {
 public:
-	int indexOf(const uint8_t bssid[])
+	int indexOf(const MacAddress& bssid)
 	{
 		for(unsigned i = 0; i < count(); ++i) {
-			if(memcmp(elementAt(i).bssid, bssid, ETH_MAC_LEN) == 0) {
+			if(elementAt(i).bssid == bssid) {
 				return i;
 			}
 		}
@@ -77,10 +78,10 @@ public:
 class ClientInfoList : public Vector<ClientInfo>
 {
 public:
-	int indexOf(const uint8_t station[])
+	int indexOf(const MacAddress& station)
 	{
 		for(unsigned i = 0; i < count(); ++i) {
-			if(memcmp(elementAt(i).station, station, ETH_MAC_LEN) == 0) {
+			if(elementAt(i).station == station) {
 				return i;
 			}
 		}

--- a/Sming/Core/Data/HexString.cpp
+++ b/Sming/Core/Data/HexString.cpp
@@ -11,7 +11,7 @@
 #include "HexString.h"
 #include <stringutil.h>
 
-String makeHexString(const uint8_t* data, unsigned length, char separator)
+String makeHexString(const void* data, unsigned length, char separator)
 {
 	if(data == nullptr || length == 0) {
 		return nullptr;
@@ -27,13 +27,14 @@ String makeHexString(const uint8_t* data, unsigned length, char separator)
 		return nullptr;
 	}
 
-	char* p = result.begin();
-	for(unsigned i = 0; i < length; ++i) {
+	auto inptr = static_cast<const uint8_t*>(data);
+	char* outptr = result.begin();
+	for(unsigned i = 0; i < length; ++i, ++inptr) {
 		if(i != 0 && separator != '\0') {
-			*p++ = separator;
+			*outptr++ = separator;
 		}
-		*p++ = hexchar(data[i] >> 4);
-		*p++ = hexchar(data[i] & 0x0F);
+		*outptr++ = hexchar(*inptr >> 4);
+		*outptr++ = hexchar(*inptr & 0x0F);
 	}
 
 	return result;

--- a/Sming/Core/Data/HexString.h
+++ b/Sming/Core/Data/HexString.h
@@ -20,4 +20,4 @@
  *  @param separator optional character to put between hex-encoded bytes
  *  @retval String
  */
-String makeHexString(const uint8_t* data, unsigned length, char separator = '\0');
+String makeHexString(const void* data, unsigned length, char separator = '\0');

--- a/Sming/Wiring/MacAddress.h
+++ b/Sming/Wiring/MacAddress.h
@@ -35,7 +35,7 @@
  * @author mikee47 <mike@sillyhouse.net>
  * 	Sming integration
  */
-class MacAddress : public Printable
+class MacAddress
 {
 	// https://www.artima.com/cppsource/safebool.html
 	using bool_type = void (MacAddress::*)() const;
@@ -103,6 +103,11 @@ public:
 	 */
 	String toString(char sep = ':') const;
 
+	operator String() const
+	{
+		return toString();
+	}
+
 	/**
 	 * @brief Equality operator.
 	 */
@@ -146,11 +151,6 @@ public:
 	 * @note This does not uniquely identify the key
 	 */
 	uint32_t getHash() const;
-
-	size_t printTo(Print& p) const override
-	{
-		return p.print(toString());
-	}
 
 private:
 	Octets octets = {0};

--- a/samples/Arducam/app/ArduCamCommand.cpp
+++ b/samples/Arducam/app/ArduCamCommand.cpp
@@ -43,8 +43,8 @@ void ArduCamCommand::processSetCommands(String commandLine, CommandOutput* comma
 	}
 	// handle command ->   set
 	else if(commandToken[1] == "help") {
-		commandOutput->printf("set img 	[bmp|jpeg]\r\n");
-		commandOutput->printf("set size [160|176|320|352|640|800|1024|1280|1600]\r\n");
+		*commandOutput << _F("set img 	[bmp|jpeg]") << endl;
+		*commandOutput << _F("set size [160|176|320|352|640|800|1024|1280|1600]") << endl;
 	}
 
 	// handle command ->   set
@@ -56,10 +56,11 @@ void ArduCamCommand::processSetCommands(String commandLine, CommandOutput* comma
 				set_format(BMP);
 			} else if(commandToken[2] == "jpg") {
 				set_format(JPEG);
-			} else
-				commandOutput->printf("invalid image format [%s]\r\n", commandToken[2].c_str());
+			} else {
+				*commandOutput << _F("invalid image format [") << commandToken[2] << ']' << endl;
+			}
 		} else {
-			commandOutput->printf("Syntax: set img [bmp|jpeg]\r\n");
+			*commandOutput << _F("Syntax: set img [bmp|jpeg]") << endl;
 		}
 		showSettings(commandOutput);
 	}
@@ -103,10 +104,10 @@ void ArduCamCommand::processSetCommands(String commandLine, CommandOutput* comma
 				myCAM->OV2640_set_JPEG_size(OV2640_1600x1200);
 				set_format(JPEG);
 			} else {
-				commandOutput->printf("invalid size definition[%s]\r\n", commandToken[2].c_str());
+				*commandOutput << _F("invalid size definition[") << commandToken[2] << ']' << endl;
 			}
 		} else {
-			commandOutput->printf("Syntax: set size [160|176|320|352|640|800|1024|1280|1600]\r\n");
+			*commandOutput << _F("Syntax: set size [160|176|320|352|640|800|1024|1280|1600]") << endl;
 		}
 		showSettings(commandOutput);
 	}

--- a/samples/Arducam/app/application.cpp
+++ b/samples/Arducam/app/application.cpp
@@ -77,10 +77,10 @@ void initCam()
 	myCAM.rdSensorReg8_8(OV2640_CHIPID_HIGH, &vid);
 	myCAM.rdSensorReg8_8(OV2640_CHIPID_LOW, &pid);
 	if((vid != 0x26) || (pid != 0x42)) {
-		Serial.println("Can't find OV2640 module!");
+		Serial.println(_F("Can't find OV2640 module!"));
 		Serial << "vid = [" << String(vid, HEX) << "], pid = [" << String(pid, HEX) << "]" << endl;
 	} else {
-		Serial.println("OV2640 detected");
+		Serial.println(_F("OV2640 detected"));
 	}
 
 	// initialize SPI:
@@ -94,15 +94,16 @@ void initCam()
 
 	uint8_t temp = myCAM.read_reg(ARDUCHIP_TEST1);
 	if(temp != 0x55) {
-		Serial.println("SPI interface Error!");
-		while(1)
-			;
+		Serial.println(_F("SPI interface Error!"));
+		while(1) {
+			// loop forever
+		}
 	} else {
-		Serial.println("SPI interface OK!");
+		Serial.println(_F("SPI interface OK!"));
 	}
 
 	// init CAM
-	Serial.println("Initialize the OV2640 module");
+	Serial.println(_F("Initialize the OV2640 module"));
 	myCAM.set_format(JPEG);
 	myCAM.InitCAM();
 }

--- a/samples/Basic_Storage/app/application.cpp
+++ b/samples/Basic_Storage/app/application.cpp
@@ -9,9 +9,7 @@ void listSpiffsPartitions()
 {
 	Serial.println(_F("** Enumerate registered SPIFFS partitions"));
 	for(auto part : Storage::findPartition(Storage::Partition::SubType::Data::spiffs)) {
-		Serial.print(F(">> Mounting '"));
-		Serial.print(part.name());
-		Serial.println("' ...");
+		Serial << _F(">> Mounting '") << part.name() << "' ..." << endl;
 		bool ok = spiffs_mount(part);
 		Serial.println(ok ? "OK, listing files:" : "Mount failed!");
 		if(ok) {
@@ -22,9 +20,7 @@ void listSpiffsPartitions()
 					Serial.println(dir.stat().name);
 				}
 			}
-			Serial.print(dir.count());
-			Serial.println(F(" files found"));
-			Serial.println();
+			Serial << dir.count() << _F(" files found") << endl << endl;
 		}
 	}
 }
@@ -35,16 +31,16 @@ void printPart(Storage::Partition part)
 	char buf[bufSize];
 	OneShotFastUs timer;
 	if(!part.read(0, buf, bufSize)) {
-		debug_e("Error reading from partition '%s'", part.name().c_str());
+		Serial << _F("Error reading from partition '") << part.name() << "'" << endl;
 	} else {
 		auto elapsed = timer.elapsedTime();
 		String s = part.getDeviceName();
 		s += '/';
 		s += part.name();
 		m_printHex(s.c_str(), buf, std::min(128U, bufSize));
-		m_printf(_F("Elapsed: %s\r\n"), elapsed.toString().c_str());
+		Serial << _F("Elapsed: ") << elapsed.toString() << endl;
 		if(elapsed != 0) {
-			m_printf(_F("Speed:   %u KB/s\r\n\r\n"), 1000 * bufSize / elapsed);
+			Serial << _F("Speed:   ") << 1000 * bufSize / elapsed << " KB/s" << endl;
 		}
 	}
 	Serial.println();
@@ -54,7 +50,7 @@ void printPart(const String& partitionName)
 {
 	auto part = Storage::findPartition(partitionName);
 	if(!part) {
-		debug_e("Partition '%s' not found", partitionName.c_str());
+		Serial << _F("Partition '") << partitionName << _F("' not found") << endl;
 	} else {
 		printPart(part);
 	}

--- a/samples/SystemClock_NTP/app/NtpClientDemo.cpp
+++ b/samples/SystemClock_NTP/app/NtpClientDemo.cpp
@@ -18,24 +18,17 @@ void NtpClientDemo::ntpResult(NtpClient& client, time_t ntpTime)
 	/*
 	 * Display the new time
 	 */
-	Serial.print("ntpClientDemo Callback: ntpTime = ");
-	Serial.print(ntpTime);
-	Serial.print(", ");
-	Serial.print(SystemClock.getSystemTimeString(eTZ_UTC));
-	Serial.print(" UTC, Local time = ");
-	Serial.print(SystemClock.getSystemTimeString(eTZ_Local));
-	Serial.print(" ");
-	Serial.println(tz.utcTimeTag(ntpTime));
+	Serial << _F("ntpClientDemo Callback: ntpTime = ") << ntpTime << ", " << SystemClock.getSystemTimeString(eTZ_UTC)
+		   << _F(" UTC, Local time = ") << SystemClock.getSystemTimeString(eTZ_Local) << ' ' << tz.utcTimeTag(ntpTime)
+		   << endl;
 
 	/*
 	 * Display times of next sunrise and sunset
 	 */
 	DateTime sunrise = getNextSunriseSet(true);
 	DateTime sunset = getNextSunriseSet(false);
-	Serial.print("Next sunrise at ");
-	Serial.print(sunrise.toShortTimeString());
-	Serial.print(", sunset at ");
-	Serial.println(sunset.toShortTimeString());
+	Serial << _F("Next sunrise at ") << sunrise.toShortTimeString() << _F(", sunset at ") << sunset.toShortTimeString()
+		   << endl;
 }
 
 /*

--- a/samples/SystemClock_NTP/app/application.cpp
+++ b/samples/SystemClock_NTP/app/application.cpp
@@ -45,11 +45,8 @@ NtpClientDemo* demo;
 
 void onPrintSystemTime()
 {
-	Serial.print("Local Time: ");
-	Serial.print(SystemClock.getSystemTimeString(eTZ_Local));
-	Serial.print(" ");
-	Serial.print("UTC Time:   ");
-	Serial.println(SystemClock.getSystemTimeString(eTZ_UTC));
+	Serial << _F("Local Time: ") << SystemClock.getSystemTimeString(eTZ_Local) << _F(", UTC Time: ")
+		   << SystemClock.getSystemTimeString(eTZ_UTC) << endl;
 }
 
 // Called when time has been received by NtpClient (option 1 or 2)
@@ -59,8 +56,7 @@ void onNtpReceive(NtpClient& client, time_t timestamp)
 {
 	SystemClock.setTime(timestamp, eTZ_UTC);
 
-	Serial.print("Time synchronized: ");
-	Serial.println(SystemClock.getSystemTimeString());
+	Serial << _F("Time synchronized: ") << SystemClock.getSystemTimeString() << endl;
 }
 
 // Will be called when WiFi station timeout was reached
@@ -99,7 +95,7 @@ void init()
 {
 	Serial.begin(SERIAL_BAUD_RATE);
 	Serial.systemDebugOutput(true); // Allow debug print to serial
-	Serial.println("Sming. Let's do smart things!");
+	Serial.println(_F("Sming. Let's do smart things!"));
 
 	// Station - WiFi client
 	WifiStation.enable(true);

--- a/samples/TcpClient_NarodMon/app/application.cpp
+++ b/samples/TcpClient_NarodMon/app/application.cpp
@@ -136,7 +136,7 @@ void init()
 	// Настраиваем и включаем вывод в UART для дебага
 	Serial.begin(COM_SPEED_SERIAL);
 	Serial.systemDebugOutput(true);
-	Serial.println("Hello friendly world! :)");
+	Serial.println(_F("Hello friendly world! :)"));
 
 	// Disable AP
 	// Отключаем AP

--- a/samples/Telnet_Server/app/application.cpp
+++ b/samples/Telnet_Server/app/application.cpp
@@ -16,22 +16,21 @@ void checkHeap()
 {
 	int currentHeap = system_get_free_heap_size();
 	if(currentHeap != savedHeap) {
-		Debug.printf(_F("Heap change, current = %u\r\n"), currentHeap);
+		Debug << _F("Heap change, current = ") << currentHeap << endl;
 		savedHeap = currentHeap;
 	}
 }
 
 void applicationCommand(String commandLine, CommandOutput* commandOutput)
 {
-	commandOutput->print(_F("Hello from Telnet Example application\r\nYou entered : '"));
-	commandOutput->print(commandLine.c_str());
-	commandOutput->println('\'');
-	commandOutput->println(_F("Tokenized commandLine is : "));
+	*commandOutput << _F("Hello from Telnet Example application") << endl
+				   << _F("You entered : '") << commandLine << '\'' << endl
+				   << _F("Tokenized commandLine is : ") << endl;
 
 	Vector<String> commandToken;
 	unsigned numToken = splitString(commandLine, ' ', commandToken);
 	for(unsigned i = 0; i < numToken; i++) {
-		commandOutput->printf(_F("%u : %s\r\n"), i, commandToken.at(i).c_str());
+		*commandOutput << i << " : " << commandToken[i] << endl;
 	}
 }
 
@@ -50,7 +49,7 @@ void appheapCommand(String commandLine, CommandOutput* commandOutput)
 		savedHeap = 0;
 		memoryTimer.stop();
 	} else if(commandToken[1] == "now") {
-		commandOutput->printf(_F("Heap current free = %u\r\n"), system_get_free_heap_size());
+		*commandOutput << _F("Heap current free = ") << system_get_free_heap_size() << endl;
 	} else {
 		commandOutput->println(_F("Usage appheap on/off/now"));
 	}
@@ -86,15 +85,17 @@ void startServers()
 {
 	tcpServer.listen(8023);
 
-	Serial.println(_F("\r\n=== TCP SERVER Port 8023 STARTED ==="));
+	Serial.println(_F("\r\n"
+					  "=== TCP SERVER Port 8023 STARTED ==="));
 	Serial.println(WifiStation.getIP());
-	Serial.println(_F("==============================\r\n"));
+	Serial.println(_F("====================================\r\n"));
 
 	telnetServer.listen(23);
 
-	Serial.println(_F("\r\n=== Telnet SERVER Port 23 STARTED ==="));
+	Serial.println(_F("\r\n"
+					  "=== Telnet SERVER Port 23 STARTED ==="));
 	Serial.println(WifiStation.getIP());
-	Serial.println(_F("==============================\r\n"));
+	Serial.println(_F("=====================================\r\n"));
 
 	commandHandler.registerCommand(CommandDelegate(
 		F("application"), F("This command is defined by the application\r\n"), F("testGroup"), applicationCommand));

--- a/samples/UdpServer_Echo/app/application.cpp
+++ b/samples/UdpServer_Echo/app/application.cpp
@@ -17,8 +17,7 @@ void onReceive(UdpConnection& connection, char* data, int size, IpAddress remote
 	debugf("UDP Server callback from %s:%d, %d bytes", remoteIP.toString().c_str(), remotePort, size);
 
 	// We implement string mode server for example
-	Serial.print(">\t");
-	Serial.print(data);
+	Serial << ">\t" << data;
 
 	// Send echo to remote sender
 	String text = String("echo: ") + data;
@@ -29,11 +28,10 @@ void gotIP(IpAddress ip, IpAddress gateway, IpAddress netmask)
 {
 	udp.listen(EchoPort);
 
-	Serial.println("\r\n=== UDP SERVER STARTED ===");
-	Serial.print(WifiStation.getIP());
-	Serial.print(":");
-	Serial.println(EchoPort);
-	Serial.println("=============================\r\n");
+	Serial.println(_F("\r\n"
+					  "=== UDP SERVER STARTED ==="));
+	Serial << WifiStation.getIP() << ':' << EchoPort << endl;
+	Serial.println(_F("==========================\r\n"));
 }
 
 void init()

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -99,12 +99,12 @@ void test()
 
 		// speedTest(question);
 
-		checkLike(question, "_services._dns-sd._udp.local", true);
-		checkLike(question, "_dns-sd._udp.local", true);
-		checkLike(question, "_udp.local", true);
-		checkLike(question, "local", true);
+		checkLike(question, _F("_services._dns-sd._udp.local"), true);
+		checkLike(question, _F("_dns-sd._udp.local"), true);
+		checkLike(question, _F("_udp.local"), true);
+		checkLike(question, _F("local"), true);
 
-		checkParser("_some-service-or-other._http._tcp.sming.local");
+		checkParser(_F("_some-service-or-other._http._tcp.sming.local"));
 
 		// debug_i("(question == fstrServicesLocal): %u", question->getName() == fstrServicesLocal);
 		printMessage(Serial, query);
@@ -145,9 +145,9 @@ void onFile(HttpRequest& request, HttpResponse& response)
 {
 	String file = request.uri.getRelativePath();
 
-	if(file[0] == '.')
+	if(file[0] == '.') {
 		response.code = HTTP_STATUS_FORBIDDEN;
-	else {
+	} else {
 		response.setCache(86400, true); // It's important to use cache for better performance.
 		response.sendFile(file);
 	}
@@ -158,9 +158,10 @@ void startWebServer()
 	server.listen(80);
 	server.paths.set("/", onIndex);
 
-	Serial.println("\r\n=== WEB SERVER STARTED ===");
+	Serial.println(_F("\r\n"
+					  "=== WEB SERVER STARTED ==="));
 	Serial.println(WifiStation.getIP());
-	Serial.println("==============================\r\n");
+	Serial.println(_F("==========================\r\n"));
 }
 
 void connectFail(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)

--- a/samples/WebcamServer/app/application.cpp
+++ b/samples/WebcamServer/app/application.cpp
@@ -26,9 +26,9 @@ void onFile(HttpRequest& request, HttpResponse& response)
 {
 	String file = request.uri.getRelativePath();
 
-	if(file[0] == '.')
+	if(file[0] == '.') {
 		response.code = HTTP_STATUS_FORBIDDEN;
-	else {
+	} else {
 		response.setCache(86400, true); // It's important to use cache for better performance.
 		response.sendFile(file);
 	}
@@ -42,17 +42,17 @@ MultipartStream::BodyPart snapshotProducer()
 	result.stream = webcamStream;
 
 	result.headers = new HttpHeaders();
-	(*result.headers)["Content-Type"] = camera->getMimeType();
+	(*result.headers)[HTTP_HEADER_CONTENT_TYPE] = camera->getMimeType();
 
 	return result;
 }
 
 void onStream(HttpRequest& request, HttpResponse& response)
 {
-	Serial.printf("perform onCapture()\r\n");
+	Serial.println(_F("perform onCapture()"));
 
 	MultipartStream* stream = new MultipartStream(snapshotProducer);
-	response.sendDataStream(stream, String("multipart/x-mixed-replace; boundary=") + stream->getBoundary());
+	response.sendDataStream(stream, F("multipart/x-mixed-replace; boundary=") + stream->getBoundary());
 }
 
 void onFavicon(HttpRequest& request, HttpResponse& response)
@@ -65,10 +65,11 @@ void startWebServer()
 {
 	// Initialize the camera
 	Vector<String> images;
-	char buf[13] = {0};
 	for(unsigned int i = 1; i < 6; i++) {
-		sprintf(buf, "img%02d.jpeg", i);
-		images.add(buf);
+		String s = "img";
+		s.concat(i, DEC, 2);
+		s += ".jpeg";
+		images.add(s);
 	}
 	camera = new FakeCamera(images);
 	camera->init();

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -45,31 +45,30 @@ void wsMessageSent();
 
 void wsConnected(WebsocketConnection& wsConnection)
 {
-	Serial.printf(_F("Start sending messages every %u second(s)...\r\n"), MESSAGE_INTERVAL);
+	Serial << _F("Start sending messages every ") << MESSAGE_INTERVAL << _F(" second(s)...") << endl;
 	msgTimer.initializeMs(MESSAGE_INTERVAL * 1000, wsMessageSent);
 	msgTimer.start();
 }
 
 void wsMessageReceived(WebsocketConnection& wsConnection, const String& message)
 {
-	Serial.printf(_F("WebSocket message received: %s\r\n"), message.c_str());
-	Serial.printf(_F("Free Heap: %u\r\n"), system_get_free_heap_size());
+	Serial << _F("WebSocket message received: ") << message << endl;
+	Serial << _F("Free Heap: ") << system_get_free_heap_size() << endl;
 }
 
 void wsBinReceived(WebsocketConnection& wsConnection, uint8_t* data, size_t size)
 {
 	Serial.println(_F("WebSocket BINARY received"));
 	for(uint8_t i = 0; i < size; i++) {
-		Serial.printf("wsBin[%u] = 0x%02X\r\n", i, data[i]);
+		Serial << "wsBin[" << i << "] = 0x" << String(data[i], HEX, 2) << endl;
 	}
 
-	Serial.print(_F("Free Heap: "));
-	Serial.println(system_get_free_heap_size());
+	Serial << _F("Free Heap: ") << system_get_free_heap_size() << endl;
 }
 
 void restart()
 {
-	Serial.println("restart...");
+	Serial.println(_F("restart..."));
 
 	msg_cnt = 0;
 	wsClient.connect(String(ws_Url));
@@ -77,7 +76,7 @@ void restart()
 
 void wsDisconnected(WebsocketConnection& wsConnection)
 {
-	Serial.printf(_F("Restarting websocket client after %u seconds\r\n"), RESTART_PERIOD);
+	Serial << _F("Restarting websocket client after ") << RESTART_PERIOD << _F(" seconds") << endl;
 	msgTimer.setCallback(restart);
 	msgTimer.setIntervalMs(RESTART_PERIOD * 1000);
 	msgTimer.startOnce();
@@ -100,15 +99,14 @@ void wsMessageSent()
 
 #ifndef WS_BINARY
 	String message = F("Hello ") + String(msg_cnt++);
-	Serial.print(_F("Sending websocket message: "));
-	Serial.println(message);
+	Serial << _F("Sending websocket message: ") << message << endl;
 	wsClient.sendString(message);
 #else
 	uint8_t buf[] = {0xF0, 0x00, 0xF0};
 	buf[1] = msg_cnt++;
 	Serial.println(_F("Sending websocket binary buffer"));
 	for(uint8_t i = 0; i < 3; i++) {
-		Serial.printf("wsBin[%u] = 0x%02X\r\n", i, buf[i]);
+		Serial << "wsBin[" << i << "] = 0x" << String(buf[i], HEX, 2) << endl;
 	}
 
 	wsClient.sendBinary(buf, 3);
@@ -117,15 +115,9 @@ void wsMessageSent()
 
 void STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway)
 {
-	Serial.print(_F("GOTIP - IP: "));
-	Serial.print(ip);
-	Serial.print(_F(", MASK: "));
-	Serial.print(mask);
-	Serial.print(_F(", GW: "));
-	Serial.println(gateway);
+	Serial << _F("GOTIP - IP: ") << ip << _F(", MASK: ") << mask << _F(", GW: ") << gateway << endl;
 
-	Serial.print(_F("Connecting to Websocket Server "));
-	Serial.println(ws_Url);
+	Serial << _F("Connecting to Websocket Server ") << ws_Url << endl;
 
 	wsClient.setMessageHandler(wsMessageReceived);
 	wsClient.setBinaryHandler(wsBinReceived);
@@ -137,10 +129,8 @@ void STAGotIP(IpAddress ip, IpAddress mask, IpAddress gateway)
 
 void STADisconnect(const String& ssid, MacAddress bssid, WifiDisconnectReason reason)
 {
-	Serial.print(_F("DISCONNECT - SSID: "));
-	Serial.print(ssid);
-	Serial.print(_F(", REASON: "));
-	Serial.println(WifiEvents.getDisconnectReasonDesc(reason));
+	Serial << _F("DISCONNECT - SSID: ") << ssid << _F(", REASON: ") << WifiEvents.getDisconnectReasonDesc(reason)
+		   << endl;
 }
 
 void init()

--- a/samples/Wifi_Sniffer/app/application.cpp
+++ b/samples/Wifi_Sniffer/app/application.cpp
@@ -14,19 +14,19 @@ SimpleTimer timer;
 static void printBeacon(const BeaconInfo& beacon)
 {
 	if(beacon.err != 0) {
-		Serial.printf(_F("BEACON ERR: (%d)\n"), beacon.err);
+		Serial << _F("BEACON ERR: (") << beacon.err << ')' << endl;
 	} else {
 		Serial.printf(_F("BEACON: <=============== [%32s]  "), beacon.ssid);
 		Serial.print(makeHexString(beacon.bssid, sizeof(beacon.bssid)));
 		Serial.printf(_F("   %2d"), beacon.channel);
-		Serial.printf(_F("   %4d\n"), beacon.rssi);
+		Serial.printf(_F("   %4d\r\n"), beacon.rssi);
 	}
 }
 
 static void printClient(const ClientInfo& client)
 {
 	if(client.err != 0) {
-		Serial.printf(_F("CLIENT ERR: (%d)\n"), client.err);
+		Serial << _F("CLIENT ERR: (") << client.err << ')' << endl;
 	} else {
 		Serial.print(_F("DEVICE: "));
 		Serial.print(makeHexString(client.station, sizeof(client.station)));
@@ -41,21 +41,23 @@ static void printClient(const ClientInfo& client)
 			Serial.print(_F("  "));
 			Serial.print(makeHexString(client.ap, sizeof(client.ap)));
 			Serial.printf(_F("  %3i"), knownAPs[ap].channel);
-			Serial.printf(_F("   %4d\n"), client.rssi);
+			Serial.printf(_F("   %4d\r\n"), client.rssi);
 		}
 	}
 }
 
 static void printSummary()
 {
-	Serial.println("\n-------------------------------------------------------------------------------------\n");
+	Serial.println("\r\n"
+				   "-------------------------------------------------------------------------------------\r\n");
 	for(unsigned u = 0; u < knownClients.count(); u++) {
 		printClient(knownClients[u]);
 	}
 	for(unsigned u = 0; u < knownAPs.count(); u++) {
 		printBeacon(knownAPs[u]);
 	}
-	Serial.println("\n-------------------------------------------------------------------------------------\n");
+	Serial.println("\r\n"
+				   "-------------------------------------------------------------------------------------\r\n");
 }
 
 static void onBeacon(const BeaconInfo& beacon)
@@ -97,7 +99,9 @@ void init()
 	Serial.begin(SERIAL_BAUD_RATE); // 115200 by default
 	Serial.systemDebugOutput(true); // Debug output to serial
 
-	Serial.printf(_F("\n\nSDK version:%s\n"), system_get_sdk_version());
+	Serial << _F("\r\n\r\n"
+				 "SDK version:")
+		   << system_get_sdk_version() << endl;
 	Serial.println(_F("ESP8266 mini-sniff by Ray Burnette http://www.hackster.io/rayburne/projects"));
 	Serial.println(_F("Type:   /-------MAC------/-----WiFi Access Point SSID-----/  /----MAC---/  Chnl  RSSI"));
 

--- a/samples/Wifi_Sniffer/app/application.cpp
+++ b/samples/Wifi_Sniffer/app/application.cpp
@@ -17,7 +17,7 @@ static void printBeacon(const BeaconInfo& beacon)
 		Serial << _F("BEACON ERR: (") << beacon.err << ')' << endl;
 	} else {
 		Serial.printf(_F("BEACON: <=============== [%32s]  "), beacon.ssid);
-		Serial.print(makeHexString(beacon.bssid, sizeof(beacon.bssid)));
+		Serial.print(beacon.bssid);
 		Serial.printf(_F("   %2d"), beacon.channel);
 		Serial.printf(_F("   %4d\r\n"), beacon.rssi);
 	}
@@ -28,18 +28,14 @@ static void printClient(const ClientInfo& client)
 	if(client.err != 0) {
 		Serial << _F("CLIENT ERR: (") << client.err << ')' << endl;
 	} else {
-		Serial.print(_F("DEVICE: "));
-		Serial.print(makeHexString(client.station, sizeof(client.station)));
-		Serial.print(_F(" ==> "));
+		Serial << _F("DEVICE: ") << client.station << _F(" ==> ");
 
 		int ap = knownAPs.indexOf(client.bssid);
 		if(ap < 0) {
-			Serial.print(_F("   Unknown/Malformed packet, BSSID = "));
-			Serial.println(makeHexString(client.bssid, sizeof(client.bssid)));
+			Serial << _F("   Unknown/Malformed packet, BSSID = ") << client.bssid << endl;
 		} else {
 			Serial.printf(_F("[%32s]"), knownAPs[ap].ssid);
-			Serial.print(_F("  "));
-			Serial.print(makeHexString(client.ap, sizeof(client.ap)));
+			Serial << "  " << client.ap;
 			Serial.printf(_F("  %3i"), knownAPs[ap].channel);
 			Serial.printf(_F("   %4d\r\n"), client.rssi);
 		}


### PR DESCRIPTION
This PR continues from #2551 to apply C++ streaming style to remaining samples, where appropriate.

Additional improvements:

- `MacAddress` no longer inherits from `Printable` so is no longer a virtual class
- The ESP8266 Network WifiSniffer now returns data using `MacAddress` instead of uint8_t[]. The corresponding sample application has also been updated to check for invalid characters in the received SSID.
- Update `makeHexString()` to accept `void*` parameter (instead of `uint8_t*`) so it can be more easily used with any type of data.