### PR TITLE
Enable better printing support for Storage/IFS classes, BitSet, TRange

### DIFF
--- a/Sming/Components/Network/src/IpAddress.h
+++ b/Sming/Components/Network/src/IpAddress.h
@@ -41,7 +41,7 @@ using ip4_addr_t = ip_addr_t;
  * @brief A class to make it easier to handle and pass around IP addresses
  * @ingroup wiring
  */
-class IpAddress : public Printable
+class IpAddress
 {
 private:
 	ip_addr_t address{0}; ///< IPv4 address
@@ -191,7 +191,7 @@ public:
 		return *this;
 	}
 
-	size_t printTo(Print& p) const override;
+	size_t printTo(Print& p) const;
 };
 
 inline String toString(IpAddress address)

--- a/Sming/Components/Network/src/Network/Http/HttpParams.h
+++ b/Sming/Components/Network/src/Network/Http/HttpParams.h
@@ -31,7 +31,7 @@
  * @ingroup http
  *
  */
-class HttpParams : public HashMap<String, String>, public Printable
+class HttpParams : public HashMap<String, String>
 {
 public:
 	HttpParams() = default;
@@ -69,7 +69,7 @@ public:
 	}
 
 	// Printable
-	size_t printTo(Print& p) const override;
+	size_t printTo(Print& p) const;
 
 	/**
 	 * @brief Printable output for debugging

--- a/Sming/Components/Network/src/Network/Mqtt/MqttBuffer.h
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttBuffer.h
@@ -16,7 +16,7 @@
 /**
  * @brief Helper class to simplify printing and parsing message buffers
  */
-class MqttBuffer : public Printable
+class MqttBuffer
 {
 public:
 	MqttBuffer(const mqtt_buffer_t& buf) : buf(buf)
@@ -28,7 +28,7 @@ public:
 		return String(reinterpret_cast<const char*>(buf.data), buf.length);
 	}
 
-	size_t printTo(Print& p) const override
+	size_t printTo(Print& p) const
 	{
 		return p.write(buf.data, buf.length);
 	}

--- a/Sming/Components/Storage/src/Debug.cpp
+++ b/Sming/Components/Storage/src/Debug.cpp
@@ -6,29 +6,12 @@ namespace Storage
 {
 namespace Debug
 {
-void printPartition(Print& out, Partition part, bool includeDevice)
-{
-	out.print(part.name());
-	if(includeDevice) {
-		out.print(" on ");
-		out.print(part.getDeviceName());
-	}
-	out.print(" (");
-	out.print(part.typeString());
-	out.print(_F(" @ 0x"));
-	out.print(part.address(), HEX);
-	out.print(_F(", size 0x"));
-	out.print(part.size(), HEX);
-	out.println(")");
-}
-
 void listPartitions(Print& out)
 {
 	out.println();
 	out.println(_F("Registered partitions:"));
 	for(auto part : Storage::findPartition()) {
-		out.print("- ");
-		printPartition(out, part);
+		out << "- " << part << endl;
 	}
 	out.println();
 }
@@ -38,14 +21,8 @@ void listDevices(Print& out, bool fullPartitionInfo)
 	out.println();
 	out.println(_F("Registered storage devices:"));
 	for(auto& dev : Storage::getDevices()) {
-		out.print("  name = '");
-		out.print(dev.getName());
-		out.print(_F("', type = "));
-		out.print(toString(dev.getType()));
-		out.print(_F(", size = 0x"));
-		out.print(dev.getSize(), HEX);
-		out.print(_F(", partitions:"));
-		if(dev.partitions().count() == 0) {
+		out << "  " << dev << _F(". Partitions:");
+		if(!dev.partitions()) {
 			out.println(_F(" None."));
 			continue;
 		}
@@ -53,11 +30,9 @@ void listDevices(Print& out, bool fullPartitionInfo)
 		out.println();
 		for(auto part : dev.partitions()) {
 			if(fullPartitionInfo) {
-				out.print("    ");
-				printPartition(out, part, false);
+				out << "    " << part << endl;
 			} else {
-				out.print(" ");
-				out.print(part.name());
+				out << " " << part.name();
 			}
 		}
 		out.println();

--- a/Sming/Components/Storage/src/Device.cpp
+++ b/Sming/Components/Storage/src/Device.cpp
@@ -12,6 +12,7 @@
 #include "include/Storage/Device.h"
 #include "include/Storage/partition_info.h"
 #include <FlashString/Vector.hpp>
+#include <Print.h>
 #include <debug_progmem.h>
 
 namespace
@@ -107,6 +108,17 @@ bool Device::loadPartitions(Device& source, uint32_t tableOffset)
 
 	// No partitions found
 	return false;
+}
+
+size_t Device::printTo(Print& p) const
+{
+	size_t n{0};
+	n += p.print(getName());
+	n += p.print(_F(": type "));
+	n += p.print(getType());
+	n += p.print(_F(", size 0x"));
+	n += p.print(getSize(), HEX);
+	return n;
 }
 
 } // namespace Storage

--- a/Sming/Components/Storage/src/Partition.cpp
+++ b/Sming/Components/Storage/src/Partition.cpp
@@ -11,6 +11,7 @@
 #include "include/Storage/Partition.h"
 #include "include/Storage/Device.h"
 #include <FlashString/Map.hpp>
+#include <Print.h>
 #include <debug_progmem.h>
 
 using namespace Storage;
@@ -246,6 +247,26 @@ bool Partition::erase_range(uint32_t offset, size_t size)
 	}
 
 	return mDevice ? mDevice->erase_range(addr, size) : false;
+}
+
+size_t Partition::printTo(Print& p) const
+{
+	size_t n{0};
+	if(*this) {
+		n += p.print(getDeviceName());
+		n += p.print('/');
+		n += p.print(name());
+		n += p.print(" (");
+		n += p.print(typeString());
+		n += p.print(" @ 0x");
+		n += p.print(address(), HEX);
+		n += p.print(_F(", size 0x"));
+		n += p.print(size(), HEX);
+		n += p.print(')');
+	} else {
+		n += p.print(_F("(none)"));
+	}
+	return n;
 }
 
 } // namespace Storage

--- a/Sming/Components/Storage/src/include/Storage/Debug.h
+++ b/Sming/Components/Storage/src/include/Storage/Debug.h
@@ -7,7 +7,6 @@ namespace Storage
 {
 namespace Debug
 {
-void printPartition(Print& out, Partition part, bool includeDevice = true);
 void listPartitions(Print& out);
 void listDevices(Print& out, bool fullPartitionInfo = true);
 

--- a/Sming/Components/Storage/src/include/Storage/Device.h
+++ b/Sming/Components/Storage/src/include/Storage/Device.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include <WString.h>
+#include <Printable.h>
 #include <Data/LinkedObjectList.h>
 #include "PartitionTable.h"
 
@@ -138,6 +139,8 @@ public:
 	 * @retval bool true on success, false on error
 	 */
 	virtual bool erase_range(uint32_t address, size_t size) = 0;
+
+	size_t printTo(Print& p) const;
 
 protected:
 	PartitionTable mPartitions;

--- a/Sming/Components/Storage/src/include/Storage/Partition.h
+++ b/Sming/Components/Storage/src/include/Storage/Partition.h
@@ -26,6 +26,7 @@
  ****/
 #pragma once
 
+#include <Printable.h>
 #include <Data/BitSet.h>
 #include <Data/CString.h>
 #include <memory>
@@ -369,6 +370,8 @@ public:
 	 * @brief Obtain smallest allocation unit for erase operations
 	 */
 	size_t getBlockSize() const;
+
+	size_t printTo(Print& p) const;
 
 protected:
 	Device* mDevice{nullptr};

--- a/Sming/Components/Storage/src/include/Storage/PartitionTable.h
+++ b/Sming/Components/Storage/src/include/Storage/PartitionTable.h
@@ -22,6 +22,11 @@ public:
 	{
 	}
 
+	explicit operator bool() const
+	{
+		return mCount != 0;
+	}
+
 	/**
 	 * @name Partition search
 	 * @{

--- a/Sming/Components/ssl/include/Network/Ssl/Connection.h
+++ b/Sming/Components/ssl/include/Network/Ssl/Connection.h
@@ -33,7 +33,7 @@ class Context;
  * SSL Alerts are also reported via error codes and can be obtained
  * using a call to `getAlert()`.
  */
-class Connection : public Printable
+class Connection
 {
 public:
 	Connection(Context& context, tcp_pcb* tcp) : context(context), tcp(tcp)
@@ -99,7 +99,7 @@ public:
 	/**
 	 * @brief For debugging
 	 */
-	size_t printTo(Print& p) const override;
+	size_t printTo(Print& p) const;
 
 	int writeTcpData(uint8_t* data, size_t length);
 

--- a/Sming/Core/Data/BitSet.h
+++ b/Sming/Core/Data/BitSet.h
@@ -17,6 +17,7 @@
 #include <limits>
 #include <type_traits>
 #include <WString.h>
+#include <Print.h>
 
 /**
  * @brief Manage a set of bit values using enumeration
@@ -364,6 +365,30 @@ public:
 	operator IfHelperType() const
 	{
 		return any() ? &BitSet::IfHelper : 0;
+	}
+
+	/**
+	 * @brief Class template to print the contents of a BitSet to a String
+	 * @note Requires an implementation of `toString(E)`
+	 */
+	size_t printTo(Print& p, const String& separator = ", ") const
+	{
+		extern String toString(E e);
+
+		size_t n{0};
+
+		for(unsigned i = 0; i < size(); ++i) {
+			auto e = E(i);
+			if(!test(e)) {
+				continue;
+			}
+			if(n != 0) {
+				n += p.print(separator);
+			}
+			n += p.print(e);
+		}
+
+		return n;
 	}
 
 private:

--- a/Sming/Core/Data/Range.h
+++ b/Sming/Core/Data/Range.h
@@ -82,7 +82,7 @@ template <typename T> struct TRange {
 	/**
 	 * @brief Determine if range contains a value
 	 */
-	bool contains(T value)
+	bool contains(T value) const
 	{
 		return (value >= min) && (value <= max);
 	}
@@ -90,7 +90,7 @@ template <typename T> struct TRange {
 	/**
 	 * @brief Clip values to within the range
 	 */
-	T clip(T value)
+	T clip(T value) const
 	{
 		return (value < min) ? min : (value > max) ? max : value;
 	}
@@ -121,6 +121,11 @@ template <typename T> struct TRange {
 		s += ", ";
 		s += max;
 		return s;
+	}
+
+	operator String() const
+	{
+		return toString();
 	}
 };
 

--- a/Sming/Libraries/OtaUpgradeMqtt/samples/Upgrade/app/application.cpp
+++ b/Sming/Libraries/OtaUpgradeMqtt/samples/Upgrade/app/application.cpp
@@ -98,19 +98,19 @@ void showInfo()
 	Serial.printf(_F("System Chip ID: %x\r\n"), system_get_chip_id());
 
 	int total = 0;
-	for(auto it = OtaManager.getBootPartitions(); it; ++it) {
-		debug_d("ROM %s: 0x%08x, SubType: %s", it->name().c_str(), it->address(),
-				toLongString(it->type(), it->subType()).c_str());
+	for(auto part : OtaManager.getBootPartitions()) {
+		Serial.println(part);
 		total++;
 	}
-	debug_d("=======================");
-	debug_d("Bootable ROMs found: %d", total);
+	Serial.println(_F("======================="));
+	Serial << _F("Bootable ROMs found: ") << total << endl;
 
 	auto part = OtaManager.getRunningPartition();
 
-	Serial.printf(_F("\r\nCurrently running %s: 0x%08x. Application version: %s\r\n"), part.name().c_str(),
-				  part.address(), APP_VERSION);
-	Serial.println();
+	Serial << _F("\r\n"
+				 "Currently running ")
+		   << part.name() << ": 0x" << String(part.address(), HEX) << _F(". Application version: ") << APP_VERSION
+		   << endl;
 }
 
 void connectOk(IpAddress ip, IpAddress mask, IpAddress gateway)

--- a/Sming/Services/Profiling/MinMax.h
+++ b/Sming/Services/Profiling/MinMax.h
@@ -19,7 +19,7 @@ namespace Profiling
 /**
  * @brief Class to track minimum and maximum values of a set of data, with average, total and count
  */
-template <typename T> class MinMax : public Printable
+template <typename T> class MinMax
 {
 public:
 	MinMax(const String& title) : title(title)
@@ -57,7 +57,7 @@ public:
 		return count;
 	}
 
-	size_t printTo(Print& p) const override;
+	size_t printTo(Print& p) const;
 
 private:
 	String title;

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -226,7 +226,7 @@ public:
 	  */
 	size_t println()
 	{
-		return print("\r\n");
+		return write("\r\n", 2);
 	}
 
 	/** @brief Print value plus newline to output stream

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -260,7 +260,14 @@ protected:
 	}
 };
 
-template <typename T> Print& operator<<(Print& p, const T& value)
+inline Print& operator<<(Print& p, const char value[])
+{
+	p.print(value);
+	return p;
+}
+
+template <typename T>
+typename std::enable_if<!std::is_array<T>::value, Print&>::type operator<<(Print& p, const T& value)
 {
 	p.print(value);
 	return p;

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -179,13 +179,27 @@ public:
 		return printFloat(num, digits);
 	}
 
+	/*
+	 * Helper class using SFINAE to identify *any* class with a `printTo` method, even if not a base of `Printable`.
+	 *
+	 * https://stackoverflow.com/a/257382
+	 */
+	template <typename T> class has_printTo
+	{
+		template <typename C> static uint8_t test(decltype(&C::printTo));
+		template <typename C> static uint32_t test(...);
+
+	public:
+		enum { value = (sizeof(test<T>(0)) == 1) };
+	};
+
 	/** @brief  Prints a Printable object to output stream
-	  * @param  p Object to print
+	  * @param  obj Object to print
 	  * @retval size_t Quantity of characters written to stream
 	  */
-	size_t print(const Printable& p)
+	template <typename T> typename std::enable_if<has_printTo<T>::value, size_t>::type print(const T& obj)
 	{
-		return p.printTo(*this);
+		return obj.printTo(*this);
 	}
 
 	/** @brief  Prints a String to output stream

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -346,6 +346,14 @@ public:
 	bool concat(unsigned long long num, unsigned char base = 10, unsigned char width = 0, char pad = '0');
 	bool concat(float num);
 	bool concat(double num);
+
+	template <typename E>
+	constexpr typename std::enable_if<std::is_enum<E>::value && !std::is_convertible<E, int>::value, bool>::type
+	concat(E value)
+	{
+		extern String toString(E);
+		return concat(toString(value));
+	}
 	/** @} */
 
 	/**
@@ -371,55 +379,10 @@ public:
 		concat(cstr);
 		return (*this);
 	}
-	String& operator+=(char c)
+	template <typename T> String& operator+=(T value)
 	{
-		concat(c);
-		return (*this);
-	}
-	String& operator+=(unsigned char num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(int num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(unsigned int num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(long num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(long long num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(unsigned long num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(unsigned long long num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(float num)
-	{
-		concat(num);
-		return (*this);
-	}
-	String& operator+=(double num)
-	{
-		concat(num);
-		return (*this);
+		concat(value);
+		return *this;
 	}
 	/** @} */
 

--- a/samples/Basic_ProgMem/app/TestProgmem.cpp
+++ b/samples/Basic_ProgMem/app/TestProgmem.cpp
@@ -49,9 +49,7 @@ void testPSTR(Print& out)
 
 	// Note that characters after first nul won't be shown ...
 	out.print("> demoPSTR1 (print char*): ");
-	out.print('"');
-	out.print(_FLOAD(demoPSTR1));
-	out.println('"');
+	out << '"' << _FLOAD(demoPSTR1) << '"' << endl;
 
 	// ... now they will: note buf will be aligned up to next dword boundary though
 	out.print("> demoPSTR1 (write): ");
@@ -67,9 +65,7 @@ void testPSTR(Print& out)
 	char buf2[100];
 	strncpy_P(buf2, externalPSTR1, sizeof(buf2));
 	buf2[sizeof(buf2) - 1] = '\0';
-	out.print('"');
-	out.print(buf2);
-	out.println('"');
+	out << '"' << buf2 << '"' << endl;
 
 	//
 	out.print("> PSTR_ARRAY: ");
@@ -130,8 +126,7 @@ void testFSTR(Print& out)
 		char data[5];
 	} demoArray1 PROGMEM = {{5}, {1, 2, 3, 4, 5}};
 	auto& arr = demoArray1.object.as<FSTR::Array<uint8_t>>();
-	arr.printTo(out);
-	out.println();
+	out << arr << endl;
 
 	// Test equality operators
 #define TEST(_test) out.printf(_F("%s: %s\n"), (_test) ? _F("PASS") : _F("FAIL"), _F(#_test));
@@ -150,11 +145,11 @@ void testFSTR(Print& out)
 
 	// Table entries may be accessed directly as they are word-aligned
 	out.println(_F("FSTR tables -"));
-	out.printf(_F(" fstr1 = '%s'\n"), String(table[0]).c_str());
-	out.printf(_F(" fstr1.length() = %" PRIu32 "\n"), table[0].length());
-	out.printf(_F(" entries = %" PRIu32 "\n"), table.length());
+	out << _F(" fstr1 = '") << table[0] << endl;
+	out << _F(" fstr1.length() = ") << table[0].length() << endl;
+	out << _F(" entries = ") << table.length() << endl;
 
-	out.println("< testFSTR() end\n");
+	out.println("< testFSTR() end\r\n");
 }
 
 /*
@@ -171,14 +166,15 @@ void testSpeed(Print& out)
 
 	_FPUTS("Baseline test, read string in RAM...");
 	timer.start();
-	for(unsigned i = 0; i < iterations; ++i)
+	for(unsigned i = 0; i < iterations; ++i) {
 		tmp += sumBuffer(demoText, sizeof(demoText));
+	}
 	baseline = timer.elapsedTime();
-	out.printf("Elapsed: %" PRIu32 "\n", baseline);
+	out << "Elapsed: " << baseline << endl;
 
 #define END()                                                                                                          \
 	elapsed = timer.elapsedTime();                                                                                     \
-	out.printf("Elapsed: %" PRIu32 " (baseline + %" PRIu32 ")\n", elapsed, elapsed - baseline);
+	out << "Elapsed: " << elapsed << " (baseline + " << elapsed - baseline << ')' << endl;
 
 	_FPUTS("Load PSTR into stack buffer...");
 	timer.start();

--- a/samples/Basic_Ssl/app/application.cpp
+++ b/samples/Basic_Ssl/app/application.cpp
@@ -46,7 +46,7 @@ int onDownload(HttpConnection& connection, bool success)
 
 	auto ssl = connection.getSsl();
 	if(ssl != nullptr) {
-		ssl->printTo(Serial);
+		Serial.print(*ssl);
 	}
 
 	Serial << _F("Time to connect and download page: ") << elapsed.toString() << endl;

--- a/samples/Basic_Tasks/include/AnalogueReader.h
+++ b/samples/Basic_Tasks/include/AnalogueReader.h
@@ -157,7 +157,7 @@ ANALOGUE_READER(void)::onNotify(Notify code)
 		groupStartTicks = sampleTimer.ticks();
 		restartSampler = true;
 
-		Serial << F("sampleIntervalTicks = ") << sampleIntervalTicks << endl;
+		Serial << _F("sampleIntervalTicks = ") << sampleIntervalTicks << endl;
 		break;
 	default:;
 	}

--- a/tests/HostTests/modules/BitSet.cpp
+++ b/tests/HostTests/modules/BitSet.cpp
@@ -72,8 +72,7 @@ public:
 
 		TEST_CASE("Operations")
 		{
-			Serial.print(_F("fixedBasket contains: "));
-			Serial.println(toString(fixedBasket));
+			Serial << _F("fixedBasket contains: ") << fixedBasket << endl;
 
 			FruitBasket basket;
 			REQUIRE(basket.value() == 0);
@@ -123,8 +122,7 @@ public:
 		{
 			using NumberSet = BitSet<uint32_t, uint8_t>;
 			NumberSet numbers = uint32_t(0x12345678);
-			Serial.print(_F("numbers = "));
-			Serial.println(toString(numbers));
+			Serial << _F("numbers = ") << numbers << endl;
 			REQUIRE(numbers.value() == 0x12345678U);
 
 			numbers = NumberSet{};

--- a/tests/HostTests/modules/Network/Arch/Host/HttpRequest.cpp
+++ b/tests/HostTests/modules/Network/Arch/Host/HttpRequest.cpp
@@ -52,6 +52,7 @@ public:
 		server->paths.setDefault([](HttpRequest& request, HttpResponse& response) {
 			auto path = request.uri.getRelativePath();
 			bool ok = response.sendFile(path);
+			(void)ok;
 			debug_i("Request from '%s' for '%s': %s", request.uri.Host.c_str(), path.c_str(), ok ? "OK" : "FAIL");
 		});
 

--- a/tests/HostTests/modules/Network/Http.cpp
+++ b/tests/HostTests/modules/Network/Http.cpp
@@ -24,11 +24,12 @@ public:
 #if DEBUG_VERBOSE_LEVEL == DBG
 		for(int i = 0; i < 100; ++i) {
 			auto err = HttpError(i);
-			debug_d("httpError(%d) = \"%s\", \"%s\"", i, toString(err).c_str(), httpGetErrorDescription(err).c_str());
+			Serial << _F("httpError(") << i << ") = \"" << err << "\", \"" << httpGetErrorDescription(err) << '"'
+				   << endl;
 		}
 
 		for(int i = 100; i < 550; ++i) {
-			debug_d("HTTP Status(%d) = \"%s\"", i, toString(HttpStatus(i)).c_str());
+			Serial << _F("HTTP Status(") << i << ") = \"" << HttpStatus(i) << '"' << endl;
 		}
 #endif
 
@@ -47,7 +48,7 @@ public:
 	static void printHeaders(const HttpHeaders& headers)
 	{
 #if DEBUG_VERBOSE_LEVEL == DBG
-		debugf("  count: %d", headers.count());
+		Serial << _F("  count: ") << headers.count() << endl;
 		for(unsigned i = 0; i < headers.count(); ++i) {
 			String s = headers[i];
 			m_printHex("  ", s.c_str(), s.length(), 0, 32);
@@ -57,7 +58,7 @@ public:
 
 	void profileHttpHeaders()
 	{
-		debugf("\nPROFILING");
+		Serial.println(_F("\r\nPROFILING"));
 
 		// Allocate everything on the heap so we can track memory usage
 		auto freeHeap = system_get_free_heap_size();

--- a/tests/HostTests/modules/Network/Http.cpp
+++ b/tests/HostTests/modules/Network/Http.cpp
@@ -80,18 +80,18 @@ public:
 		headers[F("Vary")] = _F("Accept-Encoding");
 		headers[F("X-Fastly-Request-ID")] = _F("38ef411e0ec3bf681d29d8b4b51f3516d3ef9e03");
 		auto totalElapsed = timer.elapsedTime();
-		debugf("Set header values");
-		debugf("  Elapsed standard: %s, total: %s, heap used: %u", standardElapsed.toString().c_str(),
-			   totalElapsed.toString().c_str(), freeHeap - system_get_free_heap_size());
+		Serial.println(_F("Set header values"));
+		Serial << _F("  Elapsed standard: ") << standardElapsed.toString() << ", total: " << totalElapsed.toString()
+			   << ", heap used: " << freeHeap - system_get_free_heap_size() << endl;
 
 		// Query header value by field name
 		auto queryByEnum = [&](HttpHeaderFieldName name) {
-			debugf("  header[\"%s\"]: %s", headers.toString(name).c_str(), headers[name].c_str());
+			Serial << _F("  header[\"") << headers.toString(name) << "\"]: " << headers[name] << endl;
 		};
 		auto queryByString = [&](const String& name) {
-			debugf("  header[\"%s\"]: %s", name.c_str(), headers[name].c_str());
+			Serial << _F("  header[\"") << name << "\"]: " << headers[name] << endl;
 		};
-		debugf("Query header values");
+		Serial.println(_F("Query header values"));
 		timer.start();
 		queryByEnum(HTTP_HEADER_CONTENT_ENCODING);
 		queryByEnum(HTTP_HEADER_CONTENT_LENGTH);
@@ -106,15 +106,15 @@ public:
 		queryByString("Vary");
 		queryByString("X-Fastly-Request-ID");
 		totalElapsed = timer.elapsedTime();
-		debugf("  Elapsed standard: %u, total: %u", standardElapsed, totalElapsed);
-		debugf("  Elapsed standard: %s, total: %s", standardElapsed.toString().c_str(),
-			   totalElapsed.toString().c_str());
+		Serial << _F("  Elapsed standard: ") << standardElapsed << ", total: " << totalElapsed << endl;
+		Serial << _F("  Elapsed standard: ") << standardElapsed.toString() << ", total: " << totalElapsed.toString()
+			   << endl;
 
 		// Print header values - accessed by index
-		debugf("Printing %u headers", headers.count());
+		Serial << _F("Printing ") << headers.count() << _F(" headers") << endl;
 		timer.start();
 		printHeaders(headers);
-		debugf("  Elapsed: %s", timer.elapsedTime().toString().c_str());
+		Serial << _F("  Elapsed: ") << timer.elapsedTime().toString() << endl;
 
 		delete headersPtr;
 	}

--- a/tests/HostTests/modules/Network/Url.cpp
+++ b/tests/HostTests/modules/Network/Url.cpp
@@ -22,7 +22,7 @@ public:
 		TEST_CASE("formUrlParser test")
 		{
 			auto testUrl = [this](const FlashString& urlText, const char* param) {
-				debugf("URL '%s'", String(urlText).c_str());
+				Serial << _F("URL \"") << urlText << '"' << endl;
 				Url url(urlText);
 				String query = url.Query;
 				const char* p = query.c_str();
@@ -36,7 +36,7 @@ public:
 				formUrlParser(request, nullptr, PARSE_DATAEND);
 				printParams(request.postParams);
 				String cid = request.getPostParameter("cid");
-				debugf("cid = %s", cid.c_str());
+				Serial << _F("cid = ") << cid << endl;
 				REQUIRE(cid == param);
 			};
 
@@ -50,8 +50,8 @@ public:
 		TEST_CASE("HttpRequest getQueryParameter()")
 		{
 			request.uri = FS_URL2;
-			debugf("URL = \"%s\"", request.uri.toString().c_str());
-			debugf("cid = %s", request.getQueryParameter("cid").c_str());
+			Serial << _F("URL = \"") << request.uri << '"' << endl;
+			Serial << _F("cid = ") << request.getQueryParameter("cid") << endl;
 		}
 
 		TEST_CASE("HttpRequest postParams test");
@@ -60,10 +60,10 @@ public:
 							  "param+1=Mary+had+a+little+lamb%2c&param+2=It%27s+fleece+was+very+red.&param+3=The+"
 							  "reason+for+this+was%2c+you+see&param+4=It+had+a+pickaxe+through+its+head.");
 			HttpParams params;
-			params["param 1"] = "Mary had a little lamb,";
-			params["param 2"] = "It's fleece was very red.";
-			params["param 3"] = "The reason for this was, you see";
-			params["param 4"] = "It had a pickaxe through its head.";
+			params["param 1"] = F("Mary had a little lamb,");
+			params["param 2"] = F("It's fleece was very red.");
+			params["param 3"] = F("The reason for this was, you see");
+			params["param 4"] = F("It had a pickaxe through its head.");
 			UrlencodedOutputStream stream(params);
 			char buffer[256];
 			unsigned n = 0;

--- a/tests/HostTests/modules/Precache.cpp
+++ b/tests/HostTests/modules/Precache.cpp
@@ -22,7 +22,7 @@ public:
 			sum += i;
 		}
 		IRAM_PRECACHE_END(hosttests_test);
-		debugf("Sum = %u", sum);
+		Serial << _F("Sum = ") << sum << endl;
 		REQUIRE(sum == 499500);
 	}
 };

--- a/tests/HostTests/modules/Storage.cpp
+++ b/tests/HostTests/modules/Storage.cpp
@@ -64,8 +64,7 @@ public:
 	void listPartitions()
 	{
 		for(auto part : Storage::findPartition()) {
-			Serial.print("* ");
-			Storage::Debug::printPartition(Serial, part);
+			Serial << "* " << part << endl;
 
 			testRead(part, 0xE0, 0x20, true);
 			testRead(part, 10, 20, true);

--- a/tests/HostTests/modules/String.cpp
+++ b/tests/HostTests/modules/String.cpp
@@ -126,8 +126,8 @@ public:
 		String path = "/path/to";
 		String query;
 
-		debugf("path = \"%s\"", path.c_str());
-		debugf("query = \"%s\"", query.c_str());
+		Serial << _F("path = \"") << path << '"' << endl;
+		Serial << _F("query = \"") << query << '"' << endl;
 
 		TEST_CASE("validity check")
 		{
@@ -142,14 +142,14 @@ public:
 		TEST_CASE("string + nullstr")
 		{
 			String s = path + query;
-			debugf("path + query = \"%s\"", s.c_str());
+			Serial << _F("path + query = \"") << s << '"' << endl;
 			REQUIRE(s == path);
 		}
 
 		TEST_CASE("nullstr + string")
 		{
 			String s = query + path;
-			debugf("query + path = \"%s\"", s.c_str());
+			Serial << _F("query + path = \"") << s << '"' << endl;
 			REQUIRE(s == path);
 		}
 	}

--- a/tests/HostTests/modules/TemplateStream.cpp
+++ b/tests/HostTests/modules/TemplateStream.cpp
@@ -126,14 +126,14 @@ public:
 			{
 				HostFileStream fs("test-src1.out", File::CreateNewAlways | File::WriteOnly);
 				int res = fs.copyFrom(&tmpl);
-				debug_e("copyfrom(src) = %d", res);
+				Serial << _F("copyfrom(src) = ") << res << endl;
 				tmpl.gotoSection(0);
 			}
 
 			{
 				HostFileStream fs("test-src2.out", File::CreateNewAlways | File::WriteOnly);
 				int res = fs.copyFrom(&tmpl);
-				debug_e("copyfrom(src) = %d", res);
+				Serial << _F("copyfrom(src) = ") << res << endl;
 				tmpl.gotoSection(0);
 			}
 #endif

--- a/tests/HostTests/modules/Timers.cpp
+++ b/tests/HostTests/modules/Timers.cpp
@@ -29,7 +29,7 @@ public:
 	{
 		System.queueCallback(
 			[](void* param) {
-				debugf("timer1 expired");
+				Serial.println(_F("timer1 expired"));
 				auto tmr = static_cast<HardwareTimerTest*>(param);
 				if(++tmr->count == 5) {
 					tmr->stop();
@@ -47,11 +47,7 @@ public:
 		checkCallbackTimer<SimpleTimer>();
 		checkCallbackTimer<Timer>();
 
-#define SHOW_SIZE(Type)                                                                                                \
-	{                                                                                                                  \
-		Serial.print("sizeof(" #Type ") = ");                                                                          \
-		Serial.println(sizeof(Type));                                                                                  \
-	}
+#define SHOW_SIZE(Type) Serial << _F("sizeof(" #Type ") = ") << sizeof(Type) << endl
 
 		SHOW_SIZE(os_timer_t);
 		SHOW_SIZE(OsTimerApi);
@@ -127,15 +123,13 @@ public:
 				Serial.println(longTimer.toString());
 				Serial.print("Elapsed ticks = ");
 				Serial.println(ticks - longStartTicks);
-				debugf("Finally done!");
+				Serial.println(_F("Finally done!"));
 			});
-			Serial.print("longTimer.maxTicks = ");
-			Serial.println(longTimer.maxTicks());
+			Serial << _F("longTimer.maxTicks = ") << longTimer.maxTicks() << endl;
 			longTimer.setIntervalMs<15000>();
 			longTimer.startOnce();
 			longStartTicks = Timer::Clock::ticks();
-			Serial.print("longTimer.start = ");
-			Serial.println(longStartTicks);
+			Serial << _F("longTimer.start = ") << longStartTicks << endl;
 			++activeTimerCount;
 			Serial.println(longTimer.toString());
 		}
@@ -155,12 +149,8 @@ public:
 		}
 
 		auto mem = MallocCount::getCurrent();
-		Serial.print("Timers allocated, memStart = ");
-		Serial.print(memStart);
-		Serial.print(", now mem = ");
-		Serial.print(mem);
-		Serial.print(", used = ");
-		Serial.println(mem - memStart);
+		Serial << _F("Timers allocated, memStart = ") << memStart << _F(", now mem = ") << mem << _F(", used = ")
+			   << mem - memStart << endl;
 
 		pending();
 	}
@@ -169,12 +159,8 @@ public:
 	{
 		TimerType timer;
 
-		Serial.print(timer);
-		Serial.print(", maxTicks = ");
-		Serial.print(TimerType::maxTicks());
-		Serial.print(", maxTime = ");
-		Serial.print(TimerType::Micros::MaxClockTime::value());
-		Serial.println();
+		Serial << timer << _F(", maxTicks = ") << TimerType::maxTicks() << _F(", maxTime = ")
+			   << TimerType::Micros::MaxClockTime::value() << endl;
 
 		//	CpuCycleTimer timer;
 		//	Serial.print(timer);
@@ -192,30 +178,15 @@ public:
 		//
 		const auto time = NanoTime::time(NanoTime::Microseconds, 5000); //500020107;
 		auto ticks = timer.usToTicks(time);
-		Serial.print("time = ");
-		Serial.print(time.toString());
-		Serial.print(", ticks = ");
-		Serial.print(ticks);
-		Serial.print(", ");
-		Serial.print(TimerType::Micros::ticksToTime(ticks).toString());
-		Serial.println();
+		Serial << _F("time = ") << time.toString() << _F(", ticks = ") << ticks << ", "
+			   << TimerType::Micros::ticksToTime(ticks).toString() << endl;
 
 		//
 		auto t1 = timer.micros().template timeConst<5000>();
 		t1.check();
-		Serial.print("t1 = ");
-		Serial.print(t1.toString());
-		Serial.print(", ");
-		Serial.print(t1.clock().toString());
-		Serial.print(", ticksPerUnit = ");
-		Serial.print(t1.ticksPerUnit());
-		Serial.print(", ticks = ");
-		Serial.print(t1.ticks());
-		Serial.print(", ");
-		Serial.print(t1.clockTime());
-		Serial.print(", ");
-		Serial.print(t1.clockValue());
-		Serial.println();
+		Serial << _F("t1 = ") << t1.toString() << ", " << t1.clock().toString()
+			   << ", ticksPerUnit = " << t1.ticksPerUnit() << ", ticks = " << t1.ticks() << ", " << t1.clockTime()
+			   << ", " << t1.clockValue() << endl;
 
 		//	ElapseTimer et;
 		//	timer.reset<500000000>();
@@ -235,15 +206,9 @@ public:
 
 		//		auto nanos = NanoTime::TicksConst<typename TimerType::Clock, timer.maxTicks() + 1>::as<NanoTime::NanoSeconds>();
 		//		auto nanos = Nanos::template ticksConst<timer.maxTicks() + 1>();
-		Serial.print("nanos = ");
-		Serial.print(nanos.template as<NanoTime::Nanoseconds>().toString());
-		Serial.println();
+		Serial << _F("nanos = ") << nanos.template as<NanoTime::Nanoseconds>().toString() << endl;
 
-		Serial.print("interval = ");
-		Serial.print(timer.getIntervalUs());
-		Serial.print("us, ticks = ");
-		Serial.print(timer.getInterval());
-		Serial.println();
+		Serial << _F("interval = ") << timer.getIntervalUs() << _F("us, ticks = ") << timer.getInterval() << endl;
 	}
 
 private:
@@ -355,12 +320,9 @@ public:
 		Serial.println(times4);
 		Serial.println(times5);
 
-		Serial.print("Combined set/start: ");
-		Serial.println(times2a.getAverage() + times4.getAverage());
-		Serial.print("Combined set/start, ticks: ");
-		Serial.println(times3a.getAverage() + times4.getAverage());
-		Serial.print("Combined set/start, templated: ");
-		Serial.println(times2b.getAverage() + times4.getAverage());
+		Serial << _F("Combined set/start: ") << times2a.getAverage() + times4.getAverage() << endl;
+		Serial << _F("Combined set/start, ticks: ") << times3a.getAverage() + times4.getAverage() << endl;
+		Serial << _F("Combined set/start, templated: ") << times2b.getAverage() + times4.getAverage() << endl;
 
 		Serial.println();
 	}

--- a/tests/HostTests/modules/Timers.cpp
+++ b/tests/HostTests/modules/Timers.cpp
@@ -114,7 +114,7 @@ public:
 			tmp->initializeMs<1200>(
 				[](void* arg) {
 					auto self = static_cast<CallbackTimerTest*>(arg);
-					debugf("%s fired", String(self->timer64).c_str());
+					Serial << self->timer64 << _F(" fired") << endl;
 				},
 				this);
 			tmp->startOnce();


### PR DESCRIPTION
- Classes don't need to be virtual to support `printTo` method
- Avoid `strlen` call in `Print::println()`
- Fix issue with streaming operator and char[]
- Replace String += operator overloads with template method
- Update HostTests using Serial instead of debugf()
- Add BitSet printTo()
- Update HostTests printing
- Revise Storage/IFS debug printing, making Device, Partition and various IFS classes printable
- Add TRange printing
