### PR TITLE
Catch `Range::random()` divide-by-zero condition, fix off-by-1 error

### DIFF
--- a/Sming/Core/Data/Range.h
+++ b/Sming/Core/Data/Range.h
@@ -100,8 +100,12 @@ template <typename T> struct TRange {
 	 */
 	T random() const
 	{
+		auto n = 1 + max - min;
+		if(n == 0) {
+			return 0;
+		}
 		auto value = os_random();
-		return min + value % (max - min);
+		return min + value % n;
 	}
 
 	Iterator begin() const


### PR DESCRIPTION
e.g. min=0, max=10 then range=11 not 10