### PR TITLE
Fix `smg_uart_uninit()` from blocking subsequent re-initialisation

### DIFF
--- a/Sming/Arch/Esp8266/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp8266/Components/driver/uart.cpp
@@ -772,6 +772,7 @@ void smg_uart_uninit(smg_uart_t* uart)
 		break;
 	}
 
+	uartInstances[uart->uart_nr] = nullptr;
 	delete uart->rx_buffer;
 	delete uart->tx_buffer;
 	delete uart;

--- a/Sming/Arch/Host/Components/driver/uart.cpp
+++ b/Sming/Arch/Host/Components/driver/uart.cpp
@@ -347,6 +347,7 @@ void smg_uart_uninit(smg_uart_t* uart)
 		smg_uart_set_debug(UART_NO);
 	}
 
+	uartInstances[uart->uart_nr] = nullptr;
 	delete uart->rx_buffer;
 	delete uart->tx_buffer;
 	delete uart;

--- a/Sming/Core/HardwareSerial.cpp
+++ b/Sming/Core/HardwareSerial.cpp
@@ -28,12 +28,12 @@ HardwareSerial::~HardwareSerial()
 #endif
 }
 
-void HardwareSerial::begin(uint32_t baud, SerialFormat format, SerialMode mode, uint8_t txPin, uint8_t rxPin)
+bool HardwareSerial::begin(uint32_t baud, SerialFormat format, SerialMode mode, uint8_t txPin, uint8_t rxPin)
 {
 	end();
 
 	if(uartNr < 0) {
-		return;
+		return false;
 	}
 
 	smg_uart_config_t cfg = {
@@ -49,6 +49,8 @@ void HardwareSerial::begin(uint32_t baud, SerialFormat format, SerialMode mode, 
 	};
 	uart = smg_uart_init_ex(cfg);
 	updateUartCallback();
+
+	return uart != nullptr;
 }
 
 void HardwareSerial::end()

--- a/Sming/Core/HardwareSerial.cpp
+++ b/Sming/Core/HardwareSerial.cpp
@@ -32,8 +32,9 @@ void HardwareSerial::begin(uint32_t baud, SerialFormat format, SerialMode mode, 
 {
 	end();
 
-	if(uartNr < 0)
+	if(uartNr < 0) {
 		return;
+	}
 
 	smg_uart_config_t cfg = {
 		.uart_nr = (uint8_t)uartNr,
@@ -54,10 +55,6 @@ void HardwareSerial::end()
 {
 	if(uart == nullptr) {
 		return;
-	}
-
-	if(smg_uart_get_debug() == uartNr) {
-		smg_uart_set_debug(UART_NO);
 	}
 
 	smg_uart_uninit(uart);

--- a/Sming/Core/HardwareSerial.h
+++ b/Sming/Core/HardwareSerial.h
@@ -131,10 +131,11 @@ public:
 
 	/** @brief  Initialise the serial port
      *  @param  baud BAUD rate of the serial port (Default: 9600)
+	 *  @retval bool true on success
      */
-	void begin(uint32_t baud = 9600)
+	bool begin(uint32_t baud = 9600)
 	{
-		begin(baud, SERIAL_8N1, SERIAL_FULL, SERIAL_PIN_DEFAULT);
+		return begin(baud, SERIAL_8N1, SERIAL_FULL, SERIAL_PIN_DEFAULT);
 	}
 
 	/**
@@ -144,10 +145,11 @@ public:
 	 * 				 even (E), and no (N) parity, and 1 or 2 stop bits.
 	 * 		  		 To set the desired mode, call  Serial.begin(baudrate, SERIAL_8N1),
 	 * 		  		 Serial.begin(baudrate, SERIAL_6E2), etc.
+	 * @retval bool true on success
 	 */
-	void begin(uint32_t baud, SerialFormat format)
+	bool begin(uint32_t baud, SerialFormat format)
 	{
-		begin(baud, format, SERIAL_FULL, SERIAL_PIN_DEFAULT);
+		return begin(baud, format, SERIAL_FULL, SERIAL_PIN_DEFAULT);
 	}
 
 	/**
@@ -158,10 +160,11 @@ public:
 	 * 		  		 To set the desired mode, call  Serial.begin(baudrate, SERIAL_8N1),
 	 * 		  		 Serial.begin(baudrate, SERIAL_6E2), etc.
 	 * @param mode specifies if the UART supports receiving (RX), transmitting (TX) or both (FULL) operations
+	 * @retval bool true on success
 	 */
-	void begin(uint32_t baud, SerialFormat format, SerialMode mode)
+	bool begin(uint32_t baud, SerialFormat format, SerialMode mode)
 	{
-		begin(baud, format, mode, 1);
+		return begin(baud, format, mode, 1);
 	}
 
 	/**
@@ -171,8 +174,9 @@ public:
 	 * @param mode
 	 * @param txPin Can specify alternate pin for TX
 	 * @param rxPin
+	 * @retval bool true on success
 	 */
-	void begin(uint32_t baud, SerialFormat format, SerialMode mode, uint8_t txPin, uint8_t rxPin = SERIAL_PIN_DEFAULT);
+	bool begin(uint32_t baud, SerialFormat format, SerialMode mode, uint8_t txPin, uint8_t rxPin = SERIAL_PIN_DEFAULT);
 
 	/**
 	 * @brief De-inits the current UART if it is already used


### PR DESCRIPTION
This PR fixes a bug in the Esp8266 and Host uart driver implementations of `smg_uart_uninit` which causes subsequent calls to `smg_uart_init_ex` to fail as it thinks the port is in use.

This bug is exposed if a port is opened, closed and then re-opened:

```
Serial.begin(COM_SPEED_SERIAL);
...
Serial.end(); // optional - begin() calls this internally anyway
Serial.begin(9600); // fails
```

Also add a `bool` return value from `HardwareSerial::begin()` method so caller can check for errors.