### PR TITLE
Add ESP32 task watchdog reset to flash routines

### DIFF
--- a/Sming/Arch/Esp32/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Esp32/Components/spi_flash/flashmem.cpp
@@ -12,11 +12,14 @@
 #include <soc/mmu.h>
 #include <esp_flash_partitions.h>
 #include <esp_flash.h>
+#include <esp_task_wdt.h>
 #include <rom/cache.h>
 #include <esp_systemapi.h>
 
 uint32_t flashmem_write(const void* from, uint32_t toaddr, uint32_t size)
 {
+	esp_task_wdt_reset();
+
 	esp_err_t r = spi_flash_write(toaddr, from, size);
 	if(r != ESP_OK) {
 		SYSTEM_ERROR("ERROR in flash_write: r=%d at %08X\n", r, toaddr);
@@ -28,6 +31,8 @@ uint32_t flashmem_write(const void* from, uint32_t toaddr, uint32_t size)
 
 uint32_t flashmem_read(void* to, uint32_t fromaddr, uint32_t size)
 {
+	esp_task_wdt_reset();
+
 	esp_err_t r = spi_flash_read(fromaddr, to, size);
 	if(r != ESP_OK) {
 		SYSTEM_ERROR("ERROR in flash_read: r=%d at %08X\n", r, fromaddr);
@@ -39,6 +44,8 @@ uint32_t flashmem_read(void* to, uint32_t fromaddr, uint32_t size)
 
 bool flashmem_erase_sector(uint32_t sector_id)
 {
+	esp_task_wdt_reset();
+
 	debug_d("flashmem_erase_sector(0x%08x)", sector_id);
 
 	return spi_flash_erase_sector(sector_id) == SPI_FLASH_RESULT_OK;


### PR DESCRIPTION
Like ESP8266, can timeout during lengthy operations