### PR TITLE
Fix Uuid comparison for PROGMEM usage

### DIFF
--- a/Sming/Core/Data/Uuid.cpp
+++ b/Sming/Core/Data/Uuid.cpp
@@ -21,6 +21,17 @@ uint32_t os_random();
 void os_get_random(void* buf, size_t n);
 }
 
+bool Uuid::operator==(const Uuid& other) const
+{
+	// Ensure these are stricly compared as a set of words to avoid PROGMEM issues
+	struct S {
+		uint32_t a, b, c, d;
+	};
+	auto& s1 = reinterpret_cast<const S&>(*this);
+	auto& s2 = reinterpret_cast<const S&>(other);
+	return s1.a == s2.a && s1.b == s2.b && s1.c == s2.c && s1.d == s2.d;
+}
+
 bool Uuid::generate(MacAddress mac)
 {
 	uint8_t version = 1; // DCE version

--- a/Sming/Core/Data/Uuid.h
+++ b/Sming/Core/Data/Uuid.h
@@ -36,7 +36,7 @@ struct Uuid {
 	 */
 	static constexpr size_t stringSize = 36;
 
-	Uuid()
+	constexpr Uuid()
 	{
 	}
 
@@ -69,14 +69,10 @@ struct Uuid {
 
 	explicit operator bool() const
 	{
-		Uuid Null{};
-		return memcmp(this, &Null, sizeof(Null)) != 0;
+		return *this != Uuid{};
 	}
 
-	bool operator==(const Uuid& other) const
-	{
-		return memcmp(this, &other, sizeof(Uuid)) == 0;
-	}
+	bool operator==(const Uuid& other) const;
 
 	bool operator!=(const Uuid& other) const
 	{


### PR DESCRIPTION
even memcmp_P goes pop sometimes.
To be safe, compare explicitly as 4 words.