### PR TITLE
Fix "fatal: transport 'file' not allowed" error during CI builds

### DIFF
--- a/tests/SharedComponent/Makefile
+++ b/tests/SharedComponent/Makefile
@@ -63,7 +63,7 @@ $(REPO_DIR)/.git:
 # Add shared-test.repo as a submodule to the shared-test Component, but leave it un-initialised
 $(SHARED_COMPONENT_DIR)/.gitmodules: | $(SHARED_COMPONENT_DIR)/.git
 	$(Q) cd $(@D)/$(COMPONENT_NAME) && \
-	git submodule add $(CURDIR)/$(REPO_DIR) $(SUBMODULE_NAME) && \
+	git -c protocol.file.allow=always submodule add $(CURDIR)/$(REPO_DIR) $(SUBMODULE_NAME) && \
 	git submodule deinit -f $(SUBMODULE_NAME)
 
 $(SHARED_COMPONENT_DIR)/.git:


### PR DESCRIPTION
CVE-2022-39253
Git has changed the default value of protocol.file.allow to “user”, meaning that file:// clones are considered unsafe by default.