### PR TITLE
Fix ObjectList inheritance

### DIFF
--- a/Sming/Core/Data/LinkedObject.h
+++ b/Sming/Core/Data/LinkedObject.h
@@ -30,11 +30,6 @@ public:
 		return mNext;
 	}
 
-	LinkedObject* getNext() const
-	{
-		return mNext;
-	}
-
 	bool insertAfter(LinkedObject* object)
 	{
 		if(object == nullptr) {
@@ -84,7 +79,7 @@ public:
 
 		IteratorTemplate& operator++()
 		{
-			mObject = mObject->getNext();
+			this->mObject = static_cast<TPtr>(this->mObject->next());
 			return *this;
 		}
 
@@ -129,7 +124,7 @@ public:
 
 	ObjectType* getNext() const
 	{
-		return reinterpret_cast<ObjectType*>(this->next());
+		return static_cast<ObjectType*>(this->next());
 	}
 
 	bool insertAfter(ObjectType* object)

--- a/Sming/Core/Data/LinkedObjectList.h
+++ b/Sming/Core/Data/LinkedObjectList.h
@@ -89,6 +89,12 @@ protected:
 template <typename ObjectType> class LinkedObjectListTemplate : public LinkedObjectList
 {
 public:
+	using Iterator =
+		typename LinkedObjectTemplate<ObjectType>::template IteratorTemplate<ObjectType, ObjectType*, ObjectType&>;
+	using ConstIterator =
+		typename LinkedObjectTemplate<ObjectType>::template IteratorTemplate<const ObjectType, const ObjectType*,
+																			 const ObjectType&>;
+
 	LinkedObjectListTemplate() = default;
 
 	LinkedObjectListTemplate(ObjectType* object) : LinkedObjectList(object)
@@ -105,22 +111,22 @@ public:
 		return reinterpret_cast<const ObjectType*>(mHead);
 	}
 
-	typename ObjectType::Iterator begin()
+	Iterator begin()
 	{
 		return head();
 	}
 
-	typename ObjectType::Iterator end()
+	Iterator end()
 	{
 		return nullptr;
 	}
 
-	typename ObjectType::ConstIterator begin() const
+	ConstIterator begin() const
 	{
 		return head();
 	}
 
-	typename ObjectType::ConstIterator end() const
+	ConstIterator end() const
 	{
 		return nullptr;
 	}


### PR DESCRIPTION
This PR fixes a bug where inheriting from a base `LinkedObjectListTemplate` implementation does not work as expected.

By example, consider these class definitions:

```
#include <Data/LinkedObjectList.h>

class BaseObject : public LinkedObjectTemplate<BaseObject>
{
public:
	using List = LinkedObjectListTemplate<BaseObject>;
	using OwnedList = OwnedLinkedObjectListTemplate<BaseObject>;
};

class ObjectOne : public BaseObject
{
public:
	using List = LinkedObjectListTemplate<ObjectOne>;
	using OwnedList = OwnedLinkedObjectListTemplate<ObjectOne>;

public:
	ObjectOne(int value) : prop1(value)
	{
	}

	int prop1;
};

void test()
{
    ObjectOne::OwnedList list;
    for(auto obj : list) {
        Serial << obj.prop1 << " ";
    }
}

```

This fails to compile with the error `‘class {anonymous}::BaseObject’ has no member named ‘prop1’`,
because the iterator returns `BaseObject` instead of `ObjectOne`, which is incorrect behaviour.

