### PR TITLE
Partition method fixes

### DIFF
--- a/Sming/Components/Storage/src/include/Storage.h
+++ b/Sming/Components/Storage/src/include/Storage.h
@@ -54,7 +54,7 @@ inline Iterator findPartition(Partition::Type type = Partition::Type::any, uint8
 	return Iterator(type, subType);
 }
 
-template <typename T> Iterator findPartition(T subType)
+template <typename T> typename std::enable_if<std::is_enum<T>::value, Iterator>::type findPartition(T subType)
 {
 	return Iterator(Partition::Type(T::partitionType), uint8_t(subType));
 }

--- a/Sming/Components/Storage/src/include/Storage/Partition.h
+++ b/Sming/Components/Storage/src/include/Storage/Partition.h
@@ -433,6 +433,11 @@ public:
 		return mPart ? mPart->name.equals(name) : false;
 	}
 
+	template <typename T> bool operator!=(const T& other) const
+	{
+		return !operator==(other);
+	}
+
 	/**
 	 * @brief Obtain smallest allocation unit for erase operations
 	 */


### PR DESCRIPTION
Fix error calling `Storage::findPartition` with `const char*`, e.g. findPartition("rom0")

Add Partition `!=` operator