### PR TITLE
Add Host stubs for RTC mem read/write

### DIFF
--- a/Sming/Arch/Host/Components/esp_hal/include/esp_system.h
+++ b/Sming/Arch/Host/Components/esp_hal/include/esp_system.h
@@ -59,6 +59,9 @@ const char* system_get_sdk_version(void);
 
 uint32 system_get_chip_id(void);
 
+bool system_rtc_mem_read(uint8_t src_addr, void* des_addr, uint16_t load_size);
+bool system_rtc_mem_write(uint8_t des_addr, const void* src_addr, uint16_t save_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/Sming/Arch/Host/Components/esp_hal/system.cpp
+++ b/Sming/Arch/Host/Components/esp_hal/system.cpp
@@ -122,3 +122,15 @@ void xt_enable_interrupts()
 {
 	ets_intr_unlock();
 }
+
+/* RTC */
+
+bool system_rtc_mem_read(uint8_t src_addr, void* des_addr, uint16_t load_size)
+{
+	return false;
+}
+
+bool system_rtc_mem_write(uint8_t des_addr, const void* src_addr, uint16_t save_size)
+{
+	return false;
+}


### PR DESCRIPTION
This PR adds stubs for the `system_rtc_mem_read` and `system_rtc_mem_write` functions so that code compiles for the `Host` arch.

No immediate use-cases fo this, but for future consideration it might be useful to make these functional using a backing file, similar to how flash memory is handled. One area where this might be useful is improving `System.restart()` behaviour, perhaps by forking a separate process which can be restarted.
