### PR TITLE
RP2040: Bypass cache when reading flash memory directly

### DIFF
--- a/Sming/Arch/Rp2040/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Rp2040/Components/spi_flash/flashmem.cpp
@@ -131,7 +131,7 @@ uint32_t readAligned(void* to, uint32_t fromaddr, uint32_t size)
 		(void)xip_ctrl_hw->stream_fifo;
 	}
 
-	xip_ctrl_hw->stream_addr = flashaddr;
+	xip_ctrl_hw->stream_addr = XIP_NOCACHE_NOALLOC_BASE + fromaddr;
 	xip_ctrl_hw->stream_ctr = transfer_count;
 
 	/*


### PR DESCRIPTION
Using normal XIP window forces reads through cache which will affect code execution speed.