### PR TITLE
Fix build issues

### DIFF
--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -451,13 +451,13 @@ endif
 define GenerateComponentTargetRule
 ifeq (App,$1)
 $2: $1-build
-	$(Q) touch $$@
+	$(Q) touch -c "$$@"
 else ifeq (,$(wildcard $2))
 $2: $1-build
-	$(Q) touch $$@
+	$(Q) touch -c "$$@"
 else ifneq (,$(filter $1,$(FULL_COMPONENT_BUILD)))
 $2: $1-build
-	$(Q) touch $$@
+	$(Q) touch -c "$$@"
 endif
 endef
 


### PR DESCRIPTION
Fix potential build issue with LittleFS where HWCONFIG_OPTS settings don't exist for Host architecture.
For example, building the Basic_IFS sample, which uses LittleFS, with `make SMING_SOC=esp8266 HWCONFIG_OPTS=alternate` will result in `** ERROR! Option 'alternate' undefined` attempting to build fscopy.

To force re-linking of `COMPONENT_TARGETS` the build system touches the files.
Currently this creates the file if it doesn't exist but that can hide problems so is not desirable.
