### PR TITLE
Fix library CI workflow

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-20.04, windows-latest]
         variant: [esp8266, host, esp32, esp32s2, esp32c3, rp2040]
         include:
           - variant: esp8266
@@ -71,7 +71,7 @@ jobs:
         "SMING_SOC=${{ matrix.variant }}" >> $env:GITHUB_ENV
 
     - name: Install build tools for Ubuntu
-      if: ${{ matrix.os ==  'ubuntu-latest' }}
+      if: ${{ matrix.os ==  'ubuntu-20.04' }}
       run: |
         . $SMING_HOME/../Tools/export.sh
         $SMING_HOME/../Tools/ci/install.sh $SMING_ARCH
@@ -85,7 +85,7 @@ jobs:
     - name: Build and Test for ${{matrix.arch}} on Ubuntu
       env:
         CLANG_FORMAT: clang-format-8
-      if: ${{ matrix.os == 'ubuntu-latest' }}
+      if: ${{ matrix.os == 'ubuntu-20.04' }}
       run: |
         . $SMING_HOME/../Tools/export.sh
         make -j$(nproc) -f $CI_MAKEFILE


### PR DESCRIPTION
Use ubuntu-20.04; ubuntu-latest (20.04.1) doesn't have clang-format-8, etc. (See also #2587)

Also, don't run Graphics library test in Windows as it frequently hangs.