### PR TITLE
Add ESP32 support for IDF v4.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, windows-latest]
         variant: [esp8266, host, esp32, esp32s2, esp32c3, rp2040]
+        INSTALL_IDF_VER: ["4.3", "4.4"]
         include:
           - variant: esp8266
             arch: Esp8266
@@ -26,12 +27,23 @@ jobs:
             arch: Esp32
           - variant: rp2040
             arch: Rp2040
+        exclude:
+          - variant: esp8266
+            INSTALL_IDF_VER: "4.4"
+          - variant: host
+            INSTALL_IDF_VER: "4.4"
+          - variant: rp2040
+            INSTALL_IDF_VER: "4.4"
 
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-${{ toJson(matrix) }}
       cancel-in-progress: true
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      SMING_ARCH: ${{ matrix.arch }}
+      SMING_SOC: ${{ matrix.variant }}
 
     steps:
     - name: Fix autocrlf setting
@@ -46,8 +58,7 @@ jobs:
       run: |
         "CI_BUILD_DIR=" + (Resolve-Path ".").path >> $env:GITHUB_ENV
         "SMING_HOME=" + (Resolve-Path "Sming").path >> $env:GITHUB_ENV
-        "SMING_ARCH=${{ matrix.arch }}" >> $env:GITHUB_ENV
-        "SMING_SOC=${{ matrix.variant }}" >> $env:GITHUB_ENV
+        "INSTALL_IDF_VER=${{ matrix.INSTALL_IDF_VER }}" >> $env:GITHUB_ENV
 
     - name: Install build tools for Ubuntu
       if: ${{ matrix.os ==  'ubuntu-20.04' }}

--- a/Sming/Arch/Esp32/Components/esp32/src/include/esp_systemapi.h
+++ b/Sming/Arch/Esp32/Components/esp32/src/include/esp_systemapi.h
@@ -39,7 +39,7 @@
 /** @brief  Disable interrupts
  *  @retval Current interrupt level
  */
-#define noInterrupts() portENTER_CRITICAL_NESTED()
+#define noInterrupts() portSET_INTERRUPT_MASK_FROM_ISR()
 
 /** @brief  Enable interrupts
 */
@@ -47,4 +47,4 @@
 
 /** @brief Restore interrupts to level saved from previous noInterrupts() call
  */
-#define restoreInterrupts(state) portEXIT_CRITICAL_NESTED(state)
+#define restoreInterrupts(state) portCLEAR_INTERRUPT_MASK_FROM_ISR(state)

--- a/Sming/Arch/Esp32/Components/esp32/src/system.cpp
+++ b/Sming/Arch/Esp32/Components/esp32/src/system.cpp
@@ -53,8 +53,18 @@ void system_restart(void)
 	 * Doing so causes a deadlock and a task watchdog timeout.
 	 *
 	 * Delegating this call to any other task fixes the issue.
+	 *
+	 * We can use the timer task to handle the call.
+	 * This method does not free the allocated timer resources but as the system
+	 * is restarting this doesn't matter.
 	 */
-	esp_ipc_call(0, esp_ipc_func_t(esp_restart), nullptr);
+	const esp_timer_create_args_t create_args = {
+		.callback = esp_timer_cb_t(esp_restart),
+		.dispatch_method = ESP_TIMER_TASK,
+	};
+	esp_timer_handle_t handle{nullptr};
+	esp_timer_create(&create_args, &handle);
+	esp_timer_start_once(handle, 100);
 }
 
 /* Watchdog */

--- a/Sming/Arch/Esp32/Tools/install.cmd
+++ b/Sming/Arch/Esp32/Tools/install.cmd
@@ -4,7 +4,8 @@ if "%IDF_PATH%"=="" goto :EOF
 if "%IDF_TOOLS_PATH%"=="" goto :EOF
 
 if "%IDF_REPO%"=="" set IDF_REPO="https://github.com/mikee47/esp-idf.git"
-if "%IDF_BRANCH%"=="" set IDF_BRANCH="sming/release/v4.3"
+if "%INSTALL_IDF_VER%"=="" set INSTALL_IDF_VER=4.4
+set IDF_BRANCH="sming/release/v%INSTALL_IDF_VER%"
 
 git clone -b %IDF_BRANCH% %IDF_REPO% %IDF_PATH%
 

--- a/Sming/Arch/Esp32/Tools/install.sh
+++ b/Sming/Arch/Esp32/Tools/install.sh
@@ -36,9 +36,10 @@ if [ ! -L "$IDF_PATH" ] && [ -d "$IDF_PATH" ]; then
     mv "$IDF_PATH" "$IDF_PATH-old"
 fi
 
-IDF_CLONE_PATH="$(readlink -m "$IDF_PATH/..")/esp-idf-4.3"
+INSTALL_IDF_VER="${INSTALL_IDF_VER:=4.4}"
+IDF_CLONE_PATH="$(readlink -m "$IDF_PATH/..")/esp-idf-${INSTALL_IDF_VER}"
 IDF_REPO="${IDF_REPO:=https://github.com/mikee47/esp-idf.git}"
-IDF_BRANCH="${IDF_BRANCH:=sming/release/v4.3}"
+IDF_BRANCH="sming/release/v${INSTALL_IDF_VER}"
 
 if [ -d "$IDF_CLONE_PATH" ]; then
     printf "\n\n** Skipping ESP-IDF clone: '$IDF_CLONE_PATH' exists\n\n"

--- a/Sming/Arch/Esp32/build.mk
+++ b/Sming/Arch/Esp32/build.mk
@@ -145,7 +145,8 @@ CPPFLAGS += \
 	-D__ets__ \
 	-D_GNU_SOURCE \
 	-DCONFIG_NONE_OS \
-	-Dasm=__asm__
+	-Dasm=__asm__ \
+	-Dtypeof=__typeof__
 
 PROJECT_VER ?=
 export IDF_VER

--- a/Sming/Components/Network/Arch/Esp32/Network/DM9051.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Network/DM9051.cpp
@@ -28,8 +28,10 @@ bool DM9051Service::begin(const Config& config)
 	esp_netif_config_t netif_cfg = ESP_NETIF_DEFAULT_ETH();
 	netif = esp_netif_new(&netif_cfg);
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
 	// Set default handlers to process TCP/IP stuffs
 	CHECK_RET(esp_eth_set_default_handlers(netif));
+#endif
 
 	// And register our own event handlers
 	enableEventCallback(true);
@@ -69,7 +71,7 @@ bool DM9051Service::begin(const Config& config)
 
 	setMacAddress(MacAddress({0x02, 0x00, 0x00, 0x12, 0x34, 0x56}));
 
-	netif_glue = esp_eth_new_netif_glue(handle);
+	netif_glue = static_cast<void*>(esp_eth_new_netif_glue(handle));
 	CHECK_RET(esp_netif_attach(netif, netif_glue));
 	CHECK_RET(esp_eth_start(handle));
 

--- a/Sming/Components/Network/Arch/Esp32/Network/W5500.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Network/W5500.cpp
@@ -28,8 +28,10 @@ bool W5500Service::begin(const Config& config)
 	esp_netif_config_t netif_cfg = ESP_NETIF_DEFAULT_ETH();
 	netif = esp_netif_new(&netif_cfg);
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
 	// Set default handlers to process TCP/IP stuffs
 	CHECK_RET(esp_eth_set_default_handlers(netif));
+#endif
 
 	// And register our own event handlers
 	enableEventCallback(true);
@@ -69,7 +71,7 @@ bool W5500Service::begin(const Config& config)
 
 	setMacAddress(MacAddress({0x02, 0x00, 0x00, 0x12, 0x34, 0x56}));
 
-	netif_glue = esp_eth_new_netif_glue(handle);
+	netif_glue = static_cast<void*>(esp_eth_new_netif_glue(handle));
 	CHECK_RET(esp_netif_attach(netif, netif_glue));
 	CHECK_RET(esp_eth_start(handle));
 

--- a/Sming/Components/Network/Arch/Esp32/Platform/EmbeddedEthernet.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/EmbeddedEthernet.cpp
@@ -29,8 +29,10 @@ bool EmbeddedEthernet::begin(const Config& config)
 	esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
 	netif = esp_netif_new(&cfg);
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
 	// Set default handlers to process TCP/IP stuffs
 	ESP_ERROR_CHECK(esp_eth_set_default_handlers(netif));
+#endif
 
 	// And register our own event handlers
 	enableEventCallback(true);
@@ -57,7 +59,7 @@ bool EmbeddedEthernet::begin(const Config& config)
 
 	esp_eth_config_t eth_config = ETH_DEFAULT_CONFIG(mac, phy);
 	ESP_ERROR_CHECK(esp_eth_driver_install(&eth_config, &handle));
-	netif_glue = esp_eth_new_netif_glue(handle);
+	netif_glue = static_cast<void*>(esp_eth_new_netif_glue(handle));
 	ESP_ERROR_CHECK(esp_netif_attach(netif, netif_glue));
 	ESP_ERROR_CHECK(esp_eth_start(handle));
 

--- a/Sming/Components/Network/Arch/Esp32/Platform/IdfService.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/IdfService.cpp
@@ -13,6 +13,10 @@
 #include <esp_event.h>
 #include <debug_progmem.h>
 
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
+using esp_eth_netif_glue_handle_t = void*;
+#endif
+
 namespace Ethernet
 {
 void IdfService::end()
@@ -22,9 +26,11 @@ void IdfService::end()
 	}
 
 	ESP_ERROR_CHECK(esp_eth_stop(handle));
-	ESP_ERROR_CHECK(esp_eth_del_netif_glue(netif_glue));
+	ESP_ERROR_CHECK(esp_eth_del_netif_glue(static_cast<esp_eth_netif_glue_handle_t>(netif_glue)));
 	netif_glue = nullptr;
+#if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(4, 4, 0)
 	ESP_ERROR_CHECK(esp_eth_clear_default_handlers(netif));
+#endif
 
 	ESP_ERROR_CHECK(esp_eth_driver_uninstall(handle));
 	handle = nullptr;

--- a/Sming/Libraries/SPI/src/Arch/Esp32/SPI.cpp
+++ b/Sming/Libraries/SPI/src/Arch/Esp32/SPI.cpp
@@ -18,7 +18,6 @@
 #include <esp_systemapi.h>
 #undef FLAG_ATTR
 #define FLAG_ATTR(TYPE)
-#define typeof decltype
 #include <soc/spi_periph.h>
 #include <hal/spi_ll.h>
 #include <hal/clk_gate_ll.h>

--- a/Tools/ci/setenv.ps1
+++ b/Tools/ci/setenv.ps1
@@ -14,7 +14,6 @@ $env:ESP_HOME = Join-Path $TOOLS_DIR "esp-quick-toolchain"
 # Esp32
 $env:IDF_PATH = Join-Path $TOOLS_DIR "esp-idf"
 $env:IDF_TOOLS_PATH = Join-Path $TOOLS_DIR "esp32"
-$env:IDF_BRANCH = "sming/release/v4.3"
 
 # Rp2040
 $env:PICO_TOOLCHAIN_PATH = Join-Path $TOOLS_DIR "rp2040"


### PR DESCRIPTION
This PR adds support for ESP IDF version 4.4 and changes the default installed version accordingly.
Integration tests include both 4.3 and 4.4.