### PR TITLE
Fix Esp32 flashing

### DIFF
--- a/Sming/Arch/Esp32/Components/esp32/component.mk
+++ b/Sming/Arch/Esp32/Components/esp32/component.mk
@@ -365,6 +365,10 @@ $(SDK_CONFIG_DEFAULTS): $(SDK_CUSTOM_CONFIG_PATH)
 	$(Q) $(foreach f,$(SDK_CONFIG_FILES),\
 		$(if $(wildcard $f),cat $f >> $@;) \
 	)
+	$(Q) printf "\n# ESPTOOL (bootloader) settings\n" >> $@
+	$(Q) echo "CONFIG_ESPTOOLPY_FLASHMODE_$(SPI_MODE)=y" >> $@
+	$(Q) echo "CONFIG_ESPTOOLPY_FLASHFREQ_$(SPI_SPEED)M=y" >> $@
+	$(Q) echo "CONFIG_ESPTOOLPY_FLASHSIZE_$(SPI_SIZE)B=y" >> $@
 
 ##@Configuration
 

--- a/Sming/Arch/Esp32/Components/esp32/sdk/config/common
+++ b/Sming/Arch/Esp32/Components/esp32/sdk/config/common
@@ -52,3 +52,7 @@ CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
 
 # Debugging
 CONFIG_ESP_SYSTEM_PANIC_GDBSTUB=y
+
+# Don't change provided flash configuration information
+CONFIG_ESPTOOLPY_FLASHSIZE_DETECT=n
+

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -203,8 +203,9 @@ ifneq ($(STRICT),1)
 	CXXFLAGS += -Wno-reorder
 endif
 
-ifndef MAKE_CLEAN
 include $(ARCH_BASE)/build.mk
+
+ifndef MAKE_CLEAN
 
 # Detect compiler version
 DEBUG_VARS			+= GCC_VERSION


### PR DESCRIPTION
This PR fixes a couple of problems related to ESP32 bootloader flashing.

The `make sdk-configclean` build target which currently does not full clear the SDK configuration information as expected.

The bootloader debug log may show the `SHA-256 comparison failed` message.
The reason for this is that, by default, esptool will auto-detect flash settings and overwrite those values in the bootloader header. Those settings are the mode, speed and flash size settings.

This behaviour is now disabled (by setting CONFIG_ESPTOOLPY_FLASHSIZE_DETECT=n),
and the user-configured parameter values passed to the SDK.

This also fixes the problem for later versions of esptool (4+) which ignores auto-detect unless bootloader checksumming is also disabled. This results in boot failure as the flash chip size is usually too small (default is 2MB).
