### PR TITLE
Fix Esp32 'task not found' errors when calling esp_task_wdt_reset

### DIFF
--- a/Sming/Arch/Esp32/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Esp32/Components/spi_flash/flashmem.cpp
@@ -18,8 +18,6 @@
 
 uint32_t flashmem_write(const void* from, uint32_t toaddr, uint32_t size)
 {
-	esp_task_wdt_reset();
-
 	esp_err_t r = esp_flash_write(esp_flash_default_chip, from, toaddr, size);
 	if(r != ESP_OK) {
 		SYSTEM_ERROR("ERROR in flash_write: r=%d at %08X\n", r, toaddr);
@@ -31,8 +29,6 @@ uint32_t flashmem_write(const void* from, uint32_t toaddr, uint32_t size)
 
 uint32_t flashmem_read(void* to, uint32_t fromaddr, uint32_t size)
 {
-	esp_task_wdt_reset();
-
 	esp_err_t r = esp_flash_read(esp_flash_default_chip, to, fromaddr, size);
 	if(r != ESP_OK) {
 		SYSTEM_ERROR("ERROR in flash_read: r=%d at %08X\n", r, fromaddr);

--- a/Sming/Arch/Esp32/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Esp32/Services/Profiling/TaskStat.cpp
@@ -84,8 +84,8 @@ bool TaskStat::update()
 
 	std::bitset<maxTasks> startMatched, endMatched;
 
-	PSTR_ARRAY(hdrfmt, "#   | Core | Prio | Run Time | % Time | Name");
-	PSTR_ARRAY(datfmt, "%-3u |   %c  | %4u | %8u |  %3u%%  | %s\r\n");
+	PSTR_ARRAY(hdrfmt, "#   | Core | Prio | Handle   | Run Time | % Time | Name");
+	PSTR_ARRAY(datfmt, "%-3u |   %c  | %4u | %08x | %8u |  %3u%%  | %s\r\n");
 	out.println();
 	out.println(hdrfmt);
 	// Match each task in startInfo.status to those in the endInfo.status
@@ -108,7 +108,7 @@ bool TaskStat::update()
 			coreId = status.xCoreID;
 #endif
 			out.printf(datfmt, status.xTaskNumber, (coreId == CONFIG_FREERTOS_NO_AFFINITY) ? '-' : ('0' + coreId),
-					   status.uxCurrentPriority, taskElapsedTime, percentageTime, status.pcTaskName);
+					   status.uxCurrentPriority, status.xHandle, taskElapsedTime, percentageTime, status.pcTaskName);
 		}
 	}
 

--- a/Sming/Arch/Esp8266/Components/spi_flash/flashmem.c
+++ b/Sming/Arch/Esp8266/Components/spi_flash/flashmem.c
@@ -267,8 +267,6 @@ uint32_t flashmem_write_internal( const void *from, uint32_t toaddr, uint32_t si
 {
   assert(IS_ALIGNED(from) && IS_ALIGNED(toaddr) && IS_ALIGNED(size));
 
-  WDT_FEED();
-
   SpiFlashOpResult r = spi_flash_write(toaddr, (uint32*)from, size);
   if(SPI_FLASH_RESULT_OK == r)
     return size;
@@ -281,8 +279,6 @@ uint32_t flashmem_write_internal( const void *from, uint32_t toaddr, uint32_t si
 uint32_t flashmem_read_internal( void *to, uint32_t fromaddr, uint32_t size )
 {
   assert(IS_ALIGNED(to) && IS_ALIGNED(fromaddr) && IS_ALIGNED(size));
-
-  WDT_FEED();
 
   SpiFlashOpResult r = spi_flash_read(fromaddr, (uint32*)to, size);
   if(SPI_FLASH_RESULT_OK == r)

--- a/Sming/Arch/Rp2040/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Rp2040/Components/spi_flash/flashmem.cpp
@@ -300,6 +300,7 @@ uint32_t flashmem_read(void* to, uint32_t fromaddr, uint32_t size)
 bool flashmem_erase_sector(uint32_t sector_id)
 {
 	debug_d("flashmem_erase_sector(0x%08x)", sector_id);
+	system_soft_wdt_feed();
 	flash_range_erase(sector_id * FLASH_SECTOR_SIZE, FLASH_SECTOR_SIZE);
 	return true;
 }


### PR DESCRIPTION
Testing the Basic_IFS sample application shows lots of `esp_task_wdt_reset(786): task not found` errors logged.
This can be traced to 'flashmem_read' calls, executed via TCP/IP task events.

This PR fixes the issue by removing the watchdog reset calls from flash read/write.
The watchdog reset is required because spiffs_format can take a long time,
so placing the call in flash_erase is sufficient.

For consistency, the Esp8266 and Rp2040 implementations have been updated accordingly.