### PR TITLE
Load cached variables *before* parsing project's component.mk

### DIFF
--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -241,9 +241,6 @@ define ParseComponentList
 $(foreach c,$1,$(eval $(call ParseComponent,$c,$(call FindComponentDir,$c),$(SMING_HOME)/$(BUILD_BASE),$(USER_LIBDIR))))
 endef
 
-# Must parse the Application Component first to get project dependencies
-$(eval $(call ParseComponent,App,$(CURDIR),$(BUILD_BASE),$(abspath $(APP_LIBDIR))))
-
 # Load cached configuration variables. On first run this file won't exist, so all values
 # will be as specified by defaults or in project's component.mk file.
 # Values may be overridden via command line to update the cache.
@@ -252,6 +249,9 @@ CONFIG_CACHE_FILE	:= $(OUT_BASE)/config.mk
 ifeq (,$(filter config-clean dist-clean,$(MAKECMDGOALS)))
 -include $(CONFIG_CACHE_FILE)
 endif
+
+# Must parse the Application Component first to get project dependencies
+$(eval $(call ParseComponent,App,$(CURDIR),$(BUILD_BASE),$(abspath $(APP_LIBDIR))))
 
 # Also export debug variables here for access by external tools (e.g. python)
 CONFIG_DEBUG_FILE	:= $(OUT_BASE)/debug.mk

--- a/samples/Basic_IFS/app/application.cpp
+++ b/samples/Basic_IFS/app/application.cpp
@@ -215,7 +215,7 @@ bool initFileSystem()
 	Storage::registerDevice(card);
 
 	// Buffering allows byte read/write
-	card.allocateBuffers(2);
+	card->allocateBuffers(2);
 
 	if(card->begin(PIN_CARD_CS, SPI_FREQ_LIMIT)) {
 		Serial << "CSD" << endl << card->csd << endl;

--- a/samples/Basic_IFS/component.mk
+++ b/samples/Basic_IFS/component.mk
@@ -1,8 +1,6 @@
 COMPONENT_DEPENDS := \
 	Spiffs \
-	LittleFS \
-	FatIFS \
-	SdStorage
+	LittleFS
 
 # Empty SPIFFS partition please
 SPIFF_FILES :=
@@ -20,6 +18,7 @@ endif
 CONFIG_VARS += ENABLE_SDCARD
 ifeq ($(ENABLE_SDCARD),1)
 COMPONENT_CXXFLAGS += -DENABLE_SDCARD
+COMPONENT_DEPENDS += SdStorage FatIFS
 endif
 
 # For Rp2040, put firmware into partition


### PR DESCRIPTION
At present, the project component.mk file is parsed first to ensure module dependencies are handled. Only then are cached variables loaded. However, consider as an example this conditional dependency:

```
COMPONENT_VARS += ENABLE_SDCARD
ifeq ($(ENABLE_SDCARD),1)
COMPONENT_DEPENDS += SdStorage FatIFS
endif
```

The following are now broken:

- `make list-components` both SdStorage and FatIFS are missing
- `make SdStorage-clean` or `make FatIFS-clean` produces 'no rule to make target' error

It can also lead to some other more subtle and annoying bugs. Loading the cached variables first fixes this.

The Basic_IFS sample is updated to conditionally build these libraries and works as expected.