### PR TITLE
Fix Rp2040 UART rx overflow interrupt handling

### DIFF
--- a/Sming/Arch/Rp2040/Components/driver/uart.cpp
+++ b/Sming/Arch/Rp2040/Components/driver/uart.cpp
@@ -138,8 +138,8 @@ void IRAM_ATTR handleInterrupt(smg_uart_t* uart, uart_dev_t* dev)
 			 */
 			if(rxfifo_ovf) {
 				hw_clear_bits(&dev->imsc, UART_UARTIMSC_OEIM_BITS);
-			} else if(read == 0) {
-				hw_set_bits(&dev->imsc, UART_UARTIMSC_RXIM_BITS | UART_UARTIMSC_RTIM_BITS);
+			} else if(!read) {
+				hw_clear_bits(&dev->imsc, UART_UARTIMSC_RXIM_BITS | UART_UARTIMSC_RTIM_BITS);
 			}
 		}
 


### PR DESCRIPTION
The UART interrupt service routine does not correctly disable the 'fifo full/timeout' interrupts if triggered,  which can cause problems when the UART RX FIFO becomes full.