### PR TITLE
Fix rp2040 `smg_uart_wait_tx_empty()`

### DIFF
--- a/Sming/Arch/Rp2040/Components/driver/uart.cpp
+++ b/Sming/Arch/Rp2040/Components/driver/uart.cpp
@@ -396,7 +396,7 @@ void smg_uart_wait_tx_empty(smg_uart_t* uart)
 	}
 
 	auto dev = getDevice(uart->uart_nr);
-	while((dev->fr & UART_UARTFR_TXFE_BITS) != 0) {
+	while((dev->fr & UART_UARTFR_BUSY_BITS) != 0) {
 	}
 }
 


### PR DESCRIPTION
Wrong sense, causes lockups when `Serial.flush()` called. Also, should use the BUSY bit to ensure data has actually been sent rather than just looking at whether the TX FIFO is empty.