### PR TITLE
Initialise Rp2040 RTC to unix epoch at startup

### DIFF
--- a/Sming/Arch/Rp2040/Components/rp2040/src/startup.cpp
+++ b/Sming/Arch/Rp2040/Components/rp2040/src/startup.cpp
@@ -88,10 +88,14 @@ void check_bootsel()
 
 } // namespace
 
+extern void system_init_rtc();
+
 extern "C" int main(void)
 {
-	extern void system_init_clocks(void);
+	extern void system_init_clocks();
 	system_init_clocks();
+
+	system_init_rtc();
 
 	system_soft_wdt_restart();
 

--- a/Sming/Arch/Rp2040/Platform/RTC.cpp
+++ b/Sming/Arch/Rp2040/Platform/RTC.cpp
@@ -16,24 +16,15 @@ RtcClass RTC;
 
 #define NS_PER_SECOND 1000000000
 
-namespace
+void system_init_rtc()
 {
-bool initialised;
-
-void checkInit()
-{
-	if(initialised) {
-		return;
-	}
 	rtc_init();
-	initialised = true;
+	datetime_t t{.year = 1970, .month = 1, .day = 1};
+	rtc_set_datetime(&t);
 }
-
-} // namespace
 
 RtcClass::RtcClass()
 {
-	rtc_init();
 }
 
 uint64_t RtcClass::getRtcNanoseconds()
@@ -43,8 +34,6 @@ uint64_t RtcClass::getRtcNanoseconds()
 
 uint32_t RtcClass::getRtcSeconds()
 {
-	checkInit();
-
 	datetime_t t;
 	if(!rtc_get_datetime(&t)) {
 		return 0;
@@ -63,8 +52,6 @@ bool RtcClass::setRtcNanoseconds(uint64_t nanoseconds)
 
 bool RtcClass::setRtcSeconds(uint32_t seconds)
 {
-	checkInit();
-
 	DateTime dt{seconds};
 
 	datetime_t t = {


### PR DESCRIPTION
Like other SoCs, can be used to indicate cumulative system time even when not set