### PR TITLE
Delete HashMap copy assignment operator

### DIFF
--- a/Sming/Wiring/WHashMap.h
+++ b/Sming/Wiring/WHashMap.h
@@ -425,6 +425,7 @@ protected:
 
 private:
 	HashMap(const HashMap<K, V>& that);
+	HashMap& operator=(const HashMap& that);
 };
 
 template <typename K, typename V> V& HashMap<K, V>::operator[](const K& key)


### PR DESCRIPTION
Copy constructor is already deleted, but can stilll do `map1 = map2` which is bad. Should use `setMultiple`.