### PR TITLE
Add rp2040 task queue support for Core #1

### DIFF
--- a/Sming/Arch/Rp2040/Components/rp2040/pico-sdk.patch
+++ b/Sming/Arch/Rp2040/Components/rp2040/pico-sdk.patch
@@ -4,6 +4,28 @@ diff --git a/lib/cyw43-driver b/lib/cyw43-driver
 @@ -1 +1 @@
 -Subproject commit 9bfca61173a94432839cd39210f1d1afdf602c42
 +Subproject commit 9bfca61173a94432839cd39210f1d1afdf602c42-dirty
+diff --git a/src/common/pico_util/queue.c b/src/common/pico_util/queue.c
+index a5c8e18..c3b8a91 100644
+--- a/src/common/pico_util/queue.c
++++ b/src/common/pico_util/queue.c
+@@ -41,7 +41,7 @@ static inline uint16_t inc_index(queue_t *q, uint16_t index) {
+     return index;
+ }
+ 
+-static bool queue_add_internal(queue_t *q, const void *data, bool block) {
++static bool __not_in_flash_func(queue_add_internal)(queue_t *q, const void *data, bool block) {
+     do {
+         uint32_t save = spin_lock_blocking(q->core.spin_lock);
+         if (queue_get_level_unsafe(q) != q->element_count) {
+@@ -94,7 +94,7 @@ static bool queue_peek_internal(queue_t *q, void *data, bool block) {
+     } while (true);
+ }
+ 
+-bool queue_try_add(queue_t *q, const void *data) {
++bool __not_in_flash_func(queue_try_add)(queue_t *q, const void *data) {
+     return queue_add_internal(q, data, false);
+ }
+ 
 diff --git a/src/rp2_common/hardware_base/include/hardware/address_mapped.h b/src/rp2_common/hardware_base/include/hardware/address_mapped.h
 index 8e92d8b..da5feac 100644
 --- a/src/rp2_common/hardware_base/include/hardware/address_mapped.h

--- a/Sming/Arch/Rp2040/Components/rp2040/sdk/CMakeLists.txt
+++ b/Sming/Arch/Rp2040/Components/rp2040/sdk/CMakeLists.txt
@@ -29,6 +29,7 @@ target_compile_definitions(pico PUBLIC
 	PICO_PRINTF_ALWAYS_INCLUDED=1
 	PICO_FLASH_SIZE_BYTES=16777216
 	PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
+	PICO_DIVIDER_IN_RAM=1
 )
 
 pico_set_program_name(pico "Sming")

--- a/Sming/Arch/Rp2040/Components/rp2040/src/include/esp_tasks.h
+++ b/Sming/Arch/Rp2040/Components/rp2040/src/include/esp_tasks.h
@@ -29,15 +29,3 @@ bool system_os_post(os_task_priority_t prio, os_signal_t sig, os_param_t par);
 #ifdef __cplusplus
 }
 #endif
-
-#ifdef DRIVER_CODE_INIT
-// Setup default task queues
-void system_init_tasks();
-
-// Hook function to process task queues
-void system_service_tasks();
-
-typedef void (*system_task_callback_t)(os_param_t param);
-
-bool system_queue_callback(system_task_callback_t callback, os_param_t param);
-#endif

--- a/Sming/Arch/Rp2040/Core/pins_arduino.h
+++ b/Sming/Arch/Rp2040/Core/pins_arduino.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-const uint8_t A0{0}; // TODO main ADC input
+const uint8_t A0{26};
 
 #define NOT_A_PIN 0
 #define NOT_A_PORT 0

--- a/samples/Basic_Tasks/component.mk
+++ b/samples/Basic_Tasks/component.mk
@@ -1,4 +1,3 @@
-COMPONENT_SOC := esp* host
 ARDUINO_LIBRARIES := ArduinoFFT SignalGenerator
 ENABLE_TASK_COUNT := 1
 


### PR DESCRIPTION
This PR re-implements the task queue using SDK-provided queue API. This allows code running on Core #1 to queue tasks for execution by Sming (which runs on Core #0).

Some care is required running both cores together so some notes have been added to the documentation.

Note: I had a need to run some simple background analogue processing for which core 1 was an ideal solution.
I put all the code in RAM, both for performance reasons and because XIP is suspended during flash erase/write operations (such as file writes). I avoided using floating-point code for the same reasons - FP routines are large so compile to flash.

The Cortex M0+ has hardware support for integer division but these routines compile to flash by default. They're small so have set the SDK `PICO_DIVIDER_IN_RAM` flag. It seems reasonable that integer arithmetic shouldn't require flash accesses.

Note: There is also `PICO_INT64_OPS_IN_RAM` and `PICO_MEM_IN_RAM` which probably warrant further investigation/consideration.