### PR TITLE
Check user component search dirs when applying coding style

### DIFF
--- a/Sming/Makefile
+++ b/Sming/Makefile
@@ -209,7 +209,7 @@ endef
 # Files that should follow our coding standards
 
 # Root directories to search
-CS_ROOT_DIRS	?= $(abspath $(SMING_HOME)/..)
+CS_ROOT_DIRS	?= $(abspath $(SMING_HOME)/.. $(COMPONENT_SEARCH_DIRS))
 # List of single directories to search
 CS_SEARCH_DIRS	?= $(call ListAllSubDirs,$(CS_ROOT_DIRS))
 # Resultant set of directories whose contents to apply coding style to


### PR DESCRIPTION
If `COMPONENT_SEARCH_DIRS` is set then those Components should also be checked for `.cs` and coding style applied if found.