### PR TITLE
Fix Rp2040 IRAM issues

### DIFF
--- a/Sming/Arch/Rp2040/Components/driver/os_timer.cpp
+++ b/Sming/Arch/Rp2040/Components/driver/os_timer.cpp
@@ -24,12 +24,12 @@ os_timer_t* timer_list;
 class CriticalLock
 {
 public:
-	CriticalLock()
+	__forceinline CriticalLock()
 	{
 		level = save_and_disable_interrupts();
 	}
 
-	~CriticalLock()
+	__forceinline ~CriticalLock()
 	{
 		restore_interrupts(level);
 	}
@@ -38,7 +38,7 @@ private:
 	uint32_t level;
 };
 
-static void IRAM_ATTR timer_insert(uint32_t expire, os_timer_t* ptimer)
+void IRAM_ATTR timer_insert(uint32_t expire, os_timer_t* ptimer)
 {
 	debug_tmr("insert %p %u", ptimer, expire);
 

--- a/Sming/Arch/Rp2040/Components/rp2040/sdk/CMakeLists.txt
+++ b/Sming/Arch/Rp2040/Components/rp2040/sdk/CMakeLists.txt
@@ -30,6 +30,7 @@ target_compile_definitions(pico PUBLIC
 	PICO_FLASH_SIZE_BYTES=16777216
 	PICO_XOSC_STARTUP_DELAY_MULTIPLIER=64
 	PICO_DIVIDER_IN_RAM=1
+	PICO_MEM_IN_RAM=1
 )
 
 pico_set_program_name(pico "Sming")


### PR DESCRIPTION
Tracked down a few more issues where flash code may be called from interrupt routines.

I found a way to check this is to inspect the RAM code (at address 0x20000000 onwards) in the dissassembly output (out/Rp2040/debug/build/apps.dis) looking for any 'veneer' routines which are typically required for calls to flash (starting at 0x10000000).