### PR TITLE
Use of `std::iterator` is deprecated

### DIFF
--- a/Sming/Components/Storage/src/include/Storage/Iterator.h
+++ b/Sming/Components/Storage/src/include/Storage/Iterator.h
@@ -15,9 +15,15 @@ namespace Storage
 {
 class Device;
 
-class Iterator : public std::iterator<std::forward_iterator_tag, Partition>
+class Iterator
 {
 public:
+	using iterator_category = std::forward_iterator_tag;
+	using value_type = Partition;
+	using difference_type = std::ptrdiff_t;
+	using pointer = Partition*;
+	using reference = Partition&;
+
 	Iterator(Device& device) : mSearch{&device, Partition::Type::any, Partition::SubType::any}, mDevice(&device)
 	{
 		next();

--- a/Sming/Core/Data/LinkedObject.h
+++ b/Sming/Core/Data/LinkedObject.h
@@ -61,10 +61,15 @@ private:
 template <typename ObjectType> class LinkedObjectTemplate : public LinkedObject
 {
 public:
-	template <typename T, typename TPtr, typename TRef>
-	class IteratorTemplate : public std::iterator<std::forward_iterator_tag, T>
+	template <typename T, typename TPtr, typename TRef> class IteratorTemplate
 	{
 	public:
+		using iterator_category = std::forward_iterator_tag;
+		using value_type = T;
+		using difference_type = std::ptrdiff_t;
+		using pointer = T*;
+		using reference = T&;
+
 		IteratorTemplate(TPtr x) : mObject(x)
 		{
 		}

--- a/Sming/Wiring/WHashMap.h
+++ b/Sming/Wiring/WHashMap.h
@@ -107,10 +107,15 @@ public:
 	using Element = BaseElement<false>;
 	using ElementConst = BaseElement<true>;
 
-	template <bool is_const>
-	class Iterator : public std::iterator<std::random_access_iterator_tag, BaseElement<is_const>>
+	template <bool is_const> class Iterator
 	{
 	public:
+		using iterator_category = std::random_access_iterator_tag;
+		using value_type = BaseElement<is_const>;
+		using difference_type = std::ptrdiff_t;
+		using pointer = BaseElement<is_const>*;
+		using reference = BaseElement<is_const>&;
+
 		using Map = typename std::conditional<is_const, const HashMap, HashMap>::type;
 		using Value = typename std::conditional<is_const, const V, V>::type;
 

--- a/Sming/Wiring/WVector.h
+++ b/Sming/Wiring/WVector.h
@@ -33,9 +33,15 @@ template <typename Element> class Vector : public Countable<Element>
 public:
 	using Comparer = int (*)(const Element& lhs, const Element& rhs);
 
-	template <bool is_const> class Iterator : public std::iterator<std::random_access_iterator_tag, Element>
+	template <bool is_const> class Iterator
 	{
 	public:
+		using iterator_category = std::random_access_iterator_tag;
+		using value_type = Element;
+		using difference_type = std::ptrdiff_t;
+		using pointer = Element*;
+		using reference = Element&;
+
 		using V = typename std::conditional<is_const, const Vector, Vector>::type;
 		using E = typename std::conditional<is_const, const Element, Element>::type;
 


### PR DESCRIPTION
This PR removes the use of `std::iterator` as it's deprecated in C++17.