### PR TITLE
Fix `hwconfig-list` output formatting

### DIFF
--- a/Sming/Components/Storage/component.mk
+++ b/Sming/Components/Storage/component.mk
@@ -112,7 +112,7 @@ endif
 
 .PHONY: hwconfig-list
 hwconfig-list: ##List available hardware configurations
-	@echo "Available configurations: $(foreach c,$(ALL_HWCONFIG),\n $(if $(subst $c,,$(HWCONFIG)), ,*) $(shell printf "%-25s" "$c") $(filter %/$c.hw,$(ALL_HWCONFIG_PATHS)))"
+	@printf "Available configurations: $(foreach c,$(ALL_HWCONFIG),\n $(if $(subst $c,,$(HWCONFIG)), ,*) $(shell printf "%-25s" "$c") $(filter %/$c.hw,$(ALL_HWCONFIG_PATHS)))"
 	@echo
 
 .PHONY: hwconfig-options


### PR DESCRIPTION
I'm getting this:

```
[mike@fedora Basic_Blink]$ make hwconfig-list

Basic_Blink: Invoking 'hwconfig-list' for Esp8266 (debug) architecture
Available configurations: \n   spiffs-2m                 /home/mike/sandboxes/sming2/Sming/spiffs-2m.hw \n   spiffs-two-roms           /home/mike/sandboxes/sming2/Sming/Arch/Esp8266/spiffs-two-roms.hw \n   spiffs                    /home/mike/sandboxes/sming2/Sming/spiffs.hw \n   standard-4m               /home/mike/sandboxes/sming2/Sming/standard-4m.hw \n * standard                  /home/mike/sandboxes/sming2/Sming/Arch/Esp8266/standard.hw \n   two-rom-mode              /home/mike/sandboxes/sming2/Sming/Arch/Esp8266/two-rom-mode.hw
```

Should be like this:

```
[mike@fedora Basic_Blink]$ make hwconfig-list

Basic_Blink: Invoking 'hwconfig-list' for Esp8266 (debug) architecture
Available configurations: 
   spiffs-2m                 /home/mike/sandboxes/sming2/Sming/spiffs-2m.hw 
   spiffs-two-roms           /home/mike/sandboxes/sming2/Sming/Arch/Esp8266/spiffs-two-roms.hw 
   spiffs                    /home/mike/sandboxes/sming2/Sming/spiffs.hw 
   standard-4m               /home/mike/sandboxes/sming2/Sming/standard-4m.hw 
 * standard                  /home/mike/sandboxes/sming2/Sming/Arch/Esp8266/standard.hw 
   two-rom-mode              /home/mike/sandboxes/sming2/Sming/Arch/Esp8266/two-rom-mode.hw
```
