### PR TITLE
Add ARM toolchain support

### DIFF
--- a/Sming/Arch/Esp8266/Tools/install.sh
+++ b/Sming/Arch/Esp8266/Tools/install.sh
@@ -2,11 +2,13 @@
 #
 # Esp8266 install.sh
 
+EQT_REPO=https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-newlib4.0.0-gnu20
+
 if [ -d "$ESP_HOME" ]; then
     printf "\n\n** Skipping Esp8266 tools installation: '$ESP_HOME' exists\n\n"
 else
-    TOOLCHAIN=x86_64-linux-gnu.xtensa-lx106-elf-e6a192b.201211.tar.gz
-    $WGET "$SMINGTOOLS/$TOOLCHAIN" -O "$DOWNLOADS/$TOOLCHAIN"
+    TOOLCHAIN="$(uname -m)-linux-gnu.xtensa-lx106-elf-e6a192b.201211.tar.gz"
+    $WGET "$EQT_REPO/$TOOLCHAIN" -O "$DOWNLOADS/$TOOLCHAIN"
     mkdir -p "$ESP_HOME"
     tar -zxf "$DOWNLOADS/$TOOLCHAIN" -C "$ESP_HOME" --totals
 fi

--- a/Sming/Arch/Rp2040/Tools/install.sh
+++ b/Sming/Arch/Rp2040/Tools/install.sh
@@ -7,10 +7,10 @@ $PKG_INSTALL ninja-build
 if [ -d "$PICO_TOOLCHAIN_PATH/arm-none-eabi" ]; then
     printf "\n\n** Skipping Rp2040 tools installation: '$PICO_TOOLCHAIN_PATH' exists\n\n"
 else
-    TOOLCHAIN_VERSION="10.3-2021.07"
+    TOOLCHAIN_VERSION="10.3-2021.10"
     TOOLCHAIN_BASE_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm"
     TOOLCHAIN_NAME="gcc-arm-none-eabi-$TOOLCHAIN_VERSION"
-    TOOLCHAIN_FILE="$TOOLCHAIN_NAME-x86_64-linux.tar.bz2"
+    TOOLCHAIN_FILE="$TOOLCHAIN_NAME-$(uname -m)-linux.tar.bz2"
     TOOLCHAIN_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_VERSION/$TOOLCHAIN_FILE"
     $WGET "$TOOLCHAIN_URL" -O "$DOWNLOADS/$TOOLCHAIN_FILE"
     mkdir -p "$PICO_TOOLCHAIN_PATH"

--- a/Tools/install.sh
+++ b/Tools/install.sh
@@ -110,8 +110,16 @@ if [ -n "$APPVEYOR" ] || [ -n "$GITHUB_ACTION" ]; then
 
 else
 
+    MACHINE_PACKAGES=""
     case $DIST in
         debian)
+            case $(uname -m) in
+                arm | aarch64)
+                    ;;
+                *)
+                    MACHINE_PACKAGES="g++-multilib"
+                    ;;
+            esac
             sudo apt-get -y update || echo "Update failed... Try to install anyway..."
             $PKG_INSTALL \
                 cmake \
@@ -121,17 +129,22 @@ else
                 ninja-build \
                 unzip \
                 g++ \
-            	g++-multilib \
             	python3 \
             	python3-pip \
             	python3-setuptools \
                 wget \
+                $MACHINE_PACKAGES \
                 $EXTRA_PACKAGES
 
             $PKG_INSTALL clang-format-8 || printf "\nWARNING: Failed to install optional clang-format-8.\n\n"
             ;;
 
         fedora)
+            case $(uname -m) in
+                x86_64)
+                    MACHINE_PACKAGES="glibc-devel.i686 libstdc++.i686"
+                    ;;
+            esac
             $PKG_INSTALL \
                 cmake \
                 gawk \
@@ -139,15 +152,14 @@ else
                 gcc-c++ \
                 gettext \
                 git \
-                glibc-devel.i686 \
-                libstdc++.i686 \
                 make \
                 ninja-build \
                 python3 \
                 python3-pip \
                 sed \
                 unzip \
-                wget
+                wget \
+                $MACHINE_PACKAGES
             ;;
 
     esac


### PR DESCRIPTION
This PR addresses #2646 to support ARM  systems such as Raspberry PI, Orange PI.

The Rp2040 toolchain version has been updated, and installs for appropriate machine architecture.