### PR TITLE
Fix heading level for 'IDF Versions' in ESP32 README.rst

### DIFF
--- a/Sming/Arch/Esp32/README.rst
+++ b/Sming/Arch/Esp32/README.rst
@@ -102,7 +102,7 @@ See :component-esp32:`esp32` for further details.
 
 
 IDF versions
-============
+------------
 
 Sming currently supports IDF versions 4.3, 4.4 and 5.0.
 


### PR DESCRIPTION
Indentation in online docs is confusing, ESP-IDF is only used for ESP32.