### PR TITLE
Patch for TCP segment size calculation issue.

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp-open-lwip/esp-open-lwip.patch
+++ b/Sming/Arch/Esp8266/Components/esp-open-lwip/esp-open-lwip.patch
@@ -605,3 +605,16 @@ index bbb126a..4cd8840 100644
 +void espconn_init(void)
  {
  }
+diff --git a/lwip/core/tcp_out.c b/lwip/core/tcp_out.c
+index e2f8e9a..8f4d170 100644
+--- a/lwip/core/tcp_out.c
++++ b/lwip/core/tcp_out.c
+@@ -448,7 +448,7 @@ tcp_write(struct tcp_pcb *pcb, const void *arg, u16_t len, u8_t apiflags)
+     if (oversize > 0) {
+       LWIP_ASSERT("inconsistent oversize vs. space", oversize_used <= space);
+       seg = last_unsent;
+-      oversize_used = oversize < len ? oversize : len;
++      oversize_used = LWIP_MIN(space, LWIP_MIN(oversize, len)); 
+       pos += oversize_used;
+       oversize -= oversize_used;
+       space -= oversize_used;


### PR DESCRIPTION
Original fix is here: lwip-tcpip/lwip@8e8571d

Issue spotted and documented here: SmingHub/Sming#2654

PR submitted to upstream: https://github.com/pfalcon/esp-open-lwip/pull/10

Fixes #2654