### PR TITLE
Fix Rp2040 bug setting UART fifo receive level

### DIFF
--- a/Sming/Arch/Rp2040/Components/driver/uart.cpp
+++ b/Sming/Arch/Rp2040/Components/driver/uart.cpp
@@ -295,7 +295,7 @@ void smg_uart_start_isr(smg_uart_t* uart)
 
 	if(smg_uart_rx_enabled(uart)) {
 		// Trigger at >= 7/8 full
-		fifo_level_select |= 5 << UART_UARTIFLS_RXIFLSEL_LSB;
+		fifo_level_select |= 4 << UART_UARTIFLS_RXIFLSEL_LSB;
 
 		/*
 		 * There is little benefit in generating interrupts on errors, instead these


### PR DESCRIPTION
5 (0x101) is a reserved value in the datasheet; should be 4 (0x100). Fixes problem with dropped data.