### PR TITLE
Fix failing Windows host build, ninja not found

### DIFF
--- a/Tools/ci/install.cmd
+++ b/Tools/ci/install.cmd
@@ -8,4 +8,6 @@ if "%BUILD_DOCS%" == "true" (
     set INSTALL_OPTS=doc
 )
 
+choco install ninja
+
 %SMING_HOME%\..\Tools\install.cmd %SMING_ARCH% %INSTALL_OPTS%


### PR DESCRIPTION
Fails from Windows 2022 server image 20230918.1.