### PR TITLE
Provide workaround for 'dangling pointer' error/warning

### DIFF
--- a/Sming/Wiring/FakePgmSpace.cpp
+++ b/Sming/Wiring/FakePgmSpace.cpp
@@ -38,3 +38,10 @@ int memcmp_aligned(const void* ptr1, const void* ptr2, unsigned len)
 	auto tail2 = pgm_read_dword(reinterpret_cast<const uint8_t*>(ptr2) + len_aligned);
 	return memcmp(&tail1, &tail2, len - len_aligned);
 }
+
+#ifdef ARCH_HOST
+char* smg_return_local(char* buf)
+{
+	return buf;
+}
+#endif

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -75,6 +75,13 @@ extern "C" {
 		&__pstr__[0];                                                                                                  \
 	}))
 
+#ifdef ARCH_HOST
+// Internal function to prevent 'dangling pointer' compiler warning
+extern char* smg_return_local(char* buf);
+#else
+#define smg_return_local(buf) (buf)
+#endif
+
 /**
  * @brief Declare and use a flash string inline.
  * @param str
@@ -84,7 +91,7 @@ extern "C" {
 	(__extension__({                                                                                                   \
 		DEFINE_PSTR_LOCAL(__pstr__, str);                                                                              \
 		LOAD_PSTR(buf, __pstr__);                                                                                      \
-		buf;                                                                                                           \
+		smg_return_local(buf);                                                                                         \
 	}))
 
 /**


### PR DESCRIPTION
Sorts warnings for host builds as discussed in #2659.