### PR TITLE
Bugfix: Rp2040 and Host `os_timer_setfn()` can stall other timers

### DIFF
--- a/Sming/Arch/Host/Components/driver/os_timer.cpp
+++ b/Sming/Arch/Host/Components/driver/os_timer.cpp
@@ -93,11 +93,12 @@ void os_timer_disarm(struct os_timer_t* ptimer)
 
 void os_timer_setfn(struct os_timer_t* ptimer, os_timer_func_t* pfunction, void* parg)
 {
-	if(ptimer != nullptr) {
-		ptimer->timer_func = pfunction;
-		ptimer->timer_arg = parg;
-		ptimer->timer_next = reinterpret_cast<os_timer_t*>(-1);
+	if(ptimer == nullptr) {
+		return;
 	}
+	os_timer_disarm(ptimer);
+	ptimer->timer_func = pfunction;
+	ptimer->timer_arg = parg;
 }
 
 void os_timer_done(struct os_timer_t* ptimer)

--- a/Sming/Arch/Rp2040/Components/driver/os_timer.cpp
+++ b/Sming/Arch/Rp2040/Components/driver/os_timer.cpp
@@ -173,11 +173,12 @@ void IRAM_ATTR os_timer_disarm(struct os_timer_t* ptimer)
 
 void os_timer_setfn(struct os_timer_t* ptimer, os_timer_func_t* pfunction, void* parg)
 {
-	if(ptimer != nullptr) {
-		ptimer->timer_func = pfunction;
-		ptimer->timer_arg = parg;
-		ptimer->timer_next = reinterpret_cast<os_timer_t*>(-1);
+	if(ptimer == nullptr) {
+		return;
 	}
+	os_timer_disarm(ptimer);
+	ptimer->timer_func = pfunction;
+	ptimer->timer_arg = parg;
 }
 
 void os_timer_done(struct os_timer_t* ptimer)


### PR DESCRIPTION
If called on first timer in queue then subsequent timers get disconnected. Must explicitly `disarm` the timer first so it's properly removed from queue. This is consistent with esp8266 behaviour.

Also applied to host timer from whence the code originated.
This bug might explain root cause of #2594, where code hangs during intensive timer usage. Specifically, this issue gets triggered if attempting to change the callback on an active timer. (If the timer is inactive then it's not in the queue so doesn't matter.)