### PR TITLE
Fix IFS compile warnings/errors

### DIFF
--- a/Sming/Libraries/Spiffs/src/include/IFS/SPIFFS/FileSystem.h
+++ b/Sming/Libraries/Spiffs/src/include/IFS/SPIFFS/FileSystem.h
@@ -137,7 +137,7 @@ private:
 	Storage::Partition partition;
 	IProfiler* profiler{nullptr};
 	SpiffsMetaBuffer metaCache[SPIFF_FILEDESC_COUNT];
-	spiffs fs;
+	spiffs fs{};
 	uint8_t workBuffer[LOG_PAGE_SIZE * 2];
 	spiffs_fd fileDescriptors[SPIFF_FILEDESC_COUNT];
 	uint8_t cache[CACHE_SIZE];


### PR DESCRIPTION
This PR improves the IFS `ObjectBuffer` implementation to fix 'hidden virtual method' warnings produced by more recent compilers. The class is just a helper/wrapper with a set of custom 'write' methods, so shouldn't have used inheritance in the first place.

Also fixes an  'uninitialised variable' warning in the `Spiffs` IFS library, identified by running IFS integration tests through valgrind.
