### PR TITLE
Simpler fix for Dangling Pointer issue

### DIFF
--- a/Sming/Wiring/FakePgmSpace.cpp
+++ b/Sming/Wiring/FakePgmSpace.cpp
@@ -38,10 +38,3 @@ int memcmp_aligned(const void* ptr1, const void* ptr2, unsigned len)
 	auto tail2 = pgm_read_dword(reinterpret_cast<const uint8_t*>(ptr2) + len_aligned);
 	return memcmp(&tail1, &tail2, len - len_aligned);
 }
-
-#ifdef ARCH_HOST
-char* smg_return_local(char* buf)
-{
-	return buf;
-}
-#endif

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -76,12 +76,8 @@ extern "C" {
 	}))
 
 #ifdef ARCH_HOST
-// Internal function to prevent 'dangling pointer' compiler warning
-extern char* smg_return_local(char* buf);
+#define _F(str) (str)
 #else
-#define smg_return_local(buf) (buf)
-#endif
-
 /**
  * @brief Declare and use a flash string inline.
  * @param str
@@ -91,8 +87,10 @@ extern char* smg_return_local(char* buf);
 	(__extension__({                                                                                                   \
 		DEFINE_PSTR_LOCAL(__pstr__, str);                                                                              \
 		LOAD_PSTR(buf, __pstr__);                                                                                      \
-		smg_return_local(buf);                                                                                         \
+		buf;                                                                                                           \
 	}))
+
+#endif
 
 /**
  * @brief copy memory aligned to word boundaries


### PR DESCRIPTION
Whilst using a function to 'hide' the stack return appears to work, integration tests fail in a couple of scenarios (FlashString, RapidXML) because of the way stack space gets used. For Host builds, the most pragmatic solution is to make `_F(s)` return `s` directly. That means it gives a `const char*` rather than `char*`, and any attempt to pass this to a function requiring a regular `char*` will fail.