### PR TITLE
Add MemoryDataStream::reset() method

### DIFF
--- a/Sming/Core/Data/Stream/MemoryDataStream.h
+++ b/Sming/Core/Data/Stream/MemoryDataStream.h
@@ -104,6 +104,17 @@ public:
 		readPos = 0;
 	}
 
+	/**
+	 * @brief Clear stream and release allocated memory
+	 */
+	void reset()
+	{
+		clear();
+		free(buffer);
+		buffer = nullptr;
+		capacity = 0;
+	}
+
 	size_t getSize() const
 	{
 		return size;


### PR DESCRIPTION
The class already has a `clear()` method but this leaves existing memory allocated. The purpose is to allow re-use of an existing class instance efficiently by reducing memory reallocations.

The new `reset()` method allows the instance to be cleared and also release allocated memory. The new name is consistent with `std::unique_ptr::reset()` usage.

A similar thing can be accomplished by using `std::unique_ptr<MemoryDataStream>` however an in-built reset() method makes for cleaner code.