### PR TITLE
Set ESP32 CONFIG_FREERTOS_UNICORE=y by default

### DIFF
--- a/Sming/Arch/Esp32/Components/esp32/sdk/config/common
+++ b/Sming/Arch/Esp32/Components/esp32/sdk/config/common
@@ -53,5 +53,8 @@ CONFIG_MBEDTLS_CERTIFICATE_BUNDLE=n
 # Don't change provided flash configuration information
 CONFIG_ESPTOOLPY_FLASHSIZE_DETECT=n
 
-#' We'll handle WDT initialisation ourselves thankyouverymuch
+# We'll handle WDT initialisation ourselves thankyouverymuch
 CONFIG_ESP_TASK_WDT_INIT=n
+
+# Issues with dual-core CPU, see #2653
+CONFIG_FREERTOS_UNICORE=y


### PR DESCRIPTION
As discussed in #2653 there is an issue on dual-core CPUs which causes hang and WDT on IDF 5.0 (and 5.2).
Setting `CONFIG_FREERTOS_UNICORE=y` fixes the problem. This setting is described as follows:

> This version of FreeRTOS normally takes control of all cores of the CPU. Select this if you only want to start it on the first core. This is needed when e.g. another process needs complete control over the second core.

I'd suggest this is a better default behaviour anyway.