### PR TITLE
Fix esp32 timer issues

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
@@ -62,7 +62,8 @@ public:
 #else
 		int source = timer_group_periph_signals.groups[group].timer_irq_id[index];
 #endif
-		esp_intr_alloc_intrstatus(source, ESP_INTR_FLAG_IRAM, status_reg, mask, timerIsr, this, &isr_handle);
+		esp_intr_alloc_intrstatus(source, ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_INTRDISABLED, status_reg, mask, timerIsr,
+								  this, &isr_handle);
 		clear_intr_status();
 		enable_intr(true);
 	}

--- a/Sming/Arch/Esp32/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/hw_timer.h
@@ -147,6 +147,7 @@ uint32_t hw_timer1_read(void);
 __forceinline static uint32_t hw_timer2_read(void)
 {
 #if CONFIG_ESP_TIMER_IMPL_TG0_LAC
+	REG_WRITE(TIMG_LACTUPDATE_REG(0), 1);
 	return REG_READ(TIMG_LACTLO_REG(0));
 #elif ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(4, 4, 0)
 	systimer_ll_counter_snapshot(&SYSTIMER, 0);

--- a/Sming/Core/CallbackTimer.h
+++ b/Sming/Core/CallbackTimer.h
@@ -33,6 +33,12 @@ template <typename ApiDef> struct CallbackTimerApi {
 		return ApiDef::typeName();
 	}
 
+	CallbackTimerApi()
+	{
+	}
+
+	CallbackTimerApi(const CallbackTimerApi&) = delete;
+
 	String name() const
 	{
 		String s;
@@ -50,7 +56,6 @@ template <typename ApiDef> struct CallbackTimerApi {
 		s += static_cast<const ApiDef*>(this)->getInterval();
 		s += ", ticks = ";
 		s += static_cast<const ApiDef*>(this)->ticks();
-		//		s += ApiDef::Clock::ticks();
 		return s;
 	}
 

--- a/tests/HostTests/host-tests-esp32.hw
+++ b/tests/HostTests/host-tests-esp32.hw
@@ -3,7 +3,7 @@
     "base_config": "host-tests",
     "partitions": {
         "factory": {
-            "size": "1M"
+            "size": "1600K"
         }
     }
 }

--- a/tests/HostTests/modules/Timers.cpp
+++ b/tests/HostTests/modules/Timers.cpp
@@ -81,7 +81,7 @@ public:
 			String s;
 			s += system_get_time();
 			s += " ";
-			s += statusTimer;
+			s += String(statusTimer);
 			s += " fired, timercount = ";
 			s += activeTimerCount;
 			s += ", mem = ";


### PR DESCRIPTION
HostTests fails on esp32 due to following issues:

**Flawed `hw_timer2_read()` implementation**

Without setting update bit counter value won't change. Probably worked previously because some other code did this.

**WDT with callback timers**

Checked against IDF implementations and there's a missing flag which keeps interrupts initially disabled during setup.

**Callbacks missing during timer testing**

Offending code looks like this:

```
Timer timer;
String s;
s += timer; //<< Not what I expected
```

The above line actually calls the `Timer` copy constructor. Delete this and the compiler catches the error. The corrected line now reads `s += String(timer)`.

**HostTests needs more program space for ESP32**

Builds are getting chunky!
