### PR TITLE
Only esp8266 requires special handling for _F()

### DIFF
--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -75,9 +75,7 @@ extern "C" {
 		&__pstr__[0];                                                                                                  \
 	}))
 
-#ifdef ARCH_HOST
-#define _F(str) (str)
-#else
+#ifdef ARCH_ESP8266
 /**
  * @brief Declare and use a flash string inline.
  * @param str
@@ -89,7 +87,8 @@ extern "C" {
 		LOAD_PSTR(buf, __pstr__);                                                                                      \
 		buf;                                                                                                           \
 	}))
-
+#else
+#define _F(str) (str)
 #endif
 
 /**


### PR DESCRIPTION
The dangling pointer warnings for the `_F()` macro (discussed in #2659 and #2675) are affecting other builds. The purpose of the macro is to enforce word-aligned flash accesses on the esp8266: unaligned accesses result in a CPU exception. Other architectures do not have these alignment requirements.

The `HostTests` application has been built and run on all other SOCs currently supported: rp2040, esp32, esp32c3, esp32s2. I do not have any esp32s3 devices to test against but these use the same xtensa LX7 core as the esp32s2.

The net effect of this change is that the `_F()` macro is transparent, so `Serial.print("test string");` and `Serial.print(_F("test string");`, for example, produce identical code for these SOCs. Continued use of the _F() macro is obviously necessary to ensure continued compatibility with esp8266.