### PR TITLE
Fix esp32c3 FPU issues

### DIFF
--- a/Sming/Arch/Esp32/Components/esp32/sdk/pthread.mk
+++ b/Sming/Arch/Esp32/Components/esp32/sdk/pthread.mk
@@ -4,7 +4,10 @@
 SDK_UNDEF_SYMBOLS += \
 	pthread_include_pthread_impl \
 	pthread_include_pthread_cond_impl \
-	pthread_include_pthread_local_storage_impl
+	pthread_include_pthread_cond_var_impl \
+	pthread_include_pthread_local_storage_impl \
+	pthread_include_pthread_rwlock_impl \
+	pthread_include_pthread_semaphore_impl
 
 ifdef CONFIG_FREERTOS_ENABLE_STATIC_TASK_CLEAN_UP
 SDK_WRAP_SYMBOLS += vPortCleanUpTCB

--- a/Sming/Arch/Esp32/Components/esp32/sdk/soc.mk
+++ b/Sming/Arch/Esp32/Components/esp32/sdk/soc.mk
@@ -1,0 +1,10 @@
+#
+# soc
+#
+
+ifeq (esp32,$(SMING_SOC))
+    # esp_dport_access_reg_read is added as an undefined symbol because otherwise
+    # the linker can ignore dport_access.c as it would no other files depending on any symbols in it.
+	SDK_UNDEF_SYMBOLS += \
+		esp_dport_access_reg_read
+endif

--- a/Sming/Arch/Esp32/Components/esp32/sdk/soc.mk
+++ b/Sming/Arch/Esp32/Components/esp32/sdk/soc.mk
@@ -3,8 +3,6 @@
 #
 
 ifeq (esp32,$(SMING_SOC))
-    # esp_dport_access_reg_read is added as an undefined symbol because otherwise
-    # the linker can ignore dport_access.c as it would no other files depending on any symbols in it.
 	SDK_UNDEF_SYMBOLS += \
 		esp_dport_access_reg_read
 endif

--- a/Sming/Arch/Esp32/app.mk
+++ b/Sming/Arch/Esp32/app.mk
@@ -9,6 +9,12 @@ LDFLAGS	+= \
 	-nostdlib \
 	-Wl,-static
 
+ifdef IDF_TARGET_ARCH_RISCV
+	LDFLAGS += \
+		-nostartfiles \
+		-march=$(ESP32_RISCV_ARCH) \
+		--specs=nosys.specs
+endif
 
 .PHONY: application
 application: $(TARGET_BIN)

--- a/Sming/Arch/Esp32/build.mk
+++ b/Sming/Arch/Esp32/build.mk
@@ -41,6 +41,12 @@ ESP32_COMPILER_PREFIX := xtensa-$(ESP_VARIANT)-elf
 else
 ESP32_COMPILER_PREFIX := riscv32-esp-elf
 IDF_TARGET_ARCH_RISCV := 1
+# This is important as no hardware FPU is available on these SOCs
+ifeq ($(IDF_VERSION),v5.2)
+ESP32_RISCV_ARCH := rv32imc_zicsr_zifencei
+else
+ESP32_RISCV_ARCH := rv32imc
+endif
 endif
 
 # $1 => Tool sub-path/name
@@ -153,7 +159,10 @@ export PROJECT_VER
 # Flags which control code generation and dependency generation, both for C and C++
 CPPFLAGS += -Wno-frame-address
 
-ifndef IDF_TARGET_ARCH_RISCV
+ifdef IDF_TARGET_ARCH_RISCV
+CPPFLAGS += \
+	-march=$(ESP32_RISCV_ARCH)
+else
 CPPFLAGS += \
 	-mlongcalls \
 	-mtext-section-literals


### PR DESCRIPTION
The HostTests application crashes on the esp32c3 because it doesn't have hardware floating-point support. By default code is compiled with FPU instructions which produce 'illegal instruction' exceptions.

The `-march=rv32imc` setting is required for these processors so emulation code is used instead. The IDF 5.2 compilers have additional `zicsr` and `zifencei` extensions. Haven't looked into these, these settings are just copied from the IDF makefiles.

Similiarly, a scan of the IDF makefiles shows a few missing definitions. Don't know whether these are 100% necessary or not but don't seem to do any harm.