### PR TITLE
Fix hw_timer1_read() for esp32

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
@@ -143,6 +143,7 @@ public:
 		timer_ll_get_counter_value(dev, index, &val);
 		return val;
 #else
+		timer_ll_trigger_soft_capture(dev, index);
 		return timer_ll_get_counter_value(dev, index);
 #endif
 	}
@@ -214,7 +215,7 @@ void IRAM_ATTR hw_timer1_disable(void)
 	timer.enable_counter(false);
 }
 
-uint32_t hw_timer1_read(void)
+uint32_t IRAM_ATTR hw_timer1_read(void)
 {
 	return timer.get_counter_value();
 }


### PR DESCRIPTION
In IDF >= 5.0 reading the timer1 counter value always returns 0. This is because the low-level HAL call `timer_ll_get_counter_value` was changed and requires a separate call to `timer_ll_trigger_soft_capture`.

Timer1 is used for callbacks (`HardwareTimer` class) and this bug doesn't affect that behaviour since it relies only on the alarm functionality.
 
