### PR TITLE
Fix esp8266 'no network' build of HostTests

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp_no_wifi/component.mk
+++ b/Sming/Arch/Esp8266/Components/esp_no_wifi/component.mk
@@ -23,6 +23,7 @@ EXTRA_OBJ := extra.o
 $(COMPONENT_RULE)$(EXTRA_OBJ): sdk/user_interface.o
 	$(Q) $(OBJCOPY) \
 		-j *UND* \
+		-j .sdk.version.* \
 		$(addprefix -j .text.,$(NOWIFI_SYMS)) \
 		$(foreach f,$(NOWIFI_SYMS),--rename-section .text.$f=.iram.text) \
 		$< $@
@@ -40,7 +41,10 @@ endef
 LIBMAIN_COMMANDS += $(NOWIFI_LIBMAIN_COMMANDS)
 
 LIBDIRS += $(COMPONENT_PATH)
-EXTRA_LDFLAGS := -Tno.wifi.ld -u call_user_start_local
+EXTRA_LDFLAGS := \
+	-Tno.wifi.ld \
+	-u call_user_start_local \
+	-u SDK_VERSION
 
 ##
 

--- a/Sming/Arch/Esp8266/Components/esp_no_wifi/user_interface.c
+++ b/Sming/Arch/Esp8266/Components/esp_no_wifi/user_interface.c
@@ -1,6 +1,7 @@
 #include <esp_systemapi.h>
 #include <spi_flash.h>
 #include <eagle_soc.h>
+#include <esp8266_peri.h>
 
 bool protect_flag;
 bool timer2_ms_flag;
@@ -336,4 +337,16 @@ int os_printf_plus(const char* format, ...)
 	va_end(args);
 
 	return n;
+}
+
+const char* system_get_sdk_version()
+{
+	extern char SDK_VERSION[];
+	return SDK_VERSION;
+}
+
+uint32_t system_get_chip_id()
+{
+	// from chip_id() method in esptool.py
+	return (MAC0 >> 24) | ((MAC1 & 0x00ffffff) << 8);
 }


### PR DESCRIPTION
Implementations of `system_get_sdk_version()` and `system_get_chip_id()` required.