### PR TITLE
Fix build error for IDF 5.0

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
@@ -143,7 +143,9 @@ public:
 		timer_ll_get_counter_value(dev, index, &val);
 		return val;
 #else
+#if ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
 		timer_ll_trigger_soft_capture(dev, index);
+#endif
 		return timer_ll_get_counter_value(dev, index);
 #endif
 	}


### PR DESCRIPTION
Re. #2701 call to `timer_ll_trigger_soft_capture` only required for IDF 5.2, as while `timer_ll_get_counter_value` function signature changed in IDF 5.0 it retains previous behaviour.