### PR TITLE
Update requirements.txt

### DIFF
--- a/Sming/Libraries/nanopb/requirements.txt
+++ b/Sming/Libraries/nanopb/requirements.txt
@@ -1,1 +1,2 @@
+grpcio-tools
 protobuf


### PR DESCRIPTION
In our CI system sometimes the installed protoc version on the system is incompatible with the installed python-protobuf version. This fix, recommended here: https://groups.google.com/g/nanopb/c/YJn3DlY20_g, should take care of this.