### PR TITLE
Provide better implementation for `FileStream::id()`

### DIFF
--- a/tests/HostTests/modules/Files.cpp
+++ b/tests/HostTests/modules/Files.cpp
@@ -88,6 +88,7 @@ public:
 		{
 			fileSetContent(testFileName, testContent);
 			FileStream fs(testFileName);
+			Serial << testFileName << " ID: " << fs.id() << endl;
 			res = fs.truncate(100);
 			pos = fs.getPos();
 			size = fs.getSize();


### PR DESCRIPTION
This PR provides a better ID string for file streams.

How ETAGs are generated is not specified. Previous implementation was like this:

```
m_snprintf(buf, ETAG_SIZE, _F("00f-%x-%x0-%x"), stat.id, stat.size, stat.name.length);
```

Issues are:
- on some architectures compiler warns about differing types %x vs arguments
- name can change without length being affected; if name changes then file lookup would fail anyway
- modification timestamp is a good metric, should be incorporated
