### PR TITLE
Fix compiler warnings

### DIFF
--- a/Sming/Components/Network/src/Network/MqttClient.h
+++ b/Sming/Components/Network/src/Network/MqttClient.h
@@ -217,6 +217,8 @@ protected:
 	void onFinished(TcpClientState finishState) override;
 
 private:
+	using TcpClient::connect; // Keep compiler happy but prevent access to base method by clients
+
 	// TCP methods
 	virtual bool onTcpReceive(TcpClient& client, char* data, int size);
 

--- a/Sming/Core/NanoTime.h
+++ b/Sming/Core/NanoTime.h
@@ -107,14 +107,8 @@ constexpr BasicRatio32 unitTicks[UnitMax + 1] = {
  * @brief Class template to define tick std::ratio type
  * @tparam unit
  * @retval std::ratio Ticks per second
- * @note This would be preferable:
- * `template <Unit unit> using UnitTickRatio = std::ratio<unitTicks[unit].num, unitTicks[unit].den>;`
- * But GCC 4.8 doesn't like it (lvalue required as unary '&' operand)
  */
-template <Unit unit> struct UnitTickRatio {
-	static constexpr uint64_t num = unitTicks[unit].num;
-	static constexpr uint64_t den = unitTicks[unit].den;
-};
+template <Unit unit> using UnitTickRatio = std::ratio<unitTicks[unit].num, unitTicks[unit].den>;
 
 // Forward declarations
 template <class Clock_, Unit unit_, uint64_t time_> struct TimeConst;

--- a/Sming/Libraries/OneWire/OneWire.cpp
+++ b/Sming/Libraries/OneWire/OneWire.cpp
@@ -151,10 +151,10 @@ void OneWire::begin(uint8_t pinOneWire)
 //
 // Returns 1 if a device asserted a presence pulse, 0 otherwise.
 //
-uint8_t OneWire::reset(void)
+uint8_t OneWire::reset()
 {
 	IO_REG_TYPE mask = bitmask;
-	volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
+	SMING_UNUSED volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
 	uint8_t r;
 	uint8_t retries = 125;
 
@@ -188,7 +188,7 @@ uint8_t OneWire::reset(void)
 void OneWire::write_bit(uint8_t v)
 {
 	IO_REG_TYPE mask=bitmask;
-	volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
+	SMING_UNUSED volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
 
 	if (v & 1) {
 		noInterrupts();
@@ -213,10 +213,10 @@ void OneWire::write_bit(uint8_t v)
 // Read a bit. Port and bit is used to cut lookup time and provide
 // more certain timing.
 //
-uint8_t OneWire::read_bit(void)
+uint8_t OneWire::read_bit()
 {
 	IO_REG_TYPE mask=bitmask;
-	volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
+	SMING_UNUSED volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
 	uint8_t r;
 
 	noInterrupts();

--- a/Sming/Libraries/OneWire/OneWire.h
+++ b/Sming/Libraries/OneWire/OneWire.h
@@ -142,13 +142,13 @@ public:
     // Perform a 1-Wire reset cycle. Returns 1 if a device responds
     // with a presence pulse.  Returns 0 if there is no device or the
     // bus is shorted or otherwise held low for more than 250uS
-    uint8_t reset(void);
+    uint8_t reset();
 
     // Issue a 1-Wire rom select command, you do the reset first.
     void select(const uint8_t rom[8]);
 
     // Issue a 1-Wire rom skip command, to address all on bus.
-    void skip(void);
+    void skip();
 
     // Write a byte. If 'power' is one then the wire is held high at
     // the end for parasitically powered devices. You are responsible
@@ -159,7 +159,7 @@ public:
     void write_bytes(const uint8_t *buf, uint16_t count, bool power = 0);
 
     // Read a byte.
-    uint8_t read(void);
+    uint8_t read();
 
     void read_bytes(uint8_t *buf, uint16_t count);
 
@@ -168,14 +168,14 @@ public:
     void write_bit(uint8_t v);
 
     // Read a bit.
-    uint8_t read_bit(void);
+    uint8_t read_bit();
 
     // Stop forcing power onto the bus. You only need to do this if
     // you used the 'power' flag to write() or used a write_bit() call
     // and aren't about to do another read or write. You would rather
     // not leave this powered if you don't have to, just in case
     // someone shorts your bus.
-    void depower(void);
+    void depower();
 
 #if ONEWIRE_SEARCH
     // Clear the search state so that if will start from the beginning again.

--- a/Sming/Wiring/FakePgmSpace.h
+++ b/Sming/Wiring/FakePgmSpace.h
@@ -60,7 +60,13 @@ extern "C" {
 		m_printf(__localF, ##__VA_ARGS__);                                                                             \
 	}))
 
-#define printf_P printf_P_stack
+#ifdef ARCH_ESP8266
+// ESP8266 requires byte-aligned flash accesses for format string...
+#define printf_P(fmt, ...) printf_P_stack(fmt, ##__VA_ARGS__)
+#else
+// ... but other architectures do not
+#define printf_P(fmt, ...) m_printf(fmt, ##__VA_ARGS__)
+#endif
 
 /**
  * @brief Define and use a counted flash string inline

--- a/samples/Basic_Utility/app/utility.cpp
+++ b/samples/Basic_Utility/app/utility.cpp
@@ -28,7 +28,7 @@ void testWebConstants()
 			contentType = "(NOT FOUND)";
 		}
 		MimeType mimeType = ContentType::fromString(contentType);
-		m_printf("  %u %s: %s (#%u)\n", i, ext, contentType.c_str(), mimeType);
+		m_printf("  %u %s: %s (#%u)\n", i, ext, contentType.c_str(), unsigned(mimeType));
 	}
 }
 
@@ -53,8 +53,8 @@ void init()
 				 "  make run HOST_PARAMETERS='command=%s'\n",
 				 String(Command::testWebConstants).c_str());
 	} else {
-		m_printf("Command-line parameters:\n", parameters.count());
-		for(int i = 0; i < parameters.count(); ++i) {
+		m_printf("Command-line parameters: %u\n", parameters.count());
+		for(unsigned i = 0; i < parameters.count(); ++i) {
 			auto param = parameters[i];
 			m_printf("  %u: text =  '%s'\n", i, param.text);
 			m_printf("     name  = '%s'\n", param.getName().c_str());

--- a/samples/HttpServer_AJAX/app/application.cpp
+++ b/samples/HttpServer_AJAX/app/application.cpp
@@ -17,7 +17,7 @@ const int countInputs = sizeof(inputs) / sizeof(inputs[0]);
 void onIndex(HttpRequest& request, HttpResponse& response)
 {
 	TemplateFileStream* tmpl = new TemplateFileStream("index.html");
-	auto& vars = tmpl->variables();
+	//auto& vars = tmpl->variables();
 	//vars["counter"] = String(counter);
 	response.sendNamedStream(tmpl); // this template object will be deleted automatically
 }

--- a/samples/HttpServer_WebSockets/app/application.cpp
+++ b/samples/HttpServer_WebSockets/app/application.cpp
@@ -21,7 +21,7 @@ CUserData userGeorge("George", "I like SMING");
 void onIndex(HttpRequest& request, HttpResponse& response)
 {
 	auto tmpl = new TemplateFileStream(F("index.html"));
-	auto& vars = tmpl->variables();
+	//auto& vars = tmpl->variables();
 	//vars["counter"] = String(counter);
 	response.sendNamedStream(tmpl); // this template object will be deleted automatically
 }

--- a/samples/UdpServer_mDNS/app/application.cpp
+++ b/samples/UdpServer_mDNS/app/application.cpp
@@ -71,7 +71,7 @@ void test()
 
 	auto submit = [&](const String& name, ResourceType type) {
 		Query query;
-		auto question = query.addQuestion(name, type);
+		query.addQuestion(name, type);
 		printMessage(Serial, query);
 		responder.onMessage(query);
 	};

--- a/tests/HostTests/modules/Clocks.cpp
+++ b/tests/HostTests/modules/Clocks.cpp
@@ -53,10 +53,12 @@ public:
 			debug_w("Ratio: x %f", float(elapsedTicks) / (time - startTime));
 			uint32_t us = Micros::ticksToTime(elapsedTicks);
 			debug_w("Apparent time: %u", us);
+#ifndef ARCH_HOST
 			// Up-timers may report 0 if inactive
 			if(endTicks != 0 || startTicks != 0) {
 				REQUIRE(abs(int(us - duration)) < 500); // Allow some latitude
 			}
+#endif
 		}
 	}
 

--- a/tests/HostTests/modules/Network/Arch/Host/TcpClient.cpp
+++ b/tests/HostTests/modules/Network/Arch/Host/TcpClient.cpp
@@ -43,7 +43,7 @@ public:
 		server->setKeepAlive(USHRT_MAX); // disable connection timeout
 
 		// Tcp Client
-		bool connected = client.connect(WifiStation.getIP(), port);
+		SMING_UNUSED bool connected = client.connect(WifiStation.getIP(), port);
 		debug_d("Connected: %d", connected);
 
 		TEST_CASE("TcpClient::send stream")


### PR DESCRIPTION
- Don't fail clock check as Host timers cannot be guaranteed jitter-free
- Fix failing checks on std::ratio_divide with GCC 13.2.1.
- Fix various compiler warnings
- Simplify `printf_P` for architectures without restricted flash access
