### PR TITLE
Fix esp32 IDF version number handling for patch releases

### DIFF
--- a/Sming/Arch/Esp32/Components/esp32/component.mk
+++ b/Sming/Arch/Esp32/Components/esp32/component.mk
@@ -169,7 +169,7 @@ endif
 endif
 
 ifeq ($(ENABLE_BLUETOOTH),1)
-ifeq (esp32s3-v5.2,$(ESP_VARIANT)-$(IDF_VERSION))
+ifeq (esp32s3-1,$(ESP_VARIANT)-$(IDF_VERSION_5x))
 ESP_BT_VARIANT := esp32c3
 else
 ESP_BT_VARIANT := $(ESP_VARIANT)

--- a/Sming/Arch/Esp32/build.mk
+++ b/Sming/Arch/Esp32/build.mk
@@ -12,9 +12,12 @@ export IDF_PATH := $(call FixPath,$(IDF_PATH))
 
 # Extract IDF version
 ifndef IDF_VER
+# e.g. v5.2-beta1-265-g405b8b5512 or v5.0.5-173-g9d6770dfbb
 IDF_VER := $(shell (cd $$IDF_PATH && git describe --always --tags --dirty) | cut -c 1-31)
 endif
-IDF_VERSION := $(firstword $(subst -, ,$(IDF_VER)))
+# Now just vmajor.minor
+IDF_VERSION := $(subst ., ,$(firstword $(subst -, ,$(IDF_VER))))
+IDF_VERSION := $(firstword $(IDF_VERSION)).$(word 2,$(IDF_VERSION))
 
 # By default, downloaded tools will be installed under $HOME/.espressif directory
 # (%USERPROFILE%/.espressif on Windows). This path can be modified by setting


### PR DESCRIPTION
Patch releases such as v5.0.5 break toolchain identification since we require just 'v5.0'.
This PR fixes that issue.

Note that all sming esp32 IDF versions have been brought up to date by merging latest release branch for each version.
Tags have have been applied as follows; the latest merged upstream commit is shown.


| Sming branch       | Tag              | Espressif Tag              | Date       |
|--------------------|------------------|----------------------------|------------|
| sming/release/v4.3 | v4.3.7-sming     | v4.3.7-1-g3a71941503       | 2/1/2024   |
| sming/release/v4.4 | v4.4.6-sming     | v4.4.6-374-gbb8dd9d35b     | 3/1/2024   |
| sming/release/v5.0 | v5.0.5-sming     | v5.0.5-166-g209a0361c0     | 5/1/2024   |
| sming/release/v5.2 | v5.2-beta1-sming | v5.2-beta1-263-ge49823f10c | 18/12/2023 |

