### PR TITLE
Fix bluetooth build with esp32s3 for latest IDF 4.4

### DIFF
--- a/Sming/Arch/Esp32/Components/esp32/component.mk
+++ b/Sming/Arch/Esp32/Components/esp32/component.mk
@@ -169,7 +169,7 @@ endif
 endif
 
 ifeq ($(ENABLE_BLUETOOTH),1)
-ifeq (esp32s3-1,$(ESP_VARIANT)-$(IDF_VERSION_5x))
+ifeq (esp32s3,$(ESP_VARIANT))
 ESP_BT_VARIANT := esp32c3
 else
 ESP_BT_VARIANT := $(ESP_VARIANT)


### PR DESCRIPTION
It appears esp32s3 just uses esp32c3 HAL for bluetooth in all IDF versions now.