### PR TITLE
Fix Esp32 hardware timer callbacks

### DIFF
--- a/Sming/Arch/Esp32/Components/esp32/src/include/esp_clk.h
+++ b/Sming/Arch/Esp32/Components/esp32/src/include/esp_clk.h
@@ -1,7 +1,11 @@
 #pragma once
 
 #include <c_types.h>
+#if ESP_IDF_VERSION_MAJOR < 5
 #include <hal/cpu_hal.h>
+#else
+#include <esp_cpu.h>
+#endif
 #include <sming_attr.h>
 #include <esp_idf_version.h>
 

--- a/tests/HostTests/modules/Timers.cpp
+++ b/tests/HostTests/modules/Timers.cpp
@@ -29,10 +29,12 @@ public:
 	{
 		System.queueCallback(
 			[](void* param) {
-				Serial.println(_F("timer1 expired"));
-				auto tmr = static_cast<HardwareTimerTest*>(param);
-				if(++tmr->count == 5) {
-					tmr->stop();
+				auto self = static_cast<CallbackTimerTest*>(param);
+				++self->timer1.count;
+				Serial << self->timer1.count << _F(" timer1 expired") << endl;
+				if(self->timer1.count == 5) {
+					self->timer1.stop();
+					self->timer1complete();
 				}
 			},
 			arg);
@@ -58,9 +60,15 @@ public:
 		SHOW_SIZE(Timer1TestApi);
 		SHOW_SIZE(HardwareTimerTest);
 
-		timer1.initializeMs<500>(timer1Callback, &timer1);
+		timer1.initializeMs<500>(timer1Callback, this);
 		timer1.start();
 
+		Serial << _F("Waiting for timer1 callback test to complete") << endl;
+		pending();
+	}
+
+	void timer1complete()
+	{
 		statusTimer.initializeMs<1000>([this]() {
 			bool done = false;
 			++statusTimerCount;


### PR DESCRIPTION
Fix esp32 hardware timer callbacks

PR #2697 was supposed to fix the WDT from hardware timer interrupts.
It did this by disabling interrupts (and therefore callbacks) completely.

The actual reason for the WDT is twofold:

1. IDF version 5 changed some low-level HAL calls to accept bit masks instead of timer index.
2. Argument to interrupt callback wasn't stored or passed correctly so user-provided callback got junk for this parameter.

This PR fixes those issues and fixes incomplete testing in HostTests.

Also checked Basic_Blink sample using HardwareTimer.
