### PR TITLE
Fix HttpUpgrader duplicate stream de-allocation

### DIFF
--- a/Sming/Components/rboot/src/Network/RbootHttpUpdater.cpp
+++ b/Sming/Components/rboot/src/Network/RbootHttpUpdater.cpp
@@ -49,17 +49,19 @@ void RbootHttpUpdater::start()
 
 int RbootHttpUpdater::itemComplete(HttpConnection& client, bool success)
 {
+	auto& it = items[currentItem];
+
 	if(!success) {
+		it.stream.release(); // Owned by HttpRequest
 		updateFailed();
 		return -1;
 	}
 
-	auto& it = items[currentItem];
 	debug_d("Finished: URL: %s, Offset: 0x%X, Length: %u", it.url.c_str(), it.stream->getStartAddress(),
 			it.stream->available());
 
 	it.size = it.stream->available();
-	it.stream = nullptr; // the actual deletion will happen outside of this class
+	it.stream.release(); // the actual deletion will happen outside of this class
 	currentItem++;
 
 	return 0;
@@ -75,11 +77,6 @@ int RbootHttpUpdater::updateComplete(HttpConnection& client, bool success)
 	debug_d("\r\nFirmware download finished!");
 	for(unsigned i = 0; i < items.count(); i++) {
 		debug_d(" - item: %u, addr: 0x%X, url: %s", i, items[i].targetOffset, items[i].url.c_str());
-	}
-
-	if(!success) {
-		updateFailed();
-		return -1;
 	}
 
 	if(updateDelegate) {

--- a/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
+++ b/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
@@ -79,11 +79,6 @@ int HttpUpgrader::updateComplete(HttpConnection& client, bool success)
 		debug_d(" - item: %u, addr: 0x%X, url: %s", i, items[i].partition.address(), items[i].url.c_str());
 	}
 
-	if(!success) {
-		updateFailed();
-		return -1;
-	}
-
 	if(updateDelegate) {
 		updateDelegate(*this, true);
 	}

--- a/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
+++ b/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
@@ -32,7 +32,7 @@ void HttpUpgrader::start()
 		}
 
 		request->setMethod(HTTP_GET);
-		request->setResponseStream(it.releaseStream());
+		request->setResponseStream(it.getStream());
 
 		if(i == items.count() - 1) {
 			request->onRequestComplete(RequestCompletedDelegate(&HttpUpgrader::updateComplete, this));

--- a/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
+++ b/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
@@ -49,17 +49,19 @@ void HttpUpgrader::start()
 
 int HttpUpgrader::itemComplete(HttpConnection& client, bool success)
 {
+	auto& it = items[currentItem];
+
 	if(!success) {
+		it.stream.release(); // Owned by HttpRequest
 		updateFailed();
 		return -1;
 	}
 
-	auto& it = items[currentItem];
 	debug_d("Finished: URL: %s, Offset: 0x%X, Length: %u", it.url.c_str(), it.partition.address(),
 			it.stream->available());
 
 	it.size = it.stream->available();
-	it.stream = nullptr; // the actual deletion will happen outside of this class
+	it.stream.release(); // the actual deletion will happen outside of this class
 	currentItem++;
 
 	return 0;

--- a/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
+++ b/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
@@ -32,7 +32,7 @@ void HttpUpgrader::start()
 		}
 
 		request->setMethod(HTTP_GET);
-		request->setResponseStream(it.getStream());
+		request->setResponseStream(it.releaseStream());
 
 		if(i == items.count() - 1) {
 			request->onRequestComplete(RequestCompletedDelegate(&HttpUpgrader::updateComplete, this));

--- a/Sming/Libraries/OtaNetwork/src/include/Ota/Network/HttpUpgrader.h
+++ b/Sming/Libraries/OtaNetwork/src/include/Ota/Network/HttpUpgrader.h
@@ -43,12 +43,12 @@ public:
 		{
 		}
 
-		ReadWriteStream* getStream()
+		ReadWriteStream* releaseStream()
 		{
 			if(!stream) {
-				stream.reset(new Ota::UpgradeOutputStream(partition));
+				return new Ota::UpgradeOutputStream(partition);
 			}
-			return stream.get();
+			return stream.release();
 		}
 	};
 

--- a/Sming/Libraries/OtaNetwork/src/include/Ota/Network/HttpUpgrader.h
+++ b/Sming/Libraries/OtaNetwork/src/include/Ota/Network/HttpUpgrader.h
@@ -43,12 +43,12 @@ public:
 		{
 		}
 
-		ReadWriteStream* releaseStream()
+		ReadWriteStream* getStream()
 		{
 			if(!stream) {
-				return new Ota::UpgradeOutputStream(partition);
+				stream.reset(new Ota::UpgradeOutputStream(partition));
 			}
-			return stream.release();
+			return stream.get();
 		}
 	};
 


### PR DESCRIPTION
This PR fixes the issue raised in #2720, where a stream object gets free'd twice resulting in unpredictable behaviour.

Looks like this bug was introduced in #2643.