### PR TITLE
Improvements to OtaNetwork Http upgrader

### DIFF
--- a/Sming/Arch/Host/spiffs-two-roms.hw
+++ b/Sming/Arch/Host/spiffs-two-roms.hw
@@ -2,6 +2,9 @@
 	"name": "Two ROM slots with single SPIFFS",
 	"base_config": "spiffs",
 	"partitions": {
+		"rom0": {
+			"subtype": "ota_0"
+		},
 		"rom1": {
 			"address": "0x108000",
 			"size": "992K",

--- a/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
+++ b/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
@@ -22,6 +22,10 @@ void HttpUpgrader::start()
 
 void HttpUpgrader::fetchNextItem()
 {
+	if(currentItem >= items.count()) {
+		return;
+	}
+
 	auto& it = items[currentItem];
 	debug_d("Download file:\r\n"
 			"    (%u) %s -> %s @ 0x%X",

--- a/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
+++ b/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
@@ -17,33 +17,33 @@ namespace Network
 {
 void HttpUpgrader::start()
 {
-	for(unsigned i = 0; i < items.count(); i++) {
-		auto& it = items[i];
-		debug_d("Download file:\r\n"
-				"    (%u) %s -> %s @ 0x%X",
-				currentItem, it.url.c_str(), it.partition.name().c_str(), it.partition.address());
+	fetchNextItem();
+}
 
-		HttpRequest* request;
-		if(baseRequest != nullptr) {
-			request = baseRequest->clone();
-			request->setURL(it.url);
-		} else {
-			request = new HttpRequest(it.url);
-		}
+void HttpUpgrader::fetchNextItem()
+{
+	auto& it = items[currentItem];
+	debug_d("Download file:\r\n"
+			"    (%u) %s -> %s @ 0x%X",
+			currentItem, it.url.c_str(), it.partition.name().c_str(), it.partition.address());
 
-		request->setMethod(HTTP_GET);
-		request->setResponseStream(it.getStream());
+	HttpRequest* request;
+	if(baseRequest != nullptr) {
+		request = baseRequest->clone();
+		request->setURL(it.url);
+	} else {
+		request = new HttpRequest(it.url);
+	}
 
-		if(i == items.count() - 1) {
-			request->onRequestComplete(RequestCompletedDelegate(&HttpUpgrader::updateComplete, this));
-		} else {
-			request->onRequestComplete(RequestCompletedDelegate(&HttpUpgrader::itemComplete, this));
-		}
+	request->setMethod(HTTP_GET);
+	request->setResponseStream(it.getStream());
 
-		if(!send(request)) {
-			debug_e("ERROR: Rejected sending new request.");
-			break;
-		}
+	request->onRequestComplete(RequestCompletedDelegate(&HttpUpgrader::itemComplete, this));
+
+	if(!send(request)) {
+		debug_e("ERROR: Rejected sending new request.");
+		it.stream.release();
+		downloadFailed();
 	}
 }
 
@@ -52,43 +52,44 @@ int HttpUpgrader::itemComplete(HttpConnection& client, bool success)
 	auto& it = items[currentItem];
 
 	if(!success) {
-		it.stream.release(); // Owned by HttpRequest
-		updateFailed();
+		it.stream.release();
+		downloadFailed();
 		return -1;
 	}
 
-	debug_d("Finished: URL: %s, Offset: 0x%X, Length: %u", it.url.c_str(), it.partition.address(),
-			it.stream->available());
-
 	it.size = it.stream->available();
+	debug_d("Finished: URL: %s, Offset: 0x%X, Length: %u", it.url.c_str(), it.partition.address(), it.size);
+
 	it.stream.release(); // the actual deletion will happen outside of this class
 	currentItem++;
+
+	if(currentItem < items.count()) {
+		fetchNextItem();
+	} else {
+		downloadComplete();
+	}
 
 	return 0;
 }
 
-int HttpUpgrader::updateComplete(HttpConnection& client, bool success)
+void HttpUpgrader::downloadComplete()
 {
-	int hasError = itemComplete(client, success);
-	if(hasError != 0) {
-		return hasError;
-	}
-
+#if DEBUG_VERBOSE_LEVEL >= DBG
 	debug_d("\r\nFirmware download finished!");
 	for(unsigned i = 0; i < items.count(); i++) {
-		debug_d(" - item: %u, addr: 0x%X, url: %s", i, items[i].partition.address(), items[i].url.c_str());
+		auto& it = items[i];
+		debug_d(" - item: %u, addr: 0x%X, size: 0x%X, url: %s", i, it.partition.address(), it.size, it.url.c_str());
 	}
+#endif
 
 	if(updateDelegate) {
 		updateDelegate(*this, true);
 	}
 
 	applyUpdate();
-
-	return 0;
 }
 
-void HttpUpgrader::updateFailed()
+void HttpUpgrader::downloadFailed()
 {
 	debug_e("\r\nFirmware download failed..");
 	if(updateDelegate) {

--- a/Sming/Libraries/OtaNetwork/src/include/Ota/Network/HttpUpgrader.h
+++ b/Sming/Libraries/OtaNetwork/src/include/Ota/Network/HttpUpgrader.h
@@ -124,10 +124,11 @@ public:
 
 protected:
 	void applyUpdate();
-	void updateFailed();
+	void downloadFailed();
+	void downloadComplete();
+	void fetchNextItem();
 
-	virtual int itemComplete(HttpConnection& client, bool success);
-	virtual int updateComplete(HttpConnection& client, bool success);
+	int itemComplete(HttpConnection& client, bool success);
 
 protected:
 	ItemList items;

--- a/samples/Basic_Ota/component.mk
+++ b/samples/Basic_Ota/component.mk
@@ -1,4 +1,4 @@
-COMPONENT_SOC := esp*
+COMPONENT_SOC := esp* host
 COMPONENT_DEPENDS := OtaNetwork
 
 HWCONFIG := ota


### PR DESCRIPTION
This PR addresses issue #2724.

- Queue only one OTA item at a time for download.
- Only moving to the next one after successful completion.
- The `itemComplete` method handles each request directly - `updateComplete` has been removed.
- If `HttpClient::send` (line 43) fails then the relevant stream must be released to avoid a 'double delete' exception.
- Enable Host support for Basic_Ota sample
