### PR TITLE
[WIP]rboot missing `RBOOT_BIG_FLASH` definition

### DIFF
--- a/Sming/Components/rboot/component.mk
+++ b/Sming/Components/rboot/component.mk
@@ -108,6 +108,7 @@ APP_CFLAGS				+= -DRBOOT_INTEGRATION
 export RBOOT_BUILD_BASE	:= $(abspath $(COMPONENT_BUILD_DIR))
 export RBOOT_FW_BASE	:= $(abspath $(FW_BASE))
 export ESPTOOL2
+export RBOOT_BIG_FLASH
 
 # multiple roms per 1mb block?
 ifeq ($(RBOOT_TWO_ROMS),1)

--- a/Sming/Components/rboot/component.mk
+++ b/Sming/Components/rboot/component.mk
@@ -108,7 +108,6 @@ APP_CFLAGS				+= -DRBOOT_INTEGRATION
 export RBOOT_BUILD_BASE	:= $(abspath $(COMPONENT_BUILD_DIR))
 export RBOOT_FW_BASE	:= $(abspath $(FW_BASE))
 export ESPTOOL2
-export RBOOT_BIG_FLASH
 
 # multiple roms per 1mb block?
 ifeq ($(RBOOT_TWO_ROMS),1)


### PR DESCRIPTION
Bootloader code never gets `BOOT_BIG_FLASH` definition. This is evident by unexpected absence of `rBoot Option: Big flash` during (non-silent) boot. Looks like this crept in with #1817.

Prior to Sming 4.3 this is quite important as it affects how rboot determines the active flash memory size. If it needs to reset the boot configuration it won't be correct.

With 4.3 the boot configuration is validated against the partition table so largely unaffected. However, if performing OTA update on a device running an earlier bootloader then the flash layout may not be as expected and addresses could be wrong.
