### PR TITLE
Use `std::make_unique`

### DIFF
--- a/Sming/Arch/Esp32/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Esp32/Services/Profiling/TaskStat.cpp
@@ -27,7 +27,7 @@ struct TaskStat::Info {
 TaskStat::TaskStat(Print& out) : out(out)
 {
 #if CONFIG_FREERTOS_USE_TRACE_FACILITY && CONFIG_FREERTOS_GENERATE_RUN_TIME_STATS
-	taskInfo.reset(new Info[2]);
+	taskInfo = std::make_unique<Info[]>(2);
 #endif
 }
 

--- a/Sming/Arch/Host/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Host/Components/driver/hw_timer.cpp
@@ -205,7 +205,7 @@ static std::unique_ptr<CTimerThread> timer1;
 
 void hw_timer_init(void)
 {
-	timer1.reset(new CTimerThread("Timer1"));
+	timer1 = std::make_unique<CTimerThread>("Timer1");
 }
 
 void hw_timer_cleanup()

--- a/Sming/Arch/Host/Components/driver/uart_server.cpp
+++ b/Sming/Arch/Host/Components/driver/uart_server.cpp
@@ -170,9 +170,9 @@ void startup(const Config& config)
 
 		auto& server = servers[i];
 		if(devname == nullptr) {
-			server.reset(new CUartPort(i));
+			server = std::make_unique<CUartPort>(i);
 		} else {
-			server.reset(new CUartDevice(i, devname, config.baud[i]));
+			server = std::make_unique<CUartDevice>(i, devname, config.baud[i]);
 		}
 		server->execute();
 	}
@@ -450,7 +450,7 @@ void* CUartDevice::thread_routine()
 	while(!done) {
 		if(txsem.timedwait(IDLE_SLEEP_MS * 1000)) {
 			if(uart != nullptr && !device) {
-				device.reset(new SerialDevice);
+				device = std::make_unique<SerialDevice>();
 				char res = device->openDevice(deviceName, uart->baud_rate);
 				if(res != 1) {
 					host_debug_e("UART%u error %d opening serial device '%s'", uart_nr, res, deviceName);

--- a/Sming/Arch/Rp2040/Components/rp2040/src/include/esp_systemapi.h
+++ b/Sming/Arch/Rp2040/Components/rp2040/src/include/esp_systemapi.h
@@ -32,7 +32,6 @@ extern void ets_wdt_enable(void);
 extern void ets_wdt_disable(void);
 extern void wdt_feed(void);
 
-
 /** @brief  Disable interrupts
  *  @retval Current interrupt level
  *  @note Hardware timer is unaffected if operating in non-maskable mode

--- a/Sming/Arch/Rp2040/Components/rp2040/src/tasks.cpp
+++ b/Sming/Arch/Rp2040/Components/rp2040/src/tasks.cpp
@@ -4,17 +4,17 @@
 #include <pico/util/queue.h>
 #include <sming_attr.h>
 
-namespace {
-
+namespace
+{
 class TaskQueue
 {
 public:
 	static void init()
 	{
-	 	spinlock = spin_lock_claim_unused(true);
+		spinlock = spin_lock_claim_unused(true);
 	}
 
-	TaskQueue(os_task_t callback, uint8_t length): callback(callback)
+	TaskQueue(os_task_t callback, uint8_t length) : callback(callback)
 	{
 		queue_init_with_spinlock(&queue, sizeof(os_event_t), length, spinlock);
 	}
@@ -26,7 +26,7 @@ public:
 
 	bool __forceinline post(os_signal_t sig, os_param_t par)
 	{
-		os_event_t event {sig, par};
+		os_event_t event{sig, par};
 		return queue_try_add(&queue, &event);
 	}
 
@@ -60,7 +60,7 @@ const uint8_t SYSTEM_TASK_QUEUE_LENGTH = 8;
 
 TaskQueue* task_queues[SYSTEM_TASK_PRIO + 1];
 
-};
+}; // namespace
 
 bool system_os_task(os_task_t callback, os_task_priority_t prio, os_event_t* events, uint8_t qlen)
 {

--- a/Sming/Arch/Rp2040/Components/rp2040/src/wifi.cpp
+++ b/Sming/Arch/Rp2040/Components/rp2040/src/wifi.cpp
@@ -26,14 +26,12 @@ namespace {
 
 class Decompressor {
 public:
-	explicit Decompressor(const FSTR::ObjectBase& data)
+	explicit Decompressor(const FSTR::ObjectBase& data) : stream(new FlashMemoryStream(data))
 	{
-		stream.reset(new FlashMemoryStream(data));
 	}
 
-	explicit Decompressor(Storage::Partition part)
+	explicit Decompressor(Storage::Partition part) : stream(new Storage::PartitionStream(part))
 	{
-		stream.reset(new Storage::PartitionStream(part));
 	}
 
 	bool init()
@@ -90,13 +88,13 @@ std::unique_ptr<Decompressor> decompressor;
 int cyw43_storage_init()
 {
 #ifdef CYW43_FIRMWARE
-	decompressor.reset(new Decompressor(cyw43_firmware));
+	decompressor = std::make_unique<Decompressor>(cyw43_firmware);
 #else
 	auto part = Storage::findPartition("cyw43_fw");
 	if(!part) {
 		debug_e("Failed to find CYW43 firmware partition");
 	} else {
-		decompressor.reset(new Decompressor(part));
+		decompressor = std::make_unique<Decompressor>(part);
 	}
 #endif
 

--- a/Sming/Arch/Rp2040/Components/rp2040/src/wifi.cpp
+++ b/Sming/Arch/Rp2040/Components/rp2040/src/wifi.cpp
@@ -19,12 +19,13 @@ extern "C" {
 IMPORT_FSTR_ARRAY_LOCAL(cyw43_firmware, uint8_t, CYW43_FIRMWARE)
 #endif
 
-namespace {
-
+namespace
+{
 #define BUFFER_SIZE 16384
 #define DICT_SIZE 32767
 
-class Decompressor {
+class Decompressor
+{
 public:
 	explicit Decompressor(const FSTR::ObjectBase& data) : stream(new FlashMemoryStream(data))
 	{
@@ -39,24 +40,24 @@ public:
 		uzlib_init();
 		uzlib_uncompress_init(&state, dict, DICT_SIZE);
 		state.source_read_cb = read_source;
-	    int res = uzlib_gzip_parse_header(&state);
-		if (res != TINF_OK) {
+		int res = uzlib_gzip_parse_header(&state);
+		if(res != TINF_OK) {
 			debug_e("[CYW] bad GZIP header %d", res);
 			return false;
 		}
-    	return true;
+		return true;
 	}
 
 	bool read(void* dest, size_t length)
 	{
-	    state.dest = static_cast<uint8_t*>(dest);
-    	state.dest_limit = state.dest + length;
-	    int res = uzlib_uncompress_chksum(&state);
+		state.dest = static_cast<uint8_t*>(dest);
+		state.dest_limit = state.dest + length;
+		int res = uzlib_uncompress_chksum(&state);
 		if(res != TINF_OK) {
 			debug_e("[CYW] Decompress error %d", res);
 			return false;
 		}
-    	return true;
+		return true;
 	}
 
 private:
@@ -75,15 +76,16 @@ private:
 		return *self->state.source++;
 	}
 
-    struct uzlib_uncomp state{};
+	struct uzlib_uncomp state {
+	};
 	uint8_t src_buffer[BUFFER_SIZE]{};
-    uint8_t dict[DICT_SIZE];
+	uint8_t dict[DICT_SIZE];
 	std::unique_ptr<IDataSourceStream> stream;
 };
 
 std::unique_ptr<Decompressor> decompressor;
 
-}
+} // namespace
 
 int cyw43_storage_init()
 {
@@ -98,12 +100,12 @@ int cyw43_storage_init()
 	}
 #endif
 
-    if (!decompressor || !decompressor->init()) {
+	if(!decompressor || !decompressor->init()) {
 		decompressor.reset();
-        return -1;
-    }
+		return -1;
+	}
 
-    return 0;
+	return 0;
 }
 
 uint32_t cyw43_storage_read(void* dest, uint32_t length)
@@ -115,9 +117,9 @@ uint32_t cyw43_storage_read(void* dest, uint32_t length)
 	if(!decompressor->read(dest, length)) {
 		decompressor.reset();
 		return 0;
-    }
+	}
 
-    return length;
+	return length;
 }
 
 void cyw43_storage_cleanup()

--- a/Sming/Components/Hosted/include/Hosted/Transport/TcpClientTransport.h
+++ b/Sming/Components/Hosted/include/Hosted/Transport/TcpClientTransport.h
@@ -25,10 +25,9 @@ namespace Transport
 class TcpClientTransport : public TcpTransport
 {
 public:
-	TcpClientTransport(TcpClient& client)
+	TcpClientTransport(TcpClient& client) : stream(new TcpClientStream(client))
 	{
 		client.setReceiveDelegate(TcpClientDataDelegate(&TcpClientTransport::process, this));
-		stream.reset(new TcpClientStream(client));
 	}
 
 protected:

--- a/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
@@ -522,7 +522,7 @@ bool StationImpl::smartConfigStart(SmartConfigType sctype, SmartConfigDelegate c
 		return false;
 	}
 
-	smartConfigEventInfo.reset(new SmartConfigEventInfo{});
+	smartConfigEventInfo = std::make_unique<SmartConfigEventInfo>();
 	if(!smartConfigEventInfo) {
 		return false;
 	}

--- a/Sming/Components/Network/Arch/Esp8266/Platform/AccessPointImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp8266/Platform/AccessPointImpl.cpp
@@ -82,7 +82,7 @@ bool AccessPointImpl::config(const String& ssid, String password, AUTH_MODE mode
 			debugf("AP configuration was updated");
 		} else {
 			debugf("Set AP configuration in background");
-			runConfig.reset(new softap_config(config));
+			runConfig = std::make_unique<softap_config>(config);
 		}
 	} else {
 		debugf("AP configuration loaded");

--- a/Sming/Components/rboot/include/Network/RbootHttpUpdater.h
+++ b/Sming/Components/rboot/include/Network/RbootHttpUpdater.h
@@ -37,15 +37,14 @@ public:
 		std::unique_ptr<RbootOutputStream> stream; // (optional) output stream to use.
 
 		Item(String url, uint32_t targetOffset, size_t size, RbootOutputStream* stream)
-			: url(url), targetOffset(targetOffset), size(size)
+			: url(url), targetOffset(targetOffset), size(size), stream(stream)
 		{
-			this->stream.reset(stream);
 		}
 
 		RbootOutputStream* getStream()
 		{
 			if(!stream) {
-				stream.reset(new RbootOutputStream(targetOffset, size));
+				stream = std::make_unique<RbootOutputStream>(targetOffset, size);
 			}
 			return stream.get();
 		}

--- a/Sming/Components/ssl/Axtls/AxConnection.h
+++ b/Sming/Components/ssl/Axtls/AxConnection.h
@@ -61,7 +61,7 @@ public:
 	const Certificate* getCertificate() const override
 	{
 		if(!certificate && ssl->x509_ctx != nullptr) {
-			certificate.reset(new AxCertificate(ssl));
+			certificate = std::make_unique<AxCertificate>(ssl);
 		}
 
 		return certificate.get();

--- a/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
@@ -69,8 +69,8 @@ void BrClientConnection::startCert(uint32_t length)
 		return;
 	}
 
-	certificate.reset(new BrCertificate);
-	x509Decoder.reset(new X509Decoder(&certificate->subject, &certificate->issuer));
+	certificate = std::make_unique<BrCertificate>();
+	x509Decoder = std::make_unique<X509Decoder>(&certificate->subject, &certificate->issuer);
 
 	auto& types = context.session.validators.fingerprintTypes;
 	resetHash(certSha1Context, types.contains(Fingerprint::Type::CertSha1));

--- a/Sming/Components/ssl/BearSsl/BrConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrConnection.cpp
@@ -106,7 +106,7 @@ int BrConnection::init(size_t bufferSize, bool bidi)
 		bufferSize += MAX_OUT_OVERHEAD;
 	}
 	debug_i("Using buffer size of %u bytes", bufferSize);
-	buffer.reset(new uint8_t[bufferSize]);
+	buffer = std::make_unique<uint8_t[]>(bufferSize);
 	if(!buffer) {
 		debug_e("Buffer allocation failed");
 		return -BR_ERR_BAD_PARAM;

--- a/Sming/Components/ssl/BearSsl/BrConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrConnection.cpp
@@ -106,7 +106,7 @@ int BrConnection::init(size_t bufferSize, bool bidi)
 		bufferSize += MAX_OUT_OVERHEAD;
 	}
 	debug_i("Using buffer size of %u bytes", bufferSize);
-	buffer = std::make_unique<uint8_t[]>(bufferSize);
+	buffer.reset(new uint8_t[bufferSize]);
 	if(!buffer) {
 		debug_e("Buffer allocation failed");
 		return -BR_ERR_BAD_PARAM;

--- a/Sming/Components/ssl/src/Session.cpp
+++ b/Sming/Components/ssl/src/Session.cpp
@@ -200,7 +200,7 @@ void Session::handshakeComplete(bool success)
 		// If requested, take a copy of the session ID for later re-use
 		if(options.sessionResume) {
 			if(!sessionId) {
-				sessionId.reset(new SessionId);
+				sessionId = std::make_unique<SessionId>();
 			}
 			*sessionId = connection->getSessionId();
 		}

--- a/Sming/Core/Data/CsvReader.h
+++ b/Sming/Core/Data/CsvReader.h
@@ -47,10 +47,9 @@ public:
 	 */
 	CsvReader(IDataSourceStream* source, char fieldSeparator = ',', const CStringArray& headings = nullptr,
 			  size_t maxLineLength = 2048)
-		: fieldSeparator(fieldSeparator), userHeadingsProvided(headings), maxLineLength(maxLineLength),
+		: source(source), fieldSeparator(fieldSeparator), userHeadingsProvided(headings), maxLineLength(maxLineLength),
 		  headings(headings)
 	{
-		this->source.reset(source);
 		reset();
 	}
 

--- a/Sming/Core/Data/Stream/EndlessMemoryStream.cpp
+++ b/Sming/Core/Data/Stream/EndlessMemoryStream.cpp
@@ -27,7 +27,7 @@ bool EndlessMemoryStream::seek(int len)
 size_t EndlessMemoryStream::write(const uint8_t* buffer, size_t size)
 {
 	if(!stream) {
-		stream.reset(new MemoryDataStream());
+		stream = std::make_unique<MemoryDataStream>();
 	}
 
 	return stream->write(buffer, size);

--- a/Sming/Core/Data/Stream/SectionStream.cpp
+++ b/Sming/Core/Data/Stream/SectionStream.cpp
@@ -22,7 +22,7 @@ void SectionStream::scanSource(uint8_t maxSections)
 	constexpr size_t bufSize{512};
 	char buffer[bufSize];
 
-	sections.reset(new Section[maxSections]{});
+	sections = std::make_unique<Section[]>(maxSections);
 
 	size_t offset{0};
 	while(sectionCount < maxSections && !stream->isFinished()) {

--- a/Sming/Core/Data/StreamTransformer.cpp
+++ b/Sming/Core/Data/StreamTransformer.cpp
@@ -20,8 +20,8 @@ uint16_t StreamTransformer::readMemoryBlock(char* data, int bufSize)
 		return 0;
 	}
 
-	if(tempStream == nullptr) {
-		tempStream.reset(new CircularBuffer(NETWORK_SEND_BUFFER_SIZE + 10));
+	if(!tempStream) {
+		tempStream = std::make_unique<CircularBuffer>(NETWORK_SEND_BUFFER_SIZE + 10);
 	}
 
 	// Use provided buffer as a temporary store for this operation

--- a/Sming/Core/Data/StreamTransformer.cpp
+++ b/Sming/Core/Data/StreamTransformer.cpp
@@ -20,8 +20,8 @@ uint16_t StreamTransformer::readMemoryBlock(char* data, int bufSize)
 		return 0;
 	}
 
-	if(!tempStream) {
-		tempStream = std::make_unique<CircularBuffer>(NETWORK_SEND_BUFFER_SIZE + 10);
+	if(tempStream == nullptr) {
+		tempStream.reset(new CircularBuffer(NETWORK_SEND_BUFFER_SIZE + 10));
 	}
 
 	// Use provided buffer as a temporary store for this operation

--- a/Sming/Libraries/OtaNetwork/src/include/Ota/Network/HttpUpgrader.h
+++ b/Sming/Libraries/OtaNetwork/src/include/Ota/Network/HttpUpgrader.h
@@ -46,7 +46,7 @@ public:
 		ReadWriteStream* getStream()
 		{
 			if(!stream) {
-				stream.reset(new Ota::UpgradeOutputStream(partition));
+				stream = std::make_unique<Ota::UpgradeOutputStream>(partition);
 			}
 			return stream.get();
 		}

--- a/Sming/Libraries/Yeelight/YeelightBulb.cpp
+++ b/Sming/Libraries/Yeelight/YeelightBulb.cpp
@@ -34,7 +34,7 @@ bool YeelightBulb::connect()
 		return true;
 	}
 
-	connection.reset(new TcpClient(TcpClientDataDelegate(&YeelightBulb::onResponse, this)));
+	connection = std::make_unique<TcpClient>(TcpClientDataDelegate(&YeelightBulb::onResponse, this));
 
 	connection->setTimeOut(USHRT_MAX); // Stay connected forever
 

--- a/samples/Basic_Audio/app/application.cpp
+++ b/samples/Basic_Audio/app/application.cpp
@@ -57,7 +57,7 @@ static struct {
 		Serial << _F("Generating sine wave table @ ") << frequency << _F(" Hz, ") << sampleCount << _F(" samples")
 			   << endl;
 
-		samples.reset(new uint16_t[sampleCount]);
+		samples = std::make_unique<uint16_t[]>(sampleCount);
 		if(!samples) {
 			debug_e("Memory allocation failed");
 			return false;

--- a/samples/Basic_Ota/app/application.cpp
+++ b/samples/Basic_Ota/app/application.cpp
@@ -49,7 +49,7 @@ void doUpgrade()
 	Serial.println(F("Updating..."));
 
 	// need a clean object, otherwise if run before and failed will not run again
-	otaUpdater.reset(new Ota::Network::HttpUpgrader);
+	otaUpdater = std::make_unique<Ota::Network::HttpUpgrader>();
 
 	// select rom slot to flash
 	auto part = ota.getNextBootPartition();

--- a/samples/Basic_Serial/include/SerialTransmitDemo.h
+++ b/samples/Basic_Serial/include/SerialTransmitDemo.h
@@ -8,9 +8,8 @@
 class SerialTransmitDemo
 {
 public:
-	SerialTransmitDemo(HardwareSerial& serial, IDataSourceStream* stream) : serial(serial)
+	SerialTransmitDemo(HardwareSerial& serial, IDataSourceStream* stream) : serial(serial), stream(stream)
 	{
-		this->stream.reset(stream);
 		serial.onTransmitComplete(TransmitCompleteDelegate(&SerialTransmitDemo::onTransmitComplete, this));
 	}
 


### PR DESCRIPTION
This PR improves use of `std::unique_ptr` by using `std::make_unique` where appropriate instead of `reset()`, and also updating some class constructors to use direct assignment.

https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#r23-use-make_unique-to-make-unique_ptrs