### PR TITLE
Bugfix: stale HTTP connections may get missed in cleanup

### DIFF
--- a/Sming/Components/Network/src/Network/HttpClient.cpp
+++ b/Sming/Components/Network/src/Network/HttpClient.cpp
@@ -68,13 +68,16 @@ void HttpClient::cleanInactive()
 {
 	debug_d("Total connections: %d", httpConnectionPool.count());
 
-	for(size_t i = 0; i < httpConnectionPool.count(); i++) {
+	size_t i = 0;
+	while(i < httpConnectionPool.count()) {
 		auto connection = httpConnectionPool.valueAt(i);
 
 		if(connection->getConnectionState() > eTCS_Connecting && !connection->isActive()) {
 			debug_d("Removing stale connection: State: %d, Active: %d, Finished: %d", connection->getConnectionState(),
 					connection->isActive(), connection->isFinished());
 			httpConnectionPool.removeAt(i);
+		} else {
+			++i;
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes the `cleanInactive` method.

By code inspection if a stale connection is deleted from the list then the loop index is increment, skipping over the next item.
