### PR TITLE
Fix client Websockets (broken)

### DIFF
--- a/Sming/Components/Network/component.mk
+++ b/Sming/Components/Network/component.mk
@@ -93,3 +93,14 @@ COMPONENT_INCDIRS += \
 endif
 
 endif
+
+##@Testing
+
+# Websocket Server
+CACHE_VARS			+= WSSERVER_PORT
+WSSERVER_PORT		?= 9999
+.PHONY: wsserver
+wsserver: ##Launch a simple python Websocket echo server for testing client applications
+	$(info Starting Websocket server for TESTING)
+	$(Q) $(PYTHON) $(CMP_Network_PATH)/tools/wsserver.py $(WSSERVER_PORT)
+

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -291,7 +291,7 @@ void WebsocketConnection::broadcast(const char* message, size_t length, ws_frame
 
 void WebsocketConnection::close()
 {
-	debug_d("Terminating Websocket connection.");
+	debug_d("WS: Terminating connection %p", connection);
 	websocketList.removeElement(this);
 	if(state != eWSCS_Closed) {
 		state = eWSCS_Closed;
@@ -307,6 +307,7 @@ void WebsocketConnection::close()
 
 	if(connection) {
 		connection->setTimeOut(2);
+		connection->setAutoSelfDestruct(true);
 		connection = nullptr;
 	}
 }

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -55,6 +55,14 @@ WebsocketConnection::WebsocketConnection(HttpConnection* connection, bool isClie
 	ws_parser_init(&parser);
 }
 
+void WebsocketConnection::setConnection(HttpConnection* connection, bool isClientConnection)
+{
+	assert(this->connection == nullptr);
+	this->connection = connection;
+	this->isClientConnection = isClientConnection;
+	this->state = connection ? eWSCS_Ready : eWSCS_Closed;
+}
+
 bool WebsocketConnection::bind(HttpRequest& request, HttpResponse& response)
 {
 	String version = request.headers[HTTP_HEADER_SEC_WEBSOCKET_VERSION];

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -237,8 +237,7 @@ bool WebsocketConnection::send(IDataSourceStream* source, ws_frame_type_t type, 
 		packetLength += 4; // we use mask with size 4 bytes
 	}
 
-	uint8_t packet[packetLength];
-	memset(packet, 0, packetLength);
+	uint8_t packet[packetLength]{};
 
 	int i = 0;
 	// byte 0
@@ -271,11 +270,10 @@ bool WebsocketConnection::send(IDataSourceStream* source, ws_frame_type_t type, 
 	}
 
 	if(useMask) {
-		uint8_t maskKey[4] = {0x00, 0x00, 0x00, 0x00};
-		for(uint8_t x = 0; x < sizeof(maskKey); x++) {
-			maskKey[x] = (char)os_random();
-			packet[i++] = maskKey[x];
-		}
+		uint8_t maskKey[4];
+		os_get_random(maskKey, sizeof(maskKey));
+		memcpy(&packet[i], maskKey, sizeof(maskKey));
+		i += sizeof(maskKey);
 
 		auto xorStream = new XorOutputStream(source, maskKey, sizeof(maskKey));
 		if(xorStream == nullptr) {

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -319,7 +319,9 @@ void WebsocketConnection::close()
 	websocketList.removeElement(this);
 	if(state != eWSCS_Closed) {
 		state = eWSCS_Closed;
-		if(isClientConnection) {
+		if(controlFrame.type == WS_FRAME_CLOSE) {
+			send(controlFrame.payload, controlFrame.payloadLength, WS_FRAME_CLOSE);
+		} else {
 			uint16_t status = htons(1000);
 			send(reinterpret_cast<char*>(&status), sizeof(status), WS_FRAME_CLOSE);
 		}

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -212,7 +212,7 @@ bool WebsocketConnection::send(IDataSourceStream* source, ws_frame_type_t type, 
 	}
 
 	int available = source->available();
-	if(available < 1) {
+	if(available < 0) {
 		debug_e("Streams without known size are not supported");
 		return false;
 	}

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -311,7 +311,11 @@ void WebsocketConnection::broadcast(const char* message, size_t length, ws_frame
 
 void WebsocketConnection::close()
 {
-	debug_d("WS: Terminating connection %p", connection);
+	if(connection == nullptr) {
+		return;
+	}
+
+	debug_d("WS: Terminating connection %p, state %u", connection, state);
 	websocketList.removeElement(this);
 	if(state != eWSCS_Closed) {
 		state = eWSCS_Closed;
@@ -325,11 +329,9 @@ void WebsocketConnection::close()
 		}
 	}
 
-	if(connection) {
-		connection->setTimeOut(2);
-		connection->setAutoSelfDestruct(true);
-		connection = nullptr;
-	}
+	connection->setTimeOut(2);
+	connection->setAutoSelfDestruct(true);
+	connection = nullptr;
 }
 
 void WebsocketConnection::reset()

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -313,7 +313,8 @@ void WebsocketConnection::close()
 	if(state != eWSCS_Closed) {
 		state = eWSCS_Closed;
 		if(isClientConnection) {
-			send(nullptr, 0, WS_FRAME_CLOSE);
+			uint16_t status = htons(1000);
+			send(reinterpret_cast<char*>(&status), sizeof(status), WS_FRAME_CLOSE);
 		}
 		activated = false;
 		if(wsDisconnect) {
@@ -322,7 +323,7 @@ void WebsocketConnection::close()
 	}
 
 	if(connection) {
-		connection->setTimeOut(1);
+		connection->setTimeOut(2);
 		connection = nullptr;
 	}
 }

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -186,6 +186,7 @@ bool WebsocketConnection::send(const char* message, size_t length, ws_frame_type
 	size_t written = stream->write(message, length);
 	if(written != length) {
 		debug_e("Unable to store data in memory buffer");
+		delete stream;
 		return false;
 	}
 

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.h
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.h
@@ -109,14 +109,14 @@ public:
 
 	/**
 	 * @brief Sends websocket message from a stream
-	 * @param stream
+	 * @param source The stream to send - we get ownership of the stream
 	 * @param type
 	 * @param useMask MUST be true for client connections
 	 * @param isFin true if this is the final frame
 	 *
 	 * @retval bool true on success
 	 */
-	bool send(IDataSourceStream* stream, ws_frame_type_t type = WS_FRAME_TEXT, bool useMask = false, bool isFin = true);
+	bool send(IDataSourceStream* source, ws_frame_type_t type = WS_FRAME_TEXT, bool useMask = false, bool isFin = true);
 
 	/**
 	 * @brief Broadcasts a message to all active websocket connections

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.h
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.h
@@ -56,13 +56,6 @@ struct WsFrameInfo {
 	ws_frame_type_t type = WS_FRAME_TEXT;
 	char* payload = nullptr;
 	size_t payloadLength = 0;
-
-	WsFrameInfo() = default;
-
-	WsFrameInfo(ws_frame_type_t type, char* payload, size_t payloadLength)
-		: type(type), payload(payload), payloadLength(payloadLength)
-	{
-	}
 };
 
 class WebsocketConnection

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.h
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.h
@@ -73,7 +73,7 @@ public:
 	 * @param connection the transport connection
 	 * @param isClientConnection true when the passed connection is an http client connection
 	 */
-	WebsocketConnection(HttpConnection* connection, bool isClientConnection = true);
+	WebsocketConnection(HttpConnection* connection = nullptr, bool isClientConnection = true);
 
 	virtual ~WebsocketConnection()
 	{
@@ -271,11 +271,7 @@ public:
 	 * @param connection the transport connection
 	 * @param isClientConnection true when the passed connection is an http client connection
 	 */
-	void setConnection(HttpConnection* connection, bool isClientConnection = true)
-	{
-		this->connection = connection;
-		this->isClientConnection = isClientConnection;
-	}
+	void setConnection(HttpConnection* connection, bool isClientConnection = true);
 
 	/** @brief  Gets the state of the websocket connection
 	  * @retval WsConnectionState
@@ -311,7 +307,7 @@ protected:
 
 	void* userData = nullptr;
 
-	WsConnectionState state = eWSCS_Ready;
+	WsConnectionState state;
 
 private:
 	ws_frame_type_t frameType = WS_FRAME_TEXT;
@@ -322,9 +318,8 @@ private:
 
 	static WebsocketList websocketList;
 
-	bool isClientConnection = true;
-
 	HttpConnection* connection = nullptr;
+	bool isClientConnection;
 	bool activated = false;
 };
 

--- a/Sming/Components/Network/src/Network/TcpConnection.h
+++ b/Sming/Components/Network/src/Network/TcpConnection.h
@@ -50,10 +50,14 @@ public:
 
 	virtual ~TcpConnection();
 
-public:
 	virtual bool connect(const String& server, int port, bool useSsl = false);
 	virtual bool connect(IpAddress addr, uint16_t port, bool useSsl = false);
 	virtual void close();
+
+	void setAutoSelfDestruct(bool state)
+	{
+		autoSelfDestruct = state;
+	}
 
 	/** @brief Writes string data directly to the TCP buffer
 	 *  @param data null terminated string

--- a/Sming/Components/Network/src/Network/WebsocketClient.cpp
+++ b/Sming/Components/Network/src/Network/WebsocketClient.cpp
@@ -48,14 +48,9 @@ bool WebsocketClient::connect(const Url& url)
 	state = eWSCS_Ready;
 
 	// Generate the key
-	unsigned char keyStart[17] = {0};
-	char b64Key[25];
-	memset(b64Key, 0, sizeof(b64Key));
-
-	for(int i = 0; i < 16; ++i) {
-		keyStart[i] = 1 + os_random() % 255;
-	}
-	key = base64_encode(keyStart, sizeof(keyStart));
+	unsigned char keyData[16];
+	os_get_random(keyData, sizeof(keyData));
+	key = base64_encode(keyData, sizeof(keyData));
 
 	HttpRequest* request = new HttpRequest(uri);
 	request->headers[HTTP_HEADER_UPGRADE] = WSSTR_WEBSOCKET;

--- a/Sming/Components/Network/src/Network/WebsocketClient.cpp
+++ b/Sming/Components/Network/src/Network/WebsocketClient.cpp
@@ -82,9 +82,9 @@ int WebsocketClient::verifyKey(HttpConnection& connection, HttpResponse& respons
 	auto hash = Crypto::Sha1().calculate(keyToHash);
 	String base64hash = base64_encode(hash.data(), hash.size());
 	if(base64hash != serverHashedKey) {
-		debug_e("wscli key mismatch: %s | %s", serverHashedKey.c_str(), base64hash.c_str());
+		debug_e("WS: key mismatch: %s | %s", serverHashedKey.c_str(), base64hash.c_str());
 		state = eWSCS_Closed;
-		WebsocketConnection::getConnection()->setTimeOut(1);
+		connection.setTimeOut(1);
 		return -3;
 	}
 

--- a/Sming/Components/Network/src/Network/WebsocketClient.cpp
+++ b/Sming/Components/Network/src/Network/WebsocketClient.cpp
@@ -17,11 +17,25 @@
 #include "Http/HttpHeaders.h"
 #include <Data/WebHelpers/base64.h>
 
+class WebsocketClientConnection : public HttpClientConnection
+{
+protected:
+	// Prevent HttpClientConnection from resetting our receive delegate set by activate() call
+	err_t onConnected(err_t err) override
+	{
+		if(err == ERR_OK) {
+			state = eHCS_Ready;
+		}
+
+		return HttpConnection::onConnected(err);
+	}
+};
+
 HttpConnection* WebsocketClient::getHttpConnection()
 {
 	auto connection = WebsocketConnection::getConnection();
 	if(connection == nullptr && state == eWSCS_Closed) {
-		connection = new HttpClientConnection();
+		connection = new WebsocketClientConnection();
 		setConnection(connection);
 	}
 

--- a/Sming/Components/Network/src/Network/WebsocketClient.h
+++ b/Sming/Components/Network/src/Network/WebsocketClient.h
@@ -31,11 +31,7 @@
 class WebsocketClient : protected WebsocketConnection
 {
 public:
-	WebsocketClient() : WebsocketConnection(new HttpClientConnection)
-	{
-	}
-
-	WebsocketClient(HttpConnection* connection) : WebsocketConnection(connection)
+	WebsocketClient(HttpConnection* connection = nullptr) : WebsocketConnection(connection)
 	{
 	}
 

--- a/Sming/Components/Network/tools/wsserver.py
+++ b/Sming/Components/Network/tools/wsserver.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+import asyncio
+from websockets.server import serve
+import logging
+
+async def echo(websocket):
+    async for message in websocket:
+        await websocket.send(message)
+
+async def main():
+    logging.basicConfig(
+        format="%(asctime)s %(message)s",
+        level=logging.DEBUG,
+    )
+    async with serve(echo, None, 8000):
+        await asyncio.Future()  # run forever
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/Sming/Core/Data/Stream/XorOutputStream.h
+++ b/Sming/Core/Data/Stream/XorOutputStream.h
@@ -28,8 +28,9 @@ public:
 	 * @param maskLenth
 	 */
 	XorOutputStream(IDataSourceStream* stream, uint8_t* mask, size_t maskLength)
-		: stream(stream), mask(mask), maskLength(maskLength)
+		: stream(stream), mask(new uint8_t[maskLength]), maskLength(maskLength)
 	{
+		memcpy(this->mask.get(), mask, maskLength);
 	}
 
 	StreamType getStreamType() const override
@@ -72,7 +73,7 @@ public:
 
 private:
 	std::unique_ptr<IDataSourceStream> stream;
-	uint8_t* mask;
+	std::unique_ptr<uint8_t[]> mask;
 	size_t maskLength;
 	size_t maskPos = 0;
 };

--- a/samples/Websocket_Client/README.rst
+++ b/samples/Websocket_Client/README.rst
@@ -2,9 +2,17 @@ Websocket Client
 ================
 
 This is a simple demo of the WebsocketClient class.
+It shows connection, closing and reconnection methods of WebsocketClient.
 
-The client tries to connect to *echo.websocket.org*.
+The client tries to connect to a websocket echo server.
 It sents 10 messages then client connection is closed.
-It reconnects and sends 25 messages and continues doing same.
+This sequence repeats after 20 seconds.
 
-This demo shows connection, closing and reconnection methods of WebsocketClient.
+The sample was originally written to communicate with *echo.websocket.org*
+but that service no longer exists.
+Instead, run ``make wsserver`` to run a local test server.
+This has the advantage of showing detailed diagnostic information which may be helpful.
+
+Build with ``WS_URL`` set to the server address. For example:
+
+    make WS_URL=ws://192.168.1.10:8000

--- a/samples/Websocket_Client/component.mk
+++ b/samples/Websocket_Client/component.mk
@@ -1,2 +1,9 @@
 # Uncomment the option below if you want SSL support
 #ENABLE_SSL=1
+
+CONFIG_VARS += WS_URL
+
+# Use wss: for secure connection
+WS_URL ?= ws://127.0.0.1:8000
+
+COMPONENT_CXXFLAGS += -DWS_URL=\"$(WS_URL)\"

--- a/samples/Websocket_Client/test.py
+++ b/samples/Websocket_Client/test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+#
+# Test python application to send test message to server
+#
+# Shows connection detail so we can compare it to Sming code
+#
+
+import argparse
+import logging
+import asyncio
+from websockets.sync.client import connect
+
+def main():
+    parser = argparse.ArgumentParser(description='Simple websocket client test')
+    parser.add_argument('URL', help='Connection URL', default='ws://192.168.13.10/ws')
+
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        format="%(asctime)s %(message)s",
+        level=logging.DEBUG,
+    )
+    print(f'Connecting to {args.URL}...')
+    with connect(args.URL) as websocket:
+        websocket.send("Hello world!")
+        websocket.recv()
+        websocket.recv()
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR addresses several issues discovered in the client websocket stack. A simple local websocket echo server has been added for testing, which can be run using `make wsserver`.

**Memory leaks**

Running `HttpServer_Websockets` sample with valgrind shows a memory leak (details below, fig 1).
I can see from the logic of `WebsocketConnection::send` that there are multiple reasons the call could fail, but the `source` stream is only destroyed in one of them.

**Failed connection**

Testing with the local server failed with `websockets.exceptions.InvalidHeaderValue: invalid Sec-WebSocket-Key header`.
The key was 17 bytes instead of 16.

**utf-8 decoding errors**

Turns out message was getting corrupted because mask value passed to XorStream is on stack, which then gets overwritten before message has been sent out. Fixed by taking a copy of the value.

**CLOSE message not being sent**

Tested with `Websocket_Client` sample (running local echo server) to confirm correct behaviour, noticed a `Streams without known size are not supported` message when closing the connection. This blocked sending 'CLOSE' notifications which have no payload.

**Issues during CLOSE**

The TCP socket was being closed too soon, causing additional errors. Increasing timeout to 2 seconds fixes this. Also included a status code in the CLOSE message indicating normal closure; this is optional, but seems like a good thing to do.

RFC 6455 states: *The application MUST NOT send any more data frames after sending a Close frame. If an endpoint receives a Close frame and did not previously send a Close frame, the endpoint MUST send a Close frame in response.*

Therefore, the `close()` logic has been changed so that a CLOSE message is *always* sent, either in response to a previous incoming request (in which case the received status is echoed back) or as notification that we're closing (status 1000 - normal closure). Checked server operation with `HttpServer_Websockets` sample 


**Simplify packet generation**

It's not necessary to pre-calculate the packet length as it's never more than 14 bytes in length.

**WebsocketConnection not getting destroyed**

HttpConnection objects are not 'auto-released' so leaks memory every time a WebsocketConnection is destroyed (512+ bytes). Simplest fix for this is to add a `setAutoSelfDestruct` method to `TcpConnection` so this can be changed.

**Messages not being received**

Connection is activated OK, but `HttpClientConnection` then calls `init` in its `onConnected` handler which resets the new `receive` delegate. This causes incoming websocket frames to be passed to the http parser, instead of the WS parser, hence the `HTTP parser error: HPE_INVALID_CONSTANT` message.


====

Fig 1: Initial memory leak reported by valgrind

```
==1291918== 
==1291918== HEAP SUMMARY:
==1291918==     in use at exit: 4,133 bytes in 16 blocks
==1291918==   total heap usage: 573 allocs, 557 frees, 71,139 bytes allocated
==1291918== 
==1291918== 64 bytes in 2 blocks are definitely lost in loss record 10 of 13
==1291918==    at 0x4041D7D: operator new(unsigned int) (vg_replace_malloc.c:476)
==1291918==    by 0x8075BC5: WebsocketConnection::send(char const*, unsigned int, ws_frame_type_t) (WebsocketConnection.cpp:180)
==1291918==    by 0x804EB65: send (WebsocketConnection.h:107)
==1291918==    by 0x804EB65: sendString (WebsocketConnection.h:145)
==1291918==    by 0x804EB65: wsCommandReceived(WebsocketConnection&, String const&) (application.cpp:88)
==1291918==    by 0x807575D: operator() (std_function.h:591)
==1291918==    by 0x807575D: WebsocketConnection::staticOnDataPayload(void*, char const*, unsigned int) (WebsocketConnection.cpp:128)
==1291918==    by 0x8081E5C: ws_parser_execute (ws_parser.c:263)
==1291918==    by 0x80756C6: WebsocketConnection::processFrame(TcpClient&, char*, int) (WebsocketConnection.cpp:103)
==1291918==    by 0x8079305: operator() (std_function.h:591)
==1291918==    by 0x8079305: TcpClient::onReceive(pbuf*) (TcpClient.cpp:150)
==1291918==    by 0x8078A8E: TcpConnection::internalOnReceive(pbuf*, signed char) (TcpConnection.cpp:484)
==1291918==    by 0x8058560: tcp_input (in /stripe/sandboxes/sming-dev/samples/HttpServer_WebSockets/out/Host/debug/firmware/app)
==1291918==    by 0x80627F3: ip4_input (in /stripe/sandboxes/sming-dev/samples/HttpServer_WebSockets/out/Host/debug/firmware/app)
==1291918==    by 0x8063C89: ethernet_input (in /stripe/sandboxes/sming-dev/samples/HttpServer_WebSockets/out/Host/debug/firmware/app)
==1291918==    by 0x8064245: tapif_select (in /stripe/sandboxes/sming-dev/samples/HttpServer_WebSockets/out/Host/debug/firmware/app)
==1291918== 
==1291918== LEAK SUMMARY:
==1291918==    definitely lost: 64 bytes in 2 blocks
==1291918==    indirectly lost: 0 bytes in 0 blocks
==1291918==      possibly lost: 0 bytes in 0 blocks
==1291918==    still reachable: 4,069 bytes in 14 blocks
==1291918==         suppressed: 0 bytes in 0 blocks
==1291918== Reachable blocks (those to which a pointer was found) are not shown.
==1291918== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==1291918== 
==1291918== For lists of detected and suppressed errors, rerun with: -s
==1291918== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```