### PR TITLE
Fix failing CI (module exfat not found)

### DIFF
--- a/Tools/install.sh
+++ b/Tools/install.sh
@@ -104,7 +104,7 @@ if [ -n "$APPVEYOR" ] || [ -n "$GITHUB_ACTION" ]; then
         g++-multilib \
         python3-setuptools \
         ninja-build \
-        linux-modules-extra-azure \
+        linux-modules-extra-$(uname -r) \
         exfatprogs \
         $EXTRA_PACKAGES
 


### PR DESCRIPTION
Wrong version of `linux-modules-extra` being installed. Fix to #2735.