### PR TITLE
PYTHON not set correctly in export.sh

### DIFF
--- a/Tools/export.sh
+++ b/Tools/export.sh
@@ -28,7 +28,7 @@ if [ -z "$SMING_HOME" ]; then
 fi
 
 # Common
-export PYTHON=${PYTHON:=/usr/bin/python3}
+export PYTHON=${PYTHON:=$(which python3)}
 
 # Esp8266
 export ESP_HOME=${ESP_HOME:=/opt/esp-quick-toolchain}


### PR DESCRIPTION
The `PYTHON` environment variable isn't set correctly for CI builds, or for other installations where non-standard locations may be used. This can result in unexpected behaviour where multiple python3 versions are installed.

Update to #2735.
