### PR TITLE
Fix and expand DateTime class, address 64-bit time_t issues

### DIFF
--- a/Sming/Arch/Host/Components/libc/gmtime_r.c
+++ b/Sming/Arch/Host/Components/libc/gmtime_r.c
@@ -1,0 +1,122 @@
+/*
+ * gmtime_r.c
+ * Original Author: Adapted from tzcode maintained by Arthur David Olson.
+ * Modifications:
+ * - Changed to mktm_r and added __tzcalc_limits - 04/10/02, Jeff Johnston
+ * - Fixed bug in mday computations - 08/12/04, Alex Mogilnikov <alx@intellectronika.ru>
+ * - Fixed bug in __tzcalc_limits - 08/12/04, Alex Mogilnikov <alx@intellectronika.ru>
+ * - Move code from _mktm_r() to gmtime_r() - 05/09/14, Freddie Chopin <freddie_chopin@op.pl>
+ * - Fixed bug in calculations for dates after year 2069 or before year 1901. Ideas for
+ *   solution taken from musl's __secs_to_tm() - 07/12/2014, Freddie Chopin
+ *   <freddie_chopin@op.pl>
+ * - Use faster algorithm from civil_from_days() by Howard Hinnant - 12/06/2014,
+ * Freddie Chopin <freddie_chopin@op.pl>
+ *
+ * Converts the calendar time pointed to by tim_p into a broken-down time
+ * expressed as local time. Returns a pointer to a structure containing the
+ * broken-down time.
+ */
+
+#ifdef __WIN32
+
+#include <time.h>
+
+#define SECSPERMIN	60L
+#define MINSPERHOUR	60L
+#define HOURSPERDAY	24L
+#define SECSPERHOUR	(SECSPERMIN * MINSPERHOUR)
+#define SECSPERDAY	(SECSPERHOUR * HOURSPERDAY)
+#define DAYSPERWEEK	7
+#define MONSPERYEAR	12
+
+#define YEAR_BASE	1900
+#define EPOCH_YEAR      1970
+#define EPOCH_WDAY      4
+#define EPOCH_YEARS_SINCE_LEAP 2
+#define EPOCH_YEARS_SINCE_CENTURY 70
+#define EPOCH_YEARS_SINCE_LEAP_CENTURY 370
+
+#define isleap(y) ((((y) % 4) == 0 && ((y) % 100) != 0) || ((y) % 400) == 0)
+
+/* Move epoch from 01.01.1970 to 01.03.0000 (yes, Year 0) - this is the first
+ * day of a 400-year long "era", right after additional day of leap year.
+ * This adjustment is required only for date calculation, so instead of
+ * modifying time_t value (which would require 64-bit operations to work
+ * correctly) it's enough to adjust the calculated number of days since epoch.
+ */
+#define EPOCH_ADJUSTMENT_DAYS	719468L
+/* year to which the adjustment was made */
+#define ADJUSTED_EPOCH_YEAR	0
+/* 1st March of year 0 is Wednesday */
+#define ADJUSTED_EPOCH_WDAY	3
+/* there are 97 leap years in 400-year periods. ((400 - 97) * 365 + 97 * 366) */
+#define DAYS_PER_ERA		146097L
+/* there are 24 leap years in 100-year periods. ((100 - 24) * 365 + 24 * 366) */
+#define DAYS_PER_CENTURY	36524L
+/* there is one leap year every 4 years */
+#define DAYS_PER_4_YEARS	(3 * 365 + 366)
+/* number of days in a non-leap year */
+#define DAYS_PER_YEAR		365
+/* number of days in January */
+#define DAYS_IN_JANUARY		31
+/* number of days in non-leap February */
+#define DAYS_IN_FEBRUARY	28
+/* number of years per era */
+#define YEARS_PER_ERA		400
+
+struct tm *
+gmtime_r (const time_t *__restrict tim_p,
+	struct tm *__restrict res)
+{
+  long days, rem;
+  const time_t lcltime = *tim_p;
+  int era, weekday, year;
+  unsigned erayear, yearday, month, day;
+  unsigned long eraday;
+
+  days = lcltime / SECSPERDAY + EPOCH_ADJUSTMENT_DAYS;
+  rem = lcltime % SECSPERDAY;
+  if (rem < 0)
+    {
+      rem += SECSPERDAY;
+      --days;
+    }
+
+  /* compute hour, min, and sec */
+  res->tm_hour = (int) (rem / SECSPERHOUR);
+  rem %= SECSPERHOUR;
+  res->tm_min = (int) (rem / SECSPERMIN);
+  res->tm_sec = (int) (rem % SECSPERMIN);
+
+  /* compute day of week */
+  if ((weekday = ((ADJUSTED_EPOCH_WDAY + days) % DAYSPERWEEK)) < 0)
+    weekday += DAYSPERWEEK;
+  res->tm_wday = weekday;
+
+  /* compute year, month, day & day of year */
+  /* for description of this algorithm see
+   * http://howardhinnant.github.io/date_algorithms.html#civil_from_days */
+  era = (days >= 0 ? days : days - (DAYS_PER_ERA - 1)) / DAYS_PER_ERA;
+  eraday = days - era * DAYS_PER_ERA;	/* [0, 146096] */
+  erayear = (eraday - eraday / (DAYS_PER_4_YEARS - 1) + eraday / DAYS_PER_CENTURY -
+      eraday / (DAYS_PER_ERA - 1)) / 365;	/* [0, 399] */
+  yearday = eraday - (DAYS_PER_YEAR * erayear + erayear / 4 - erayear / 100);	/* [0, 365] */
+  month = (5 * yearday + 2) / 153;	/* [0, 11] */
+  day = yearday - (153 * month + 2) / 5 + 1;	/* [1, 31] */
+  month += month < 10 ? 2 : -10;
+  year = ADJUSTED_EPOCH_YEAR + erayear + era * YEARS_PER_ERA + (month <= 1);
+
+  res->tm_yday = yearday >= DAYS_PER_YEAR - DAYS_IN_JANUARY - DAYS_IN_FEBRUARY ?
+      yearday - (DAYS_PER_YEAR - DAYS_IN_JANUARY - DAYS_IN_FEBRUARY) :
+      yearday + DAYS_IN_JANUARY + DAYS_IN_FEBRUARY + isleap(erayear);
+  res->tm_year = year - YEAR_BASE;
+  res->tm_mon = month;
+  res->tm_mday = day;
+
+  res->tm_isdst = 0;
+
+  return (res);
+}
+
+#endif // __WIN32
+

--- a/Sming/Arch/Host/Components/libc/include/time.h
+++ b/Sming/Arch/Host/Components/libc/include/time.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include_next <time.h>
+
+#ifdef __WIN32
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct tm* gmtime_r(const time_t*, struct tm*);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Sming/Arch/Host/build.mk
+++ b/Sming/Arch/Host/build.mk
@@ -23,7 +23,8 @@ GCC_UPGRADE_URL := https://sming.readthedocs.io/en/latest/arch/host/host-emulato
 CPPFLAGS += \
 	-m32 \
 	-Wno-deprecated-declarations \
-	-D_FILE_OFFSET_BITS=64
+	-D_FILE_OFFSET_BITS=64 \
+	-D_TIME_BITS=64
 
 # => Tools
 MEMANALYZER = size

--- a/Sming/Components/axtls-8266/axtls-8266.patch
+++ b/Sming/Components/axtls-8266/axtls-8266.patch
@@ -220,7 +220,7 @@ index 53509d0..25c568d 100644
  #endif
  
 diff --git a/replacements/time.c b/replacements/time.c
-index 4972119..3e7e407 100644
+index 4972119..d39481c 100644
 --- a/replacements/time.c
 +++ b/replacements/time.c
 @@ -16,29 +16,25 @@
@@ -286,7 +286,7 @@ index 4972119..3e7e407 100644
  {
      sntp_stop();
  
-@@ -93,22 +89,24 @@ void configTime(int timezone, int daylightOffset_sec, const char* server1, const
+@@ -93,22 +89,16 @@ void configTime(int timezone, int daylightOffset_sec, const char* server1, const
      sntp_init();
  }
  
@@ -302,21 +302,20 @@ index 4972119..3e7e407 100644
      return 0;
  }
  
- // seconds since 1970
+-// seconds since 1970
 -time_t mktime(struct tm *t)
-+time_t WEAK_ATTR mktime(struct tm *t)
- {
-     // system_mktime expects month in range 1..12
-     #define START_MONTH 1
-     return DIFF1900TO1970 + system_mktime(t->tm_year, t->tm_mon + START_MONTH, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
- }
- 
+-{
+-    // system_mktime expects month in range 1..12
+-    #define START_MONTH 1
+-    return DIFF1900TO1970 + system_mktime(t->tm_year, t->tm_mon + START_MONTH, t->tm_mday, t->tm_hour, t->tm_min, t->tm_sec);
+-}
+-
 -time_t time(time_t * t)
 +time_t WEAK_ATTR time(time_t * t)
  {
      time_t seconds = sntp_get_current_timestamp();
      if (t)
-@@ -118,30 +116,32 @@ time_t time(time_t * t)
+@@ -118,30 +108,32 @@ time_t time(time_t * t)
      return seconds;
  }
  

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -244,7 +244,7 @@ void DateTime::fromUnixTime(time_t timep, uint8_t* psec, uint8_t* pmin, uint8_t*
 	// *pdayofyear=epoch;  // days since jan 1 this year
 
 	uint8_t month;
-	for(month = 0; month < 12; month++) {
+	for(month = dtJanuary; month <= dtDecember; month++) {
 		uint8_t monthDays = getMonthDays(month, year);
 		if(epoch >= monthDays) {
 			epoch -= monthDays;
@@ -279,8 +279,8 @@ time_t DateTime::toUnixTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t day,
 		}
 	}
 	// add days for this year
-	for(unsigned i = 0; i < month; i++) {
-		seconds += SECS_PER_DAY * getMonthDays(i, year);
+	for(unsigned m = dtJanuary; m < month; ++m) {
+		seconds += SECS_PER_DAY * getMonthDays(m, year);
 	}
 
 	seconds += (day - 1) * SECS_PER_DAY;
@@ -429,15 +429,15 @@ String DateTime::format(const char* sFormat)
 void DateTime::calcDayOfYear()
 {
 	DayofYear = 0;
-	for(auto i = 0; i < Month; ++i) {
-		switch(i) {
-		case 8:  // Sep
-		case 3:  // Apr
-		case 5:  // Jun
-		case 10: // Nov
+	for(unsigned m = dtJanuary; m < Month; ++m) {
+		switch(m) {
+		case dtSeptember:
+		case dtApril:
+		case dtJune:
+		case dtNovember:
 			DayofYear += 30;
 			break;
-		case 1: // Feb
+		case dtFebruary:
 			DayofYear += isLeapYear(Year) ? 29 : 28;
 			break;
 		default:

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -103,7 +103,7 @@ void DateTime::setTime(time_t time)
 	calcDayOfYear();
 }
 
-bool DateTime::isNull()
+bool DateTime::isNull() const
 {
 	return Second == 0 && Minute == 0 && Hour == 0 && Day == 0 && Month == 0 && Year == 0 && DayofWeek == 0 &&
 		   Milliseconds == 0;
@@ -169,32 +169,32 @@ bool DateTime::fromHttpDate(const String& httpDate)
 	return true;
 }
 
-time_t DateTime::toUnixTime()
+time_t DateTime::toUnixTime() const
 {
 	return toUnixTime(Second + (Milliseconds / 1000), Minute, Hour, Day, Month, Year);
 }
 
-String DateTime::toShortDateString()
+String DateTime::toShortDateString() const
 {
 	return format(_F("%d.%m.%Y"));
 }
 
-String DateTime::toShortTimeString(bool includeSeconds)
+String DateTime::toShortTimeString(bool includeSeconds) const
 {
 	return format(includeSeconds ? _F("%T") : _F("%r"));
 }
 
-String DateTime::toFullDateTimeString()
+String DateTime::toFullDateTimeString() const
 {
 	return format(_F("%x %T"));
 }
 
-String DateTime::toISO8601()
+String DateTime::toISO8601() const
 {
 	return format(_F("%FT%TZ"));
 }
 
-String DateTime::toHTTPDate()
+String DateTime::toHTTPDate() const
 {
 	return format(_F("%a, %d %b %Y %T GMT"));
 }
@@ -298,7 +298,7 @@ time_t DateTime::toUnixTime(int sec, int min, int hour, int day, uint8_t month, 
 	return seconds;
 }
 
-String DateTime::format(const char* sFormat)
+String DateTime::format(const char* sFormat) const
 {
 	if(sFormat == nullptr) {
 		return nullptr;
@@ -454,7 +454,7 @@ void DateTime::calcDayOfYear()
 	DayofYear += Day;
 }
 
-uint8_t DateTime::calcWeek(uint8_t firstDay)
+uint8_t DateTime::calcWeek(uint8_t firstDay) const
 {
 	int16_t startOfWeek = DayofYear - DayofWeek + firstDay;
 	int8_t firstDayofWeek = startOfWeek % 7;

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -117,17 +117,19 @@ bool DateTime::fromHttpDate(const String& httpDate)
 	// Parse and return a decimal number and update ptr to the first non-numeric character after it
 	auto parseNumber = [&ptr]() { return strtol(ptr, const_cast<char**>(&ptr), 10); };
 
-	if(!matchName(ptr, DayofWeek, isoDayNames, 7)) {
-		return false; // Invalid day of week
-	}
-	if(ptr[0] == ',' && ptr[1] == ' ') {
-		// Accept "Sun, ", etc.
-		ptr += 2;
-	} else if(strncmp(ptr, "day, ", 5) == 0) {
-		// Accept "Sunday, ", etc
-		ptr += 5;
-	} else {
-		return false;
+	if(!isdigit(*ptr)) {
+		if(!matchName(ptr, DayofWeek, isoDayNames, 7)) {
+			return false; // Invalid day of week
+		}
+		if(ptr[0] == ',' && ptr[1] == ' ') {
+			// Accept "Sun, ", etc.
+			ptr += 2;
+		} else if(strncmp(ptr, "day, ", 5) == 0) {
+			// Accept "Sunday, ", etc
+			ptr += 5;
+		} else {
+			return false;
+		}
 	}
 
 	Day = parseNumber();

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -9,7 +9,17 @@
 
 #include "DateTime.h"
 #include "Data/CStringArray.h"
-#include <stringconversion.h>
+
+#ifdef ARCH_ESP32
+#include <esp_idf_version.h>
+#endif
+
+#if defined(__WIN32) || (defined(ARCH_ESP32) && ESP_IDF_VERSION_MAJOR < 5)
+static_assert(sizeof(time_t) != 8, "Great! Now supports 64-bit - please update code");
+#warning "**Y2038** time_t is only 32-bits in this build configuration"
+#else
+static_assert(sizeof(time_t) == 8, "Expecting 64-bit time_t");
+#endif
 
 #define LEAP_YEAR(year) ((year % 4) == 0)
 

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -13,8 +13,10 @@
 
 #define LEAP_YEAR(year) ((year % 4) == 0)
 
-DEFINE_FSTR_LOCAL(flashMonthNames, LOCALE_MONTH_NAMES);
-DEFINE_FSTR_LOCAL(flashDayNames, LOCALE_DAY_NAMES);
+namespace
+{
+DEFINE_FSTR(flashMonthNames, LOCALE_MONTH_NAMES);
+DEFINE_FSTR(flashDayNames, LOCALE_DAY_NAMES);
 
 /* We can more efficiently compare text of 4 character length by comparing as words */
 union FourDigitName {
@@ -27,12 +29,12 @@ union FourDigitName {
 	}
 };
 
-static const FourDigitName isoDayNames[7] PROGMEM = {
+const FourDigitName isoDayNames[7] PROGMEM = {
 	{'S', 'u', 'n', '\0'}, {'M', 'o', 'n', '\0'}, {'T', 'u', 'e', '\0'}, {'W', 'e', 'd', '\0'},
 	{'T', 'h', 'u', '\0'}, {'F', 'r', 'i', '\0'}, {'S', 'a', 't', '\0'},
 };
 
-static const FourDigitName isoMonthNames[12] PROGMEM = {
+const FourDigitName isoMonthNames[12] PROGMEM = {
 	{'J', 'a', 'n', '\0'}, {'F', 'e', 'b', '\0'}, {'M', 'a', 'r', '\0'}, {'A', 'p', 'r', '\0'},
 	{'M', 'a', 'y', '\0'}, {'J', 'u', 'n', '\0'}, {'J', 'u', 'l', '\0'}, {'A', 'u', 'g', '\0'},
 	{'S', 'e', 'p', '\0'}, {'O', 'c', 't', '\0'}, {'N', 'o', 'v', '\0'}, {'D', 'e', 'c', '\0'},
@@ -43,11 +45,13 @@ static const FourDigitName isoMonthNames[12] PROGMEM = {
  *  @param year
  *  @retval uint8_t number of days in the month
  */
-static uint8_t getMonthDays(uint8_t month, uint8_t year)
+uint8_t getMonthDays(uint8_t month, uint8_t year)
 {
 	static const uint8_t monthDays[] PROGMEM = {31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
 	return (month == 1 && LEAP_YEAR(year)) ? 29 : pgm_read_byte(&monthDays[month]);
 }
+
+} // namespace
 
 //******************************************************************************
 //* DateTime Public Methods

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -502,8 +502,12 @@ String DateTime::format(const char* sFormat) const
 		case 'R': // Short time (HH:MM)
 			sReturn += format(_F("%H:%M"));
 			break;
-		case 'T': // ISO 8601 time format (HH:MM:SS)
+		case 'T': // ISO 8601 time format (HH:MM:SS{.mmm})
 			sReturn += format(_F("%H:%M:%S"));
+			if(Milliseconds != 0) {
+				sReturn += '.';
+				sReturn.concat(Milliseconds, DEC, 3);
+			}
 			break;
 		case 'p': // Meridiem [AM,PM]
 			sReturn += (Hour < 12) ? "AM" : "PM";

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -23,22 +23,18 @@ union FourDigitName {
 	char c[4];
 	uint32_t value;
 
+	// Compare without case-sensitivity
 	bool operator==(const FourDigitName& name) const
 	{
-		return value == name.value;
+		constexpr uint32_t caseMask{~0x20202020U};
+		return ((value ^ name.value) & caseMask) == 0;
 	}
 };
 
-const FourDigitName isoDayNames[7] PROGMEM = {
-	{'S', 'u', 'n', '\0'}, {'M', 'o', 'n', '\0'}, {'T', 'u', 'e', '\0'}, {'W', 'e', 'd', '\0'},
-	{'T', 'h', 'u', '\0'}, {'F', 'r', 'i', '\0'}, {'S', 'a', 't', '\0'},
-};
+const FourDigitName isoDayNames[7] PROGMEM = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
-const FourDigitName isoMonthNames[12] PROGMEM = {
-	{'J', 'a', 'n', '\0'}, {'F', 'e', 'b', '\0'}, {'M', 'a', 'r', '\0'}, {'A', 'p', 'r', '\0'},
-	{'M', 'a', 'y', '\0'}, {'J', 'u', 'n', '\0'}, {'J', 'u', 'l', '\0'}, {'A', 'u', 'g', '\0'},
-	{'S', 'e', 'p', '\0'}, {'O', 'c', 't', '\0'}, {'N', 'o', 'v', '\0'}, {'D', 'e', 'c', '\0'},
-};
+const FourDigitName isoMonthNames[12] PROGMEM = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
+												 "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
 /*
  * @brief Match a day or month name against a list of values and set the required value
@@ -47,6 +43,8 @@ const FourDigitName isoMonthNames[12] PROGMEM = {
  * @isoNames Array of values
  * @nameCount Number of names in array
  * @retval bool false on failure
+ *
+ * Names are compared without case-sensitivity
  */
 bool matchName(const char* ptr, uint8_t& value, const FourDigitName isoNames[], unsigned nameCount)
 {

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -264,7 +264,7 @@ void DateTime::fromUnixTime(time_t timep, uint8_t* psec, uint8_t* pmin, uint8_t*
 	}
 }
 
-time_t DateTime::toUnixTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t day, uint8_t month, uint16_t year)
+time_t DateTime::toUnixTime(int sec, int min, int hour, int day, uint8_t month, uint16_t year)
 {
 	if(year < 69) {
 		year += 2000;
@@ -290,9 +290,9 @@ time_t DateTime::toUnixTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t day,
 		seconds += SECS_PER_DAY * getMonthDays(m, year);
 	}
 
-	seconds += (day - 1) * SECS_PER_DAY;
-	seconds += hour * SECS_PER_HOUR;
-	seconds += min * SECS_PER_MIN;
+	seconds += time_t(day - 1) * SECS_PER_DAY;
+	seconds += time_t(hour) * SECS_PER_HOUR;
+	seconds += time_t(min) * SECS_PER_MIN;
 	seconds += sec;
 
 	return seconds;

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -158,6 +158,29 @@ public:
 	 */
 	bool fromHttpDate(const String& httpDate);
 
+	/** @brief  Parse an ISO8601 date/time string
+	 *  @param  datetime Date and optional time in ISO8601 format, e.g. "1994-11-06", "1994-11-06T08:49:37". Separators are optional.
+	 *  @retval bool True on success
+	 *  @see See https://en.wikipedia.org/wiki/ISO_8601
+	 *
+	 * `Basic format` doesn't include separators, whereas `Extended format` does.
+	 *
+	 * Acceptable date formats:
+	 *
+	 * 	YYYY-MM-DD or YYYYMMDD
+	 * 	YYYY-MM (but not YYYYMM)
+	 *
+	 * Acceptable time formats:
+	 *
+	 * 	Thh:mm:ss.sss or Thhmmss.sss
+	 * 	Thh:mm:ss or Thhmmss
+	 * 	Thh:mm.mmm or Thhmm.mmm
+	 * 	Thh:mm or Thhmm
+	 * 	Thh.hhh
+	 * 	Thh
+	 */
+	bool fromISO8601(const String& datetime);
+
 	/** @brief  Check if time date object is initialised
 	 *  @retval True if object has no value. False if initialised.
 	 */

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -234,7 +234,7 @@ public:
 	 *  @note   This static function  may be used without instantiating a DateTime object, e.g. `time_t unixTime = DateTime::toUnixTime(...);`
 	 *  @note   Unix time does not account for leap seconds.
 	 */
-	static time_t toUnixTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t day, uint8_t month, uint16_t year);
+	static time_t toUnixTime(int sec, int min, int hour, int day, uint8_t month, uint16_t year);
 
 	/** @brief  Create string formatted with time and date placeholders
 	 *  @param  formatString String including date and time formatting

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -57,13 +57,30 @@
 /** @brief  Days of week
 */
 enum dtDays_t {
-	dtSunday,	///< Sunday
-	dtMonday,	///< Monday
-	dtTuesday,   ///< Tuesday
-	dtWednesday, ///< Wednesday
-	dtThursday,  ///< Thursday
-	dtFriday,	///< Friday
-	dtSaturday   ///< Saturday
+	dtSunday,
+	dtMonday,
+	dtTuesday,
+	dtWednesday,
+	dtThursday,
+	dtFriday,
+	dtSaturday,
+};
+
+/** @brief  Months
+*/
+enum dtMonth_t {
+	dtJanuary,
+	dtFebruary,
+	dtMarch,
+	dtApril,
+	dtMay,
+	dtJune,
+	dtJuly,
+	dtAugust,
+	dtSeptember,
+	dtOctober,
+	dtNovember,
+	dtDecember,
 };
 
 /** @brief  Date and time class

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -314,6 +314,14 @@ public:
 		return format(formatString.c_str());
 	}
 
+	static bool isLeapYear(uint16_t year);
+	static uint8_t getMonthDays(uint8_t month, uint16_t year);
+	static String getLocaleDayName(uint8_t day);
+	static String getLocaleMonthName(uint8_t month);
+	static String getIsoDayName(uint8_t day);
+	static String getIsoMonthName(uint8_t month);
+	static uint16_t getDaysInYear(uint16_t year);
+
 private:
 	// Helper methods
 	void calcDayOfYear();					  // Calculate day of year

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -227,11 +227,11 @@ public:
 	 *  @param  min Minutes
 	 *  @param  hour Hours
 	 *  @param  day Days
-	 *  @param  month Month (0-11, Jan=0, Feb=1, ...Dec=11)
-	 *  @param  year Year (1901-2036), either full 4 digit year or 2 digits for 1970-2036
+	 *  @param  month Month (0-11, Jan=0, Feb=1, ...Dec=11), or enum (dtJanuary, ...)
+	 *  @param  year Year, either full 4 digit year or 2 digits for 2000-2068
+	 *  @retval time_t Number of seconds since unix epoch (Midnight, Jan 1 1970)
 	 *  @note   Seconds, minutes, hours and days may be any value, e.g. to calculate the value for 300 days since 1970 (epoch), set day=300
-	 *  @note   This static function  may be used without instantiating a DateTime object, e.g. time_t unixTime = DateTime::convertToUnixTime(...);
-	 *  @note   32-bit Unix time is valid between 1901-12-13 and 03:14:07 2038-01-19
+	 *  @note   This static function  may be used without instantiating a DateTime object, e.g. `time_t unixTime = DateTime::toUnixTime(...);`
 	 *  @note   Unix time does not account for leap seconds.
 	 */
 	static time_t toUnixTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t day, uint8_t month, uint16_t year);

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -73,8 +73,15 @@ enum dtDays_t {
  * This means that timespan calculation and free-running clocks may be inaccurate if they span leap seconds.
  * To facilitate leap seconds, reference must be made to leap second table.
  * This will not be done within the Sming framework and must be handled by application code if required.
+ * @see https://www.eecis.udel.edu/~mills/leap.html
  *
- *  @note   Sming uses 32-bit signed integer for its time_t data type which supports a range of +/-68 years. This means Sming is susceptible to Year 2038 problem.
+ * @note time_t is a signed 64-bit value for all architectures **except** Windows Host and esp32 ESP-IDF 4.x.
+ *
+ * 32-bit signed values support a range of +/-68 years; the Unix epoch is midnight 1 Jan 1970, so overflows at about 3am on 19 Jan 2038.
+ * The value is signed which allows dates prior to 1970 to be represented.
+ *
+ * An unsigned 32-bit value can be used to store dates provided they are after 1970.
+ * These are good until February 2106.
  */
 class DateTime
 {
@@ -141,7 +148,7 @@ public:
 
 	/** @brief  Get Unix time
 	 *  @retval time_t Unix time, quantity of seconds since 00:00:00 1970-01-01
-	 *  @note   Unix time does not account for leap seconds. To convert Unix time to UTC requires reference to a leap second table.
+	 *  @note   Unix time does not account for leap seconds.
 	 */
 	time_t toUnixTime();
 
@@ -190,7 +197,7 @@ public:
 	 *  @note   Pass the Unix timedate value and pointers to existing integers. The integers are updated with the converted values
 	 *  @note   This static function  may be used without instantiating a DateTime object, e.g. DateTime::convertFromUnixTime(...);
 	 *  @note   32-bit Unix time has year 2036 issue.
-	 *  @note   Unix time does not account for leap seconds. To convert Unix time to UTC requires reference to a leap second table.
+	 *  @note   Unix time does not account for leap seconds.
 	 *  @note   All of the return values are optional, specify nullptr if not required
 	 */
 	static void fromUnixTime(time_t timep, uint8_t* psec, uint8_t* pmin, uint8_t* phour, uint8_t* pday, uint8_t* pwday,
@@ -208,7 +215,7 @@ public:
 	 *  @note   Seconds, minutes, hours and days may be any value, e.g. to calculate the value for 300 days since 1970 (epoch), set day=300
 	 *  @note   This static function  may be used without instantiating a DateTime object, e.g. time_t unixTime = DateTime::convertToUnixTime(...);
 	 *  @note   32-bit Unix time is valid between 1901-12-13 and 03:14:07 2038-01-19
-	 *  @note   Unix time does not account for leap seconds. To convert Unix time to UTC requires reference to a leap second table.
+	 *  @note   Unix time does not account for leap seconds.
 	 */
 	static time_t toUnixTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t day, uint8_t month, uint16_t year);
 

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -21,7 +21,6 @@
 #include "SmingLocale.h"
 #include <sming_attr.h>
 
-/*==============================================================================*/
 /* Useful Constants */
 #define SECS_PER_MIN (60UL)
 #define SECS_PER_HOUR (3600UL)
@@ -30,29 +29,6 @@
 #define SECS_PER_WEEK (SECS_PER_DAY * DAYS_PER_WEEK)
 #define SECS_PER_YEAR (SECS_PER_WEEK * 52L)
 #define SECS_YR_2000 (946681200UL)
-
-/* Useful Macros for getting elapsed time */
-/** Get just seconds part of given Unix time */
-#define numberOfSeconds(_time_) (_time_ % SECS_PER_MIN)
-/** Get just minutes part of given Unix time */
-#define numberOfMinutes(_time_) ((_time_ / SECS_PER_MIN) % SECS_PER_MIN)
-/** Get just hours part of given Unix time */
-#define numberOfHours(_time_) ((_time_ % SECS_PER_DAY) / SECS_PER_HOUR)
-/** Get day of week from given Unix time */
-#define dayOfWeek(_time_) ((_time_ / SECS_PER_DAY + 4) % DAYS_PER_WEEK) // 0 = Sunday
-/** Get elapsed days since 1970-01-01 from given Unix time */
-#define elapsedDays(_time_) (_time_ / SECS_PER_DAY) // this is number of days since Jan 1 1970
-/** Get quantity of seconds since midnight from given Unix time */
-#define elapsedSecsToday(_time_) (_time_ % SECS_PER_DAY) // the number of seconds since last midnight
-/** Get Unix time of midnight at start of day from given Unix time */
-#define previousMidnight(_time_) ((_time_ / SECS_PER_DAY) * SECS_PER_DAY) // time at the start of the given day
-/** Get Unix time of midnight at end of day from given just Unix time */
-#define nextMidnight(_time_) (previousMidnight(_time_) + SECS_PER_DAY) // time at the end of the given day
-/** Get quantity of seconds since midnight at start of previous Sunday from given Unix time */
-#define elapsedSecsThisWeek(_time_) (elapsedSecsToday(_time_) + (dayOfWeek(_time_) * SECS_PER_DAY))
-
-// todo add date math macros
-/*============================================================================*/
 
 /** @brief  Days of week
 */
@@ -82,6 +58,62 @@ enum dtMonth_t {
 	dtNovember,
 	dtDecember,
 };
+
+/* Useful functions for getting elapsed time */
+
+/** Get just seconds part of given Unix time */
+inline constexpr uint8_t numberOfSeconds(time_t time)
+{
+	return time % SECS_PER_MIN;
+}
+
+/** Get just minutes part of given Unix time */
+inline constexpr uint8_t numberOfMinutes(time_t time)
+{
+	return (time / SECS_PER_MIN) % SECS_PER_MIN;
+}
+
+/** Get just hours part of given Unix time */
+inline constexpr uint8_t numberOfHours(time_t time)
+{
+	return (time % SECS_PER_DAY) / SECS_PER_HOUR;
+}
+
+/** Get day of week from given Unix time */
+inline constexpr dtDays_t dayOfWeek(time_t time)
+{
+	return dtDays_t((time / SECS_PER_DAY + 4) % DAYS_PER_WEEK);
+}
+
+/** Get elapsed days since 1970-01-01 from given Unix time */
+inline constexpr uint8_t elapsedDays(time_t time)
+{
+	return time / SECS_PER_DAY;
+}
+
+/** Get quantity of seconds since midnight from given Unix time */
+inline constexpr unsigned elapsedSecsToday(time_t time)
+{
+	return time % SECS_PER_DAY;
+}
+
+/** Get Unix time of midnight at start of day from given Unix time */
+inline constexpr time_t previousMidnight(time_t time)
+{
+	return (time / SECS_PER_DAY) * SECS_PER_DAY;
+}
+
+/** Get Unix time of midnight at end of day from given just Unix time */
+inline constexpr time_t nextMidnight(time_t time)
+{
+	return previousMidnight(time) + SECS_PER_DAY;
+}
+
+/** Get quantity of seconds since midnight at start of previous Sunday from given Unix time */
+inline constexpr unsigned elapsedSecsThisWeek(time_t time)
+{
+	return elapsedSecsToday(time) + dayOfWeek(time) * SECS_PER_DAY;
+}
 
 /** @brief  Date and time class
  *

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -161,39 +161,39 @@ public:
 	/** @brief  Check if time date object is initialised
 	 *  @retval True if object has no value. False if initialised.
 	 */
-	bool isNull();
+	bool isNull() const;
 
 	/** @brief  Get Unix time
 	 *  @retval time_t Unix time, quantity of seconds since 00:00:00 1970-01-01
 	 *  @note   Unix time does not account for leap seconds.
 	 */
-	time_t toUnixTime();
+	time_t toUnixTime() const;
 
 	/** @brief  Get human readable date
 	 *  @retval String Date in requested format, e.g. DD.MM.YYYY
 	 */
-	String toShortDateString();
+	String toShortDateString() const;
 
 	/** @brief  Get human readable time
 	 *  @param  includeSeconds True to include seconds (Default: false)
 	 *  @retval String Time in format hh:mm or hh:mm:ss
 	 */
-	String toShortTimeString(bool includeSeconds = false);
+	String toShortTimeString(bool includeSeconds = false) const;
 
 	/** @brief  Get human readable date and time
 	 *  @retval String Date and time in format DD.MM.YYYY hh:mm:ss
 	 */
-	String toFullDateTimeString();
+	String toFullDateTimeString() const;
 
 	/** @brief  Get human readable date and time
 	 *  @retval String Date and time in format YYYY-MM-DDThh:mm:ssZ
 	 */
-	String toISO8601();
+	String toISO8601() const;
 
 	/** @brief  Get human readable date and time
 	 *  @retval String Date and time in format DDD, DD MMM YYYY hh:mm:ss GMT
 	 */
-	String toHTTPDate();
+	String toHTTPDate() const;
 
 	/** @brief  Add time to date time object
 	 *  @param  add Quantity of milliseconds to add to object
@@ -279,21 +279,22 @@ public:
 	 *  | %%Y   | Year as a decimal number (range 1970 to ...) |  |
 	 *  | %%    | Percent sign |  |
 	 */
-	String format(const char* formatString);
+	String format(const char* formatString) const;
 
 	/** @brief  Create string formatted with time and date placeholders
 	 *  @param  formatString String including date and time formatting
 	 *  @retval String Formatted string
 	 *  @note see format(const char*) for parameter details
 	 */
-	String format(const String& formatString)
+	String format(const String& formatString) const
 	{
 		return format(formatString.c_str());
 	}
 
 private:
-	void calcDayOfYear();				// Helper function calculates day of year
-	uint8_t calcWeek(uint8_t firstDay); //Helper function calculates week number based on firstDay of week
+	// Helper methods
+	void calcDayOfYear();					  // Calculate day of year
+	uint8_t calcWeek(uint8_t firstDay) const; // Calculate week number based on firstDay of week
 
 public:
 	uint8_t Hour = 0;		   ///< Hour (0-23)

--- a/docs/source/upgrading/5.1-5.2.rst
+++ b/docs/source/upgrading/5.1-5.2.rst
@@ -3,7 +3,7 @@ From v5.1 to v5.2
 
 .. highlight:: c++
 
-**Breaking change**
+**PartitionStream: Breaking change**
 
 The :cpp:class:`Storage::PartitionStream` constructors with ``blockErase`` parameter have been deprecated.
 The intended default behaviour is read-only, however previously this also allowed writing without block erase.
@@ -11,3 +11,33 @@ This can result in corrupted flash contents where the flash has not been explici
 
 The new constructors instead use a :cpp:enum:`Storage::Mode` so behaviour is more explicit.
 The default is read-only and writes will now be failed.
+
+
+**64-bit time_t**
+
+There is some variability in whether `time_t` is 32 or 64 bits. See issue #2758.
+
+This is dependent on the toolchain and accompanying C library.
+
+32-bits:
+
+- Esp32 IDF 4.x
+- Windows Host (using mingw)
+- Linux host builds prior to Sming v5.2
+
+Range of time_t:
+
+    -0x80000000: 1901-12-13 20:45:52
+    0x00000000: 1970-01-01 00:00:00
+    0x7fffffff: 2038-01-19 03:14:07
+
+All others use 64-bit values.
+
+For reference, C library source code can be found here https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/
+
+Rp2040 builds with standard ARM toolkit so probably accommodated by the standard repo.
+
+Espressif toolchains use forks:
+
+esp8266: https://github.com/earlephilhower/newlib-xtensa/blob/xtensa-4_0_0-lock-arduino/newlib/libc/
+esp32: https://github.com/espressif/newlib-esp32/blob/esp-4.3.0/newlib/libc/

--- a/samples/Basic_DateTime/app/application.cpp
+++ b/samples/Basic_DateTime/app/application.cpp
@@ -11,7 +11,7 @@ namespace
 {
 DEFINE_FSTR_LOCAL(commandPrompt, "Enter Unix timestamp: ");
 
-void showTime(DateTime dt)
+void showTime(const DateTime& dt)
 {
 	auto printFormat = [&dt](const String& fmt, const String& msg) -> void {
 		Serial << fmt << ' ' << msg << ": " << dt.format(fmt) << endl;
@@ -85,10 +85,9 @@ void onRx(Stream& source, char arrivedChar, unsigned short availableCharsCount)
 		String s(buffer);
 		buffer.clear();
 		char* p;
-		time_t timestamp = strtoul(s.c_str(), &p, 0);
+		time_t timestamp = strtoll(s.c_str(), &p, 0);
 		if(p == s.end()) {
-			Serial << endl
-				   << _F("****Showing DateTime formatting options for Unix timestamp: ") << uint32_t(timestamp) << endl;
+			Serial << endl << _F("****Showing DateTime formatting options for Unix timestamp: ") << timestamp << endl;
 			showTime(timestamp);
 			break;
 		}
@@ -100,7 +99,13 @@ void onRx(Stream& source, char arrivedChar, unsigned short availableCharsCount)
 			break;
 		}
 
-		Serial << endl << _F("Please enter a valid numeric timestamp, or HTTP time string!") << endl;
+		if(dt.fromISO8601(s)) {
+			Serial << endl << _F("****Showing DateTime formatting options for ISO8601 date/time: ") << s << endl;
+			showTime(dt);
+			break;
+		}
+
+		Serial << endl << _F("Please enter a valid numeric timestamp, HTTP or ISO8601 date/time string!") << endl;
 		break;
 	}
 

--- a/tests/HostTests/README.rst
+++ b/tests/HostTests/README.rst
@@ -1,0 +1,13 @@
+HostTests
+=========
+
+Modular tests which must build and run on all architectures.
+
+DateTime
+--------
+
+Test data in ``include/DateTimeData.h`` is generated using python script ``tools/datetime-test.py``.
+
+If this file is changed, re-generate by running::
+
+    tools/datetime-test.py include/DateTimeData.h

--- a/tests/HostTests/include/DateTimeData.h
+++ b/tests/HostTests/include/DateTimeData.h
@@ -1,0 +1,76 @@
+
+/*
+    * DateTime test data
+    *
+    * File generated Thu Apr 11 14:30:36 2024
+    *
+    */
+
+// clang-format off
+
+namespace
+{
+struct TestDate {
+    const FlashString* stringToParse;
+    const FlashString* expectedString;
+    int64_t unixTimestamp;
+    uint16_t milliseconds;
+};
+
+#define VALID_HTTP_DATE_MAP(XX) \
+  XX(DT_1, "Sun, 06 Nov 1994 08:49:37 GMT", "Sun, 06 Nov 1994 08:49:37 GMT", 0x2ebc98a1LL, 0) \
+  XX(DT_2, "Sunday, 06 Nov 1994 08:49:37 GMT", "Sun, 06 Nov 1994 08:49:37 GMT", 0x2ebc98a1LL, 0) \
+  XX(DT_3, "Sunday, 06-Nov-94 08:49:37 GMT", "Sun, 06 Nov 1994 08:49:37 GMT", 0x2ebc98a1LL, 0) \
+  XX(DT_4, "Mon, 07 November 1994 00:00:00", "Mon, 07 Nov 1994 00:00:00 GMT", 0x2ebd6e00LL, 0) \
+  XX(DT_5, "  1   JAN\t \r\n \t2000    23:59:59", "Sat, 01 Jan 2000 23:59:59 GMT", 0x386e94ffLL, 0)
+
+#define VALID_ISO_DATETIME_MAP(XX) \
+  XX(DT_6, "2024-01-31", "2024-01-31T00:00:00Z", 0x65b98d80LL, 0) \
+  XX(DT_7, "20240131", "2024-01-31T00:00:00Z", 0x65b98d80LL, 0) \
+  XX(DT_8, "2024-01", "2024-01-01T00:00:00Z", 0x65920080LL, 0) \
+  XX(DT_9, "1901-12-13T20:45:53", "1901-12-13T20:45:53Z", -0x7fffffffLL, 0) \
+  XX(DT_10, "1901-12-13T20:45:52", "1901-12-13T20:45:52Z", -0x80000000LL, 0) \
+  XX(DT_11, "1970-01-01T00:00:00", "1970-01-01T00:00:00Z", 0x0LL, 0) \
+  XX(DT_12, "2038-01-19T03:14:07", "2038-01-19T03:14:07Z", 0x7fffffffLL, 0) \
+  XX(DT_13, "1950-01-01", "1950-01-01T00:00:00Z", -0x259e9d80LL, 0) \
+  XX(DT_14, "2024-04-08T12:33:17", "2024-04-08T12:33:17Z", 0x6613e40dLL, 0) \
+  XX(DT_15, "2024-04-09T12:33:16", "2024-04-09T12:33:16Z", 0x6615358cLL, 0)
+
+#define VALID_ISO_DATETIME64_MAP(XX) \
+  XX(DT_16, "2038-01-19T03:14:08", "2038-01-19T03:14:08Z", 0x80000000LL, 0) \
+  XX(DT_17, "2099-12-31T23:59:59", "2099-12-31T23:59:59Z", 0xf48656ffLL, 0) \
+  XX(DT_18, "2105-12-31T23:59:59", "2105-12-31T23:59:59Z", 0xffcedd7fLL, 0) \
+  XX(DT_19, "2106-02-07T06:28:15", "2106-02-07T06:28:15Z", 0xffffffffLL, 0) \
+  XX(DT_20, "2106-02-07T06:28:15", "2106-02-07T06:28:15Z", 0xffffffffLL, 0) \
+  XX(DT_21, "2106-02-07T06:28:16", "2106-02-07T06:28:16Z", 0x100000000LL, 0) \
+  XX(DT_22, "1901-12-13T20:45:52", "1901-12-13T20:45:52Z", -0x80000000LL, 0)
+
+#define VALID_ISO_TIME_MAP(XX) \
+  XX(DT_23, "T18:47:12.123", "18:47:12.123", 0x10830LL, 123) \
+  XX(DT_24, "T18:47:12.123456", "18:47:12.123", 0x10830LL, 123) \
+  XX(DT_25, "T12:34:12", "12:34:12", 0xb0c4LL, 0) \
+  XX(DT_26, "T23:59:59", "23:59:59", 0x1517fLL, 0) \
+  XX(DT_27, "12:34", "12:34:00", 0xb0b8LL, 0) \
+  XX(DT_28, "T2359", "23:59:00", 0x15144LL, 0)
+
+
+#define XX(tag, str, str2, ...) \
+    DEFINE_FSTR_LOCAL(STR1_##tag, str) \
+    DEFINE_FSTR_LOCAL(STR2_##tag, str2)
+  VALID_HTTP_DATE_MAP(XX)
+  VALID_ISO_DATETIME_MAP(XX)
+  VALID_ISO_DATETIME64_MAP(XX)
+  VALID_ISO_TIME_MAP(XX)
+
+#undef XX
+
+#define XX(tag, str, str2, ...) {&STR1_##tag, &STR2_##tag, ##__VA_ARGS__},
+DEFINE_FSTR_ARRAY(VALID_HTTP_DATE, TestDate, VALID_HTTP_DATE_MAP(XX))
+DEFINE_FSTR_ARRAY(VALID_ISO_DATETIME, TestDate, VALID_ISO_DATETIME_MAP(XX))
+DEFINE_FSTR_ARRAY(VALID_ISO_DATETIME64, TestDate, VALID_ISO_DATETIME64_MAP(XX))
+DEFINE_FSTR_ARRAY(VALID_ISO_TIME, TestDate, VALID_ISO_TIME_MAP(XX))
+
+#undef XX
+
+} // namespace
+

--- a/tests/HostTests/modules/DateTime.cpp
+++ b/tests/HostTests/modules/DateTime.cpp
@@ -1,6 +1,8 @@
 #include <HostTests.h>
-
 #include <DateTime.h>
+#include <FlashString/Array.hpp>
+
+#include "DateTimeData.h"
 
 class DateTimeTest : public TestGroup
 {
@@ -11,46 +13,121 @@ public:
 
 	void execute() override
 	{
-		DEFINE_FSTR_LOCAL(testDateString, "Sun, 06 Nov 1994 08:49:37 GMT");
-		constexpr time_t testDate = 784111777;
-		DateTime dt;
+		Serial << _F("time_t is ") << sizeof(time_t) * 8 << _F(" bits") << endl;
 
 		TEST_CASE("fromHttpDate()")
 		{
-			REQUIRE(dt.fromHttpDate(testDateString) == true);
+			checkHttpDates(VALID_HTTP_DATE);
 		}
 
-		TEST_CASE("toUnixTime()")
+		TEST_CASE("fromISO8601 (32-bit)")
 		{
-			debug_i("parseHttpDate(\"%s\") produced \"%s\"", String(testDateString).c_str(),
-					dt.toFullDateTimeString().c_str());
-			time_t unixTime = dt.toUnixTime();
-			REQUIRE(unixTime == testDate);
+			checkIsoTimes(VALID_ISO_DATETIME, false);
 		}
 
-		dt = testDate;
-		debug_d("\"%s\"", dt.toFullDateTimeString().c_str());
+		TEST_CASE("fromISO8601 (time only)")
+		{
+			checkIsoTimes(VALID_ISO_TIME, true);
+		}
+
+		if(sizeof(time_t) == 8) {
+			TEST_CASE("fromISO8601 (64-bit)")
+			{
+				checkIsoTimes(VALID_ISO_DATETIME64, false);
+			}
+		}
+
+		// dt = testDate;
+		// debug_d("\"%s\"", dt.toFullDateTimeString().c_str());
 
 		TEST_CASE("setTime")
 		{
-			checkSetTime(59, 59, 23, 14, 2, 2019);
-			checkSetTime(13, 1, 1, 1, 1, 1970);
+			checkSetTime(VALID_HTTP_DATE);
+			checkSetTime(VALID_ISO_DATETIME);
+			if(sizeof(time_t) == 8) {
+				checkSetTime(VALID_ISO_DATETIME64);
+			}
 		}
 	}
 
-	void checkSetTime(uint8_t sec, uint8_t min, uint8_t hour, uint8_t day, uint8_t month, uint16_t year)
+	void checkHttpDates(const FSTR::Array<TestDate>& dates)
 	{
-		DateTime dt;
-		dt.setTime(sec, min, hour, day, month, year);
-		debug_i("Checking '%s'", dt.toFullDateTimeString().c_str());
-		time_t unixTime = dt.toUnixTime();
-		dt.setTime(unixTime);
-		REQUIRE(dt.Second == sec);
-		REQUIRE(dt.Minute == min);
-		REQUIRE(dt.Hour == hour);
-		REQUIRE(dt.Day == day);
-		REQUIRE(dt.Month == month);
-		REQUIRE(dt.Year == year);
+		for(auto date : VALID_HTTP_DATE) {
+			DateTime dt;
+			String s(*date.stringToParse);
+			Serial << s << endl;
+			REQUIRE(dt.fromHttpDate(s));
+			REQUIRE_EQ(date.unixTimestamp, dt.toUnixTime());
+
+			dt.setTime(date.unixTimestamp);
+			REQUIRE_EQ(date.unixTimestamp, dt.toUnixTime());
+
+			REQUIRE_EQ(String(*date.expectedString), dt.toHTTPDate());
+			Serial.println();
+		}
+	}
+
+	void checkIsoTimes(const FSTR::Array<TestDate>& dates, bool timeOnly)
+	{
+		for(auto date : dates) {
+			DateTime dt;
+			String s(*date.stringToParse);
+			Serial << s << ", " << String(time_t(date.unixTimestamp), HEX) << endl;
+			REQUIRE(dt.fromISO8601(s));
+			Serial << dt.toISO8601() << endl;
+			REQUIRE_EQ(date.unixTimestamp, dt.toUnixTime());
+			REQUIRE_EQ(date.milliseconds, dt.Milliseconds);
+
+			if(timeOnly) {
+				REQUIRE_EQ(String(*date.expectedString), dt.format("%T"));
+			} else {
+				REQUIRE_EQ(String(*date.expectedString), dt.toISO8601());
+			}
+
+			dt.setTime(date.unixTimestamp);
+			REQUIRE_EQ(date.unixTimestamp, dt.toUnixTime());
+
+			Serial.println();
+		}
+	}
+
+	void checkSetTime(const FSTR::Array<TestDate>& dates)
+	{
+		for(auto date : dates) {
+			const DateTime refDate(date.unixTimestamp);
+
+			Serial << "RefDate " << refDate.toFullDateTimeString() << endl;
+
+			auto check = [&](int secOffset, int minOffset, int hourOffset, int dayOffset) {
+				const int sec = secOffset + refDate.Second;
+				const int min = minOffset + refDate.Minute;
+				const int hour = hourOffset + refDate.Hour;
+				const int day = dayOffset + refDate.Day;
+				DateTime dt = DateTime ::toUnixTime(sec, min, hour, day, refDate.Month, refDate.Year);
+				time_t refTime = DateTime::toUnixTime(0, 0, 0, 1, refDate.Month, refDate.Year);
+				refTime += sec;
+				refTime += int64_t(min) * 60;
+				refTime += int64_t(hour) * 60 * 60;
+				refTime += int64_t(day - 1) * 24 * 60 * 60;
+				time_t calcTime = dt.toUnixTime();
+				if(calcTime == refTime) {
+					return;
+				}
+
+				char buf[100];
+				m_snprintf(buf, sizeof(buf), " (%ds, %dm %dh, %dd)", secOffset, minOffset, hourOffset, dayOffset);
+				Serial << _F("Check ") << DateTime(refTime).toFullDateTimeString() << buf << endl;
+				Serial << _F("Got   ") << dt.toFullDateTimeString() << ", diff " << refTime - calcTime << endl;
+				REQUIRE_EQ(refTime, calcTime);
+			};
+
+			for(int offset = -10000; offset < 10000; offset += 555) {
+				check(offset, 0, 0, 0);
+				check(0, offset, 0, 0);
+				check(0, 0, offset, 0);
+				check(0, 0, 0, offset);
+			}
+		};
 	}
 };
 

--- a/tests/HostTests/modules/DateTime.cpp
+++ b/tests/HostTests/modules/DateTime.cpp
@@ -48,6 +48,45 @@ public:
 				checkSetTime(VALID_ISO_DATETIME64);
 			}
 		}
+
+		TEST_CASE("setTime speed check")
+		{
+			OneShotFastUs timer;
+			unsigned count = checkSetTime(VALID_HTTP_DATE);
+			count += checkSetTime(VALID_ISO_DATETIME);
+			auto elapsed = timer.elapsedTime();
+			Serial << "Checked " << count << " dates in " << elapsed.toString() << ", " << elapsed / count
+				   << " per date" << endl;
+		}
+
+		TEST_CASE("getMonthDays")
+		{
+			for(auto year : {1980, 1981}) {
+				unsigned yearDays{0};
+				for(unsigned month = dtJanuary; month <= dtDecember; ++month) {
+					auto days = DateTime::getMonthDays(month, year);
+					yearDays += days;
+					Serial << DateTime::getIsoMonthName(month) << ' ' << year << " : " << days << endl;
+				}
+				REQUIRE_EQ(yearDays, DateTime::getDaysInYear(year));
+			}
+		}
+
+		TEST_CASE("getDayName")
+		{
+			for(unsigned day = dtSunday; day <= dtSaturday; ++day) {
+				Serial << day << ": " << DateTime::getIsoDayName(day) << ", " << DateTime::getLocaleDayName(day)
+					   << endl;
+			}
+		}
+
+		TEST_CASE("getMonthName")
+		{
+			for(unsigned month = dtJanuary; month <= dtDecember; ++month) {
+				Serial << month << ": " << DateTime::getIsoMonthName(month) << ", "
+					   << DateTime::getLocaleMonthName(month) << endl;
+			}
+		}
 	}
 
 	void checkHttpDates(const FSTR::Array<TestDate>& dates)
@@ -91,14 +130,20 @@ public:
 		}
 	}
 
-	void checkSetTime(const FSTR::Array<TestDate>& dates)
+	// Return number of dates checked
+	unsigned checkSetTime(const FSTR::Array<TestDate>& dates, bool silent = false)
 	{
+		unsigned checkCount{0};
+
 		for(auto date : dates) {
 			const DateTime refDate(date.unixTimestamp);
 
-			Serial << "RefDate " << refDate.toFullDateTimeString() << endl;
+			if(!silent) {
+				Serial << "RefDate " << refDate.toFullDateTimeString() << endl;
+			}
 
 			auto check = [&](int secOffset, int minOffset, int hourOffset, int dayOffset) {
+				++checkCount;
 				const int sec = secOffset + refDate.Second;
 				const int min = minOffset + refDate.Minute;
 				const int hour = hourOffset + refDate.Hour;
@@ -128,6 +173,8 @@ public:
 				check(0, 0, 0, offset);
 			}
 		};
+
+		return checkCount;
 	}
 };
 

--- a/tests/HostTests/tools/datetime-test.py
+++ b/tests/HostTests/tools/datetime-test.py
@@ -1,0 +1,211 @@
+#!/usr/bin/python3
+#
+# Generate test data for DateTime module:
+#
+#   python datetime-test.py include/DateTimeData.h
+#
+#
+
+import os
+import sys
+from dataclasses import dataclass
+import datetime
+import email.utils
+
+"""
+ISO datetimes can be strings in short form (i.e. no separators) or extended form (with separators)
+For testing unix timestamp values give that and we'll translate it accordingly.
+
+Python doesn't accept all formats specified by standard
+In these cases, specify a tuple (str, python_str)
+
+There are some gotchas with Python version:
+
+- short-form unsupported before 3.11
+- Windows craps itself when given negative timestamps
+
+"""
+
+def check_compatibility():
+    version = 100 * sys.version_info.major + sys.version_info.minor
+    if version < 311:
+        raise DeprecationWarning("Require at least python 3.11")
+    if sys.platform == 'win32':
+        raise DeprecationWarning("Windows doesn't support negative unix timestamps!")
+
+
+@dataclass
+class Record:
+    string: str
+    string2: str
+    timestamp: int
+    milliseconds: int
+
+
+def parse_http_date(value: str) -> Record:
+    dt = email.utils.parsedate_to_datetime(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return Record(value, email.utils.format_datetime(dt, usegmt=True), dt.timestamp(), 0)
+
+
+def parse_iso_datetime(value: str | tuple | int) -> Record:
+    if isinstance(value, int):
+        dt = datetime.datetime.fromtimestamp(value, tz=datetime.timezone.utc)
+        s = dt.isoformat().removesuffix('+00:00')
+    elif isinstance(value, tuple):
+        s = value[0]
+        dt = datetime.datetime.fromisoformat(value[1])
+    else:
+        s = value
+        dt = datetime.datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    iso_string = dt.isoformat().removesuffix('+00:00') + 'Z'
+    return Record(s, iso_string, dt.timestamp(), dt.microsecond // 1000)
+
+
+def parse_iso_time(value: str) -> Record:
+    t = datetime.time.fromisoformat(value)
+    o = t.second + (t.minute * 60) + (t.hour * 60 * 60)
+    if t.microsecond:
+        iso_string = t.isoformat(timespec='milliseconds')
+    else:
+        iso_string = t.isoformat()
+    return Record(value, iso_string, o, t.microsecond // 1000)
+
+
+"""
+Consider these as appropriate for HTTP and ISO date strings.
+
+valid dates must include:
+    all days
+    min/max day numbers
+    all month names
+    min/max month numbers
+    selection of years from min to max
+
+invalid dates must include:
+    bad day numbers (month-specific)
+    leap years
+    bad month numbers
+    bad month names
+    bad day names
+
+times
+    24-hour only
+    hours:mins
+    hours:mins:secs
+    hours:mins:secs.milliseconds
+
+After basic validation can use DateTime to generate strings and then verify they can be decoded back again.
+"""
+
+MAP_LIST = {
+    'VALID_HTTP_DATE': (
+        parse_http_date,
+        [
+            "Sun, 06 Nov 1994 08:49:37 GMT",
+            "Sunday, 06 Nov 1994 08:49:37 GMT",
+            "Sunday, 06-Nov-94 08:49:37 GMT",
+            "Mon, 07 November 1994 00:00:00",
+            "  1   JAN\t \r\n 	2000    23:59:59",
+        ]),
+    'VALID_ISO_DATETIME': (
+        parse_iso_datetime,
+        [
+            "2024-01-31",
+            "20240131",
+            ("2024-01", "2024-01-01"),
+            -0x7fffffff,
+            -0x80000000,
+            0,
+            0x7fffffff,
+            "1950-01-01",
+            0x6613e40d,
+            0x6615358c,
+        ]),
+    'VALID_ISO_DATETIME64': (
+        parse_iso_datetime,
+        [
+            0x80000000,
+            "2099-12-31T23:59:59",
+            "2105-12-31T23:59:59",
+            "2106-02-07T06:28:15",
+            "2106-02-07T06:28:15",
+            0x100000000,
+            -0x80000000,
+        ]),
+    'VALID_ISO_TIME': (
+        parse_iso_time,
+        [
+            "T18:47:12.123",
+            "T18:47:12.123456",
+            "T12:34:12",
+            "T23:59:59",
+            "12:34",
+            "T2359",
+        ]),
+}
+
+
+def main():
+    check_compatibility()
+
+    output = f"""
+/*
+    * DateTime test data
+    *
+    * File generated {datetime.datetime.now().ctime()}
+    *
+    */
+
+// clang-format off
+
+namespace
+{{
+struct TestDate {{
+    const FlashString* stringToParse;
+    const FlashString* expectedString;
+    int64_t unixTimestamp;
+    uint16_t milliseconds;
+}};
+
+"""
+
+    index = 1
+    for name, (parse, data) in MAP_LIST.items():
+        records = [f'#define {name}_MAP(XX)']
+        for value in data:
+            r = parse(value)
+            s = r.string.encode('unicode_escape').decode()
+            records += [f'XX(DT_{index}, "{s}", "{r.string2}", {hex(int(r.timestamp))}LL, {r.milliseconds})']
+            index += 1
+        output += " \\\n  ".join(records)
+        output += "\n\n"
+
+    output += f"""
+#define XX(tag, str, str2, ...) \\
+    DEFINE_FSTR_LOCAL(STR1_##tag, str) \\
+    DEFINE_FSTR_LOCAL(STR2_##tag, str2)
+{"".join(f'  {name}_MAP(XX)\n' for name in MAP_LIST)}
+#undef XX
+
+#define XX(tag, str, str2, ...) {{&STR1_##tag, &STR2_##tag, ##__VA_ARGS__}},
+{"".join(f'DEFINE_FSTR_ARRAY({name}, TestDate, {name}_MAP(XX))\n' for name in MAP_LIST)}
+#undef XX
+
+}} // namespace
+"""
+
+    if len(sys.argv) > 1:
+        filename = sys.argv[1]
+        print('Creating file', repr(filename))
+        with open(filename, 'w') as f:
+            print(output, file=f)
+    else:
+        print(output)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR improves test coverage for the `DateTime` class and adds a number of necessary fixes. It also adds some obvious omissions.

**Compare day/month names without case-sensitivity**

Allows more use cases when converting strings.

**Ensure host builds (linux) use 64-bit `time_t`**

Defaults to 32-bit if not specified by `_TIME_BITS`.
Now consistent with embedded toolchains which use fixed size (all but IDF 4.x are 64-bit).
See issue #2758.

**Document and add static check for time_t range**

CI will fail build if incorrect.
For legacy toolchains (Windows host, IDF 4.x) will fail if it ever gets fixed as a reminder.

**`mktime` broken by axtls. Correct implementation available in newlib.**

Calls esp8266 ROM function which doesn't support 64-bit time_t.

**Fix `isLeapYear` implementation**

Doesn't account for century.

**Add enumeration for Month value**

For backward compatibility methods use standard types, but makes code easier to read and avoids off-by-one errors in application code.

**Fix `toUnixTime` to accommodate negative values**

`time_t` can represent dates before 1 Jan 1970.

**Fix `toUnixTime` parameter handling outside normal range**

Comment reads: "Seconds, minutes, hours and days may be any value, e.g. to calculate the value for 300 days since 1970 (epoch), set day=300"
This requires a more appropriate parameter type (int) and casting so calculations are 64-bit.

**Apply `const` to DateTime methods**

As appropriate.

**Add `fromISO8601` method**

Complements `toISO8601`. Update Basic_DateTime sample so strings can be interpreted.

**Expand HTTP string conversion**

Various RFC versions suggest more relaxed interpretation of strings.
Accept e.g. "Sun" or "Sunday". Also "Sunasdlfkj" but do we care?
Make leading day of week optional, since the value gets discarded anyway
Fold whitespace

**Fix `setTime`, `fromUnixTime` methods**

Results are not always correct. e.g. Out by a whole day for `0x66152e16`.
Code in `gmtime_r` markedly different, and not bloaty, so just use that.

**Provide `gmtime_r` implementation for Windows host builds**

Windows does have `gmtime` but doesn't behave like glibc/newlib does.
Safest to just copy the code from newlib.
https://sourceware.org/git/?p=newlib-cygwin.git;a=blob;f=newlib/libc/time/gmtime_r.c

**Use DateTime to produce default IFS TimeStamp string**

Just output UTC, localising will likely be wrong.

**Include milliseconds with '%T' format if non-zero**

Consistent with ISO time strings.
This is different from libC `strftime` behaviour, but then `struct tm` doesn't have a fractional seconds field.

**Update tests**

Generate test data using python script
Check dates before 1970
Include 64-bit-only tests
Verify `setTime` calls with out-of-range offsets

**Pull out some utility methods. Some internal functions could be useful so add those as static methods:**

bool isLeapYear(uint16_t year);
uint8_t getMonthDays(uint8_t month, uint16_t year);
String getLocaleDayName(uint8_t day);
String getLocaleMonthName(uint8_t month);
String getIsoDayName(uint8_t day);
String getIsoMonthName(uint8_t month);
uint16_t getDaysInYear(uint16_t year);

**Replace helper macros with inline functions**

