### PR TITLE
esp8266: NMI not disabled when timer1 ISR cleared

### DIFF
--- a/Sming/Arch/Esp8266/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Esp8266/Components/driver/hw_timer.cpp
@@ -36,6 +36,28 @@ static void IRAM_ATTR nmi_handler()
 	nmi_callback.func(nmi_callback.arg);
 }
 
+/*
+ * The `ETS_FRC_TIMER1_NMI_INTR_ATTACH` macro calls SDK `NmiTimSetFunc` which
+ * doesn't actually disable NMI (a known bug).
+ * If we subsequently enable FRC interrupts, the timer won't work so we need to properly
+ * disable NMI manually.
+ *
+ * The NmiTimSetFunc code looks like this:
+ *
+ * 		uint32_t value = REG_READ(NMI_INT_ENABLE_REG);
+ * 		value &= ~0x1f;
+ * 		value |= 0x0f;
+ * 		REG_WRITE(NMI_INT_ENABLE_REG, value);
+ *
+ * Note that there is no published documentation for this register.
+ * Clearing it to zero appears to work but may have unintended side-effects.
+ */
+static void IRAM_ATTR hw_timer1_disable_nmi()
+{
+	auto value = REG_READ(NMI_INT_ENABLE_REG);
+	REG_WRITE(NMI_INT_ENABLE_REG, value & ~0x1f);
+}
+
 void hw_timer1_attach_interrupt(hw_timer_source_type_t source_type, hw_timer_callback_t callback, void* arg)
 {
 	if(source_type == TIMER_NMI_SOURCE) {
@@ -47,6 +69,7 @@ void hw_timer1_attach_interrupt(hw_timer_source_type_t source_type, hw_timer_cal
 			ETS_FRC_TIMER1_NMI_INTR_ATTACH(nmi_handler);
 		}
 	} else {
+		hw_timer1_disable_nmi();
 		ETS_FRC_TIMER1_INTR_ATTACH(callback, arg);
 	}
 }
@@ -54,27 +77,7 @@ void hw_timer1_attach_interrupt(hw_timer_source_type_t source_type, hw_timer_cal
 void IRAM_ATTR hw_timer1_detach_interrupt(void)
 {
 	hw_timer1_disable();
-
-	/*
-	 * This macro calls SDK `NmiTimSetFunc` which doesn't actually disable NMI (a known bug).
-	 * If we subsequently enable FRC interrupts, the timer won't work so we need to properly
-	 * disable NMI manually.
-	 *
-	 * The NmiTimSetFunc code looks like this:
-	 *
-	 * 		uint32_t value = REG_READ(NMI_INT_ENABLE_REG);
-	 * 		value &= ~0x1f;
-	 * 		value |= 0x0f;
-	 * 		REG_WRITE(NMI_INT_ENABLE_REG, value);
-	 *
-	 * Note that there is no published documentation for this register.
-	 * Clearing it to zero appears to work but may have unintended side-effects.
-	 */
-	ETS_FRC_TIMER1_NMI_INTR_ATTACH(NULL);
-	auto value = REG_READ(NMI_INT_ENABLE_REG);
-	REG_WRITE(NMI_INT_ENABLE_REG, value & ~0x1f);
-
-	// FRC interrupts
+	hw_timer1_disable_nmi();
 	ETS_FRC_TIMER1_INTR_ATTACH(NULL, NULL);
 }
 

--- a/Sming/Arch/Esp8266/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Esp8266/Components/driver/include/driver/hw_timer.h
@@ -123,13 +123,7 @@ __forceinline void IRAM_ATTR hw_timer1_disable(void)
 /**
  * @brief Detach interrupt from the timer
  */
-__forceinline void IRAM_ATTR hw_timer1_detach_interrupt(void)
-{
-	hw_timer1_disable();
-	ETS_FRC_TIMER1_NMI_INTR_ATTACH(NULL);
-	REG_WRITE(NMI_INT_ENABLE_REG, 0);
-	ETS_FRC_TIMER1_INTR_ATTACH(NULL, NULL);
-}
+void hw_timer1_detach_interrupt(void);
 
 /**
  * @brief Get timer1 count

--- a/Sming/Arch/Esp8266/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Esp8266/Components/driver/include/driver/hw_timer.h
@@ -127,6 +127,7 @@ __forceinline void IRAM_ATTR hw_timer1_detach_interrupt(void)
 {
 	hw_timer1_disable();
 	ETS_FRC_TIMER1_NMI_INTR_ATTACH(NULL);
+	REG_WRITE(NMI_INT_ENABLE_REG, 0);
 	ETS_FRC_TIMER1_INTR_ATTACH(NULL, NULL);
 }
 

--- a/Sming/Arch/Esp8266/Components/esp8266/include/espinc/eagle_soc.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/espinc/eagle_soc.h
@@ -126,6 +126,7 @@
 //}}
 
 //Interrupt remap control registers define{{
+#define NMI_INT_ENABLE_REG          (PERIPHS_DPORT_BASEADDR)
 #define EDGE_INT_ENABLE_REG         (PERIPHS_DPORT_BASEADDR + 0x04)
 #define WDT_EDGE_INT_ENABLE()       SET_PERI_REG_MASK(EDGE_INT_ENABLE_REG, BIT0)
 #define TM1_EDGE_INT_ENABLE()       SET_PERI_REG_MASK(EDGE_INT_ENABLE_REG, BIT1)

--- a/tests/HostTests/modules/Timers.cpp
+++ b/tests/HostTests/modules/Timers.cpp
@@ -79,9 +79,6 @@ public:
 				statusTimer.stop();
 				Serial.print("statusTimer stopped: ");
 				Serial.println(statusTimer);
-
-				// Release any allocated delegate memory
-				timer64.setCallback(TimerDelegate(nullptr));
 				done = true;
 			}
 
@@ -112,17 +109,6 @@ public:
 		statusTimer.start();
 
 		Serial.println(statusTimer);
-
-		{
-			auto tmp = new Timer;
-			tmp->initializeMs<1200>(
-				[](void* arg) {
-					auto self = static_cast<CallbackTimerTest*>(arg);
-					Serial << self->timer64 << _F(" fired") << endl;
-				},
-				this);
-			tmp->startOnce();
-		}
 
 		if(1) {
 			longTimer.setCallback([this]() {
@@ -222,7 +208,6 @@ public:
 private:
 	Timer statusTimer;
 	unsigned statusTimerCount = 0;
-	Timer timer64;
 	HardwareTimerTest timer1;
 	Timer longTimer;
 	uint32_t longStartTicks = 0;


### PR DESCRIPTION
Fixes #2763. 

SDK doesn't actually disable NMI interrupts when interrupt callback cleared. This blocks regular (FRC) timer1 interrupts if subsequently enabled.

The HardwareTimer (timer1) appears to stop working if applications switch from using NMI interrupts to regular timer interrupts.

A more subtle manifestation of this bug is that the original NMI callback continues to be called when a different FRC handler is set.

TODO:

* [x] Check nothing else gets broken (e.g. Wifi)
* [x] Currently using SDK 3.0.3; does anything change in 3.0.4 or 3.0.5 ?
