### PR TITLE
Fixes to hardware config editing/display

### DIFF
--- a/Sming/Components/Storage/Tools/hwconfig/common.py
+++ b/Sming/Components/Storage/Tools/hwconfig/common.py
@@ -109,6 +109,9 @@ def json_save(data, filename):
 def to_json(obj):
     return json.dumps(obj, indent=4)
 
+def get_basename_no_ext(filename):
+    basename = os.path.basename(filename)
+    return os.path.splitext(basename)[0]
 
 def lookup_keyword(t, keywords):
     for k, v in keywords.items():

--- a/Sming/Components/Storage/Tools/hwconfig/config.py
+++ b/Sming/Components/Storage/Tools/hwconfig/config.py
@@ -87,6 +87,8 @@ class Config(object):
         self.options = []
         self.option_library = load_option_library()
         self.base_config = None
+        self.name = ''
+        self.comment = ''
 
     def __str__(self):
         return "'%s' for %s" % (self.name, self.arch)
@@ -119,6 +121,8 @@ class Config(object):
         self.depends.append(filename)
         data = json_load(filename)
         self.parse_dict(data)
+        self.name = data.get('name', '')
+        self.comment = data.get('comment', '')
 
     def parse_options(self, options):
         """Apply any specified options.
@@ -163,9 +167,6 @@ class Config(object):
                 self.devices.parse_dict(v)
             elif k != 'name' and k != 'comment':
                 raise InputError("Unknown config key '%s'" % k)
-
-        self.name = data.get('name', '')
-        self.comment = data.get('comment', '')
 
         if not partitions is None:
             self.partitions.parse_dict(partitions, self.devices)

--- a/Sming/Components/Storage/Tools/hwconfig/config.py
+++ b/Sming/Components/Storage/Tools/hwconfig/config.py
@@ -168,7 +168,7 @@ class Config(object):
             elif k != 'name' and k != 'comment':
                 raise InputError("Unknown config key '%s'" % k)
 
-        if not partitions is None:
+        if partitions:
             self.partitions.parse_dict(partitions, self.devices)
 
     def dict(self):

--- a/Sming/Components/Storage/Tools/hwconfig/editor.py
+++ b/Sming/Components/Storage/Tools/hwconfig/editor.py
@@ -39,7 +39,7 @@ def read_property(obj, name):
 
 def get_dict_value(dict, key, default):
     """Read dictionary value, creating one if it doesn't exist."""
-    if not key in dict:
+    if key not in dict:
         dict[key] = default
     return dict[key]
 
@@ -370,7 +370,7 @@ class EditState(dict):
         self.array = {} # dictionary for array element variables
         self.row = 0
         keys = self.schema['properties'].keys()
-        if not 'name' in keys:
+        if 'name' not in keys:
             self.addControl('name')
         for k in keys:
             self.addControl(k)
@@ -1279,7 +1279,7 @@ class Editor:
 
         options = get_dict_value(self.json, 'options', [])
         for opt in configVars.get('HWCONFIG_OPTS', '').replace(' ', '').split():
-            if not opt in options:
+            if opt not in options:
                 options.append(opt)
 
         self.reload()

--- a/Sming/Components/Storage/Tools/hwconfig/editor.py
+++ b/Sming/Components/Storage/Tools/hwconfig/editor.py
@@ -1150,16 +1150,23 @@ class Editor:
                 self.loadConfig(filename)
 
         def fileSave():
-            filename = self.json['name']
+            filename = self._filename
+            if not filename:
+                filename = self.json.get('name')
+            if not filename:
+                filename = get_basename_no_ext(filename)
             filename = filedialog.asksaveasfilename(
                 title='Save profile to file',
                 filetypes=hwFilter,
                 initialfile=filename,
                 initialdir=os.getcwd())
-            if len(filename) != 0 and checkProfilePath(filename):
+            if filename and checkProfilePath(filename):
                 ext = os.path.splitext(filename)[1]
                 if ext != HW_EXT:
                     filename += HW_EXT
+                if not self.json.get('name'):
+                    self.json['name'] = get_basename_no_ext(filename)
+                    self.reload()
                 json_save(self.json, filename)
 
         # Toolbar
@@ -1268,6 +1275,7 @@ class Editor:
             self.json['base_config'] = config_name
         else:
             self.json = json_load(filename)
+        self._filename = os.path.basename(filename)
 
         options = get_dict_value(self.json, 'options', [])
         for opt in configVars.get('HWCONFIG_OPTS', '').replace(' ', '').split():
@@ -1280,7 +1288,7 @@ class Editor:
 
     def updateWindowTitle(self):
         name = self.json.get('name', None)
-        if name is None:
+        if not name:
             name = '(new)'
         else:
             name = '"' + name + '"'
@@ -1290,8 +1298,9 @@ class Editor:
         self.tree.clear()
         self.map.clear()
         self.status.set('')
+        self._filename = ''
         self.json = OrderedDict()
-        self.json['name'] = 'New Profile'
+        self.json['name'] = ''
         self.json['base_config'] = 'standard'
         self.reload()
         self.updateWindowTitle()

--- a/Sming/Components/Storage/Tools/hwconfig/partition.py
+++ b/Sming/Components/Storage/Tools/hwconfig/partition.py
@@ -583,7 +583,7 @@ class Map(Table):
         # Devices with no defined partitions
         pdevs = set(p.device for p in partitions)
         for dev in config.devices:
-            if not dev in pdevs:
+            if dev not in pdevs:
                 add_unused(partitions, dev, dev.size, -1)
 
         partitions.sort()

--- a/Sming/Components/Storage/Tools/hwconfig/partition.py
+++ b/Sming/Components/Storage/Tools/hwconfig/partition.py
@@ -414,7 +414,7 @@ class Entry(object):
                 res[k] = stringnum(self.type_str())
             elif k == 'subtype':
                 res[k] = stringnum(self.subtype_str())
-            elif v is not None and k != 'name':
+            elif v is not None and k not in ['name', 'unused_before', 'unused_after']:
                 res[k] = v
         return res
 

--- a/samples/Basic_IFS/basic_ifs_Esp32.hw
+++ b/samples/Basic_IFS/basic_ifs_Esp32.hw
@@ -1,4 +1,5 @@
 {
+    "name": "Basic IFS sample (ESP32)",
     "base_config": "basic_ifs",
     "arch": "Esp32",
     "partitions": {

--- a/samples/Basic_IFS/basic_ifs_Esp8266.hw
+++ b/samples/Basic_IFS/basic_ifs_Esp8266.hw
@@ -1,4 +1,5 @@
 {
+    "name": "Basic IFS (ESP8266)",
     "base_config": "basic_ifs",
     "arch": "Esp8266",
     "partitions": {

--- a/samples/Basic_IFS/basic_ifs_Host.hw
+++ b/samples/Basic_IFS/basic_ifs_Host.hw
@@ -1,4 +1,5 @@
 {
+    "name": "Basic IFS (HOST)",
     "base_config": "basic_ifs",
     "arch": "Host",
     "partitions": {

--- a/samples/Basic_IFS/basic_ifs_Rp2040.hw
+++ b/samples/Basic_IFS/basic_ifs_Rp2040.hw
@@ -1,7 +1,7 @@
 {
-    "name": "Rp2040 config",
-    "arch": "Rp2040",
+    "name": "Basic IFS sample (RP2040)",
     "base_config": "basic_ifs",
+    "arch": "Rp2040",
     "options": [
         "2m",
         "cyw43_fw"

--- a/samples/Basic_Ota/ota.hw
+++ b/samples/Basic_Ota/ota.hw
@@ -1,4 +1,5 @@
 {
+	"name": "Basic OTA sample",
 	"base_config": "spiffs-two-roms",
 	"partitions": {
 		"rom0": {

--- a/samples/FtpServer_Files/ftpserver-esp32.hw
+++ b/samples/FtpServer_Files/ftpserver-esp32.hw
@@ -1,5 +1,5 @@
 {
-    "name": "FTP Server sample",
+    "name": "FTP Server sample (ESP32)",
     "base_config": "ftpserver",
     "partitions": {
         "factory": {

--- a/samples/FtpServer_Files/ftpserver-esp8266.hw
+++ b/samples/FtpServer_Files/ftpserver-esp8266.hw
@@ -1,5 +1,5 @@
 {
-    "name": "FTP Server sample",
+    "name": "FTP Server sample (ESP8266)",
     "base_config": "ftpserver",
     "partitions": {
         "rom0": {


### PR DESCRIPTION
**If name not specified when loading config then 'save' raises exception**

For example, `Basic_Ota` sample doesn't have its `name` field set in `ota.hw`:

- Run `make hwconfig-edit`
- Click 'save'

So ensure we provide a default name based on filename.


**Ensure all sample .hw files have names**

For consistency.


**Remove 'unused_before' and 'unused_after' fields from `make hwconfig` output**

These are only used for map building so shouldn't be visible.
Example:

```
        "phy_init": {
            "device": "spiFlash",
            "address": "0x000fc000",
            "size": "4K",
            "type": "data",
            "subtype": "phy",
            "readonly": false,
            "encrypted": false,
            "filename": "$(FLASH_INIT_DATA)",
            "unused_before": 0, ///<
            "unused_after": 0   ///< Don't show
        },
```


**Don't set name, comment fields from option data**

For example, `Basic_Blink` sample uses default config. Running `make hwconfig` gives:

```
{
    "name": "Standard config with single ROM",
    "comment": "Should work with any Esp8266 variant",
    "arch": "Esp8266",
    "options": [],
```

If we run `make hwconfig HWCONFIG_OPTS=4m` we get this:

```
{
    "name": "",
    "comment": "",
    "arch": "Esp8266",
    "options": [
        "4m"
    ],
```

The `name` and `comment` have been wiped out, should be as before.


**Fix use of `not in` and `is not` operators**

e.g. `x not in [...]` preferred to `not x in [...]`
