### PR TITLE
Fix valgrind allocator mismatch warnings

### DIFF
--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -299,9 +299,11 @@ bool WebsocketConnection::send(IDataSourceStream* source, ws_frame_type_t type, 
 
 void WebsocketConnection::broadcast(const char* message, size_t length, ws_frame_type_t type)
 {
-	char* copy = new char[length];
-	memcpy(copy, message, length);
-	std::shared_ptr<const char[]> data(copy);
+	std::shared_ptr<char[]> data(new char[length]);
+	if(!data) {
+		return;
+	}
+	memcpy(data.get(), message, length);
 
 	for(auto skt : websocketList) {
 		auto stream = new SharedMemoryStream<const char[]>(data, length);

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -301,10 +301,10 @@ void WebsocketConnection::broadcast(const char* message, size_t length, ws_frame
 {
 	char* copy = new char[length];
 	memcpy(copy, message, length);
-	std::shared_ptr<const char> data(copy, [](const char* ptr) { delete[] ptr; });
+	std::shared_ptr<const char[]> data(copy);
 
 	for(auto skt : websocketList) {
-		auto stream = new SharedMemoryStream<const char>(data, length);
+		auto stream = new SharedMemoryStream<const char[]>(data, length);
 		skt->send(stream, type);
 	}
 }

--- a/Sming/Core/Data/Stream/LimitedMemoryStream.cpp
+++ b/Sming/Core/Data/Stream/LimitedMemoryStream.cpp
@@ -50,7 +50,10 @@ int LimitedMemoryStream::seekFrom(int offset, SeekOrigin origin)
 size_t LimitedMemoryStream::write(const uint8_t* data, size_t size)
 {
 	if(buffer == nullptr) {
-		buffer = new char[capacity];
+		buffer = static_cast<char*>(malloc(capacity));
+		if(buffer == nullptr) {
+			return 0;
+		}
 		owned = true;
 	}
 

--- a/Sming/Core/Data/Stream/LimitedMemoryStream.h
+++ b/Sming/Core/Data/Stream/LimitedMemoryStream.h
@@ -44,7 +44,7 @@ public:
 	~LimitedMemoryStream()
 	{
 		if(owned) {
-			delete[] buffer;
+			free(buffer);
 		}
 	}
 

--- a/Sming/Core/Data/Stream/SharedMemoryStream.h
+++ b/Sming/Core/Data/Stream/SharedMemoryStream.h
@@ -26,9 +26,9 @@ template <typename T> class SharedMemoryStream : public IDataSourceStream
 public:
 	/** @brief Constructor for use with pre-existing buffer
 	 *  @param buffer
-	 *  @param capacity Size of buffer in elements
+	 *  @param size Size of buffer in elements
 	 */
-	SharedMemoryStream(std::shared_ptr<T>(buffer), size_t size) : buffer(buffer), capacity(size * sizeof(T))
+	SharedMemoryStream(std::shared_ptr<T>(buffer), size_t size) : buffer(buffer), capacity(size * sizeof(buffer[0]))
 	{
 	}
 

--- a/tests/HostTests/modules/Stream.cpp
+++ b/tests/HostTests/modules/Stream.cpp
@@ -180,21 +180,21 @@ public:
 
 		TEST_CASE("SharedMemoryStream")
 		{
-			char* message = new char[18];
-			memcpy(message, "Wonderful data...", 18);
-			std::shared_ptr<const char[]> data(message);
+			const char* message = "Wonderful data...";
+			const size_t msglen = strlen(message);
+			std::shared_ptr<char[]> data(new char[msglen]);
+			memcpy(data.get(), message, msglen);
 
 			debug_d("RefCount: %d", data.use_count());
 
 			Vector<SharedMemoryStream<const char[]>*> list;
 			for(unsigned i = 0; i < 4; i++) {
-				list.addElement(new SharedMemoryStream<const char[]>(data, strlen(message)));
+				list.addElement(new SharedMemoryStream<const char[]>(data, msglen));
 			}
 
-			for(unsigned i = 0; i < list.count(); i++) {
+			for(auto element : list) {
 				constexpr size_t bufferSize{5};
 				char buffer[bufferSize]{};
-				auto element = list[i];
 
 				String output;
 				while(!element->isFinished()) {

--- a/tests/HostTests/modules/Stream.cpp
+++ b/tests/HostTests/modules/Stream.cpp
@@ -171,8 +171,8 @@ public:
 
 		{
 			// STL may perform one-time memory allocation for mutexes, etc.
-			std::shared_ptr<const char> data(new char[18]);
-			SharedMemoryStream<const char>(data, 18);
+			std::shared_ptr<const char[]> data(new char[18]);
+			SharedMemoryStream stream(data, 18);
 		}
 
 		auto memStart = MallocCount::getCurrent();
@@ -182,13 +182,13 @@ public:
 		{
 			char* message = new char[18];
 			memcpy(message, "Wonderful data...", 18);
-			std::shared_ptr<const char> data(message, [&message](const char* p) { delete[] p; });
+			std::shared_ptr<const char[]> data(message);
 
 			debug_d("RefCount: %d", data.use_count());
 
-			Vector<SharedMemoryStream<const char>*> list;
+			Vector<SharedMemoryStream<const char[]>*> list;
 			for(unsigned i = 0; i < 4; i++) {
-				list.addElement(new SharedMemoryStream<const char>(data, strlen(message)));
+				list.addElement(new SharedMemoryStream<const char[]>(data, strlen(message)));
 			}
 
 			for(unsigned i = 0; i < list.count(); i++) {


### PR DESCRIPTION
This PR fixes warnings flagged by valgrind when running HostTests.

**Fix mismatched new/delete issues with SharedMemoryStream**

Use correct templated allocation, also simplifies code.

**Fix mismatched allocators with `LimitedMemoryStream`**

Use malloc/free` instead of new/delete, as for MemoryDataStream.
Resolves issue with mismatch highlighted by valgrind using `moveString`.
Also add null check in allocation.
