### PR TITLE
A few DateTime tweaks

### DIFF
--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -531,23 +531,11 @@ String DateTime::format(const char* sFormat) const
 
 void DateTime::calcDayOfYear()
 {
-	DayofYear = 0;
+	uint16_t prevMonthDays{0};
 	for(unsigned m = dtJanuary; m < Month; ++m) {
-		switch(m) {
-		case dtSeptember:
-		case dtApril:
-		case dtJune:
-		case dtNovember:
-			DayofYear += 30;
-			break;
-		case dtFebruary:
-			DayofYear += isLeapYear(Year) ? 29 : 28;
-			break;
-		default:
-			DayofYear += 31;
-		}
+		prevMonthDays += getMonthDays(m, Year);
 	}
-	DayofYear += Day;
+	DayofYear = prevMonthDays + Day;
 }
 
 uint8_t DateTime::calcWeek(uint8_t firstDay) const

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -360,15 +360,15 @@ private:
 	uint8_t calcWeek(uint8_t firstDay) const; // Calculate week number based on firstDay of week
 
 public:
+	uint16_t Year = 0;		   ///< Full Year number
+	uint16_t DayofYear = 0;	///< Day of year (0-365)
+	uint8_t DayofWeek = 0;	 ///< Day of week (0-6 Sunday is day 0)
+	uint8_t Month = 0;		   ///< Month (0-11 Jan is month 0)
+	uint8_t Day = 0;		   ///< Day of month (1-31)
 	uint8_t Hour = 0;		   ///< Hour (0-23)
 	uint8_t Minute = 0;		   ///< Minute (0-59)
 	uint8_t Second = 0;		   ///< Second (0-59)
 	uint16_t Milliseconds = 0; ///< Milliseconds (0-999)
-	uint8_t Day = 0;		   ///< Day of month (1-31)
-	uint8_t DayofWeek = 0;	 ///< Day of week (0-6 Sunday is day 0)
-	uint16_t DayofYear = 0;	///< Day of year (0-365)
-	uint8_t Month = 0;		   ///< Month (0-11 Jan is month 0)
-	uint16_t Year = 0;		   ///< Full Year number
 };
 
 /** @} */


### PR DESCRIPTION
Some further minor updates to `DateTime`:

- Reduce class size. Member variables misaligned so consumes 14 bytes instead of 12.
- Simplify `calcDayOfYear()`
