### PR TITLE
Make `time_t` size check message more helpful

### DIFF
--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -18,7 +18,7 @@
 static_assert(sizeof(time_t) != 8, "Great! Now supports 64-bit - please update code");
 #warning "**Y2038** time_t is only 32-bits in this build configuration"
 #else
-static_assert(sizeof(time_t) == 8, "Expecting 64-bit time_t");
+static_assert(sizeof(time_t) == 8, "Expecting 64-bit time_t - please use GCC 10 or later");
 #endif
 
 namespace

--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -17,6 +17,8 @@
 #if defined(__WIN32) || (defined(ARCH_ESP32) && ESP_IDF_VERSION_MAJOR < 5)
 static_assert(sizeof(time_t) != 8, "Great! Now supports 64-bit - please update code");
 #warning "**Y2038** time_t is only 32-bits in this build configuration"
+#elif defined(ARCH_HOST) && !defined(__USE_TIME_BITS64)
+#warning "**Y2038** Expecting 64-bit time_t - please use GCC 10 or later"
 #else
 static_assert(sizeof(time_t) == 8, "Expecting 64-bit time_t - please use GCC 10 or later");
 #endif


### PR DESCRIPTION
Further to #2758 host builds should generally match code run on hardware. As mentioned this is not straightforward for Windows, but for Linux we should expect 64-bits as the default.

GCC 10+ can make use of `_TIME_BITS` to ensure we get this behaviour. More specifically, this is a feature of `glibc` shipped with those versions.

For earlier versions, even though the compiler is 64-bit we are building in 32-bit mode and `time_t` stays stuck in 32-bits. There are various discussions about this but the short answer is that prior to GCC 10 (libc 4) 32-bit applications get 32-bit `time_t`.

Instead of generating a `static_assert` (which stops compilation) we get a compiler warning - this still requires building in STRICT mode.
