### PR TITLE
Fix IFS build inconsistencies

### DIFF
--- a/Sming/Arch/Host/Components/hostlib/include/hostlib/hostlib.h
+++ b/Sming/Arch/Host/Components/hostlib/include/hostlib/hostlib.h
@@ -19,10 +19,6 @@
 
 #pragma once
 
-// Required for sleep(), probably others
-#undef _POSIX_C_SOURCE
-#define _POSIX_C_SOURCE 200112L
-
 #ifdef __WIN32
 // Prevent early inclusion of winsock.h
 #include <winsock2.h>

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -158,7 +158,8 @@ CPPFLAGS = \
 	-Wl,-EL \
 	-finline-functions \
 	-fdata-sections \
-	-ffunction-sections
+	-ffunction-sections \
+	-D_POSIX_C_SOURCE=200809L
 
 # Required to access peripheral registers using structs
 # e.g. `uint32_t value: 8` sitting at a byte or word boundary will be 'optimised' to


### PR DESCRIPTION
This PR addresses a couple of issues which have arisen in testing.

**Globally define _POSIX_C_SOURCE**

Value set by Sming to 200809L making available functionality from the 2008 edition of the POSIX standard (IEEE Standard 1003.1-2008). See https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html.

We should expect those features to be available generally.
IFS library no longer needs to defined this.

**Fix IFS issues**

- Fix README links
- Build images using environment variables with regular Windows paths require 'fixing', e.g. "/C/dir/path" -> "C:/dir/path"

- Remove `TimeStamp::String()` operator completely: it's ambiguous

TimeStamp has implicit `time_t` cast, which is appropriate.
Calling `String(timestamp)` could yield the numeric value or the string value. Instead, call `toString()` method.

For example, when calling `Serial.println(timestamp);` GCC 10.2 calls `TimeStamp::String()`, whereas GCC 14.1 uses `String(time_t)`.
