### PR TITLE
Remove legacy compiler build options

### DIFF
--- a/Sming/Arch/Host/build.mk
+++ b/Sming/Arch/Host/build.mk
@@ -22,7 +22,6 @@ GCC_UPGRADE_URL := https://sming.readthedocs.io/en/latest/arch/host/host-emulato
 
 CPPFLAGS += \
 	-m32 \
-	-Wno-deprecated-declarations \
 	-D_FILE_OFFSET_BITS=64 \
 	-D_TIME_BITS=64
 

--- a/Sming/Core/Data/CStringArray.h
+++ b/Sming/Core/Data/CStringArray.h
@@ -71,16 +71,15 @@ public:
 		init();
 	}
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	CStringArray(String&& rval) noexcept : String(std::move(rval))
 	{
 		init();
 	}
+
 	CStringArray(StringSumHelper&& rval) noexcept : String(std::move(rval))
 	{
 		init();
 	}
-#endif
 	/** @} */
 
 	CStringArray& operator=(const char* cstr)

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -35,12 +35,10 @@ String::String(const char* cstr) : String()
 		copy(cstr, strlen(cstr));
 }
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 String::String(StringSumHelper&& rval) noexcept : String()
 {
 	move(rval);
 }
-#endif
 
 String::String(char c) : String()
 {
@@ -265,7 +263,6 @@ String& String::copy(flash_string_t pstr, size_t length)
 	return *this;
 }
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 void String::move(String& rhs)
 {
 	if(rhs.isNull()) {
@@ -300,7 +297,6 @@ void String::move(String& rhs)
 	rhs.ptr.capacity = 0;
 	rhs.ptr.len = 0;
 }
-#endif
 
 String& String::operator=(const String& rhs)
 {
@@ -316,7 +312,6 @@ String& String::operator=(const String& rhs)
 	return *this;
 }
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 String& String::operator=(StringSumHelper&& rval) noexcept
 {
 	if(this != &rval) {
@@ -324,7 +319,6 @@ String& String::operator=(StringSumHelper&& rval) noexcept
 	}
 	return *this;
 }
-#endif
 
 String& String::operator=(const char* cstr)
 {

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -68,10 +68,6 @@
  */
 using FlashString = FSTR::String;
 
-#ifndef __GXX_EXPERIMENTAL_CXX0X__
-#define __GXX_EXPERIMENTAL_CXX0X__
-#endif
-
 // When compiling programs with this class, the following gcc parameters
 // dramatically increase performance and memory (RAM) efficiency, typically
 // with little or no increase in code size.
@@ -184,13 +180,11 @@ public:
 		setString(pstr);
 	}
 
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	String(String&& rval) noexcept : String()
 	{
 		move(rval);
 	}
 	String(StringSumHelper&& rval) noexcept;
-#endif
 	explicit String(char c);
 	explicit String(unsigned char, unsigned char base = DEC, unsigned char width = 0, char pad = '0');
 	explicit String(int num, unsigned char base = DEC, unsigned char width = 0, char pad = '0')
@@ -300,7 +294,6 @@ public:
      *
      * @{
      */
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	String& operator=(String&& rval) noexcept
 	{
 		if(this != &rval)
@@ -308,7 +301,6 @@ public:
 		return *this;
 	}
 	String& operator=(StringSumHelper&& rval) noexcept;
-#endif
 	/** @} */
 
 	/**
@@ -882,9 +874,7 @@ protected:
 	// copy and move
 	String& copy(const char* cstr, size_t length);
 	String& copy(flash_string_t pstr, size_t length);
-#ifdef __GXX_EXPERIMENTAL_CXX0X__
 	void move(String& rhs);
-#endif
 };
 
 /** @} */


### PR DESCRIPTION
Remove `__GXX_EXPERIMENTAL_CXX0X__`, it's for obsolete compiler versions.

Enable deprecated warnings for Host builds. These were originally masked but there's currently no reason for it.
