### PR TITLE
Use npcap SDK from SmingTools

### DIFF
--- a/Sming/Components/lwip/src/Arch/Host/arch.mk
+++ b/Sming/Components/lwip/src/Arch/Host/arch.mk
@@ -13,6 +13,9 @@ ifeq ($(UNAME),Windows)
 	COMPONENT_PREREQUISITES += $(NPCAP_SRCDIR)/.ok
 	PCAP_SRC := npcap-sdk-1.05.zip
 
+	# PCAP_URL := https://npcap.com/dist/
+	PCAP_URL := https://github.com/SmingHub/SmingTools/releases/download/1.0/
+
 $(NPCAP_SRCDIR)/.ok:
 	@echo Fetching npcap...
 	$(Q) \
@@ -20,7 +23,7 @@ $(NPCAP_SRCDIR)/.ok:
 		mkdir -p $(@D) && \
 		cd $(@D) && \
 		powershell -Command "Set-Variable ProgressPreference SilentlyContinue; \
-			Invoke-WebRequest https://npcap.com/dist/$(PCAP_SRC) -OutFile $(PCAP_SRC); \
+			Invoke-WebRequest $(PCAP_URL)$(PCAP_SRC) -OutFile $(PCAP_SRC); \
 			Expand-Archive $(PCAP_SRC) ." && \
 		$(call ApplyPatch,$(LWIP_ARCH_SRCDIR)/npcap.patch) && \
 		touch $@


### PR DESCRIPTION
The npcap SDK is required by Host networking in Windows, and is downloaded on demand from `npcam.com`. This site has been down since yesterday and whilst it may come back up again it makes sense to keep a cached copy of this in SmingTools.