### PR TITLE
Fix delayed sending of websocket messages

### DIFF
--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -294,7 +294,11 @@ bool WebsocketConnection::send(IDataSourceStream* source, ws_frame_type_t type, 
 	}
 
 	// Pass stream to connection
-	return connection->send(sourceRef.release());
+	if(!connection->send(sourceRef.release())) {
+		return false;
+	}
+	connection->commit();
+	return true;
 }
 
 void WebsocketConnection::broadcast(const char* message, size_t length, ws_frame_type_t type)


### PR DESCRIPTION
Fixes #2780 by kicking TCP when messages are queued. Without this messages are sent lazily by lwip stack.