### PR TITLE
Upgrade toolchains

### DIFF
--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -21,6 +21,10 @@ jobs:
             idf_version: "4.3"
           - variant: esp32c2
             idf_version: "4.4"
+          - idf_version: "4.3"
+            os: windows-latest
+          - idf_version: "5.0"
+            os: windows-latest
 
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-${{ toJson(matrix) }}

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -22,7 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        variant: [esp8266, host, esp32, esp32s2, esp32c3, rp2040]
+        variant: [esp8266, host, esp32, esp32s2, esp32c3, esp32s3, esp32c2, rp2040]
+        idf_version: ["4.4", ""] # "" denotes default, currently 5.2
         include:
           - variant: esp8266
             arch: Esp8266
@@ -34,14 +35,32 @@ jobs:
             arch: Esp32
           - variant: esp32c3
             arch: Esp32
+          - variant: esp32s3
+            arch: Esp32
+          - variant: esp32c2
+            arch: Esp32
           - variant: rp2040
             arch: Rp2040
+        exclude:
+          - variant: esp32c2
+            idf_version: "4.4"
+          - variant: esp8266
+            idf_version: "4.4"
+          - variant: host
+            idf_version: "4.4"
+          - variant: rp2040
+            idf_version: "4.4"
 
     concurrency: 
       group: ${{ github.workflow }}-${{ github.ref }}-${{ toJson(matrix) }}
       cancel-in-progress: true
 
     runs-on: ${{ matrix.os }}
+
+    env:
+      SMING_ARCH: ${{ matrix.arch }}
+      SMING_SOC: ${{ matrix.variant }}
+      INSTALL_IDF_VER: ${{ matrix.idf_version }}
 
     steps:
     - name: Fix autocrlf setting
@@ -72,8 +91,6 @@ jobs:
         "SMING_HOME=" + (Resolve-Path "../../sming/Sming").path >> $env:GITHUB_ENV
         "COMPONENT_SEARCH_DIRS=" + (Resolve-Path "..").path >> $env:GITHUB_ENV
         "CI_MAKEFILE=" + (Resolve-Path "../../sming/Tools/ci/library/Makefile") >> $env:GITHUB_ENV
-        "SMING_ARCH=${{ matrix.arch }}" >> $env:GITHUB_ENV
-        "SMING_SOC=${{ matrix.variant }}" >> $env:GITHUB_ENV
 
     - name: Install build tools for Ubuntu
       if: ${{ matrix.os ==  'ubuntu-latest' }}

--- a/Sming/Arch/Esp32/README.rst
+++ b/Sming/Arch/Esp32/README.rst
@@ -108,9 +108,9 @@ IDF versions
 
 Sming currently supports IDF versions 4.3, 4.4, 5.0 and 5.2.
 
-The default installed IDF version is 4.4. This can be changed as follows::
+The default installed IDF version is 5.2. This can be changed as follows::
 
-    INSTALL_IDF_VER=5.2 $SMING_HOME/../Tools/install.sh esp32
+    INSTALL_IDF_VER=4.4 $SMING_HOME/../Tools/install.sh esp32
 
 The installation script creates a soft-link in ``/opt/esp-idf`` pointing to the last version installed.
 Use the `IDF_PATH` environment variable or change the soft-link to select which one to use.

--- a/Sming/Arch/Esp32/Tools/install.cmd
+++ b/Sming/Arch/Esp32/Tools/install.cmd
@@ -4,7 +4,7 @@ if "%IDF_PATH%"=="" goto :EOF
 if "%IDF_TOOLS_PATH%"=="" goto :EOF
 
 if "%IDF_REPO%"=="" set IDF_REPO="https://github.com/mikee47/esp-idf.git"
-if "%INSTALL_IDF_VER%"=="" set INSTALL_IDF_VER=4.4
+if "%INSTALL_IDF_VER%"=="" set INSTALL_IDF_VER=5.2
 set IDF_BRANCH="sming/release/v%INSTALL_IDF_VER%"
 
 git clone -b %IDF_BRANCH% %IDF_REPO% %IDF_PATH%

--- a/Sming/Arch/Esp32/Tools/install.sh
+++ b/Sming/Arch/Esp32/Tools/install.sh
@@ -36,7 +36,7 @@ if [ ! -L "$IDF_PATH" ] && [ -d "$IDF_PATH" ]; then
     mv "$IDF_PATH" "$IDF_PATH-old"
 fi
 
-INSTALL_IDF_VER="${INSTALL_IDF_VER:=4.4}"
+INSTALL_IDF_VER="${INSTALL_IDF_VER:=5.2}"
 IDF_CLONE_PATH="$(readlink -m "$IDF_PATH/..")/esp-idf-${INSTALL_IDF_VER}"
 IDF_REPO="${IDF_REPO:=https://github.com/mikee47/esp-idf.git}"
 IDF_BRANCH="sming/release/v${INSTALL_IDF_VER}"

--- a/Sming/Arch/Esp32/app.mk
+++ b/Sming/Arch/Esp32/app.mk
@@ -21,8 +21,16 @@ ifdef IDF_TARGET_ARCH_RISCV
 		--specs=nosys.specs
 endif
 
+
 .PHONY: application
 application: $(TARGET_BIN)
+ifeq ($(IDF_VERSION),v4.3)
+	@printf "\033[47;1;31mWARNING! ESP-IDF 4.3 reached 'End of Life' in December 2023.\033[0m Upgrade to v5.2 recommended.\n"
+else ifeq ($(IDF_VERSION),v4.4)
+	@printf "\033[47;1;31mWARNING! ESP-IDF 4.4 support ends August 2024!\033[0m Upgrade to v5.2 recommended.\n"
+else ifeq ($(IDF_VERSION),v5.0)
+	@printf "\033[47;1;34mNOTE! ESP-IDF 5.0 not recommended for new designs.\033[0m Please consider upgrading to v5.2.\n"
+endif
 
 $(TARGET_OUT): $(COMPONENTS_AR)
 	$(info $(notdir $(PROJECT_DIR)): Linking $@)

--- a/Sming/Arch/Esp8266/Tools/install.cmd
+++ b/Sming/Arch/Esp8266/Tools/install.cmd
@@ -1,9 +1,8 @@
 REM Esp8266 install.cmd
 
-call :install "%ESP_HOME%" x86_64-w64-mingw32.xtensa-lx106-elf-e6a192b.201211.zip
-goto :EOF
+set EQT_REPO=https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.2.0-gcc10.3
+set EQT_TOOLCHAIN=x86_64-w64-mingw32.xtensa-lx106-elf-c791b74.230224.zip
 
-:install
-mkdir %1
-curl -Lo %DOWNLOADS%/%2 %SMINGTOOLS%/%2
-7z -o%1 x %DOWNLOADS%/%2
+mkdir %ESP_HOME%
+curl -Lo %DOWNLOADS%/%EQT_TOOLCHAIN% %EQT_REPO%/%EQT_TOOLCHAIN%
+7z -o%ESP_HOME% x %DOWNLOADS%/%EQT_TOOLCHAIN%

--- a/Sming/Arch/Esp8266/Tools/install.sh
+++ b/Sming/Arch/Esp8266/Tools/install.sh
@@ -2,13 +2,13 @@
 #
 # Esp8266 install.sh
 
-EQT_REPO=https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.0.0-newlib4.0.0-gnu20
+EQT_REPO="https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.2.0-gcc10.3"
+EQT_TOOLCHAIN="$(uname -m)-linux-gnu.xtensa-lx106-elf-c791b74.230224.tar.gz"
 
 if [ -d "$ESP_HOME" ]; then
     printf "\n\n** Skipping Esp8266 tools installation: '$ESP_HOME' exists\n\n"
 else
-    TOOLCHAIN="$(uname -m)-linux-gnu.xtensa-lx106-elf-e6a192b.201211.tar.gz"
-    $WGET "$EQT_REPO/$TOOLCHAIN" -O "$DOWNLOADS/$TOOLCHAIN"
+    $WGET "$EQT_REPO/$EQT_TOOLCHAIN" -O "$DOWNLOADS/$EQT_TOOLCHAIN"
     mkdir -p "$ESP_HOME"
-    tar -zxf "$DOWNLOADS/$TOOLCHAIN" -C "$ESP_HOME" --totals
+    tar -zxf "$DOWNLOADS/$EQT_TOOLCHAIN" -C "$ESP_HOME" --totals
 fi

--- a/Sming/Arch/Rp2040/Components/libc/component.mk
+++ b/Sming/Arch/Rp2040/Components/libc/component.mk
@@ -8,4 +8,14 @@ LIBC_DEFSYMS := \
 	__wrap_vprintf=m_vprintf \
 	__wrap_printf=m_printf
 
-EXTRA_LDFLAGS := $(call DefSym,$(LIBC_DEFSYMS))
+LIBC_UNDEFSYMS := \
+	_close_r \
+	_lseek_r \
+	_read_r \
+	_write_r \
+	_isatty_r
+
+
+EXTRA_LDFLAGS := \
+	$(call DefSym,$(LIBC_DEFSYMS)) \
+	$(call Undef,$(LIBC_UNDEFSYMS))

--- a/Sming/Arch/Rp2040/Components/libc/src/libc_replacements.c
+++ b/Sming/Arch/Rp2040/Components/libc/src/libc_replacements.c
@@ -1,0 +1,86 @@
+/*
+ libc_replacements.c - replaces libc functions with functions
+ from Espressif SDK
+
+ Copyright (c) 2015 Ivan Grokhotkov. All rights reserved.
+ This file is part of the esp8266 core for Arduino environment.
+
+ This library is free software; you can redistribute it and/or
+ modify it under the terms of the GNU Lesser General Public
+ License as published by the Free Software Foundation; either
+ version 2.1 of the License, or (at your option) any later version.
+
+ This library is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ Lesser General Public License for more details.
+
+ You should have received a copy of the GNU Lesser General Public
+ License along with this library; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+
+ Modified 03 April 2015 by Markus Sattler
+
+ */
+
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <sys/reent.h>
+#include <esp_attr.h>
+#include <m_printf.h>
+
+int _open_r(struct _reent* unused, const char* ptr, int mode)
+{
+	(void)unused;
+	(void)ptr;
+	(void)mode;
+	return 0;
+}
+
+int _close_r(struct _reent* unused, int file)
+{
+	(void)unused;
+	(void)file;
+	return 0;
+}
+
+int _fstat_r(struct _reent* unused, int file, struct stat* st)
+{
+	(void)unused;
+	(void)file;
+	st->st_mode = S_IFCHR;
+	return 0;
+}
+
+int _lseek_r(struct _reent* unused, int file, int ptr, int dir)
+{
+	(void)unused;
+	(void)file;
+	(void)ptr;
+	(void)dir;
+	return 0;
+}
+
+int _read_r(struct _reent* unused, int file, char* ptr, int len)
+{
+	(void)unused;
+	(void)file;
+	(void)ptr;
+	(void)len;
+	return 0;
+}
+
+int _write_r(struct _reent* r, int file, char* ptr, int len)
+{
+	(void)r;
+	if(file == STDOUT_FILENO) {
+		return m_nputs(ptr, len);
+	}
+	return 0;
+}
+
+int _isatty_r(struct _reent* r, int fd)
+{
+	return 0;
+}

--- a/Sming/Arch/Rp2040/README.rst
+++ b/Sming/Arch/Rp2040/README.rst
@@ -85,20 +85,29 @@ The following instructions should help.
 
 Compiler/linker
    The RP2040 contains two ARM Cortex-M0+ cores. Tools for all platforms can be downloaded from the
-   `ARM developer website <https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads>`__.
+   `ARM developer website <https://developer.arm.com/downloads/-/arm-gnu-toolchain-downloads>`__.
 
    Unzip the archive to a suitable location (e.g. ``/opt/rp2040`` or ``c:\tools\rp2040``) and set :envvar:`PICO_TOOLCHAIN_PATH` accordingly.
 
    .. note::
 
-      At time of writing the Ubuntu repositories contain an older version of this toolchain.
-      It also does not contain GDB, but can be installed separately:
+      The Sming installer script can do this for you ``Tools/install.sh rp2040``
 
+   You can alternatively use the toolchains provided in your GNU/Linux distribution.
+
+   Ubuntu
+      ::
          sudo apt install gcc-arm-none-eabi gdb-multiarch
 
-      To use gdb-multiarch you'll need to do this:
+      To use gdb-multiarch you'll need to do this::
 
          make gdb GDB=gdb-multiarch
+
+   Fedora
+      ::
+         sudo dnf install arm-none-eabi-gcc-cs-c++ arm-none-eabi-newlib
+
+      The standard GDB appears to work OK.
 
 Ninja
    This is used to build the RP2040 SDK code:

--- a/Sming/Arch/Rp2040/Tools/install.cmd
+++ b/Sming/Arch/Rp2040/Tools/install.cmd
@@ -1,11 +1,11 @@
 REM Rp2040 install.cmd
 
 if exist "%PICO_TOOLCHAIN_PATH%/arm-none-eabi" goto :already_got
-set TOOLCHAIN_VERSION=10.3-2021.07
-set TOOLCHAIN_BASE_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm
-set TOOLCHAIN_NAME=gcc-arm-none-eabi-%TOOLCHAIN_VERSION%
-set TOOLCHAIN_FILE=%TOOLCHAIN_NAME%-win32.zip
-curl -Lo tmp.zip %TOOLCHAIN_BASE_URL%/%TOOLCHAIN_VERSION%/%TOOLCHAIN_FILE% || goto :EOF
+set TOOLCHAIN_VERSION=13.2.rel1
+set TOOLCHAIN_BASE_URL=https://developer.arm.com/-/media/Files/downloads/gnu
+set TOOLCHAIN_NAME=arm-gnu-toolchain-%TOOLCHAIN_VERSION%-mingw-w64-i686-arm-none-eabi
+set TOOLCHAIN_FILE=%TOOLCHAIN_NAME%.zip
+curl -Lo tmp.zip %TOOLCHAIN_BASE_URL%/%TOOLCHAIN_VERSION%/binrel/%TOOLCHAIN_FILE% || goto :EOF
 7z -o"%PICO_TOOLCHAIN_PATH%-tmp" x tmp.zip || goto :EOF
 del tmp.zip
 move "%PICO_TOOLCHAIN_PATH%-tmp/%TOOLCHAIN_NAME%" "%PICO_TOOLCHAIN_PATH%"

--- a/Sming/Arch/Rp2040/Tools/install.sh
+++ b/Sming/Arch/Rp2040/Tools/install.sh
@@ -6,14 +6,13 @@ $PKG_INSTALL ninja-build
 
 if [ -d "$PICO_TOOLCHAIN_PATH/arm-none-eabi" ]; then
     printf "\n\n** Skipping Rp2040 tools installation: '$PICO_TOOLCHAIN_PATH' exists\n\n"
-else
-    TOOLCHAIN_VERSION="10.3-2021.10"
-    TOOLCHAIN_BASE_URL="https://developer.arm.com/-/media/Files/downloads/gnu-rm"
-    TOOLCHAIN_NAME="gcc-arm-none-eabi-$TOOLCHAIN_VERSION"
-    TOOLCHAIN_FILE="$TOOLCHAIN_NAME-$(uname -m)-linux.tar.bz2"
-    TOOLCHAIN_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_VERSION/$TOOLCHAIN_FILE"
+elif [ -n "$PICO_TOOLCHAIN_PATH" ]; then
+    TOOLCHAIN_VERSION="13.2.rel1"
+    TOOLCHAIN_BASE_URL="https://developer.arm.com/-/media/Files/downloads/gnu"
+    TOOLCHAIN_FILE="arm-gnu-toolchain-$TOOLCHAIN_VERSION-$(uname -m)-arm-none-eabi.tar.xz"
+    TOOLCHAIN_URL="$TOOLCHAIN_BASE_URL/$TOOLCHAIN_VERSION/binrel/$TOOLCHAIN_FILE"
     $WGET "$TOOLCHAIN_URL" -O "$DOWNLOADS/$TOOLCHAIN_FILE"
     mkdir -p "$PICO_TOOLCHAIN_PATH"
-    tar -jxf "$DOWNLOADS/$TOOLCHAIN_FILE" -C "$PICO_TOOLCHAIN_PATH" --totals --transform='s|^/*||'
-    mv "$PICO_TOOLCHAIN_PATH/$TOOLCHAIN_NAME/"* "$PICO_TOOLCHAIN_PATH"
+    tar -xf "$DOWNLOADS/$TOOLCHAIN_FILE" -C "$PICO_TOOLCHAIN_PATH" --totals --transform='s|^/*||'
+    mv "$PICO_TOOLCHAIN_PATH/"*/* "$PICO_TOOLCHAIN_PATH"
 fi

--- a/Sming/Arch/Rp2040/app.mk
+++ b/Sming/Arch/Rp2040/app.mk
@@ -6,6 +6,7 @@
 
 # linker flags used to generate the main object file
 LDFLAGS	+= \
+	-Wl,--no-warn-rwx-segments \
 	-Wl,--build-id=none \
 	--specs=nosys.specs \
 	-mcpu=cortex-m0plus \

--- a/Sming/Arch/Rp2040/build.mk
+++ b/Sming/Arch/Rp2040/build.mk
@@ -26,11 +26,10 @@ ifeq (,$(wildcard $(PICO_TOOLCHAIN_PATH)/$(CONFIG_TOOLPREFIX)))
 $(error PICO_TOOLCHAIN_PATH not set correctly: $(PICO_TOOLCHAIN_PATH))
 endif
 else
-PICO_TOOLCHAIN_PATH := $(shell which $(CONFIG_TOOLPREFIX)-gcc)
-ifeq (,$(PICO_TOOLCHAIN_PATH))
+ifeq (,$(shell which $(CONFIG_TOOLPREFIX)-gcc))
 $(error Toolchain not found, maybe set PICO_TOOLCHAIN_PATH)
 endif
-TOOLSPEC := $(dir $(PICO_TOOLCHAIN_PATH))$(CONFIG_TOOLPREFIX)-
+TOOLSPEC := $(CONFIG_TOOLPREFIX)-
 endif
 
 # select which tools to use as assembler, compiler, librarian and linker
@@ -42,7 +41,7 @@ LD				:= $(TOOLSPEC)gcc
 NM				:= $(TOOLSPEC)nm
 OBJCOPY		 	:= $(TOOLSPEC)objcopy
 OBJDUMP		 	:= $(TOOLSPEC)objdump
-GDB				:= $(TOOLSPEC)gdb
+GDB				:= gdb
 
 CPPFLAGS += \
 	-nostdlib

--- a/docs/source/upgrading/5.1-5.2.rst
+++ b/docs/source/upgrading/5.1-5.2.rst
@@ -43,7 +43,14 @@ esp8266: https://github.com/earlephilhower/newlib-xtensa/blob/xtensa-4_0_0-lock-
 esp32: https://github.com/espressif/newlib-esp32/blob/esp-4.3.0/newlib/libc/
 
 
-**Esp32 IDF**
+**Toolchain versions updated**
 
-The installation scripts now install IDF version 5.2 by default.
-See :ref:`idf_versions` for further details.
+Esp8266
+    The installer has been updated to use the latest toolchain (Feb 23), gcc 10.3.
+
+Esp32 IDF
+    The installation scripts now install IDF version 5.2 by default.
+    See :ref:`idf_versions` for further details.
+
+RP2040
+    The installer has been updated to use the latest toolchain (Oct 23), gcc 13.2.

--- a/docs/source/upgrading/5.1-5.2.rst
+++ b/docs/source/upgrading/5.1-5.2.rst
@@ -41,3 +41,9 @@ Espressif toolchains use forks:
 
 esp8266: https://github.com/earlephilhower/newlib-xtensa/blob/xtensa-4_0_0-lock-arduino/newlib/libc/
 esp32: https://github.com/espressif/newlib-esp32/blob/esp-4.3.0/newlib/libc/
+
+
+**Esp32 IDF**
+
+The installation scripts now install IDF version 5.2 by default.
+See :ref:`idf_versions` for further details.


### PR DESCRIPTION
This PR updates the embedded toolchains to more recent versions, setting the new default installed version for Esp32 to IDF 5.2. The library testing github actions script has been updated to include missing esp32c2 architecture and test against IDF 4.4 and 5.2.

**Esp32 IDF SDK**

The installation scripts now install IDF version 5.2 by default (see issue #2784 regarding docker build failure because of Y2038 warning with IDF < 5).
Deprecation warnings printed for IDF 4.3 and 4.4 after final link step. See #2732 for discussion regarding old versions.
Windows CI tests for IDF 4.3, 5.0 removed.

**Extend library tests to include missing esp32 variants**

CI testing when developing libraries is much more efficient than running the main Sming CI tests.
Looks like these haven't been updated for a while so have added the `esp32s3` and `esp32c2` variants
and testing against IDF 5.2 for all esp32 variants. Previously was only 4.4 (old default).

**Esp8266 Toolchain**

The installer has been updated to use the latest toolchain (Feb 23), gcc 10.3.

**RP2040 Toolchain**

The installer has been updated to use the latest toolchain (Oct 23), gcc 13.2.
