### PR TITLE
Use physical serial port if present on WSL2

### DIFF
--- a/Sming/Arch/Rp2040/Components/uf2/component.mk
+++ b/Sming/Arch/Rp2040/Components/uf2/component.mk
@@ -9,7 +9,7 @@ DEBUG_VARS += UF2CONV_PY
 UF2CONV_PY := $(COMPONENT_PATH)/uf2conv.py
 
 
-# Invoke uf2conf utility
+# Invoke uf2conv utility
 # $1 -> Parameters
 ifdef WSL_ROOT
 Uf2Conv = powershell.exe -Command "$(PYTHON) $(UF2CONV_PY) $(if $V,--verbose) $1"

--- a/Sming/Components/terminal/README.rst
+++ b/Sming/Components/terminal/README.rst
@@ -33,6 +33,7 @@ Options
 .. envvar:: TERMINAL
 
    Command line to use when running ``make terminal``.
+   This is normally empty (undefined) which causes the default python terminal application to run.
    Redefine if you want to use a different terminal application.
 
 .. envvar:: KILL_TERM

--- a/Sming/Components/terminal/component.mk
+++ b/Sming/Components/terminal/component.mk
@@ -17,11 +17,6 @@ endif
 CACHE_VARS		+= COM_OPTS KILL_TERM TERMINAL
 COM_OPTS		?= --raw --encoding ascii --rts 0 --dtr 0
 KILL_TERM		?= pkill -9 -f "$(COM_PORT) $(COM_SPEED_SERIAL)" || exit 0
-ifdef WSL_ROOT
-TERMINAL		?= powershell.exe -Command "python -m serial.tools.miniterm $(COM_OPTS) $(COM_PORT) $(COM_SPEED_SERIAL)"
-else
-TERMINAL		?= $(PYTHON) -m serial.tools.miniterm $(COM_OPTS) $(COM_PORT) $(COM_SPEED_SERIAL)
-endif
 
 
 ##@Tools
@@ -33,4 +28,10 @@ kill_term:
 
 .PHONY: terminal
 terminal: kill_term ##Open the serial terminal
+ifdef TERMINAL
 	$(TERMINAL)
+else ifeq ($(WSL_COMPORT_POWERSHELL),1)
+	powershell.exe -Command "python -m serial.tools.miniterm $(COM_OPTS) $(COM_PORT) $(COM_SPEED_SERIAL)"
+else
+	$(PYTHON) -m serial.tools.miniterm $(COM_OPTS) $(COM_PORT) $(COM_SPEED_SERIAL)
+endif

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -94,6 +94,8 @@ else ifeq ($(UNAME), Linux)
  	ifdef WSL_DISTRO_NAME
         DEBUG_VARS += WSL_ROOT
         WSL_ROOT := //wsl$$/$(WSL_DISTRO_NAME)
+		# If serial device is available, use it directly, otherwise via powershell
+		WSL_COMPORT_POWERSHELL = $(if $(wildcard $(COM_PORT)),,1)
  	endif
 else ifeq ($(UNAME), Darwin)
  	#OS X

--- a/Sming/component.mk
+++ b/Sming/component.mk
@@ -128,9 +128,9 @@ flash: all kill_term ##Write the boot loader and all defined partition images
 	$(Q) $(call CheckPartitionChunks,$(FLASH_PARTITION_CHUNKS))
 	$(call WriteFlash,$(FLASH_BOOT_CHUNKS) $(FLASH_MAP_CHUNK) $(FLASH_PARTITION_CHUNKS))
 ifeq ($(ENABLE_GDB), 1)
-	$(GDB_CMDLINE)
+	$(MAKE) gdb
 else ifneq ($(SMING_ARCH),Host)
-	$(TERMINAL)
+	$(MAKE) terminal
 endif
 
 .PHONY: mergeflash

--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -589,7 +589,7 @@ TCP_SERIAL_REDIRECT = $(SMING_HOME)/../Tools/tcp_serial_redirect.py $(COM_PORT) 
 .PHONY: tcp-serial-redirect
 tcp-serial-redirect: ##Redirect COM port to TCP port
 	$(info Starting serial redirector)
-ifdef WSL_ROOT
+ifeq ($(WSL_COMPORT_POWERSHELL),1)
 	$(Q) cmd.exe /c start /MIN python3 $(WSL_ROOT)/$(TCP_SERIAL_REDIRECT)
 else
 	$(Q) $(call DetachCommand,$(PYTHON) $(TCP_SERIAL_REDIRECT))

--- a/docs/source/getting-started/windows/wsl.rst
+++ b/docs/source/getting-started/windows/wsl.rst
@@ -91,12 +91,23 @@ This will ensure that the build system can run python scripts either in WSL2 or 
 Flashing devices
 ----------------
 
-WSL2 does not currently support access to USB serial devices, so the Sming build system runs
+WSL2 does not natively support access to USB serial devices, so the Sming build system runs
 the appropriate application directly under Windows using ``powershell.exe``.
 
 Therefore, use the normal Windows COM port name rather than the linux ones (such as /dev/ttyUSB0)::
 
    make flash COM_PORT=COM4
+
+
+Some USB serial adapters are supported by the `usbipd <https://github.com/dorssel/usbipd-win>`__ project.
+If so, then devices such as ``/dev/ttyUSB0``, etc. will be present as usual.
+If Sming sees that ``COM_PORT`` actually exists when running in WSL2 then the above powershell workaround
+will not be used.
+
+.. note::
+   
+   The :envvar:`TERMINAL` environment variable is cached by Sming so if the terminal isn't running as expected
+   try ``make config-clean`` to clear the cached value.
 
 
 Serial debugging


### PR DESCRIPTION
WSL2 doesn't natively support USB devices such as serial ports, so Sming uses runs the python terminal application inside Windows natively using powershell.

However, as discussed in #2789 this prevents software such as [usbipd](https://github.com/dorssel/usbipd-win) from working.

This PR adds an additional check when running inside WSL2 to see if the nominated port, via `COM_PORT`, is actually present. If so, then it runs the python terminal application normally. If the path isn't present then it is assumed to be a Windows port and powershell is invoked as usual.

Because the `TERMINAL` environment variable is cached by Sming this can cause issues. To maintain existing behaviour this variable is still cached but left empty to indicate default behaviour. If `TERMINAL` has been redefined then that will be run instead. This will require `make config-clean` to clear the existing cached value.