### PR TITLE
Update lwip2 to upstream master

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -97,7 +97,7 @@
 	ignore = dirty
 [submodule "Esp8266.lwip2"]
 	path = Sming/Arch/Esp8266/Components/lwip2/lwip2
-	url = https://github.com/mikee47/esp82xx-nonos-linklayer.git
+	url = https://github.com/d-a-v/esp82xx-nonos-linklayer.git
 	ignore = dirty
 [submodule "Esp8266.umm_malloc"]
 	path = Sming/Arch/Esp8266/Components/heap/umm_malloc

--- a/Sming/Arch/Esp8266/Components/esp8266/include/esp_wifi.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/esp_wifi.h
@@ -29,7 +29,7 @@
 #pragma once
 
 #include "os_type.h"
-#include "lwip/ip_addr.h"
+#include "ipv4_addr.h"
 #include "../sdk/include/queue.h"
 #include "gpio.h"
 
@@ -227,13 +227,13 @@ struct station_info {
 	STAILQ_ENTRY(station_info) next;
 
 	uint8_t bssid[6];
-	struct ip_addr ip;
+	struct ipv4_addr ip;
 };
 
 struct dhcps_lease {
 	bool enable;
-	struct ip_addr start_ip;
-	struct ip_addr end_ip;
+	struct ipv4_addr start_ip;
+	struct ipv4_addr end_ip;
 };
 
 enum dhcps_offer_option {
@@ -244,7 +244,7 @@ enum dhcps_offer_option {
 
 uint8_t wifi_softap_get_station_num(void);
 struct station_info* wifi_softap_get_station_info(void);
-bool wifi_softap_set_station_info (uint8_t* mac, struct ip_addr*);
+bool wifi_softap_set_station_info (uint8_t* mac, struct ipv4_addr*);
 void wifi_softap_free_station_info(void);
 
 bool wifi_softap_dhcps_start(void);
@@ -375,9 +375,9 @@ typedef struct {
 } Event_StaMode_AuthMode_Change_t;
 
 typedef struct {
-	struct ip_addr ip;
-	struct ip_addr mask;
-	struct ip_addr gw;
+	struct ipv4_addr ip;
+	struct ipv4_addr mask;
+	struct ipv4_addr gw;
 } Event_StaMode_Got_IP_t;
 
 typedef struct {
@@ -387,7 +387,7 @@ typedef struct {
 
 typedef struct {
 	uint8_t mac[6];
-	struct ip_addr ip;
+	struct ipv4_addr ip;
 	uint8_t aid;
 } Event_SoftAPMode_Distribute_Sta_IP_t;
 

--- a/Sming/Arch/Esp8266/Components/esp8266/include/ipv4_addr.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/ipv4_addr.h
@@ -1,0 +1,77 @@
+/*
+ * ESPRESSIF MIT License
+ *
+ * Copyright (c) 2016 <ESPRESSIF SYSTEMS (SHANGHAI) PTE LTD>
+ *
+ * Permission is hereby granted for use on ESPRESSIF SYSTEMS ESP8266 only, in which case,
+ * it is free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the Software is furnished
+ * to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef __IPV4_ADDR_H__
+#define __IPV4_ADDR_H__
+
+struct ip_info;
+
+#include <lwip/ip_addr.h>
+
+#ifdef LWIP14GLUE
+
+#define ipv4_addr ip_addr
+
+#else
+
+#ifdef __LWIP_IP_ADDR_H__
+
+#define ipv4_addr ip_addr
+typedef struct ip4_addr ip4_addr_t;
+
+#else
+
+#include <lwip/init.h>
+
+// ipv4_addr is necessary for lwIP-v2 because
+// - espressif binary firmware is IPv4 only, under the name of ip_addr/_t
+// - ip_addr/_t is different when IPv6 is enabled with lwIP-v2
+// hence ipv4_addr/t is IPv4 version/copy of IPv4 ip_addr/_t
+// when IPv6 is enabled so we can deal with IPv4 use from firmware API.
+
+#define ipv4_addr ip4_addr
+#define ipv4_addr_t ip4_addr_t
+
+// official lwIP's definitions
+#if LWIP_VERSION_MAJOR == 1
+struct ip4_addr { uint32_t addr; };
+typedef struct ip4_addr ip4_addr_t;
+#else
+
+#include <lwip/ip4_addr.h>
+
+// defined in lwip-v1.4 sources only, used in fw
+struct ip_info {
+    struct ipv4_addr ip;
+    struct ipv4_addr netmask;
+    struct ipv4_addr gw;
+};
+
+#endif
+
+#endif // __LWIP_IP_ADDR_H__
+
+#endif // LWIP14GLUE
+
+#endif // __IPV4_ADDR_H__

--- a/Sming/Arch/Esp8266/Components/lwip2/Makefile.sming
+++ b/Sming/Arch/Esp8266/Components/lwip2/Makefile.sming
@@ -1,0 +1,50 @@
+# Modified version of lwip2/makefiles/Makefile.build-lwip2
+# Make from ./lwip2 directory
+
+include makefiles/Makefile.defs
+
+export LWIP_ESP=glue-esp/lwip-1.4-arduino/include
+export LWIP_LIB=$(BUILD)/liblwip2.a
+export target=arduino
+export BUILD
+export TCP_MSS
+export LWIP_FEATURES
+export LWIP_IPV6
+export V
+export DEFINE_TARGET=ARDUINO
+export LWIP_INCLUDES_RELEASE=include
+
+AUTO := \
+	glue-lwip/lwip-err-t.h \
+	glue-lwip/lwip-git-hash.h
+
+all: patch $(LWIP_LIB_RELEASE)
+
+.PHONY: upstream
+upstream: lwip2-src/README
+
+.PHONY: patch
+patch: upstream $(AUTO)
+	$(Q) $(MAKE) --no-print-directory -C lwip2-src/src -f ../../makefiles/Makefile.patches
+
+lwip2-src/README:
+	$(Q) git clone --depth=1 -b $(UPSTREAM_VERSION) https://github.com/lwip-tcpip/lwip lwip2-src
+
+glue-lwip/lwip-err-t.h: $(LWIP_ESP)/arch/cc.h upstream
+	$(Q) ( \
+	echo "// script-generated, extracted from espressif SDK's lwIP arch/cc.h"; \
+	echo "#define LWIP_NO_STDINT_H 1"; \
+	echo "typedef signed short sint16_t;"; \
+	grep -e LWIP_ERR_T -e ^typedef $< \
+	) > $@
+
+glue-lwip/lwip-git-hash.h: upstream
+	makefiles/make-lwip-hash
+
+$(LWIP_LIB_RELEASE): $(LWIP_LIB)
+	@cp $< $@
+
+$(LWIP_LIB):
+	$(Q) $(MAKE) -f makefiles/Makefile.glue-esp
+	$(Q) $(MAKE) -f makefiles/Makefile.glue
+	$(Q) $(MAKE) -C lwip2-src/src -f ../../makefiles/Makefile.lwip2

--- a/Sming/Arch/Esp8266/Components/lwip2/README.rst
+++ b/Sming/Arch/Esp8266/Components/lwip2/README.rst
@@ -1,4 +1,36 @@
 Esp8266 LWIP Version 2
 ======================
 
-This Component implements the current Version 2 LWIP stack. Note that at present espconn\_* functions are not supported.
+This Component implements the current Version 2 LWIP stack.
+Note that at present espconn\_* functions are not supported.
+
+
+.. envvar:: TCP_MSS
+
+    Maximum TCP segment size. Default 1460.
+
+
+.. envvar:: LWIP_IPV6
+
+    default: 0 (disabled)
+
+    Set to enable IPv6 support.
+
+
+.. envvar:: LWIP_FEATURES
+
+    If anyone knows of an actual reference for this setting, link here please!
+
+    Looking at glue-lwip/arduino/lwipopts.h, setting ``LWIP_FEATURES`` to 1 enables these LWIP flags:
+
+    - IP_FORWARD
+    - IP_REASSEMBLY
+    - IP_FRAG
+    - IP_NAPT (IPV4 only)
+    - LWIP_AUTOIP
+    - LWIP_DHCP_AUTOIP_COOP
+    - LWIP_TCP_SACK_OUT
+    - TCP_LISTEN_BACKLOG
+    - SNTP_MAX_SERVERS = 3
+
+    Also DHCP discovery gets hooked.

--- a/Sming/Arch/Esp8266/Components/lwip2/component.mk
+++ b/Sming/Arch/Esp8266/Components/lwip2/component.mk
@@ -10,33 +10,69 @@ ifeq ($(SMING_RELEASE),1)
 endif
 
 COMPONENT_VARS		:= ENABLE_LWIPDEBUG ENABLE_ESPCONN
-ENABLE_LWIPDEBUG	?= 0
+ifneq ($(ENABLE_LWIPDEBUG),1)
+override ENABLE_LWIPDEBUG := 0
+endif
 ENABLE_ESPCONN		?= 0
 
 EXTRA_CFLAGS_LWIP  := \
 	-I$(SMING_HOME)/System/include \
 	-I$(ARCH_COMPONENTS)/esp8266/include \
-	-I$(ARCH_COMPONENTS)/libc/include
+	-I$(ARCH_COMPONENTS)/libc/include \
+	-DULWIPDEBUG=$(ENABLE_LWIPDEBUG)
 
-ifeq ($(ENABLE_LWIPDEBUG), 1)
-	EXTRA_CFLAGS_LWIP += -DLWIP_DEBUG
-endif
 
-ifeq ($(ENABLE_ESPCONN), 1)
-$(error LWIP2 does not support espconn_* functions. Make sure to set ENABLE_CUSTOM_LWIP to 0 or 1.)
-endif
-
-COMPONENT_SUBMODULES	:= lwip2
-COMPONENT_INCDIRS		:= lwip2/glue-esp/include-esp lwip2/include
+COMPONENT_SUBMODULES := lwip2
+COMPONENT_INCDIRS := \
+	lwip2/glue-lwip/arduino \
+	lwip2/glue-lwip \
+	lwip2/glue \
+	lwip2/lwip2-src/src/include
 
 LWIP2_PATH := $(COMPONENT_PATH)/lwip2
+LWIP2_LIBPATH := $(COMPONENT_LIBDIR)
+
+#
+COMPONENT_VARS += TCP_MSS LWIP_IPV6 LWIP_FEATURES
+TCP_MSS ?= 1460
+ifneq ($(LWIP_IPV6),1)
+override LWIP_IPV6 := 0
+endif
+ifneq ($(LWIP_FEATURES),1)
+LWIP_FEATURES := 0
+endif
+
+LWIP2_HASHVAL   := $(foreach v,$(COMPONENT_VARS),$v=$($v))
+LWIP2_LIBHASH   := $(call CalculateVariantHash,LWIP2_HASHVAL)
+LWIP2_BUILD_DIR := $(COMPONENT_BUILD_BASE)/$(LWIP2_LIBHASH)
+
+GLOBAL_CFLAGS += \
+	-DTCP_MSS=$(TCP_MSS) \
+	-DLWIP_IPV6=$(LWIP_IPV6) \
+	-DLWIP_FEATURES=$(LWIP_FEATURES) \
+	-DULWIPDEBUG=$(ENABLE_LWIPDEBUG)
 
 # Make is pretty complex for LWIP2, and mucks about with output sections so build as a regular library
 LWIP2_LIB			:= $(COMPONENT_NAME)
-LWIP2_TARGET		:= $(COMPONENT_LIBDIR)/lib$(LWIP2_LIB).a
+LWIP2_TARGET		:= $(LWIP2_BUILD_DIR)/lib$(LWIP2_LIB).a
 COMPONENT_TARGETS	:= $(LWIP2_TARGET)
 EXTRA_LIBS			:= $(LWIP2_LIB)
 
+LIBDIRS += $(LWIP2_BUILD_DIR)
+
+COMPONENT_PREREQUISITES := $(LWIP2_PATH)/glue-lwip/lwip-err-t.h
+
+$(LWIP2_PATH)/glue-lwip/lwip-err-t.h:
+	$(Q) $(MAKE) -C $(LWIP2_PATH) -f ../Makefile.sming patch
+
 $(COMPONENT_RULE)$(LWIP2_TARGET):
-	$(Q) $(MAKE) -C $(LWIP2_PATH) -f Makefile.sming BUILD=$(COMPONENT_BUILD_DIR) \
-				USER_LIBDIR=$(COMPONENT_LIBDIR)/ CFLAGS_EXTRA="$(EXTRA_CFLAGS_LWIP)" CC=$(CC) AR=$(AR) all
+	$(Q) $(MAKE) --no-print-directory -C $(LWIP2_PATH) -f ../Makefile.sming \
+		all \
+		CFLAGS_EXTRA="$(EXTRA_CFLAGS_LWIP)" \
+		LWIP_LIB_RELEASE=$(LWIP2_TARGET) \
+		TOOLS=$(TOOLSPEC) \
+		TCP_MSS=$(TCP_MSS) \
+		LWIP_FEATURES=$(LWIP_FEATURES) \
+		LWIP_IPV6=$(LWIP_IPV6) \
+		BUILD=$(LWIP2_BUILD_DIR)/build \
+		Q=$(Q) V=$(if $V,1,0)

--- a/Sming/Arch/Esp8266/Components/lwip2/lwip2.patch
+++ b/Sming/Arch/Esp8266/Components/lwip2/lwip2.patch
@@ -1,0 +1,134 @@
+diff --git a/glue-lwip/arch/cc.h b/glue-lwip/arch/cc.h
+index 0b73cba..fff12b0 100644
+--- a/glue-lwip/arch/cc.h
++++ b/glue-lwip/arch/cc.h
+@@ -56,8 +56,6 @@ void sntp_set_system_time (uint32_t t);
+ #endif
+ #endif // defined(LWIP_BUILD)
+ 
+-#include "mem.h" // useful for os_malloc used in esp-arduino's mDNS
+-
+ #include "glue.h" // include assembly locking macro used below
+ typedef uint32_t sys_prot_t;
+ #define SYS_ARCH_DECL_PROTECT(lev) sys_prot_t lev
+diff --git a/glue-lwip/esp-dhcpserver.c b/glue-lwip/esp-dhcpserver.c
+index 6ac8a41..cd1faf0 100644
+--- a/glue-lwip/esp-dhcpserver.c
++++ b/glue-lwip/esp-dhcpserver.c
+@@ -12,7 +12,7 @@
+ #include "lwip/apps-esp/dhcpserver.h"
+ 
+ #include "user_interface.h"
+-#include "mem.h"
++#include <sdk/mem.h>
+ 
+ #include "glue.h"
+ #include "lwip-helper.h"
+diff --git a/glue/esp-missing.h b/glue/esp-missing.h
+index b9fea2a..63bbb45 100644
+--- a/glue/esp-missing.h
++++ b/glue/esp-missing.h
+@@ -12,18 +12,15 @@ uint32_t r_rand (void);
+ 
+ // TODO: Patch these in from SDK
+ 
+-#if ARDUINO
+-void* pvPortZalloc (size_t, const char*, int);
+-void* pvPortMalloc (size_t xWantedSize, const char* file, int line) __attribute__((malloc, alloc_size(1)));
+-void vPortFree (void *ptr, const char* file, int line);
+-#else
+-void *pvPortZalloc (size_t sz, const char *, unsigned);
+-void *pvPortMalloc (size_t sz, const char *, unsigned) __attribute__((malloc, alloc_size(1)));
+-void vPortFree (void *p, const char *, unsigned);
+-#endif
++#include <sdk/mem.h>
++
++#define ets_post system_os_post
++#define ets_task system_os_task
+ 
+ struct netif* eagle_lwip_getif (int netif_index);
+ 
++#if 0
++
+ void ets_intr_lock (void);
+ void ets_intr_unlock (void);
+ 
+@@ -61,3 +58,5 @@ struct ip_info;
+ #define os_memcpy	ets_memcpy
+ 
+ #endif
++
++#endif
+diff --git a/glue/gluedebug.h b/glue/gluedebug.h
+index 9358878..905e41e 100644
+--- a/glue/gluedebug.h
++++ b/glue/gluedebug.h
+@@ -10,10 +10,10 @@
+ // because it is shared by both sides of glue
+ 
+ #define UNDEBUG		1	// 0 or 1 (1: uassert removed = saves flash)
+-#define UDEBUG		0	// 0 or 1 (glue debug)
++#define UDEBUG		ULWIPDEBUG	// 0 or 1 (glue debug)
+ #define UDUMP		0	// 0 or 1 (glue: dump packet)
+ 
+-#define ULWIPDEBUG	0	// 0 or 1 (trigger lwip debug)
++// #define ULWIPDEBUG	0	// 0 or 1 (trigger lwip debug)
+ #define ULWIPASSERT	0	// 0 or 1 (trigger lwip self-check, 0 saves flash)
+ 
+ #if ARDUINO
+@@ -58,7 +58,7 @@ extern void (*phy_capture) (int netif_idx, const char* data, size_t len, int out
+ 
+ #include <osapi.h> // os_printf* definitions + ICACHE_RODATA_ATTR
+ 
+-#if defined(ARDUINO)
++#if 0
+ // os_printf() does not understand ("%hhx",0x12345678) => "78") and prints 'h' instead
+ // now hacking/using ::printf() from updated and patched esp-quick-toolchain-by-Earle
+ #include <stdio.h>
+diff --git a/makefiles/Makefile.glue b/makefiles/Makefile.glue
+index 366d849..3fe3a6c 100644
+--- a/makefiles/Makefile.glue
++++ b/makefiles/Makefile.glue
+@@ -3,6 +3,7 @@
+ 
+ GLUE_LWIP = lwip-git.c
+ GLUE_LWIP += esp-ping.c
++GLUE_LWIP += esp-dhcpserver.c
+ ifneq ($(target),arduino)
+ GLUE_LWIP += esp-dhcpserver.c
+ GLUE_LWIP += esp-time.c
+@@ -14,7 +15,7 @@ OBJ = \
+ 	$(patsubst %.c,$(BUILD)/%.o,$(wildcard glue/*.c)) \
+ 	$(patsubst %.c,$(BUILD)/glue-lwip/%.o,$(GLUE_LWIP)) \
+ 
+-BUILD_INCLUDES = -I$(BUILD) -Iglue -Iglue-lwip -Iglue-lwip/$(target) -Ilwip2-src/src/include -I$(SDK)/include
++BUILD_INCLUDES = -I$(BUILD) -Iglue -Iglue-lwip -Iglue-lwip/$(target) -Ilwip2-src/src/include $(CFLAGS_EXTRA)
+ 
+ include makefiles/Makefile.defs
+ include makefiles/Makefile.rules
+diff --git a/makefiles/Makefile.glue-esp b/makefiles/Makefile.glue-esp
+index 8b756ff..ea414b1 100644
+--- a/makefiles/Makefile.glue-esp
++++ b/makefiles/Makefile.glue-esp
+@@ -6,7 +6,7 @@ ifeq ($(LWIP_ESP),)
+ $(error LWIP_ESP must point to espressif sdk lwip/include)
+ endif
+ 
+-BUILD_INCLUDES = -I$(BUILD) -I$(SDK)/include -I$(LWIP_ESP) -Iglue
++BUILD_INCLUDES = -I$(BUILD) $(CFLAGS_EXTRA) -I$(LWIP_ESP) -Iglue
+ BUILD_FLAGS += -DLWIP14GLUE
+ 
+ include makefiles/Makefile.defs
+diff --git a/makefiles/Makefile.lwip2 b/makefiles/Makefile.lwip2
+index 6a4ccbd..01133ec 100644
+--- a/makefiles/Makefile.lwip2
++++ b/makefiles/Makefile.lwip2
+@@ -13,7 +13,7 @@ OBJ = \
+ #	$(subst ../../lwip2-contrib-src/,contrib/, \
+ #		$(patsubst %.c,$(BUILD)/%.o,$(wildcard ../../lwip2-contrib-src/apps/ping/*.c)))
+ 
+-BUILD_INCLUDES = -I$(BUILD) -I$(SDK)/include -Iinclude -I../../glue -I../../glue-lwip -I../../glue-lwip/$(target)
++BUILD_INCLUDES = -I$(BUILD) $(CFLAGS_EXTRA) -Iinclude -I../../glue -I../../glue-lwip -I../../glue-lwip/$(target)
+ #BUILD_INCLUDES += -I../../lwip2-contrib-src/apps/ping
+ 
+ all: $(LWIP_LIB)

--- a/Sming/Components/Network/src/IpAddress.h
+++ b/Sming/Components/Network/src/IpAddress.h
@@ -20,15 +20,13 @@
 #pragma once
 
 #include <lwip/init.h>
-#include <lwip/ip_addr.h>
+#include <ipv4_addr.h>
 #include "Printable.h"
 #include "WString.h"
 
 #if LWIP_VERSION_MAJOR == 2
 #define LWIP_IP_ADDR_T const ip_addr_t
 #else
-using ip_addr_t = struct ip_addr;
-using ip4_addr_t = ip_addr_t;
 #define IP_ADDR4(IP, A, B, C, D) IP4_ADDR(IP, A, B, C, D)
 #define ip_addr_set_ip4_u32(IP, U32) ip4_addr_set_u32(IP, U32)
 #define ip_addr_get_ip4_u32(IP) ip4_addr_get_u32(IP)
@@ -154,7 +152,7 @@ public:
 	// Overloaded index operator to allow getting and setting individual octets of the address
 	uint8_t operator[](int index) const
 	{
-		if(unsigned(index) >= sizeof(ip4_addr_t)) {
+		if(unsigned(index) >= sizeof(address)) {
 			abort();
 		}
 
@@ -163,7 +161,7 @@ public:
 
 	uint8_t& operator[](int index)
 	{
-		if(unsigned(index) >= sizeof(ip4_addr_t)) {
+		if(unsigned(index) >= sizeof(address)) {
 			abort();
 		}
 


### PR DESCRIPTION
This PR at long last brings lwip2 out of the dark ages. Seems to work reliably, here it is for testing anyway.

Instead of using a fork this uses the lwip2 repo used by esp8266 arduino, with some minimal patching.

lwip2 now updated from 2.0.2 to 2.1.3.