### PR TITLE
Update ArduinoJson6 to current 6.x release

### DIFF
--- a/Sming/Libraries/ArduinoJson6/ArduinoJson.patch
+++ b/Sming/Libraries/ArduinoJson6/ArduinoJson.patch
@@ -1,0 +1,48 @@
+diff --git a/src/ArduinoJson/Document/JsonDocument.hpp b/src/ArduinoJson/Document/JsonDocument.hpp
+index 39c1536f..1b129120 100644
+--- a/src/ArduinoJson/Document/JsonDocument.hpp
++++ b/src/ArduinoJson/Document/JsonDocument.hpp
+@@ -181,6 +181,11 @@ class JsonDocument : public detail::VariantOperators<const JsonDocument&> {
+     return {*this, key};
+   }
+ 
++  inline detail::MemberProxy<JsonDocument&, ::String>
++    operator[](const FSTR::String& key) {
++    return {*this, ::String(key)};
++  }
++
+   // Gets or sets a root object's member.
+   // https://arduinojson.org/v6/api/jsondocument/subscript/
+   template <typename TChar>
+diff --git a/src/ArduinoJson/Object/JsonObject.hpp b/src/ArduinoJson/Object/JsonObject.hpp
+index 7cdc1c76..2e006b1e 100644
+--- a/src/ArduinoJson/Object/JsonObject.hpp
++++ b/src/ArduinoJson/Object/JsonObject.hpp
+@@ -115,6 +115,11 @@ class JsonObject : public detail::VariantOperators<JsonObject> {
+     return {*this, key};
+   }
+ 
++  inline detail::MemberProxy<JsonObject, ::String>
++    operator[](const FSTR::String& key) const {
++    return {*this, ::String(key)};
++  }
++
+   // Gets or sets the member with specified key.
+   // https://arduinojson.org/v6/api/jsonobject/subscript/
+   template <typename TChar>
+diff --git a/src/ArduinoJson/Variant/VariantRefBase.hpp b/src/ArduinoJson/Variant/VariantRefBase.hpp
+index 2afdda6a..6b48e102 100644
+--- a/src/ArduinoJson/Variant/VariantRefBase.hpp
++++ b/src/ArduinoJson/Variant/VariantRefBase.hpp
+@@ -244,6 +244,11 @@ class VariantRefBase : public VariantTag {
+                                   MemberProxy<TDerived, TChar*>>::type
+   operator[](TChar* key) const;
+ 
++  inline MemberProxy<TDerived, ::String>
++  operator[](const FSTR::String& key) const {
++    return MemberProxy<TDerived, ::String>(derived(), ::String(key));
++  }
++
+   // Creates an array and adds it to the object.
+   // https://arduinojson.org/v6/api/jsonvariant/createnestedarray/
+   template <typename TString>

--- a/Sming/Libraries/ArduinoJson6/include/FlashStringReader.hpp
+++ b/Sming/Libraries/ArduinoJson6/include/FlashStringReader.hpp
@@ -6,33 +6,15 @@
 
 #pragma once
 
-namespace ARDUINOJSON_NAMESPACE
-{
-template <> struct Reader<FlashString, void> {
-	explicit Reader(const FlashString& str) : str(str)
+#include <FlashString/String.hpp>
+#include <ArduinoJson/Deserialization/Readers/FlashReader.hpp>
+
+ARDUINOJSON_BEGIN_PRIVATE_NAMESPACE
+
+template <> struct Reader<const FSTR::String, void> : public BoundedReader<const __FlashStringHelper*, void> {
+	explicit Reader(const FSTR::String& str) : BoundedReader(str.data(), str.length())
 	{
 	}
-
-	int read()
-	{
-		if(index >= str.length()) {
-			return -1;
-		}
-		unsigned char c = str[index];
-		++index;
-		return c;
-	}
-
-	size_t readBytes(char* buffer, size_t length)
-	{
-		auto count = str.read(index, buffer, length);
-		index += count;
-		return count;
-	}
-
-private:
-	const FlashString& str;
-	unsigned index = 0;
 };
 
-} // namespace ARDUINOJSON_NAMESPACE
+ARDUINOJSON_END_PRIVATE_NAMESPACE

--- a/Sming/Libraries/ArduinoJson6/include/FlashStringRefAdapter.hpp
+++ b/Sming/Libraries/ArduinoJson6/include/FlashStringRefAdapter.hpp
@@ -6,67 +6,23 @@
 
 #pragma once
 
-#include <ArduinoJson/Strings/IsWriteableString.hpp>
+#include <FlashString/String.hpp>
+#include <ArduinoJson/Strings/Adapters/FlashString.hpp>
 
-namespace ARDUINOJSON_NAMESPACE
-{
-class FlashStringRefAdapter
-{
-public:
-	explicit FlashStringRefAdapter(const FlashString& str) : str(str)
+ARDUINOJSON_BEGIN_PRIVATE_NAMESPACE
+
+template <> struct StringAdapter<FSTR::String> {
+	typedef FlashString AdaptedString;
+
+	static AdaptedString adapt(const FSTR::String& str)
 	{
+		return FlashString(str.data(), str.length());
 	}
-
-	bool equals(const char* expected) const
-	{
-		return str.equals(expected);
-	}
-
-	bool isNull() const
-	{
-		return str.isNull();
-	}
-
-	char* save(MemoryPool* pool) const
-	{
-		size_t n = str.size();
-		char* dup = pool->allocFrozenString(n);
-		if(dup) {
-			str.read(0, dup, n);
-		}
-		return dup;
-	}
-
-	const char* data() const
-	{
-		// Cannot access directly using a char*
-		return nullptr;
-	}
-
-	size_t size() const
-	{
-		return str.length();
-	}
-
-	bool isStatic() const
-	{
-		// Whilst  our value won't change, it cannot be accessed using a regular char*
-		return false;
-	}
-
-private:
-	const FlashString& str;
 };
 
-inline FlashStringRefAdapter adaptString(const FlashString& str)
+inline CompareResult compare(JsonVariantConst lhs, const FSTR::String& rhs)
 {
-	return FlashStringRefAdapter(str);
+	return compare(lhs, String(rhs));
 }
 
-template <> struct IsString<FlashString> : true_type {
-};
-
-template <> struct IsWriteableString<FlashString> : false_type {
-};
-
-} // namespace ARDUINOJSON_NAMESPACE
+ARDUINOJSON_END_PRIVATE_NAMESPACE

--- a/tests/HostTests/modules/ArduinoJson6.cpp
+++ b/tests/HostTests/modules/ArduinoJson6.cpp
@@ -80,7 +80,7 @@ public:
 		}
 
 		// Keep a reference copy for when doc gets messed up
-		StaticJsonDocument<512> sourceDoc = doc;
+		auto sourceDoc = doc;
 
 		TEST_CASE("Json::serialize(doc, String), then save to file")
 		{
@@ -246,6 +246,12 @@ public:
 			const uint64_t testnum = 0x12345678ABCDEF99ULL;
 			root["longtest"] = testnum;
 			REQUIRE(root["longtest"] == testnum);
+		}
+
+		TEST_CASE("FSTR comparison")
+		{
+			doc[FS_number2] = FS_number2;
+			REQUIRE(doc[FS_number2] == FS_number2);
 		}
 
 		/*


### PR DESCRIPTION
ArduinoJson is currently at v7 but there are many breaking changes to consider so would require a new library.
This PR updates v6 to the latest release:

Was v6.15.2, released15/5/20
v6.21.3 released 23/7/23
Now v6.x, released 6/11/23

FlashString (FSTR::String) support has been simplified, and includes a couple of minor patches to ArduinoJson. This ensures FlashString objects are always passed by reference.