### PR TITLE
SMTP Client improvements.

### DIFF
--- a/Sming/Components/Network/src/Network/MailMessage.cpp
+++ b/Sming/Components/Network/src/Network/MailMessage.cpp
@@ -48,13 +48,11 @@ MailMessage& MailMessage::setBody(String&& body, MimeType mime) noexcept
 
 MailMessage& MailMessage::setBody(IDataSourceStream* stream, MimeType mime)
 {
-	if(this->stream != nullptr) {
+	if(this->stream) {
 		debug_e("MailMessage::setBody: Discarding already set stream!");
-		delete this->stream;
-		this->stream = nullptr;
 	}
 
-	this->stream = stream;
+	this->stream.reset(stream);
 	headers[HTTP_HEADER_CONTENT_TYPE] = toString(mime);
 
 	return *this;

--- a/Sming/Components/Network/src/Network/MailMessage.h
+++ b/Sming/Components/Network/src/Network/MailMessage.h
@@ -38,6 +38,15 @@ public:
 	String subject;
 	String cc;
 
+	~MailMessage()
+	{
+		delete stream;
+		for(auto attachment: attachments) {
+			delete attachment.headers;
+			delete attachment.stream;
+		}
+	}
+
 	/**
 	 * @brief Set a header value
 	 * @param name

--- a/Sming/Components/Network/src/Network/MailMessage.h
+++ b/Sming/Components/Network/src/Network/MailMessage.h
@@ -40,8 +40,7 @@ public:
 
 	~MailMessage()
 	{
-		delete stream;
-		for(auto attachment : attachments) {
+		for(auto& attachment : attachments) {
 			delete attachment.headers;
 			delete attachment.stream;
 		}
@@ -115,7 +114,7 @@ public:
 	MailMessage& addAttachment(IDataSourceStream* stream, const String& mime, const String& filename = "");
 
 private:
-	IDataSourceStream* stream = nullptr;
+	std::unique_ptr<IDataSourceStream> stream = nullptr;
 	HttpHeaders headers;
 	Vector<MultipartStream::BodyPart> attachments;
 };

--- a/Sming/Components/Network/src/Network/MailMessage.h
+++ b/Sming/Components/Network/src/Network/MailMessage.h
@@ -41,7 +41,7 @@ public:
 	~MailMessage()
 	{
 		delete stream;
-		for(auto attachment: attachments) {
+		for(auto attachment : attachments) {
 			delete attachment.headers;
 			delete attachment.stream;
 		}

--- a/Sming/Components/Network/src/Network/SmtpClient.cpp
+++ b/Sming/Components/Network/src/Network/SmtpClient.cpp
@@ -289,7 +289,7 @@ void SmtpClient::sendMailHeaders(MailMessage* mail)
 
 	if(!mail->headers.contains(HTTP_HEADER_CONTENT_TRANSFER_ENCODING)) {
 		mail->headers[HTTP_HEADER_CONTENT_TRANSFER_ENCODING] = _F("quoted-printable");
-		mail->stream.reset(new QuotedPrintableOutputStream(mail->stream.release()));
+		mail->stream = std::make_unique<QuotedPrintableOutputStream>(mail->stream.release());
 	}
 
 	if(!mail->attachments.isEmpty()) {

--- a/Sming/Components/Network/src/Network/SmtpClient.cpp
+++ b/Sming/Components/Network/src/Network/SmtpClient.cpp
@@ -390,8 +390,13 @@ int SmtpClient::smtpParse(char* buffer, size_t len)
 			RETURN_ON_ERROR(SMTP_CODE_SERVICE_READY);
 
 			if(!useSsl && (options & SMTP_OPT_STARTTLS)) {
-				useSsl = true;
-				TcpConnection::internalOnConnected(ERR_OK);
+				if(!TcpConnection::sslCreateSession()) {
+					bitClear(options, SMTP_OPT_STARTTLS);
+				} else {
+					TcpConnection::ssl->hostName = url.Host;
+					useSsl = true;
+					TcpConnection::internalOnConnected(ERR_OK);
+				}
 			}
 
 			sendString(F("EHLO ") + url.Host + "\r\n");

--- a/Sming/Components/Network/src/Network/TcpConnection.cpp
+++ b/Sming/Components/Network/src/Network/TcpConnection.cpp
@@ -440,7 +440,9 @@ bool TcpConnection::enableSsl(const String& hostName)
 	ssl->hostName = hostName;
 
 	useSsl = true;
-	useSsl = (internalOnConnected(ERR_OK) == ERR_OK);
+	if(internalOnConnected(ERR_OK) != ERR_OK) {
+		useSsl = false;
+	}
 	return useSsl;
 }
 

--- a/Sming/Components/Network/src/Network/TcpConnection.cpp
+++ b/Sming/Components/Network/src/Network/TcpConnection.cpp
@@ -437,9 +437,7 @@ bool TcpConnection::enableSsl(const String& hostName)
 		return false;
 	}
 
-	if(hostName) {
-		ssl->hostName = hostName;
-	}
+	ssl->hostName = hostName;
 
 	useSsl = true;
 	useSsl = (internalOnConnected(ERR_OK) == ERR_OK);

--- a/Sming/Components/Network/src/Network/TcpConnection.cpp
+++ b/Sming/Components/Network/src/Network/TcpConnection.cpp
@@ -423,6 +423,29 @@ err_t TcpConnection::internalOnConnected(err_t err)
 	return res;
 }
 
+bool TcpConnection::enableSsl(const String& hostName)
+{
+	if(tcp == nullptr) {
+		return false;
+	}
+
+	if(tcp->state != ESTABLISHED) {
+		return false;
+	}
+
+	if(!sslCreateSession()) {
+		return false;
+	}
+
+	if(hostName) {
+		ssl->hostName = hostName;
+	}
+
+	useSsl = true;
+	useSsl = (internalOnConnected(ERR_OK) == ERR_OK);
+	return useSsl;
+}
+
 err_t TcpConnection::internalOnReceive(pbuf* p, err_t err)
 {
 	sleep = 0;

--- a/Sming/Components/Network/src/Network/TcpConnection.h
+++ b/Sming/Components/Network/src/Network/TcpConnection.h
@@ -154,6 +154,13 @@ public:
 		return ssl;
 	}
 
+	/**
+	 * @brief Enables Secure Socket Layer on the current connection
+	 * @param hostName
+	 * @retval true on success, false otherwise
+	 */
+	bool enableSsl(const String& hostName = nullptr);
+
 protected:
 	void initialize(tcp_pcb* pcb);
 	bool internalConnect(IpAddress addr, uint16_t port);

--- a/Sming/Components/Network/src/Network/Url.cpp
+++ b/Sming/Components/Network/src/Network/Url.cpp
@@ -86,6 +86,8 @@ String Url::toString() const
 			result += ':';
 			result += Password;
 		}
+
+		result += '@';
 	}
 
 	result += getHostWithPort();

--- a/samples/SmtpClient/app/application.cpp
+++ b/samples/SmtpClient/app/application.cpp
@@ -24,7 +24,7 @@ int onServerError(SmtpClient& client, int code, char* status)
 {
 	debugf("Status: %s", status);
 
-	return 0; // return non-zero value to abort the connection
+	return -1; // return non-zero value to abort the connection
 }
 
 int onMailSent(SmtpClient& client, int code, char* status)


### PR DESCRIPTION
- Continue plain-text communication if SSL is not compiled
- Fix memory leaks in MailMessage
- Expose `TcpConnection::enableSsl(hostName)` which allows a plain-text TCP connection to be changed to SSL one after the tcp connection is established.