### PR TITLE
Fix spiFlash type mismatch warning during init

### DIFF
--- a/Sming/Arch/Host/Components/hostlib/startup.cpp
+++ b/Sming/Arch/Host/Components/hostlib/startup.cpp
@@ -246,6 +246,8 @@ int main(int argc, char* argv[])
 		}
 	}
 
+	m_setPuts(&host_nputs);
+
 	host_debug_i("\nWelcome to the Sming Host emulator\n\n");
 
 	auto i = get_first_non_option();
@@ -309,7 +311,7 @@ int main(int argc, char* argv[])
 	pause(config.exitpause);
 
 	// Avoid issues with debug statements whilst running exit handlers
-	m_setPuts(nullptr);
+	m_setPuts(&host_nputs);
 
 	return exitCode;
 }

--- a/Sming/Arch/Host/standard.hw
+++ b/Sming/Arch/Host/standard.hw
@@ -3,7 +3,12 @@
 	"arch": "Host",
 	"bootloader_size": "0x2000",
 	"partition_table_offset": "0x2000",
-	"options": ["4m"],
+	"devices": {
+		"spiFlash": {
+			"type": "flash",
+			"size": "4M"
+		}
+	},
 	"partitions": {
 		"rom0": {
 			"address": "0x008000",

--- a/Sming/Arch/Rp2040/standard.hw
+++ b/Sming/Arch/Rp2040/standard.hw
@@ -4,9 +4,12 @@
 	"arch": "Rp2040",
 	"bootloader_size": 0,
 	"partition_table_offset": "self.devices[0].size - 0x1000",
-	"options": [
-		"2m"
-	],
+	"devices": {
+		"spiFlash": {
+			"type": "flash",
+			"size": "2M"
+		}
+	},
 	"partitions": {
 		"rom0": {
 			"address": 0,


### PR DESCRIPTION
This PR makes a small change to Host builds, enabling all `debug_x` statements during init/exit.
This highlights one issue, fixed, caused by missing device entry in Rp2040, Host hardware configs:
    
```
[Device] 'spiFlash' type mismatch, 'unknown' in partition table but device reports 'flash'
```