### PR TITLE
Fix esp32 IDF paths

### DIFF
--- a/Sming/Arch/Esp32/Tools/install.sh
+++ b/Sming/Arch/Esp32/Tools/install.sh
@@ -55,11 +55,6 @@ ln -s "$IDF_CLONE_PATH" "$IDF_PATH"
 # Install IDF tools and packages
 python3 "$IDF_PATH/tools/idf_tools.py" --non-interactive install
 python3 "$IDF_PATH/tools/idf_tools.py" --non-interactive install-python-env
-IDF_REQUIREMENTS="$IDF_PATH/requirements.txt"
-if [ ! -f "$IDF_REQUIREMENTS" ]; then
-    IDF_REQUIREMENTS="$IDF_PATH/tools/requirements/requirements.core.txt"
-fi
-python3 -m pip install --no-input -r "$IDF_REQUIREMENTS"
 
 if [ -z "$KEEP_DOWNLOADS" ]; then
     rm -rf "$IDF_TOOLS_PATH/dist"

--- a/Sming/Arch/Esp32/build.mk
+++ b/Sming/Arch/Esp32/build.mk
@@ -84,11 +84,7 @@ IDF_PATH_LIST := \
 	$(IDF_PATH)/tools \
 	$(ESP32_COMPILER_PATH) \
 	$(ESP32_ULP_PATH)/$(ESP_VARIANT)ulp-elf-binutils/bin \
-	$(ESP32_OPENOCD_PATH)/openocd-esp32/bin \
-	$(ESP32_PYTHON_PATH)/bin \
-	$(IDF_PATH)/components/esptool_py/esptool \
-	$(IDF_PATH)/components/espcoredump \
-	$(IDF_PATH)/components/partition_table
+	$(ESP32_OPENOCD_PATH)/openocd-esp32/bin
 
 ifeq ($(UNAME),Windows)
 DEBUG_VARS += ESP32_NINJA_PATH


### PR DESCRIPTION
This PR simplifies and eliminates conflict between the ESP32 IDF python installation and the one Sming uses.

esp32 IDF uses its own virtual python environment and that location gets added to the system path.
That means if our `PYTHON` variable doesn't contain an absolute path (e.g. `python3`, the default) then for esp32 builds **only** it ends up using the IDF python instead. Which is problematic.

So, do we really need **all** that crud on the path?
Turns out we don't. This PR gets rid of stuff which isn't necessary.

NB. Checked current IDF behaviour and their export script still puts everything in the PATH.

A further simplification is removal of core python requirements from the main Python environment. These aren't required.