### PR TITLE
Minor websocket client issues

### DIFF
--- a/Sming/Components/Network/component.mk
+++ b/Sming/Components/Network/component.mk
@@ -98,7 +98,7 @@ endif
 
 # Websocket Server
 CACHE_VARS			+= WSSERVER_PORT
-WSSERVER_PORT		?= 9999
+WSSERVER_PORT		?= 8000
 .PHONY: wsserver
 wsserver: ##Launch a simple python Websocket echo server for testing client applications
 	$(info Starting Websocket server for TESTING)

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketClient.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketClient.cpp
@@ -58,7 +58,9 @@ bool WebsocketClient::connect(const Url& url)
 	}
 
 	httpConnection->setSslInitHandler(sslInitHandler);
-	httpConnection->connect(uri.Host, uri.getPort(), useSsl);
+	if(!httpConnection->connect(uri.Host, uri.getPort(), useSsl)) {
+		return false;
+	}
 
 	state = eWSCS_Ready;
 

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -15,14 +15,8 @@
 #include <Data/Stream/XorOutputStream.h>
 #include <Data/Stream/SharedMemoryStream.h>
 
-DEFINE_FSTR(WSSTR_CONNECTION, "connection")
 DEFINE_FSTR(WSSTR_UPGRADE, "upgrade")
 DEFINE_FSTR(WSSTR_WEBSOCKET, "websocket")
-DEFINE_FSTR(WSSTR_HOST, "host")
-DEFINE_FSTR(WSSTR_ORIGIN, "origin")
-DEFINE_FSTR(WSSTR_KEY, "Sec-WebSocket-Key")
-DEFINE_FSTR(WSSTR_PROTOCOL, "Sec-WebSocket-Protocol")
-DEFINE_FSTR(WSSTR_VERSION, "Sec-WebSocket-Version")
 DEFINE_FSTR(WSSTR_SECRET, "258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
 
 WebsocketList WebsocketConnection::websocketList;

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.h
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.h
@@ -25,14 +25,8 @@ extern "C" {
 
 #define WEBSOCKET_VERSION 13 // 1.3
 
-DECLARE_FSTR(WSSTR_CONNECTION)
 DECLARE_FSTR(WSSTR_UPGRADE)
 DECLARE_FSTR(WSSTR_WEBSOCKET)
-DECLARE_FSTR(WSSTR_HOST)
-DECLARE_FSTR(WSSTR_ORIGIN)
-DECLARE_FSTR(WSSTR_KEY)
-DECLARE_FSTR(WSSTR_PROTOCOL)
-DECLARE_FSTR(WSSTR_VERSION)
 DECLARE_FSTR(WSSTR_SECRET)
 
 class WebsocketConnection;
@@ -292,11 +286,11 @@ protected:
 	bool processFrame(TcpClient& client, char* at, int size);
 
 protected:
-	WebsocketDelegate wsConnect = nullptr;
-	WebsocketMessageDelegate wsMessage = nullptr;
-	WebsocketBinaryDelegate wsBinary = nullptr;
-	WebsocketDelegate wsPong = nullptr;
-	WebsocketDelegate wsDisconnect = nullptr;
+	WebsocketDelegate wsConnect;
+	WebsocketMessageDelegate wsMessage;
+	WebsocketBinaryDelegate wsBinary;
+	WebsocketDelegate wsPong;
+	WebsocketDelegate wsDisconnect;
 
 	void* userData = nullptr;
 

--- a/Sming/Components/Network/tools/wsserver.py
+++ b/Sming/Components/Network/tools/wsserver.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import argparse
 import asyncio
 from websockets.server import serve
 import logging
@@ -8,13 +9,16 @@ async def echo(websocket):
     async for message in websocket:
         await websocket.send(message)
 
-async def main():
+async def main(port: int):
     logging.basicConfig(
         format="%(asctime)s %(message)s",
         level=logging.DEBUG,
     )
-    async with serve(echo, None, 8000):
+    async with serve(ws_handler=echo, port=port):
         await asyncio.Future()  # run forever
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    parser = argparse.ArgumentParser(description='Simple websocket server')
+    parser.add_argument('port', help='Port number (default 8000)', type=int, default=8000)
+    args = parser.parse_args()
+    asyncio.run(main(args.port))


### PR DESCRIPTION
This PR adds a few fixes for websockets I seem to have kicking about.

- Tidy, remove unused websocket strings
- `wsserver` tool missing port argument handling, default is 8000 not 9999

**Check return value from http `connect()`**

 I can force this to fail by calling 'connect' twice in succession, though I do notice a disparity here. If the http connection is 'processing' then `WebsocketClient::connect` returns `false`; however, `HttpClientConnection::connect` returns `true` in this situation.

TODO:

* [x] ~~Document all the various `connect` methods and clarify meaning of return value.~~ Outside scope of this PR. See #2829