### PR TITLE
Fixes to Url default handling and query parameters

### DIFF
--- a/Sming/Components/Network/src/Network/Http/HttpRequest.h
+++ b/Sming/Components/Network/src/Network/Http/HttpRequest.h
@@ -155,7 +155,7 @@ public:
 	 */
 	String getQueryParameter(const String& name, const String& defaultValue = nullptr) const
 	{
-		return static_cast<const HttpParams&>(uri.Query)[name] ?: defaultValue;
+		return uri.getQueryParameter(name, defaultValue);
 	}
 
 	/**

--- a/Sming/Components/Network/src/Network/Url.cpp
+++ b/Sming/Components/Network/src/Network/Url.cpp
@@ -85,10 +85,7 @@ String Url::getHostWithPort() const
 
 String Url::toString() const
 {
-	String result = Scheme;
-	if(result.length() == 0) {
-		result = URI_SCHEME_DEFAULT;
-	}
+	String result = getScheme();
 	result += _F("://");
 	if(User.length() != 0) {
 		result += User;

--- a/Sming/Components/Network/src/Network/Url.cpp
+++ b/Sming/Components/Network/src/Network/Url.cpp
@@ -51,6 +51,16 @@ Url& Url::operator=(String urlString)
 	return *this;
 }
 
+String Url::getScheme() const
+{
+	if(Scheme.length() == 0) {
+		return URI_SCHEME_DEFAULT;
+	}
+	String s = Scheme;
+	s.toLowerCase();
+	return s;
+}
+
 int Url::getDefaultPort(const String& scheme)
 {
 #define XX(name, str, port)                                                                                            \

--- a/Sming/Components/Network/src/Network/Url.h
+++ b/Sming/Components/Network/src/Network/Url.h
@@ -172,6 +172,20 @@ public:
 	 */
 	void debugPrintTo(Print& p) const;
 
+	/**
+	 * @brief Get a query parameter
+	 * @param name Name of parameter
+	 * @param defaultValue Optional default value to use if requested parameter not present
+	 * @retval String&
+	 *
+	 * Accessing `Query` directly risks adding the value if it doesn't exist.
+	 * This method is `const` so is guaranteed read-only.
+	 */
+	const String& getQueryParameter(const String& name, const String& defaultValue = nullptr) const
+	{
+		return Query[name] ?: defaultValue;
+	}
+
 public:
 	String Scheme; ///< without ":" and "//"
 	String User;

--- a/Sming/Components/Network/src/Network/Url.h
+++ b/Sming/Components/Network/src/Network/Url.h
@@ -121,6 +121,12 @@ public:
 		return toString();
 	}
 
+	/**
+	 * @brief Get the applicable scheme, using the default if not specified
+	 * The returned string is always lowercase.
+	 */
+	String getScheme() const;
+
 	/** @brief Obtain the default port for a given scheme
 	 *  @retval int 0 if scheme is not recognised or has no standard port defined
 	 */
@@ -132,7 +138,7 @@ public:
 	 */
 	int getPort() const
 	{
-		return Port ?: getDefaultPort(Scheme);
+		return Port ?: getDefaultPort(getScheme());
 	}
 
 	/** @brief Get hostname+port part of URL string

--- a/samples/Basic_IFS/app/application.cpp
+++ b/samples/Basic_IFS/app/application.cpp
@@ -78,7 +78,7 @@ void onFile(HttpRequest& request, HttpResponse& response)
 	++requestCount;
 
 	String file = request.uri.getRelativePath();
-	String fmt = request.uri.Query["format"];
+	String fmt = request.uri.getQueryParameter("format");
 
 	if(dirExist(file)) {
 		if(fmt.equalsIgnoreCase("archive")) {

--- a/tests/HostTests/modules/Network/Url.cpp
+++ b/tests/HostTests/modules/Network/Url.cpp
@@ -123,6 +123,8 @@ public:
 			REQUIRE(!uri.Scheme);
 			REQUIRE_EQ(uri.Port, 0);
 			REQUIRE_EQ(uri.getPort(), 80);
+			uri.Scheme = "HTTP";
+			REQUIRE_EQ(uri.toString(), FS_url);
 		}
 	}
 

--- a/tests/HostTests/modules/Network/Url.cpp
+++ b/tests/HostTests/modules/Network/Url.cpp
@@ -119,7 +119,10 @@ public:
 			uri.Query["key"] = "7XXUJWCWYTMXKN3L";
 			int sensorValue = 347;
 			uri.Query["field1"] = String(sensorValue);
-			REQUIRE(uri.toString() == FS_url);
+			REQUIRE_EQ(uri.toString(), FS_url);
+			REQUIRE(!uri.Scheme);
+			REQUIRE_EQ(uri.Port, 0);
+			REQUIRE_EQ(uri.getPort(), 80);
 		}
 	}
 


### PR DESCRIPTION
This PR addresses some inconsistencies with the `Url` class.

**Ensure Url provides default port for default scheme**

When building a URL the Scheme defaults to HTTP if not specified.
This means the port should also default to 80, but it doesn't.

For example:

```
Url url;
url.Host = "api.thingspeak.com";
url.Path = "/update";
```

This produces the correct URL text `http://api.thingspeak.com/update` with the default scheme, but `getPort()` incorrectly returns 0.

See https://github.com/SmingHub/Sming/issues/1937#issuecomment-549534674,
PR #1945 provided a fix but didn't actually resolve the underlying issue.

**Url::toString() doesn't lowercase scheme**

For example:

```
Url url;
url.Scheme = "HTTP";
url.Host = "api.thingspeak.com";
url.Path = "/update";
```

Incorrectly produces `HTTP://api.thingspeak.com/update`.

**Add `Url::getQueryParameter` method**

Care is required when reading query parameters as direct access to the `Query` member variable means non-existent keys get added. Therefore a `const` cast is required. This method provides a more convenient way for safely reading values, and also allows a default to be given where the value doesn't exist.
