### PR TITLE
Tidy up documentation for `PhyInitData`

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp8266/include/esp_phy.h
+++ b/Sming/Arch/Esp8266/Components/esp8266/include/esp_phy.h
@@ -26,25 +26,42 @@
  * @brief Structure to manage low-level adjustment of PHY data
  * Does not contain the data but a reference to it.
  * The data should not be accessed directly.
+ * @see For further details, see the following PDF documents:
+ * 	- ESP8266 Phy Init Bin Parameter Configuration Guide
+ * 	- ESP8266 Non-OS SDK API Reference (Final version is version 4)
  */
 struct PhyInitData {
+	/**
+	 * @brief Index for configurable power level, from 0-5. See `PhyInitData::set_txpwr_dqb`.
+	 */
+	using txpwr_index_t = uint8_t;
+
 	uint8_t* data; // [128]
 
 	/**
-	 * @brief version
+	 * @brief PHY data version number. Currently version 8.
 	 */
 	uint8_t get_version() const
 	{
 		return data[1];
 	}
 
-	/*
-	[26] = 225, // spur_freq_cfg, spur_freq=spur_freq_cfg/spur_freq_cfg_div
-	[27] = 10,	// spur_freq_cfg_div
-	// each bit for 1 channel, 1 to select the spur_freq if in band, else 40
-	[28] = 0xff, // spur_freq_en_h
-	[29] = 0xff, // spur_freq_en_l
-*/
+	/**
+	 * @brief Ordinal 26-29
+	 *
+	 * These values are poorly defined.
+	 *
+	 * - [26] = 225,  // spur_freq_cfg, spur_freq=spur_freq_cfg/spur_freq_cfg_div
+	 * - [27] = 10,	  // spur_freq_cfg_div
+	 *
+	 * Each bit for 1 channel, 1 to select the spur_freq if in band, else 40
+	 *
+	 * - [28] = 0xff, // spur_freq_en_h
+	 * - [29] = 0xff, // spur_freq_en_l
+	 */
+	void undocumented_26_29()
+	{
+	}
 
 	/**
 	 * @brief Configure the maximum TX powers for channels 1, 11, 13 and 14.
@@ -52,10 +69,8 @@ struct PhyInitData {
 	 * @param chan11 Limit for channel 11
 	 * @param chan13 Limit for channel 13
 	 * @param chan14 Limit for channel 14
-	 *
-	 * Valid range [0:5].
 	 */
-	void set_power_limits(uint8_t chan1, uint8_t chan11, uint8_t chan13, uint8_t chan14)
+	void set_power_limits(txpwr_index_t chan1, txpwr_index_t chan11, txpwr_index_t chan13, txpwr_index_t chan14)
 	{
 		data[78] = 2; // Enable bytes 30-33 to set maximum TX power
 		data[30] = chan1;
@@ -66,7 +81,6 @@ struct PhyInitData {
 
 	/**
 	 * @brief Disable power limits on channels 1, 11, 13 and 14
-	 * @note Devices will no longer comply with certfications and may cause unwanted RF interference.
 	 */
 	void disable_power_limits()
 	{
@@ -74,19 +88,23 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief txpwr_dqb
-	 *
+	 * @brief Set TX power level.
 	 * TX power can be switched between six levels.
 	 * Level 0 represents the maximum TX power, level 5 the minimum.
+	 * @param level Index from 0-5
+	 * @param value Power level in 0.25dB increments
+	 * @note Defaults are:
+	 * - 0: 78/4 = 19.5dBm
+	 * - 1: 74/4 = 18.5dBm
+	 * - 2: 70/4 = 17.5dBm
+	 * - 3: 64/4 = 16dBm
+	 * - 4: 60/4 = 15dBm
+	 * - 5: 56/4 = 14dBm
 	 *
-	 * target_power_qdb_0, target power is 78/4=19.5dbm
-	 * target_power_qdb_1, target power is 74/4=18.5dbm
-	 * target_power_qdb_2, target power is 70/4=17.5dbm
-	 * target_power_qdb_3, target power is 64/4=16dbm
-	 * target_power_qdb_4, target power is 60/4=15dbm
-	 * target_power_qdb_5, target power is 56/4=14dbm
+	 * @see See ESP8266 Non-OS SDK API Reference:
+	 * 	- system_phy_set_max_tpw
 	 */
-	void set_txpwr_dqb(uint8_t level, uint8_t value)
+	void set_txpwr_dqb(txpwr_index_t level, uint8_t value)
 	{
 		if(level < 6) {
 			data[34 + level] = value;
@@ -94,21 +112,21 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief txpwr_index
+	 * @brief Select target power level for specific data rate according to Modulation Coding Scheme (MCS)
+	 * @param mcs_index Modulation Coding Scheme (MCS) index, from 0-7
+	 * @param txpwr_qdb Power level 0-5. See `PhyInitData::set_txpwr_dqb`.
 	 *
-	 * Select target power level for specific data rate according to Modulation Coding Scheme (MCS).
-	 * The defaults are:
-	 *
-	 * MCS0: qdb_0	1 Mbit/s, 2 Mbit/s, 5.5 Mbit/s, 11 Mbit/s, 6 Mbit/s, 9 Mbit/s)
-	 * MCS1: qdb_0	12 Mbit/s)
-	 * MCS2: qdb_1	18 Mbit/s)
-	 * MCS3: qdb_1	24 Mbit/s
-	 * MCS4: qdb_2	36 Mbit/s
-	 * MCS5: qdb_3	48 Mbit/s
-	 * MCS6: qdb_4	54 Mbit/s
-	 * MCS7: qdb_5
+	 * @note The defaults are:
+	 * - MCS0: qdb_0	1 Mbit/s, 2 Mbit/s, 5.5 Mbit/s, 11 Mbit/s, 6 Mbit/s, 9 Mbit/s)
+	 * - MCS1: qdb_0	12 Mbit/s)
+	 * - MCS2: qdb_1	18 Mbit/s)
+	 * - MCS3: qdb_1	24 Mbit/s
+	 * - MCS4: qdb_2	36 Mbit/s
+	 * - MCS5: qdb_3	48 Mbit/s
+	 * - MCS6: qdb_4	54 Mbit/s
+	 * - MCS7: qdb_5
 	 */
-	void set_txpwr(uint8_t mcs_index, uint8_t txpwr_qdb)
+	void set_txpwr(uint8_t mcs_index, txpwr_index_t txpwr_qdb)
 	{
 		if(mcs_index < 8 && txpwr_qdb < 6) {
 			data[40 + mcs_index] = txpwr_qdb;
@@ -116,23 +134,23 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief crystal_sel
-	 *
-	 * 0: 40MHz
-	 * 1: 26MHz
-	 * 2: 24MHz
+	 * @brief Select crystal frequency
+	 * @param value Values are:
+	 * - 0: 40MHz
+	 * - 1: 26MHz
+	 * - 2: 24MHz
 	 */
-	void set_crystal_sel(uint8_t value = 1)
+	void set_crystal_freq(uint8_t value = 1)
 	{
 		data[48] = value;
 	}
 
 	/**
-	 * @brief sdio_configure
-	 *
-	 * 0: Auto by pin strapping
-	 * 1: SDIO dataoutput is at negative edges (SDIO V1.1)
-	 * 2: SDIO dataoutput is at positive edges (SDIO V2.0)
+	 * @brief Configure SDIO behaviour
+	 * @param value Values are:
+	 * - 0: Auto by pin strapping
+	 * - 1: SDIO data output is at negative edges (SDIO V1.1)
+	 * - 2: SDIO data output is at positive edges (SDIO V2.0)
 	 */
 	void set_sdio_configure(uint8_t value = 0)
 	{
@@ -140,18 +158,20 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief bt_configure
-	 *
-	 * 0: None,no bluetooth
-	 * 1: GPIO0 -> WLAN_ACTIVE/ANT_SEL_WIFI
-	 * 		MTMS -> BT_ACTIVE
-	 * 		MTCK  -> BT_PRIORITY
-	 * 		U0RXD -> ANT_SEL_BT
-	 * 2: None, have bluetooth
-	 * 3: GPIO0 -> WLAN_ACTIVE/ANT_SEL_WIFI
-	 * 		MTMS -> BT_PRIORITY
-	 * 		MTCK  -> BT_ACTIVE
-	 * 		U0RXD -> ANT_SEL_BT
+	 * @brief Configure bluetooth
+	 * @param value Values are:
+	 * - 0: None,no bluetooth
+	 * - 1: Enable, pins are:
+	 * 		- GPIO0 -> WLAN_ACTIVE/ANT_SEL_WIFI
+	 * 		- MTMS -> BT_ACTIVE
+	 * 		- MTCK  -> BT_PRIORITY
+	 * 		- U0RXD -> ANT_SEL_BT
+	 * - 2: None, have bluetooth
+	 * - 3: Enable, pins are:
+	 * 		- GPIO0 -> WLAN_ACTIVE/ANT_SEL_WIFI
+	 * 		- MTMS -> BT_PRIORITY
+	 * 		- MTCK  -> BT_ACTIVE
+	 * 		- U0RXD -> ANT_SEL_BT
 	 */
 	void set_bt_configure(uint8_t value = 0)
 	{
@@ -159,14 +179,14 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief bt_protocol
-	 *
-	 * 0: WiFi-BT are not enabled. Antenna is for WiFi
-	 * 1: WiFi-BT are not enabled. Antenna is for BT
-	 * 2: WiFi-BT 2-wire are enabled, (only use BT_ACTIVE), independent ant
-	 * 3: WiFi-BT 3-wire are enabled, (when BT_ACTIVE = 0, BT_PRIORITY must be 0), independent ant
-	 * 4: WiFi-BT 2-wire are enabled, (only use BT_ACTIVE), share ant
-	 * 5: WiFi-BT 3-wire are enabled, (when BT_ACTIVE = 0, BT_PRIORITY must be 0), share ant
+	 * @brief Configure Bluetooth protocol
+	 * @param value Values are:
+	 * - 0: WiFi-BT are not enabled. Antenna is for WiFi
+	 * - 1: WiFi-BT are not enabled. Antenna is for BT
+	 * - 2: WiFi-BT 2-wire are enabled, (only use BT_ACTIVE), independent ant
+	 * - 3: WiFi-BT 3-wire are enabled, (when BT_ACTIVE = 0, BT_PRIORITY must be 0), independent ant
+	 * - 4: WiFi-BT 2-wire are enabled, (only use BT_ACTIVE), share ant
+	 * - 5: WiFi-BT 3-wire are enabled, (when BT_ACTIVE = 0, BT_PRIORITY must be 0), share ant
 	 */
 	void set_bt_protocol(uint8_t value = 0)
 	{
@@ -174,12 +194,12 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief dual_ant_configure
-	 *
-	 * 0: None
-	 * 1: dual_ant (antenna diversity for WiFi-only): GPIO0 + U0RXD
-	 * 2: T/R switch for External PA/LNA:  GPIO0 is high and U0RXD is low during Tx
-	 * 3: T/R switch for External PA/LNA:  GPIO0 is low and U0RXD is high during Tx
+	 * @brief Configure dual antenna arrangement
+	 * @param value Values are:
+	 * - 0: None
+	 * - 1: dual_ant (antenna diversity for WiFi-only): GPIO0 + U0RXD
+	 * - 2: T/R switch for External PA/LNA:  GPIO0 is high and U0RXD is low during Tx
+	 * - 3: T/R switch for External PA/LNA:  GPIO0 is low and U0RXD is high during Tx
 	 */
 	void set_dual_ant_configure(uint8_t value = 0)
 	{
@@ -187,37 +207,44 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief share_xtal
-	 * This option is to share crystal clock for BT
-	 * The state of Crystal during sleeping
-	 * 0: Off
-	 * 1: Forceably On
-	 * 2: Automatically On according to XPD_DCDC
-	 * 3: Automatically On according to GPIO2
+	 * @brief Set Crystal state during sleep mode
+	 * 	This option is to share crystal clock for BT
+	 * @param value The state of Crystal during sleeping:
+	 * 	- 0: Off
+	 * 	- 1: Forceably On
+	 * 	- 2: Automatically On according to XPD_DCDC
+	 * 	- 3: Automatically On according to GPIO2
 	 */
 	void set_share_xtal(uint8_t value = 0)
 	{
 		data[55] = value;
 	}
 
-	/*
-	[64] = 225, // spur_freq_cfg_2, spur_freq_2=spur_freq_cfg_2/spur_freq_cfg_div_2
-	[65] = 10,	// spur_freq_cfg_div_2
-	[66] = 0,	// spur_freq_en_h_2
-	[67] = 0,	// spur_freq_en_l_2
-	[68] = 0,	// spur_freq_cfg_msb
-	[69] = 0,	// spur_freq_cfg_2_msb
-	[70] = 0,	// spur_freq_cfg_3_low
-	[71] = 0,	// spur_freq_cfg_3_high
-	[72] = 0,	// spur_freq_cfg_4_low
-	[73] = 0,	// spur_freq_cfg_4_high
-*/
+	/**
+	 * @brief Ordinal 64-73
+	 *
+	 * These values are poorly defined.
+	 *
+	 * - [64] = 225, // spur_freq_cfg_2, spur_freq_2=spur_freq_cfg_2/spur_freq_cfg_div_2
+	 * - [65] = 10,	 // spur_freq_cfg_div_2
+	 * - [66] = 0,	 // spur_freq_en_h_2
+	 * - [67] = 0,	 // spur_freq_en_l_2
+	 * - [68] = 0,	 // spur_freq_cfg_msb
+	 * - [69] = 0,	 // spur_freq_cfg_2_msb
+	 * - [70] = 0,	 // spur_freq_cfg_3_low
+	 * - [71] = 0,	 // spur_freq_cfg_3_high
+	 * - [72] = 0,	 // spur_freq_cfg_4_low
+	 * - [73] = 0,	 // spur_freq_cfg_4_high
+	*/
+	void undocumented_64_73()
+	{
+	}
 
 	/**
-	 * @brief low_power_en
-	 *
-	 * 0: disable low power mode
-	 * 1: enable low power mode
+	 * @brief Configure low-power mode
+	 * @param value Values are:
+	 * 	- 0: disable low power mode
+	 * 	- 1: enable low power mode
 	 */
 	void set_low_power_en(uint8_t value = 0)
 	{
@@ -225,18 +252,16 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief lp_rf_stg10
-	 *
-	 * The attenuation of RF gain stage 0 and 1:
-	 *
-	 * 0xf: 0db
-	 * 0xe: -2.5db
-	 * 0xd: -6db
-	 * 0x9: -8.5db
-	 * 0xc: -11.5db
-	 * 0x8: -14db
-	 * 0x4: -17.5
-	 * 0x0: -23
+	 * @brief Set attenuation of RF gain stage 0 and 1
+	 * @param value Values are:
+	 * - 0x0f: 0dB
+	 * - 0x0e: -2.5dB
+	 * - 0x0d: -6dB
+	 * - 0x09: -8.5dB
+	 * - 0x0c: -11.5dB
+	 * - 0x08: -14dB
+	 * - 0x04: -17.5dB
+	 * - 0x00: -23dB
 	 */
 	void set_lp_rf_stg10(uint8_t value = 0)
 	{
@@ -244,20 +269,18 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief lp_bb_att_ext
-	 *
-	 * The attenuation of BB gain:
-	 * 0: 0db
-	 * 1: -0.25db
-	 * 2: -0.5db
-	 * 3: -0.75db
-	 * 4: -1db
-	 * 5: -1.25db
-	 * 6: -1.5db
-	 * 7: -1.75db
-	 * 8: -2db
-	 * ...
-	 * max valve is 24 (-6db)
+	 * @brief Set attenuation of BB gain
+	 * @param value Attentuation in 0.25dB steps. Max valve is 24 (-6dB):
+	 * - 0: 0dB
+	 * - 1: -0.25dB
+	 * - 2: -0.5dB
+	 * - 3: -0.75dB
+	 * - 4: -1dB
+	 * - 5: -1.25dB
+	 * - 6: -1.5dB
+	 * - 7: -1.75dB
+	 * - 8: -2dB
+	 * etc.
 	 */
 	void set_lp_bb_att_ext(uint8_t value = 0)
 	{
@@ -265,53 +288,46 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief pwr_ind_11b_en
-	 *
-	 * 0: 11b power is same as mcs0 and 6m
-	 * 1: enable 11b power different with OFDM
+	 * @brief Set power limits for 802.11b to default,
+	 * which is same as MCS0 and 6Mbits/s modes. See `PhyInitData::set_txpwr`.
 	 */
-	void set_pwr_ind_11b_en(uint8_t value = 0)
+	void set_default_power_limits_11b()
 	{
-		data[96] = value;
+		data[96] = 0;
 	}
 
 	/**
-	 * @brief pwr_ind_11b_0
-	 *
-	 * 1m, 2m power index [0~5]
+	 * @brief Configure 802.11b power limits
+	 * @param txpwr_index_11b_0 Power level for 1Mbit/s and 2Mbit/s modes
+	 * @param txpwr_index_11b_1 Power level for 5.5Mbits/s and 11Mbits/s modes
 	 */
-	void set_pwr_ind_11b_0(uint8_t value = 0)
+	void set_power_limits_11b(txpwr_index_t txpwr_index_11b_0, txpwr_index_t txpwr_index_11b_1)
 	{
-		data[97] = value;
+		data[96] = 1;
+		data[97] = txpwr_index_11b_0;
+		data[98] = txpwr_index_11b_1;
 	}
 
 	/**
-	 * @brief pwr_ind_11b_1
+	 * @brief Set PA_VDD voltage
+	 * @param value Values are:
+	 * - 0xff: Can measure VDD33
+	 * - 18 <= value <= 36: use input voltage, where `value = voltage * 10`, so 33 is 3.3V, 30 is 3.0V, etc.
+	 * - value < 18, value > 36: default voltage is 3.3V
 	 *
-	 * 5.5m, 11m power index [0~5]
-	 */
-	void set_pwr_ind_11b_1(uint8_t value = 0)
-	{
-		data[98] = value;
-	}
-
-	/**
-	 * @brief vdd33_const
+	 * The value of this byte depends on the TOUT pin usage:
+	 * - analogRead function: `system_adc_read()`
+	 *		- Only available when wire TOUT pin 17 to external circuitry, Input Voltage Range restricted to 0 ~ 1.0V.
+	 * 		- For this function the vdd33_const must be set as real power voltage of VDD3P3 pin 3 and 4
+	 * 		- The range of operating voltage of ESP8266 is 1.8V ~ 3.6V，the unit of vdd33_const is 0.1V, so effective value range of vdd33_const is [18, 36].
+	 * - getVcc function: `system_get_vdd33()`
+	 *		- Only available when TOUT pin 17 is suspended (floating), this function measure the power voltage of VDD3P3 pin 3 and 4
+	 *		- For this function the vdd33_const must be set to 255 (0xFF).
 	 *
-	 * The voltage of PA_VDD
-	 * x=0xff: it can measure VDD33,
-	 * 18<=x<=36: use input voltage,
-	 * the value is voltage*10, 33 is 3.3V, 30 is 3.0V,
-	 * x<18 or x>36: default voltage is 3.3V
-	 *
-	 * The value of this byte depend from the TOUT pin usage (1 or 2):
-	 * 1) analogRead function (system_adc_read())
-	 * 		Only available when wire TOUT pin17 to external circuitry, Input Voltage Range restricted to 0 ~ 1.0V.
-	 * 		For this function the vdd33_const must be set as real power voltage of VDD3P3 pin 3 and 4
-	 * 		The range of operating voltage of ESP8266 is 1.8V~3.6V，the unit of vdd33_const is 0.1V，so effective value range of vdd33_const is [18,36]
-	 * 2) getVcc function (system_get_vdd33)
-	 *		Only available when TOUT pin17 is suspended (floating), this function measure the power voltage of VDD3P3 pin 3 and 4
-	 *		For this function the vdd33_const must be set to 255 (0xFF).
+	 * @see See ESP8266 Non-OS SDK API Reference:
+	 * - system_get_vdd33
+	 * - system_adc_read
+	 * - system_adc_read_fast
 	 */
 	void set_vdd33_const(uint8_t value = 33)
 	{
@@ -319,8 +335,11 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief rf_cal_disable
-	 * Disable RF calibration for certain number of times
+	 * @brief Disable RF calibration for certain number of times
+	 * @param value Number of times to disable RF calibration
+	 * @see See ESP8266 Non-OS SDK API Reference:
+	 * - system_deep_sleep_set_option
+	 * - system_phy_set_rfoption
 	 */
 	void set_rf_cal_disable(uint8_t value = 0)
 	{
@@ -328,41 +347,42 @@ struct PhyInitData {
 	}
 
 	/**
-	 * @brief freq_correct_en
+	 * @brief Enable frequency correction
+	 * @param mode Correction mode:
+	 * - 0x00: do not correct frequency offset
+	 * - 0x01: auto-correct, bbpll 168M, can correct positive and negative offsets
+	 * - 0x03: auto-correct, bbpll 160M, can only correct positive offsets
+	 * - 0x05: Correct using `force_freq_offset`, bbpll 168M, offset can be any value
+	 * - 0x07: Correct using `force_freq_offset`, bbpll 160M, offset must >= 0
+	 * @param force_freq_offset Correction figure in 8kHz steps, signed
 	 *
-	 * bit[0]:0->do not correct frequency offset, 1->correct frequency offset.
-	 * bit[1]:0->bbpll is 168M, it can correct + and - frequency offset,  1->bbpll is 160M, it only can correct + frequency offset
-	 * bit[2]:0->auto measure frequency offset and correct it, 1->use 113 byte force_freq_offset to correct frequency offset.
-	 * 0: do not correct frequency offset.
-	 * 1: auto measure frequency offset and correct it,  bbpll is 168M, it can correct + and - frequency offset.
-	 * 3: auto measure frequency offset and correct it,  bbpll is 160M, it only can correct + frequency offset.
-	 * 5: use 113 byte force_freq_offset to correct frequency offset, bbpll is 168M, it can correct + and - frequency offset.
-	 * 7: use 113 byte force_freq_offset to correct frequency offset, bbpll is 160M , it only can correct + frequency offset.
+	 * Bits are defined as follows:
+	 * - bit 0
+	 * 		- 0: do not correct frequency offset
+	 * 		- 1: correct frequency offset
+	 * - bit 1
+	 * 		- 0: bbpll is 168M, it can correct + and - frequency offset
+	 * 		- 1: bbpll is 160M, it only can correct + frequency offset
+	 * - bit 2
+	 * 		- 0: auto measure frequency offset and correct it
+	 * 		- 1: use force_freq_offset to correct frequency offset
 	 */
-	void set_freq_correct_en(uint8_t value = 3)
+	void set_freq_correct(uint8_t bbpll = 3, int8_t force_freq_offset = 0)
 	{
-		data[112] = value;
-	}
-
-	/**
-	 * @brief force_freq_offset
-	 *
-	 * signed, unit is 8kHz
-	 */
-	void set_force_freq_offset(int8_t value = 0)
-	{
-		data[113] = uint8_t(value);
+		data[112] = bbpll;
+		data[113] = uint8_t(force_freq_offset);
 	}
 
 	/**
 	 * @brief RF_calibration
-	 *
-	 * To ensure better RF performance, it is recommend to set RF_calibration to 3, otherwise the RF performance may become poor.
-	 *
-	 * 0: RF init no RF CAL, using all RF CAL data in flash, it takes about 2ms for RF init
-	 * 1: RF init only do TX power control CAL, others using RF CAL data in flash, it takes about 20ms for RF init
-	 * 2: RF init no RF CAL, using all RF CAL data in flash, it takes about 2ms for RF init  (same as 0?!)
-	 * 3: RF init do all RF CAL, it takes about 200ms for RF init
+	 * @param value Values are:
+	 * - 0: RF init no RF CAL, using all RF CAL data in flash, it takes about 2ms for RF init
+	 * - 1: RF init only do TX power control CAL, others using RF CAL data in flash, it takes about 20ms for RF init
+	 * - 2: RF init no RF CAL, using all RF CAL data in flash, it takes about 2ms for RF init  (same as 0?!)
+	 * - 3: RF init do all RF CAL, it takes about 200ms for RF init
+	 * @note To ensure better RF performance, it is recommend to set RF_calibration to 3, otherwise the RF performance may become poor.
+	 * @see See ESP8266 Non-OS SDK API Reference:
+	 * 	- system_phy_set_powerup_option
 	 */
 	void set_rf_calibration(uint8_t value = 1)
 	{


### PR DESCRIPTION
Further to #2830 generated documentation is a bit garbled so fix that. Found some references in the Non-OS SDK reference so included those as notes.

Also replace methods where parameters are closely inter-related:

- `set_pwr_ind_11b_en`, `set_pwr_ind_11b_0` and `set_pwr_ind_11b_1` with combined `set_power_limits_11b` method
- `set_freq_correct_en` and `set_force_freq_offset` with combined `set_freq_correct` method
