### PR TITLE
Remove `time_t` size check

### DIFF
--- a/Sming/Core/DateTime.cpp
+++ b/Sming/Core/DateTime.cpp
@@ -14,15 +14,6 @@
 #include <esp_idf_version.h>
 #endif
 
-#if defined(__WIN32) || (defined(ARCH_ESP32) && ESP_IDF_VERSION_MAJOR < 5)
-static_assert(sizeof(time_t) != 8, "Great! Now supports 64-bit - please update code");
-#warning "**Y2038** time_t is only 32-bits in this build configuration"
-#elif defined(ARCH_HOST) && __TIMESIZE != 64 && !defined(__USE_TIME_BITS64) && !defined(__APPLE__)
-#warning "**Y2038** Expecting 64-bit time_t - please use GCC 10 or later"
-#else
-static_assert(sizeof(time_t) == 8, "Expecting 64-bit time_t - please use GCC 10 or later");
-#endif
-
 namespace
 {
 DEFINE_FSTR(localeMonthNames, LOCALE_MONTH_NAMES);


### PR DESCRIPTION
PR #2762 and subsequent patches addressed issues relating to 64-bit time. This included a compile-time warning on the size of `time_t`.

In practice, I think this warning causes more problems than it solves. Before too long there won't be any legacy toolchains to consider so this quitely goes away. So we should remove the warning. There's also the 'outdated toolchain' build warning which pretty much covers things.

In particular, I've just been running though the online host emuilator https://killercoda.com/slaff/scenario/sming-host-emulator and the Y2038 stuff is biting again:

```
/root/Sming/Sming/Core/DateTime.cpp:21:2: error: #warning "**Y2038** Expecting 64-bit time_t - please use GCC 10 or later" [-Werror=cpp]
   21 | #warning "**Y2038** Expecting 64-bit time_t - please use GCC 10 or later"
      |  ^~~~~~~
```

We still only have the option of ubuntu20.04 here which uses GCC9. I can install GCC10 but that doesn't help as it hasn't been built with support for `_TIME_BITS`. There are a few ways to fix this:

1. Build with `STRICT=1` - doesn't fix the problem and requires complicating the 'killercoda' instructions.
2. Use `BUILD64=1`. This has its uses but don't think it should be the default unless necessary.
3. Remove the warning

Simplest option is (3).