### PR TITLE
Fix `pgm_read_word` for 64-bit host builds

### DIFF
--- a/Sming/Arch/Host/Components/libc/include/sys/pgmspace.h
+++ b/Sming/Arch/Host/Components/libc/include/sys/pgmspace.h
@@ -25,9 +25,9 @@ bool isFlashPtr(const void* ptr);
 #define PGM_P const char*
 #define PGM_VOID_P const void*
 
-#define pgm_read_byte(addr) (*(const unsigned char*)(addr))
-#define pgm_read_word(addr) (*(const unsigned short*)(addr))
-#define pgm_read_dword(addr) (*(const unsigned long*)(addr))
+#define pgm_read_byte(addr) (*(const uint8_t*)(addr))
+#define pgm_read_word(addr) (*(const uint16_t*)(addr))
+#define pgm_read_dword(addr) (*(const uint32_t*)(addr))
 #define pgm_read_float(addr) (*(const float*)(addr))
 
 #define pgm_read_byte_near(addr) pgm_read_byte(addr)


### PR DESCRIPTION
Sanitizer caught issue with `pgm_read_dword` on 64-bit build, defined as `unsigned long` instead of `uint32_t`.

Suppress sanitizer `alignment` warnings for some FlashString methods where (64-bit) pointers are aligned to 32-bit boundaries. We need everything (including pointers) to be 32-bit aligned so this isn't a bug. (It's an optimisation thing.)