### PR TITLE
Refactor DnsServer

### DIFF
--- a/Sming/Components/Network/src/Network/DnsServer.cpp
+++ b/Sming/Components/Network/src/Network/DnsServer.cpp
@@ -16,125 +16,141 @@
  ****/
 
 #include "DnsServer.h"
-#include "UdpConnection.h"
-#include "WString.h"
 #include <lwip_includes.h>
 #include <debug_progmem.h>
+
+#define MAX_ANSWER_LENGTH 16
+
+namespace
+{
+void downcaseAndRemoveWwwPrefix(String& domainName)
+{
+	domainName.toLowerCase();
+	if(domainName.startsWith(_F("www."))) {
+		domainName.remove(0, 4);
+	}
+}
+
+String getDomainNameWithoutWwwPrefix(const char* buffer, size_t buflen)
+{
+	unsigned srcpos = 12;
+	if(buflen < 13 || buffer[srcpos] == 0) {
+		return nullptr;
+	}
+
+	String name;
+	name.reserve(buflen - 12);
+	while(srcpos < buflen) {
+		unsigned labelLength = buffer[srcpos++];
+		if(srcpos + labelLength > buflen) {
+			break;
+		}
+		name.concat(&buffer[srcpos], labelLength);
+		srcpos += labelLength;
+		if(buffer[srcpos] == 0) {
+			downcaseAndRemoveWwwPrefix(name);
+			return name;
+		}
+		name += '.';
+	}
+
+	return nullptr;
+}
+
+bool requestIncludesOnlyOneQuestion(const DnsHeader& dnsHeader)
+{
+	return ntohs(dnsHeader.QDCount) == 1 && dnsHeader.ANCount == 0 && dnsHeader.NSCount == 0 && dnsHeader.ARCount == 0;
+}
+
+} // namespace
 
 bool DnsServer::start(uint16_t port, const String& domainName, const IpAddress& resolvedIP)
 {
 	this->port = port;
-	buffer = nullptr;
 	this->domainName = domainName;
 	this->resolvedIP = resolvedIP;
 	downcaseAndRemoveWwwPrefix(this->domainName);
 	return listen(this->port) == 1;
 }
 
-void DnsServer::stop()
-{
-	close();
-	delete[] buffer;
-	buffer = nullptr;
-}
-
-void DnsServer::downcaseAndRemoveWwwPrefix(String& domainName)
-{
-	domainName.toLowerCase();
-	domainName.replace(F("www."), String::empty);
-}
-
-bool DnsServer::requestIncludesOnlyOneQuestion()
-{
-	return ntohs(dnsHeader->QDCount) == 1 && dnsHeader->ANCount == 0 && dnsHeader->NSCount == 0 &&
-		   dnsHeader->ARCount == 0;
-}
-
 void DnsServer::onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort)
 {
-	delete[] buffer;
-	buffer = new char[buf->tot_len];
+	debug_d("DNS REQ from %s:%d", remoteIP.toString().c_str(), remotePort);
+
+	// Allocated buffer with additional room for answer
+	char* buffer = new char[buf->tot_len + MAX_ANSWER_LENGTH];
 	if(buffer == nullptr) {
 		return;
 	}
 
-	pbuf_copy_partial(buf, buffer, buf->tot_len, 0);
-	debug_d("DNS REQ for %s from %s:%d", getDomainNameWithoutWwwPrefix().c_str(), remoteIP.toString().c_str(),
-			remotePort);
-	dnsHeader = reinterpret_cast<DnsHeader*>(buffer);
-	if(dnsHeader->QR == DNS_QR_QUERY && dnsHeader->OPCode == DNS_OPCODE_QUERY && requestIncludesOnlyOneQuestion() &&
-	   (domainName == "*" || getDomainNameWithoutWwwPrefix() == domainName)) {
-		char response[buf->tot_len + 16];
-		int idx = buf->tot_len;
-		dnsHeader->QR = DNS_QR_RESPONSE;
-		dnsHeader->ANCount = dnsHeader->QDCount;
-		memcpy(response, buffer, idx);
-		//Set a pointer to the domain name in the question section
-		response[idx] = 0xC0;
-		response[idx + 1] = 0x0C;
+	unsigned requestLen = pbuf_copy_partial(buf, buffer, buf->tot_len, 0);
+	if(requestLen != buf->tot_len) {
+		return;
+	}
 
-		//Type: "Host Address"
-		response[idx + 2] = 0x00;
-		response[idx + 3] = 0x01;
+	debug_hex(DBG, "< DNS", buffer, requestLen);
 
-		//Set the response class to IN
-		response[idx + 4] = 0x00;
-		response[idx + 5] = 0x01;
-
-		//TTL
-		auto ttln = htonl(ttl);
-		response[idx + 6] = ttln >> 24;
-		response[idx + 7] = ttln >> 16;
-		response[idx + 8] = ttln >> 8;
-		response[idx + 9] = ttln;
-
-		//RDATA length
-		response[idx + 10] = 0x00;
-		response[idx + 11] = 0x04; //4 byte IP address
-
-		//The IP address
-		for(unsigned int i = 0; i < 4; i++) {
-			response[idx + 12 + i] = resolvedIP[i];
-		}
-
-		sendTo(remoteIP, remotePort, response, idx + 16);
-	} else if(dnsHeader->QR == DNS_QR_QUERY) {
-		dnsHeader->QR = DNS_QR_RESPONSE;
-		dnsHeader->RCode = char(errorReplyCode);
-		dnsHeader->QDCount = 0;
-		sendTo(remoteIP, remotePort, buffer, sizeof(DnsHeader));
+	auto responseLen = processQuestion(buffer, requestLen);
+	if(responseLen != 0) {
+		debug_hex(DBG, "> DNS", buffer, responseLen);
+		sendTo(remoteIP, remotePort, buffer, responseLen);
 	}
 
 	delete[] buffer;
-	buffer = nullptr;
 
 	UdpConnection::onReceive(buf, remoteIP, remotePort);
 }
 
-String DnsServer::getDomainNameWithoutWwwPrefix()
+size_t DnsServer::processQuestion(char* buffer, size_t requestLen)
 {
-	String parsedDomainName;
-	if(buffer == nullptr) {
-		return parsedDomainName;
-	}
-	char* start = buffer + 12;
-	if(*start == 0) {
-		return parsedDomainName;
+	auto& dnsHeader = *reinterpret_cast<DnsHeader*>(buffer);
+	if(dnsHeader.QR != DNS_QR_QUERY) {
+		debug_d("DNS ignoring, not QUERY");
+		return 0;
 	}
 
-	unsigned pos = 0;
-	while(true) {
-		unsigned labelLength = *(start + pos);
-		for(unsigned i = 0; i < labelLength; i++) {
-			pos++;
-			parsedDomainName += start[pos];
-		}
-		pos++;
-		if(start[pos] == 0) {
-			downcaseAndRemoveWwwPrefix(parsedDomainName);
-			return parsedDomainName;
-		} else {
-			parsedDomainName += '.';
-		}
+	String parsedDomainName = getDomainNameWithoutWwwPrefix(buffer, requestLen);
+	debug_d("DNS REQ for %s", parsedDomainName.c_str());
+
+	if(dnsHeader.OPCode == DNS_OPCODE_QUERY && requestIncludesOnlyOneQuestion(dnsHeader) &&
+	   (domainName == "*" || domainName == parsedDomainName)) {
+		dnsHeader.QR = DNS_QR_RESPONSE;
+		dnsHeader.ANCount = dnsHeader.QDCount;
+		auto response = &buffer[requestLen];
+		// Set a pointer to the domain name in the question section
+		response[0] = 0xC0;
+		response[1] = 0x0C;
+
+		// Type: "Host Address"
+		response[2] = 0x00;
+		response[3] = 0x01;
+
+		// Set the response class to IN
+		response[4] = 0x00;
+		response[5] = 0x01;
+
+		// TTL
+		auto ttln = htonl(ttl);
+		response[6] = ttln >> 24;
+		response[7] = ttln >> 16;
+		response[8] = ttln >> 8;
+		response[9] = ttln;
+
+		// RDATA length
+		response[10] = 0x00;
+		response[11] = 0x04; //4 byte IP address
+
+		// The IP address
+		response[12] = resolvedIP[0];
+		response[13] = resolvedIP[1];
+		response[14] = resolvedIP[2];
+		response[15] = resolvedIP[3];
+
+		return requestLen + 16;
 	}
+
+	dnsHeader.QR = DNS_QR_RESPONSE;
+	dnsHeader.RCode = char(errorReplyCode);
+	dnsHeader.QDCount = 0;
+	return sizeof(DnsHeader);
 }

--- a/Sming/Components/Network/src/Network/DnsServer.h
+++ b/Sming/Components/Network/src/Network/DnsServer.h
@@ -64,10 +64,6 @@ struct DnsHeader {
 class DnsServer : public UdpConnection
 {
 public:
-	DnsServer()
-	{
-	}
-
 	/**
 	 * @brief Set error reply code
 	 */
@@ -96,23 +92,21 @@ public:
 	/**
 	 * @brief Stop the DNS server
 	 */
-	void stop();
+	void stop()
+	{
+		close();
+	}
 
 protected:
 	void onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort) override;
+	size_t processQuestion(char* buffer, size_t requestLen);
 
 private:
 	uint16_t port = 0;
 	String domainName;
 	IpAddress resolvedIP;
-	char* buffer = nullptr;
-	DnsHeader* dnsHeader = nullptr;
 	uint32_t ttl = 60;
 	DnsReplyCode errorReplyCode = DnsReplyCode::NonExistentDomain;
-
-	static void downcaseAndRemoveWwwPrefix(String& domainName);
-	String getDomainNameWithoutWwwPrefix();
-	bool requestIncludesOnlyOneQuestion();
 };
 
 /** @} */


### PR DESCRIPTION
This PR is just a refactor of the `DnsServer` class as it's a bit more complex than necessary. No additional functionality added, but a few extra bounds checks have been added.

- Move `downcaseAndRemoveWwwPrefix`, `getDomainNameWithoutWwwPrefix` and `requestIncludesOnlyOneQuestion`  into private namespace (with appropriate parameter) - these do not need to be class members.

- Remove `dnsHeader` and `buffer`, these are only used locally.

- Move bulk of logic into separate `processQuestion` method.

- Add additional debug output, printing content of question/response packets.

- Fix potential issue with `getDomainNameWithoutWwwPrefix` if `www.` is contained **within** the domain name (unlikely, but possible)

- Don't allocate response buffer on stack - size is potentially unbounded. Instead, re-use the allocated buffer for the response, simpler as our answer is just appended to the received question.

Tested using nslookup with santizers active.