### PR TITLE
Fix additional warnings

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Esp32/Components/driver/hw_timer.cpp
@@ -10,7 +10,10 @@
 
 #include <driver/hw_timer.h>
 #include <driver/periph_ctrl.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <hal/timer_ll.h>
+#pragma GCC diagnostic pop
 #include <esp_intr_alloc.h>
 #include <soc/timer_periph.h>
 
@@ -43,7 +46,7 @@ public:
 #endif
 	}
 
-	void IRAM_ATTR attach_interrupt(hw_timer_source_type_t source_type, hw_timer_callback_t callback, void* arg)
+	void IRAM_ATTR attach_interrupt(hw_timer_source_type_t, hw_timer_callback_t callback, void* arg)
 	{
 		if(isr_handle != nullptr) {
 			detach_interrupt();

--- a/Sming/Arch/Esp32/Components/driver/include/driver/spi_master.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/spi_master.h
@@ -2,6 +2,7 @@
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 
 #include_next <driver/spi_master.h>
 

--- a/Sming/Arch/Esp32/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp32/Components/driver/uart.cpp
@@ -744,7 +744,7 @@ bool smg_uart_intr_config(smg_uart_t* uart, const smg_uart_intr_config_t* config
 	return true;
 }
 
-void smg_uart_swap(smg_uart_t* uart, int tx_pin)
+void smg_uart_swap(smg_uart_t*, int)
 {
 	// Not implemented
 }

--- a/Sming/Arch/Esp32/Components/esp32/src/clk.c
+++ b/Sming/Arch/Esp32/Components/esp32/src/clk.c
@@ -19,7 +19,7 @@ bool system_update_cpu_freq(uint32_t freq)
 	esp_err_t err = esp_pm_get_configuration(&config);
 	if(err != ESP_OK) {
 		debug_e("[PM] Failed to read PM config %u", err);
-	} else if(config.max_freq_mhz == freq) {
+	} else if((unsigned)config.max_freq_mhz == freq) {
 		return true;
 	}
 

--- a/Sming/Arch/Esp32/Components/esp32/src/include/esp_event.h
+++ b/Sming/Arch/Esp32/Components/esp32/src/include/esp_event.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#include_next <esp_event.h>
+
+#pragma GCC diagnostic pop

--- a/Sming/Arch/Esp32/Components/esp32/src/include/esp_systemapi.h
+++ b/Sming/Arch/Esp32/Components/esp32/src/include/esp_systemapi.h
@@ -23,12 +23,15 @@
 #include "esp_tasks.h"
 #include <heap.h>
 #include <esp_system.h>
-#include <os.h>
 #include <soc/soc.h>
 #include <driver/gpio.h>
 #include <driver/adc.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#include <os.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/portmacro.h>
+#pragma GCC diagnostic pop
 
 #include <m_printf.h>
 #include <debug_progmem.h>

--- a/Sming/Arch/Esp32/Components/esp32/src/include/esp_task.h
+++ b/Sming/Arch/Esp32/Components/esp32/src/include/esp_task.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#include_next <esp_task.h>
+
+#pragma GCC diagnostic pop

--- a/Sming/Arch/Esp32/Components/esp32/src/include/esp_task_wdt.h
+++ b/Sming/Arch/Esp32/Components/esp32/src/include/esp_task_wdt.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#include_next <esp_task_wdt.h>
+
+#pragma GCC diagnostic pop

--- a/Sming/Arch/Esp32/Components/esp32/src/include/hal/gpio_ll.h
+++ b/Sming/Arch/Esp32/Components/esp32/src/include/hal/gpio_ll.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+
+#include_next <hal/gpio_ll.h>
+
+#pragma GCC diagnostic pop

--- a/Sming/Arch/Esp32/Components/esp32/src/tasks.cpp
+++ b/Sming/Arch/Esp32/Components/esp32/src/tasks.cpp
@@ -10,9 +10,9 @@ os_task_t taskCallback;
 
 } // namespace
 
-bool system_os_task(os_task_t callback, uint8_t prio, os_event_t* events, uint8_t qlen)
+bool system_os_task(os_task_t callback, uint8_t prio, os_event_t*, uint8_t)
 {
-	auto handler = [](void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data) {
+	auto handler = [](void*, esp_event_base_t, int32_t event_id, void* event_data) {
 		assert(taskCallback != nullptr);
 
 		os_event_t ev{os_signal_t(event_id), 0};

--- a/Sming/Arch/Esp32/Components/gdbstub/gdbstub.c
+++ b/Sming/Arch/Esp32/Components/gdbstub/gdbstub.c
@@ -17,13 +17,7 @@ void gdb_detach(void)
 {
 }
 
-
-
 unsigned __gdb_no_op(void)
 {
 	return 0;
 }
-
-//#define NOOP __attribute__((weak, alias("__gdb_no_op")))
-//
-//void gdb_on_attach(bool attached) NOOP;

--- a/Sming/Arch/Esp32/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Esp32/Services/Profiling/TaskStat.cpp
@@ -9,8 +9,11 @@
  */
 
 #include <Services/Profiling/TaskStat.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "freertos/FreeRTOS.h"
 #include "freertos/task.h"
+#pragma GCC diagnostic pop
 #include <bitset>
 #include <cstdlib>
 

--- a/Sming/Arch/Esp32/Tools/install.cmd
+++ b/Sming/Arch/Esp32/Tools/install.cmd
@@ -21,6 +21,10 @@ python "%IDF_PATH%\tools\idf_tools.py" --non-interactive install
 python -m pip install %SMINGTOOLS%/gevent-1.5.0-cp39-cp39-win_amd64.whl
 python3 "%IDF_PATH%\tools\idf_tools.py" --non-interactive install-python-env
 
+if "%CI_BUILD_DIR%" NEQ "" (
+    del /q "%IDF_TOOLS_PATH%\dist\*"
+)
+
 if "%INSTALL_IDF_VER%" == "5.0" goto :install_python
 if "%INSTALL_IDF_VER%" == "5.2" goto :install_python
 goto :EOF

--- a/Sming/Arch/Esp8266/Components/driver/new-pwm/pwm.c
+++ b/Sming/Arch/Esp8266/Components/driver/new-pwm/pwm.c
@@ -115,6 +115,7 @@ static struct timer_regs* timer = (struct timer_regs*)(0x60000600);
 static void IRAM_ATTR
 pwm_intr_handler(void* param)
 {
+	(void)param;
 	if ((pwm_state.current_set[pwm_state.current_phase].off_mask == 0) &&
 	    (pwm_state.current_set[pwm_state.current_phase].on_mask == 0)) {
 		pwm_state.current_set = pwm_state.next_set;

--- a/Sming/Arch/Esp8266/Components/driver/uart.cpp
+++ b/Sming/Arch/Esp8266/Components/driver/uart.cpp
@@ -246,7 +246,7 @@ void IRAM_ATTR handle_uart_interrupt(uint8_t uart_nr, smg_uart_t* uart)
 /** @brief UART interrupt service routine
  *  @note both UARTS share the same ISR, although UART1 only supports transmit
  */
-void IRAM_ATTR uart_isr(void* arg)
+void IRAM_ATTR uart_isr(void*)
 {
 	handle_uart_interrupt(UART0, uartInstances[UART0]);
 	handle_uart_interrupt(UART1, uartInstances[UART1]);

--- a/Sming/Arch/Esp8266/Components/esp-open-lwip/esp-open-lwip.patch
+++ b/Sming/Arch/Esp8266/Components/esp-open-lwip/esp-open-lwip.patch
@@ -190,7 +190,7 @@ index 1e46ee5..cfc10f8 100644
                        ipaddr != NULL ? ip4_addr2_16(ipaddr) : 0,       \
                        ipaddr != NULL ? ip4_addr3_16(ipaddr) : 0,       \
 diff --git a/lwip/app/dhcpserver.c b/lwip/app/dhcpserver.c
-index ddb5984..ed8f912 100644
+index ddb5984..631bd34 100644
 --- a/lwip/app/dhcpserver.c
 +++ b/lwip/app/dhcpserver.c
 @@ -1,5 +1,5 @@
@@ -263,7 +263,31 @@ index ddb5984..ed8f912 100644
  
          m->op = DHCP_REPLY;
          m->htype = DHCP_HTYPE_ETHERNET;
-@@ -485,7 +478,7 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
+@@ -325,6 +318,7 @@ static void ICACHE_FLASH_ATTR send_offer(struct dhcps_msg *m)
+ 	        return;
+ 	    }
+         SendOffer_err_t = udp_sendto( pcb_dhcps, p, &broadcast_dhcps, DHCPS_CLIENT_PORT );
++		(void)SendOffer_err_t;
+ #if DHCPS_DEBUG
+ 	        os_printf("dhcps: send_offer>>udp_sendto result %x\n",SendOffer_err_t);
+ #endif
+@@ -391,6 +385,7 @@ static void ICACHE_FLASH_ATTR send_nak(struct dhcps_msg *m)
+ 	        return;
+     	}
+         SendNak_err_t = udp_sendto( pcb_dhcps, p, &broadcast_dhcps, DHCPS_CLIENT_PORT );
++		(void)SendNak_err_t;
+ #if DHCPS_DEBUG
+ 	        os_printf("dhcps: send_nak>>udp_sendto result %x\n",SendNak_err_t);
+ #endif
+@@ -458,6 +453,7 @@ static void ICACHE_FLASH_ATTR send_ack(struct dhcps_msg *m)
+ 	        return;
+ 	    }
+         SendAck_err_t = udp_sendto( pcb_dhcps, p, &broadcast_dhcps, DHCPS_CLIENT_PORT );
++		(void)SendAck_err_t;
+ #if DHCPS_DEBUG
+ 	        os_printf("dhcps: send_ack>>udp_sendto result %x\n",SendAck_err_t);
+ #endif
+@@ -485,7 +481,7 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
      	bool is_dhcp_parse_end = false;
      	struct dhcps_state s;
  
@@ -272,7 +296,7 @@ index ddb5984..ed8f912 100644
  
          u8_t *end = optptr + len;
          u16_t type = 0;
-@@ -573,7 +566,7 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
+@@ -573,7 +569,7 @@ static uint8_t ICACHE_FLASH_ATTR parse_options(uint8_t *optptr, sint16_t len)
  ///////////////////////////////////////////////////////////////////////////////////
  ///////////////////////////////////////////////////////////////////////////////////
  static sint16_t ICACHE_FLASH_ATTR parse_msg(struct dhcps_msg *m, u16_t len)
@@ -281,6 +305,25 @@ index ddb5984..ed8f912 100644
  		if(os_memcmp((char *)m->options,
                &magic_cookie,
                sizeof(magic_cookie)) == 0){
+@@ -744,6 +740,10 @@ static void ICACHE_FLASH_ATTR handle_dhcp(void *arg,
+ 									struct ip_addr *addr, 
+ 									uint16_t port)
+ {
++		(void)arg;
++		(void)pcb;
++		(void)addr;
++		(void)port;
+ 		struct dhcps_msg *pmsg_dhcps = NULL;
+ 		sint16_t tlen = 0;
+         u16_t i = 0;
+@@ -1087,7 +1087,6 @@ void ICACHE_FLASH_ATTR dhcps_coarse_tmr(void)
+ bool ICACHE_FLASH_ATTR wifi_softap_set_dhcps_offer_option(uint8 level, void* optarg)
+ {
+ 	bool offer_flag = true;
+-	uint8 option = 0;
+ 	if (optarg == NULL && wifi_softap_dhcps_status() == false)
+ 		return false;
+ 
 --- a/include/lwip/tcp_impl.h
 +++ b/include/lwip/tcp_impl.h
 @@ -130,7 +130,7 @@ u32_t            tcp_update_rcv_ann_wnd(struct tcp_pcb *pcb)ICACHE_FLASH_ATTR;
@@ -577,10 +620,20 @@ index 52cd0b0..0ea6ab0 100644
  	espconn_msg *pdelete_msg = NULL;
  	struct tcp_pcb *pcb = NULL;
 diff --git a/lwip/core/sntp.c b/lwip/core/sntp.c
-index 677de93..b645772 100644
+index 677de93..73a0dcf 100644
 --- a/lwip/core/sntp.c
 +++ b/lwip/core/sntp.c
-@@ -295,7 +295,6 @@ static ip_addr_t sntp_last_server_address;
+@@ -268,7 +268,9 @@ struct sntp_server {
+ };
+ static struct sntp_server sntp_servers[SNTP_MAX_SERVERS];
+ 
++#if SNTP_GET_SERVERS_FROM_DHCP
+ static u8_t sntp_set_servers_from_dhcp;
++#endif
+ #if SNTP_SUPPORT_MULTIPLE_SERVERS
+ /** The currently used server (initialized to 0) */
+ static u8_t sntp_current_server;
+@@ -295,7 +297,6 @@ static ip_addr_t sntp_last_server_address;
   * to compare against in response */
  static u32_t sntp_last_timestamp_sent[2];
  #endif /* SNTP_CHECK_RESPONSE >= 2 */
@@ -588,7 +641,14 @@ index 677de93..b645772 100644
  //uint32 current_stamp_1 = 0;
  //uint32 current_stamp_2 = 0;
  uint32 realtime_stamp = 0;
-
+@@ -361,7 +362,6 @@ sntp_mktm_r(const time_t * tim_p ,struct tm *res ,int is_gmtime)
+ {
+   long days, rem;
+   time_t lcltime;
+-  int i;
+   int y;
+   int yleap;
+   const int *ip;
 diff --git a/include/lwip/sntp.h b/include/lwip/sntp.h
 index 14e802e..61d36de 100644
 --- a/include/lwip/sntp.h
@@ -627,3 +687,30 @@ index e2f8e9a..8f4d170 100644
        pos += oversize_used;
        oversize -= oversize_used;
        space -= oversize_used;
+diff --git a/include/lwip/debug.h b/include/lwip/debug.h
+index d8359ea..344e274 100644
+--- a/include/lwip/debug.h
++++ b/include/lwip/debug.h
+@@ -62,8 +62,8 @@
+ #define LWIP_DBG_HALT          0x08U
+ 
+ #ifndef LWIP_NOASSERT
+-#define LWIP_ASSERT(message, assertion) do { if(!(assertion)) \
+-  LWIP_PLATFORM_ASSERT(message); } while(0)
++#define LWIP_ASSERT(message, assertion) do { if(!(assertion)) {\
++  LWIP_PLATFORM_ASSERT(message); }} while(0)
+ #else  /* LWIP_NOASSERT */
+ #define LWIP_ASSERT(message, assertion) 
+ #endif /* LWIP_NOASSERT */
+diff --git a/lwip/core/pbuf.c b/lwip/core/pbuf.c
+index 6196784..6fd0eb9 100644
+--- a/lwip/core/pbuf.c
++++ b/lwip/core/pbuf.c
+@@ -103,6 +103,7 @@ static const char mem_debug_file[] ICACHE_RODATA_ATTR = __FILE__;
+ void ICACHE_FLASH_ATTR
+ pbuf_free_ooseq_new(void* arg)
+ {
++  (void)arg;
+   struct tcp_pcb* pcb;
+   struct tcp_seg *head = NULL;
+   struct tcp_seg *seg1 = NULL;

--- a/Sming/Arch/Esp8266/Components/esp8266/crash_handler.c
+++ b/Sming/Arch/Esp8266/Components/esp8266/crash_handler.c
@@ -25,6 +25,9 @@
 extern void __real_system_restart_local();
 
 extern void __custom_crash_callback( struct rst_info * rst_info, uint32_t stack, uint32_t stack_end ) {
+    (void)rst_info;
+    (void)stack;
+    (void)stack_end;
 }
 
 extern void custom_crash_callback( struct rst_info * rst_info, uint32_t stack, uint32_t stack_end ) __attribute__ ((weak, alias("__custom_crash_callback")));

--- a/Sming/Arch/Esp8266/Components/gdbstub/appcode/gdb_hooks.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/appcode/gdb_hooks.cpp
@@ -63,7 +63,8 @@ void debug_print_stack(uint32_t start, uint32_t end)
 	m_puts(instructions);
 }
 
-void debug_crash_callback(const rst_info* rst_info, uint32_t stack, uint32_t stack_end)
+void debug_crash_callback([[maybe_unused]] const rst_info* rst_info, [[maybe_unused]] uint32_t stack,
+						  [[maybe_unused]] uint32_t stack_end)
 {
 #ifdef ENABLE_GDB
 	gdbFlushUserData();
@@ -226,7 +227,7 @@ void ATTR_GDBINIT gdb_init(void)
 #endif
 }
 
-void WEAK_ATTR gdb_enable(bool state)
+void WEAK_ATTR gdb_enable(bool)
 {
 }
 
@@ -235,7 +236,7 @@ GdbState WEAK_ATTR gdb_present(void)
 	return eGDB_NotPresent;
 }
 
-void WEAK_ATTR gdb_on_attach(bool attached)
+void WEAK_ATTR gdb_on_attach(bool)
 {
 }
 
@@ -245,7 +246,7 @@ void WEAK_ATTR gdb_detach(void)
 
 } // extern "C"
 
-int WEAK_ATTR gdb_syscall(const GdbSyscallInfo& info)
+int WEAK_ATTR gdb_syscall(const GdbSyscallInfo&)
 {
 	return -1;
 }

--- a/Sming/Arch/Esp8266/Components/gdbstub/gdbuart.cpp
+++ b/Sming/Arch/Esp8266/Components/gdbstub/gdbuart.cpp
@@ -271,7 +271,7 @@ static void IRAM_ATTR doCtrlBreak()
 	}
 }
 
-static void IRAM_ATTR gdb_uart_callback(smg_uart_t* uart, uint32_t status)
+static void IRAM_ATTR gdb_uart_callback(smg_uart_t*, uint32_t status)
 {
 #if GDBSTUB_ENABLE_UART2
 	user_uart_status = status;

--- a/Sming/Arch/Esp8266/Components/heap/alloc.cpp
+++ b/Sming/Arch/Esp8266/Components/heap/alloc.cpp
@@ -41,12 +41,12 @@ void operator delete[](void* ptr)
 	free(ptr);
 }
 
-void operator delete(void* ptr, size_t sz)
+void operator delete(void* ptr, size_t)
 {
 	free(ptr);
 }
 
-void operator delete[](void* ptr, size_t sz)
+void operator delete[](void* ptr, size_t)
 {
 	free(ptr);
 }

--- a/Sming/Arch/Esp8266/Components/heap/custom_heap.c
+++ b/Sming/Arch/Esp8266/Components/heap/custom_heap.c
@@ -20,11 +20,15 @@
 
 void* IRAM_ATTR pvPortMalloc(size_t size, const char* file, int line)
 {
+    (void)file;
+    (void)line;
     return UMM_FUNC(malloc)(size);
 }
 
 void IRAM_ATTR vPortFree(void *ptr, const char* file, int line)
 {
+    (void)file;
+    (void)line;
 	UMM_FUNC(free)(ptr);
 }
 
@@ -50,16 +54,22 @@ void IRAM_ATTR free(void *ptr)
 
 void* IRAM_ATTR pvPortCalloc(size_t count, size_t size, const char* file, int line)
 {
+    (void)file;
+    (void)line;
     return UMM_FUNC(calloc)(count, size);
 }
 
 void* IRAM_ATTR pvPortRealloc(void *ptr, size_t size, const char* file, int line)
 {
+    (void)file;
+    (void)line;
     return UMM_FUNC(realloc)(ptr, size);
 }
 
 void* IRAM_ATTR pvPortZalloc(size_t size, const char* file, int line)
 {
+    (void)file;
+    (void)line;
     return UMM_FUNC(calloc)(1, size);
 }
 

--- a/Sming/Arch/Esp8266/Components/libc/src/libc.c
+++ b/Sming/Arch/Esp8266/Components/libc/src/libc.c
@@ -23,6 +23,8 @@ int* __errno(void)
 
 void __assert_func(const char* file, int line, const char* func, const char* what)
 {
+	(void)file;
+	(void)what;
 	SYSTEM_ERROR("ASSERT: %s %d", func, line);
 	gdb_do_break();
 	while(1) {

--- a/Sming/Arch/Esp8266/Core/Interrupts.cpp
+++ b/Sming/Arch/Esp8266/Core/Interrupts.cpp
@@ -31,7 +31,7 @@ static void interruptDelegateCallback(uint32_t interruptNumber)
  *  @param  intr_mask Interrupt mask
  *  @param  arg pointer to array of arguments
  */
-static void IRAM_ATTR interruptHandler(uint32_t intr_mask, void* arg)
+static void IRAM_ATTR interruptHandler([[maybe_unused]] uint32_t intr_mask, [[maybe_unused]] void* arg)
 {
 	bool processed;
 

--- a/Sming/Arch/Esp8266/Core/i2s.cpp
+++ b/Sming/Arch/Esp8266/Core/i2s.cpp
@@ -155,7 +155,7 @@ bool i2s_read_sample(int16_t* left, int16_t* right, bool blocking)
 	return true;
 }
 
-static void IRAM_ATTR i2s_callback(void* param, i2s_event_type_t event)
+static void IRAM_ATTR i2s_callback([[maybe_unused]] void* param, i2s_event_type_t event)
 {
 	switch(event) {
 	case I2S_EVENT_TX_DONE:

--- a/Sming/Arch/Host/Components/driver/hw_timer.cpp
+++ b/Sming/Arch/Host/Components/driver/hw_timer.cpp
@@ -56,7 +56,7 @@ public:
 		callback.arg = nullptr;
 	}
 
-	void enable(hw_timer_clkdiv_t div, hw_timer_intr_type_t intr_type, bool auto_load)
+	void enable(hw_timer_clkdiv_t div, hw_timer_intr_type_t, bool auto_load)
 	{
 		stop();
 		switch(div) {

--- a/Sming/Arch/Host/Components/esp_hal/sleep.c
+++ b/Sming/Arch/Host/Components/esp_hal/sleep.c
@@ -2,11 +2,13 @@
 
 bool system_deep_sleep(uint32_t time_in_us)
 {
+	(void)time_in_us;
 	return false;
 }
 
 bool system_deep_sleep_set_option(uint8_t option)
 {
+	(void)option;
 	return false;
 }
 
@@ -24,15 +26,18 @@ void wifi_fpm_do_wakeup(void)
 
 void wifi_fpm_set_wakeup_cb(fpm_wakeup_cb cb)
 {
+	(void)cb;
 }
 
 sint8 wifi_fpm_do_sleep(uint32_t sleep_time_in_us)
 {
+	(void)sleep_time_in_us;
 	return -2; // not enabled
 }
 
 void wifi_fpm_set_sleep_type(enum sleep_type type)
 {
+	(void)type;
 }
 
 enum sleep_type wifi_fpm_get_sleep_type(void)
@@ -42,12 +47,15 @@ enum sleep_type wifi_fpm_get_sleep_type(void)
 
 void wifi_fpm_auto_sleep_set_in_null_mode(uint8_t req)
 {
+	(void)req;
 }
 
 /* GPIO */
 
 void wifi_enable_gpio_wakeup(uint32_t i, GPIO_INT_TYPE intr_status)
 {
+	(void)i;
+	(void)intr_status;
 }
 
 void wifi_disable_gpio_wakeup(void)
@@ -68,6 +76,7 @@ enum sleep_type wifi_get_sleep_type(void)
 
 bool wifi_set_sleep_level(enum sleep_level level)
 {
+	(void)level;
 	return false;
 }
 
@@ -78,6 +87,7 @@ enum sleep_level wifi_get_sleep_level(void)
 
 bool wifi_set_listen_interval(uint8_t interval)
 {
+	(void)interval;
 	return false;
 }
 

--- a/Sming/Arch/Host/Components/gdbstub/gdb_syscall.cpp
+++ b/Sming/Arch/Host/Components/gdbstub/gdb_syscall.cpp
@@ -1,7 +1,7 @@
 #include <gdb/gdb_syscall.h>
 #include <errno.h>
 
-int gdb_syscall(const GdbSyscallInfo& info)
+int gdb_syscall(const GdbSyscallInfo&)
 {
 	errno = ENODEV;
 	return -1;

--- a/Sming/Arch/Host/Components/gdbstub/gdbstub.c
+++ b/Sming/Arch/Host/Components/gdbstub/gdbstub.c
@@ -2,6 +2,7 @@
 
 void gdb_enable(bool state)
 {
+	(void)state;
 }
 
 GdbState gdb_present(void)
@@ -11,19 +12,14 @@ GdbState gdb_present(void)
 
 void __attribute__((weak)) gdb_on_attach(bool attached)
 {
+	(void)attached;
 }
 
 void gdb_detach(void)
 {
 }
 
-
-
 unsigned __gdb_no_op(void)
 {
 	return 0;
 }
-
-//#define NOOP __attribute__((weak, alias("__gdb_no_op")))
-//
-//void gdb_on_attach(bool attached) NOOP;

--- a/Sming/Arch/Host/Components/hostlib/keyb.cpp
+++ b/Sming/Arch/Host/Components/hostlib/keyb.cpp
@@ -204,8 +204,9 @@ int CKeycode::add(int c)
 			ret = 0x0300 | m_buffer[0];
 		else if(m_count == 2)
 			ret = ((m_buffer[0] & 0x0f) << 8) | m_buffer[1];
-		else
-			; //!! Unexpected
+		else {
+			//!! Unexpected
+		}
 
 		reset();
 		break;

--- a/Sming/Arch/Host/Components/hostlib/threads.cpp
+++ b/Sming/Arch/Host/Components/hostlib/threads.cpp
@@ -163,7 +163,7 @@ bool CSemaphore::timedwait(unsigned us)
 #endif
 }
 
-void CThread::startup(unsigned cpulimit)
+void CThread::startup([[maybe_unused]] unsigned cpulimit)
 {
 #ifndef __APPLE__
 	if(cpulimit != 0) {

--- a/Sming/Arch/Host/Components/spi_flash/include/iram_precache.h
+++ b/Sming/Arch/Host/Components/spi_flash/include/iram_precache.h
@@ -10,6 +10,8 @@ extern "C" {
 
 static inline void iram_precache(void* addr, uint32_t bytes)
 {
+    (void)addr;
+    (void)bytes;
 }
 
 #ifdef __cplusplus

--- a/Sming/Arch/Host/README.rst
+++ b/Sming/Arch/Host/README.rst
@@ -52,18 +52,14 @@ To find out what options are in force, use ``make list-config``.
 Configuration
 -------------
 
-.. note::
-
-   The following settings are for debugging purposes and are not 'sticky'.
-   Where used, they should generally be defined globally using ``export``.
-
-
 .. envvar:: CLI_TARGET_OPTIONS
 
    Use this to add any custom options to the emulator command line. e.g.:
 
       make run CLI_TARGET_OPTIONS=--help
       make run CLI_TARGET_OPTIONS="--debug=0 --cpulimit=2"
+
+   Note: These settings are not 'sticky'
 
 
 .. envvar:: CLANG_BUILD

--- a/Sming/Arch/Host/build.mk
+++ b/Sming/Arch/Host/build.mk
@@ -8,6 +8,7 @@ CPPFLAGS	+= -DARCH_HOST
 
 TOOLSPEC 	:=
 
+BUILD_VARS += CLANG_BUILD
 ifndef CLANG_BUILD
 override CLANG_BUILD := 0
 endif
@@ -41,6 +42,7 @@ GDB		:= $(TOOLSPEC)gdb
 
 GCC_UPGRADE_URL := https://sming.readthedocs.io/en/latest/arch/host/host-emulator.html\#c-c-32-bit-compiler-and-libraries
 
+BUILD_VARS += BUILD64
 ifeq ($(UNAME),Darwin)
 BUILD64 := 1
 CPPFLAGS += -D_DARWIN_C_SOURCE=1
@@ -53,22 +55,6 @@ endif
 CPPFLAGS += \
 	-D_FILE_OFFSET_BITS=64 \
 	-D_TIME_BITS=64
-
-# Sanitizers
-DEBUG_VARS += ENABLE_SANITIZERS SANITIZERS
-ENABLE_SANITIZERS ?= 0
-SANITIZERS ?= \
-	address \
-	pointer-compare \
-	pointer-subtract \
-	leak \
-	undefined
-ifeq ($(ENABLE_SANITIZERS),1)
-CPPFLAGS += \
-	-fstack-protector-all \
-	-fsanitize-address-use-after-scope \
-	$(foreach s,$(SANITIZERS),-fsanitize=$s)
-endif
 
 # => Tools
 MEMANALYZER = size

--- a/Sming/Arch/Rp2040/Components/driver/uart.cpp
+++ b/Sming/Arch/Rp2040/Components/driver/uart.cpp
@@ -682,7 +682,7 @@ bool smg_uart_intr_config(smg_uart_t* uart, const smg_uart_intr_config_t* config
 	return false;
 }
 
-void smg_uart_swap(smg_uart_t* uart, int tx_pin)
+void smg_uart_swap(smg_uart_t*, int)
 {
 	// Not implemented
 }

--- a/Sming/Arch/Rp2040/Components/gdbstub/gdbstub.c
+++ b/Sming/Arch/Rp2040/Components/gdbstub/gdbstub.c
@@ -17,13 +17,7 @@ void gdb_detach(void)
 {
 }
 
-
-
 unsigned __gdb_no_op(void)
 {
 	return 0;
 }
-
-//#define NOOP __attribute__((weak, alias("__gdb_no_op")))
-//
-//void gdb_on_attach(bool attached) NOOP;

--- a/Sming/Arch/Rp2040/Components/libc/src/libc_replacements.c
+++ b/Sming/Arch/Rp2040/Components/libc/src/libc_replacements.c
@@ -82,5 +82,7 @@ int _write_r(struct _reent* r, int file, char* ptr, int len)
 
 int _isatty_r(struct _reent* r, int fd)
 {
+	(void)r;
+	(void)fd;
 	return 0;
 }

--- a/Sming/Arch/Rp2040/Core/Interrupts.cpp
+++ b/Sming/Arch/Rp2040/Core/Interrupts.cpp
@@ -69,7 +69,7 @@ void interruptDelegateCallback(uint32_t gpio)
 	}
 }
 
-void IRAM_ATTR interruptHandler(uint gpio, uint32_t events)
+void IRAM_ATTR interruptHandler(uint gpio, [[maybe_unused]] uint32_t events)
 {
 	auto& handler = handlers[gpio];
 	if(handler.type == Handler::Type::interrupt) {

--- a/Sming/Components/.patches/libyuarel.patch
+++ b/Sming/Components/.patches/libyuarel.patch
@@ -1,0 +1,15 @@
+diff --git a/yuarel.c b/yuarel.c
+index a5f313f..ef9c3ee 100644
+--- a/yuarel.c
++++ b/yuarel.c
+@@ -33,8 +33,8 @@
+ static inline int
+ natoi(const char *str, size_t len)
+ {
+-	int i, r = 0;
+-	for (i = 0; i < len; i++) {
++	int r = 0;
++	for (size_t i = 0; i < len; i++) {
+ 		r *= 10;
+ 		r += str[i] - '0';
+ 	}

--- a/Sming/Components/.patches/mqtt-codec.patch
+++ b/Sming/Components/.patches/mqtt-codec.patch
@@ -1,3 +1,25 @@
+diff --git a/src/parser.c b/src/parser.c
+index 6feef41..a2ef901 100644
+--- a/src/parser.c
++++ b/src/parser.c
+@@ -507,7 +507,7 @@ static mqtt_parser_rc_t mqtt_parser_process(mqtt_parser_t* parser, mqtt_message_
+           return MQTT_PARSER_RC_INCOMPLETE;
+         }
+ 
+-        size_t consume = available < parser->needs ? available : parser->needs;
++        size_t consume = ((size_t)available < parser->needs) ? (size_t)available : parser->needs;
+ 
+         int rc =
+             parser->callbacks->on_data_payload(parser->data, message, (const char*)(data + parser->nread), consume);
+@@ -605,7 +605,7 @@ mqtt_parser_rc_t mqtt_parser_execute(mqtt_parser_t* parser, mqtt_message_t* mess
+       return MQTT_PARSER_RC_ERROR;
+     }
+ 
+-    for(int x = 0; x < overflow; x++) {
++    for(size_t x = 0; x < overflow; x++) {
+       parser->stored[x] = data[parser->nread];
+       parser->nread += 1;
+     }
 diff --git a/src/platform.h b/src/platform.h
 index dc8888d..8900b32 100644
 --- a/src/platform.h

--- a/Sming/Components/.patches/mqtt-codec.patch
+++ b/Sming/Components/.patches/mqtt-codec.patch
@@ -12,3 +12,23 @@ index dc8888d..8900b32 100644
  #endif
  
  #ifndef MQTT_MALLOC
+diff --git a/src/serialiser.c b/src/serialiser.c
+index 1fc595b..da15ea0 100644
+--- a/src/serialiser.c
++++ b/src/serialiser.c
+@@ -58,6 +58,7 @@ void mqtt_serialiser_init(mqtt_serialiser_t* serialiser) {
+ }
+ 
+ size_t mqtt_serialiser_size(mqtt_serialiser_t* serialiser, mqtt_message_t* message) {
++  (void)serialiser;
+   size_t len = 0;
+ 
+   switch(message->common.type) {
+@@ -197,6 +198,7 @@ size_t mqtt_serialiser_size(mqtt_serialiser_t* serialiser, mqtt_message_t* messa
+ 
+ mqtt_serialiser_rc_t mqtt_serialiser_write(mqtt_serialiser_t* serialiser, mqtt_message_t* message, uint8_t* buffer,
+                                            size_t len) {
++  (void)len;
+   if(serialiser == NULL || message == NULL || buffer == NULL) {
+     return MQTT_SERIALISER_RC_ERROR;
+   }

--- a/Sming/Components/Hosted-Lib/src/Wire.cpp
+++ b/Sming/Components/Hosted-Lib/src/Wire.cpp
@@ -107,44 +107,6 @@ void TwoWire::flush()
 	hostedClient->send(__PRETTY_FUNCTION__);
 }
 
-void TwoWire::onReceiveService(uint8_t* inBytes, int numBytes)
-{
-	// don't bother if user hasn't registered a callback
-	// if(!userReceiveCallback){
-	//   return;
-	// }
-	// // don't bother if rx buffer is in use by a master requestFrom() op
-	// // i know this drops data, but it allows for slight stupidity
-	// // meaning, they may not have read all the master requestFrom() data yet
-	// if(rxBufferIndex < rxBufferLength){
-	//   return;
-	// }
-	// // copy twi rx buffer into local read buffer
-	// // this enables new reads to happen in parallel
-	// for(uint8_t i = 0; i < numBytes; ++i){
-	//   rxBuffer[i] = inBytes[i];
-	// }
-	// // set rx iterator vars
-	// rxBufferIndex = 0;
-	// rxBufferLength = numBytes;
-	// // alert user program
-	// user_onReceive(numBytes);
-}
-
-void TwoWire::onRequestService()
-{
-	// // don't bother if user hasn't registered a callback
-	// if(!userRequestCallback){
-	//   return;
-	// }
-	// // reset tx buffer iterator vars
-	// // !!! this will kill any pending pre-master sendTo() activity
-	// txBufferIndex = 0;
-	// txBufferLength = 0;
-	// // alert user program
-	// user_onRequest();
-}
-
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_TWOWIRE)
 TwoWire Wire;
 #endif

--- a/Sming/Components/Hosted/include/Hosted/Transport/SerialTransport.h
+++ b/Sming/Components/Hosted/include/Hosted/Transport/SerialTransport.h
@@ -27,7 +27,7 @@ public:
 	}
 
 private:
-	void process(Stream& source, char arrivedChar, uint16_t availableCharsCount)
+	void process(Stream& source, char, uint16_t)
 	{
 		handler(source);
 	}

--- a/Sming/Components/Hosted/include/Hosted/Transport/TcpClientStream.h
+++ b/Sming/Components/Hosted/include/Hosted/Transport/TcpClientStream.h
@@ -88,7 +88,7 @@ private:
 	size_t pendingBytes{0};
 	size_t threshold;
 
-	bool store(TcpClient& client, char* data, int size)
+	bool store(TcpClient&, char* data, int size)
 	{
 		return push(reinterpret_cast<const uint8_t*>(data), size);
 	}

--- a/Sming/Components/Hosted/samples/tcp/app/application.cpp
+++ b/Sming/Components/Hosted/samples/tcp/app/application.cpp
@@ -25,7 +25,7 @@ TcpServer* server;
 TcpServerTransport* transport;
 
 // Will be called when WiFi station was connected to AP
-void connectOk(IpAddress ip, IpAddress mask, IpAddress gateway)
+void connectOk(IpAddress ip, IpAddress, IpAddress)
 {
 	if(server != nullptr) {
 		return;

--- a/Sming/Components/Network/Arch/Esp32/Platform/EmbeddedEthernet.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/EmbeddedEthernet.cpp
@@ -16,7 +16,7 @@
 
 using namespace Ethernet;
 
-bool EmbeddedEthernet::begin(const Config& config)
+bool EmbeddedEthernet::begin([[maybe_unused]] const Config& config)
 {
 #if !CONFIG_ETH_USE_ESP32_EMAC
 

--- a/Sming/Components/Network/Arch/Esp32/Platform/IdfService.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/IdfService.cpp
@@ -51,7 +51,7 @@ void IdfService::end()
 
 void IdfService::enableEventCallback(bool enable)
 {
-	auto handler = [](void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data) {
+	auto handler = [](void* arg, esp_event_base_t, int32_t event_id, void*) {
 		auto service = static_cast<IdfService*>(arg);
 		service->state = Event(event_id);
 		if(!service->eventCallback) {
@@ -70,12 +70,12 @@ void IdfService::enableEventCallback(bool enable)
 
 void IdfService::enableGotIpCallback(bool enable)
 {
-	auto handler = [](void* arg, esp_event_base_t event_base, int32_t event_id, void* event_data) {
+	auto handler = [](void* arg, esp_event_base_t, int32_t, void* event_data) {
 		auto service = static_cast<IdfService*>(arg);
 		if(!service->gotIpCallback) {
 			return;
 		}
-		ip_event_got_ip_t* event = (ip_event_got_ip_t*)event_data;
+		auto event = static_cast<ip_event_got_ip_t*>(event_data);
 		auto& ip_info = event->ip_info;
 		service->gotIpCallback(ip_info.ip.addr, ip_info.netmask.addr, ip_info.gw.addr);
 	};

--- a/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
@@ -75,7 +75,7 @@ public:
 	}
 };
 
-void StationImpl::eventHandler(esp_event_base_t base, int32_t id, void* data)
+void StationImpl::eventHandler(esp_event_base_t base, int32_t id, [[maybe_unused]] void* data)
 {
 	if(base == WIFI_EVENT) {
 		bool allowAutoConnect{true};
@@ -394,18 +394,16 @@ bool StationImpl::startScan(ScanCompletedDelegate scanCompleted)
 		return false;
 	}
 
-	auto eventHandler = [](void* arg, esp_event_base_t base, int32_t id, void* data) {
+	auto eventHandler = [](void* arg, esp_event_base_t, int32_t id, void* data) {
 		wifi_event_sta_scan_done_t* event = reinterpret_cast<wifi_event_sta_scan_done_t*>(data);
 		staticScanCompleted(event, event->status);
 	};
 
-	ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_SCAN_DONE, eventHandler, NULL));
-	if(esp_wifi_scan_start(NULL, false) != ESP_OK) {
-		auto connectHandler = [](void* arg, esp_event_base_t base, int32_t id, void* data) {
-			esp_wifi_scan_start(NULL, false);
-		};
+	ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_SCAN_DONE, eventHandler, nullptr));
+	if(esp_wifi_scan_start(nullptr, false) != ESP_OK) {
+		auto connectHandler = [](void*, esp_event_base_t, int32_t, void*) { esp_wifi_scan_start(nullptr, false); };
 
-		ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_CONNECTED, connectHandler, NULL));
+		ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_CONNECTED, connectHandler, nullptr));
 
 		debug_e("startScan failed");
 	}
@@ -505,7 +503,7 @@ void StationImpl::internalSmartConfig(smartconfig_event_t event_id, void* pdata)
 	}
 }
 
-void StationImpl::smartConfigEventHandler(void* arg, esp_event_base_t base, int32_t id, void* data)
+void StationImpl::smartConfigEventHandler(void* arg, esp_event_base_t, int32_t id, void* data)
 {
 	auto self = static_cast<StationImpl*>(arg);
 	return self->internalSmartConfig(smartconfig_event_t(id), data);

--- a/Sming/Components/Network/Arch/Esp32/Platform/init.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/init.cpp
@@ -30,7 +30,7 @@ void esp_network_initialise()
 	 * Initialise default WiFi stack
 	 */
 	esp_netif_init();
-	auto eventHandler = [](void* arg, esp_event_base_t base, int32_t id, void* data) -> void {
+	auto eventHandler = [](void*, esp_event_base_t base, int32_t id, void* data) -> void {
 		using namespace SmingInternal::Network;
 		debugf("event %s|%d\n", base, id);
 		station.eventHandler(base, id, data);

--- a/Sming/Components/Network/Arch/Esp8266/Platform/WifiSniffer.cpp
+++ b/Sming/Components/Network/Arch/Esp8266/Platform/WifiSniffer.cpp
@@ -92,10 +92,6 @@ static void parseBeaconInfo(BeaconInfo& bi, uint8_t* frame, uint16_t framelen, i
 					memset(bi.ssid, '\0', sizeof(bi.ssid));
 					break;
 				}
-				if(bi.ssid_len < 0) {
-					bi.err = -1;
-					break;
-				}
 				if(bi.ssid_len > 32) {
 					bi.err = -2;
 					break;

--- a/Sming/Components/Network/Arch/Esp8266/Platform/WifiSniffer.cpp
+++ b/Sming/Components/Network/Arch/Esp8266/Platform/WifiSniffer.cpp
@@ -23,7 +23,7 @@ static const uint8_t broadcast1[3] = {0x01, 0x00, 0x5e};
 static const uint8_t broadcast2[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 static const uint8_t broadcast3[3] = {0x33, 0x33, 0x00};
 
-static void parseClientInfo(ClientInfo& ci, uint8_t* frame, uint16_t framelen, int rssi, unsigned channel)
+static void parseClientInfo(ClientInfo& ci, uint8_t* frame, int rssi, unsigned channel)
 {
 	ci.channel = channel;
 	ci.err = 0;
@@ -145,7 +145,7 @@ void WifiSniffer::parseData(uint8_t* buf, uint16_t len)
 		if(data->buf[0] == 0x08 || data->buf[0] == 0x88) {
 			if(clientCallback) {
 				ClientInfo ci;
-				parseClientInfo(ci, data->buf, 36, data->rx_ctrl.rssi, data->rx_ctrl.channel);
+				parseClientInfo(ci, data->buf, data->rx_ctrl.rssi, data->rx_ctrl.channel);
 				// Check BSSID and station don't match (why ?)
 				if(ci.bssid != ci.station) {
 					clientCallback(ci);

--- a/Sming/Components/Network/Arch/Rp2040/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Rp2040/Platform/StationImpl.cpp
@@ -281,7 +281,7 @@ bool StationImpl::startScan(ScanCompletedDelegate scanCompleted)
 		return false;
 	}
 
-	auto scan_result = [](void* env, const cyw43_ev_scan_result_t* result) -> int {
+	auto scan_result = []([[maybe_unused]] void* env, const cyw43_ev_scan_result_t* result) -> int {
 		if(!result || !station.scanCompletedCallback) {
 			return 0;
 		}

--- a/Sming/Components/Network/Arch/Rp2040/Platform/WifiEventsImpl.cpp
+++ b/Sming/Components/Network/Arch/Rp2040/Platform/WifiEventsImpl.cpp
@@ -22,7 +22,7 @@ WifiEventsClass& WifiEvents{SmingInternal::Network::events};
 namespace
 {
 // Information Elements
-void print_eid(const uint8_t* data, size_t datalen)
+void print_eid([[maybe_unused]] const uint8_t* data, [[maybe_unused]] size_t datalen)
 {
 #ifdef ENABLE_WIFI_DEBUG
 	for(unsigned i = 0; i < datalen;) {
@@ -100,7 +100,7 @@ void WifiEventsImpl::eventHandler(EventInfo& info)
 	}
 #endif
 
-	unsigned off{0};
+	[[maybe_unused]] unsigned off{0};
 	int rssi{0};
 	MacAddress addr(info.ev.addr);
 
@@ -184,8 +184,8 @@ void WifiEventsImpl::eventHandler(EventInfo& info)
 	}
 
 	case CYW43_EV_PROBREQ_MSG: {
-		auto m = reinterpret_cast<const struct hostap_ieee80211_mgmt*>(&info.ev.data[off]);
 #ifdef WIFI_DEBUG_PROBE
+		auto m = reinterpret_cast<const struct hostap_ieee80211_mgmt*>(&info.ev.data[off]);
 		debug_i("[PB] fc 0x%04x, dur 0x%04x, da %s, sa %s, bssid %s, seq 0x%04x", m->frame_control, m->duration,
 				MacAddress(m->da).toString().c_str(), MacAddress(m->sa).toString().c_str(),
 				MacAddress(m->bssid).toString().c_str(), m->seq_ctrl);

--- a/Sming/Components/Network/src/Data/Stream/Base64OutputStream.cpp
+++ b/Sming/Components/Network/src/Data/Stream/Base64OutputStream.cpp
@@ -21,7 +21,7 @@ Base64OutputStream::Base64OutputStream(IDataSourceStream* stream, size_t resultS
 	base64_init_encodestate(&state, CHARS_PER_LINE);
 }
 
-size_t Base64OutputStream::transform(const uint8_t* source, size_t sourceLength, uint8_t* target, size_t targetLength)
+size_t Base64OutputStream::transform(const uint8_t* source, size_t sourceLength, uint8_t* target, size_t)
 {
 	if(sourceLength == 0) {
 		return base64_encode_blockend(reinterpret_cast<char*>(target), &state);

--- a/Sming/Components/Network/src/Data/Stream/QuotedPrintableOutputStream.cpp
+++ b/Sming/Components/Network/src/Data/Stream/QuotedPrintableOutputStream.cpp
@@ -12,8 +12,7 @@
 
 #include "QuotedPrintableOutputStream.h"
 
-size_t QuotedPrintableOutputStream::transform(const uint8_t* source, size_t sourceLength, uint8_t* target,
-											  size_t targetLength)
+size_t QuotedPrintableOutputStream::transform(const uint8_t* source, size_t sourceLength, uint8_t* target, size_t)
 {
 	unsigned count = 0;
 	for(unsigned i = 0; i < sourceLength; i++) {

--- a/Sming/Components/Network/src/Network/Ftp/FtpDataFileList.h
+++ b/Sming/Components/Network/src/Network/Ftp/FtpDataFileList.h
@@ -43,7 +43,7 @@ public:
 		}
 	}
 
-	void transferData(TcpConnectionEvent sourceEvent) override
+	void transferData(TcpConnectionEvent) override
 	{
 		if(completed) {
 			return;

--- a/Sming/Components/Network/src/Network/Ftp/FtpDataRetrieve.h
+++ b/Sming/Components/Network/src/Network/Ftp/FtpDataRetrieve.h
@@ -26,7 +26,7 @@ public:
 		fileClose(file);
 	}
 
-	void transferData(TcpConnectionEvent sourceEvent) override
+	void transferData(TcpConnectionEvent) override
 	{
 		if(completed) {
 			return;

--- a/Sming/Components/Network/src/Network/Ftp/FtpDataStream.h
+++ b/Sming/Components/Network/src/Network/Ftp/FtpDataStream.h
@@ -75,7 +75,7 @@ public:
 		}
 	}
 
-	virtual void transferData(TcpConnectionEvent sourceEvent)
+	virtual void transferData(TcpConnectionEvent)
 	{
 	}
 

--- a/Sming/Components/Network/src/Network/Ftp/FtpServer.cpp
+++ b/Sming/Components/Network/src/Network/Ftp/FtpServer.cpp
@@ -29,7 +29,7 @@ IFS::UserRole FtpServer::validateUser(const char* login, const char* pass)
 	return (user.password == pass) ? user.role : IFS::UserRole::None;
 }
 
-bool FtpServer::onCommand(String cmd, String data, FtpServerConnection& connection)
+bool FtpServer::onCommand(String cmd, [[maybe_unused]] String data, FtpServerConnection& connection)
 {
 	if(cmd == _F("FSFORMAT")) {
 		auto fs = connection.getFileSystem();

--- a/Sming/Components/Network/src/Network/Ftp/FtpServer.h
+++ b/Sming/Components/Network/src/Network/Ftp/FtpServer.h
@@ -48,7 +48,8 @@ protected:
 	 * @param connection The associated TCP connection to receive any response
 	 * @retval bool true if command handled and response sent
 	 */
-	virtual bool onCommand(String cmd, String data, FtpServerConnection& connection)
+	virtual bool onCommand([[maybe_unused]] String cmd, [[maybe_unused]] String data,
+						   [[maybe_unused]] FtpServerConnection& connection)
 	{
 		return false;
 	}

--- a/Sming/Components/Network/src/Network/Ftp/FtpServerConnection.cpp
+++ b/Sming/Components/Network/src/Network/Ftp/FtpServerConnection.cpp
@@ -401,7 +401,7 @@ void FtpServerConnection::onCommand(String cmd, String data)
 	}
 }
 
-err_t FtpServerConnection::onSent(uint16_t len)
+err_t FtpServerConnection::onSent(uint16_t)
 {
 	if(dataConnection != nullptr) {
 		dataConnection->onReadyToSendData(eTCE_Poll);

--- a/Sming/Components/Network/src/Network/Http/HttpClientConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/HttpClientConnection.cpp
@@ -274,6 +274,7 @@ REENTER:
 		sendRequestHeaders(request);
 
 		state = eHCS_SendingHeaders;
+		[[fallthrough]];
 	}
 
 	case eHCS_SendingHeaders: {
@@ -282,6 +283,7 @@ REENTER:
 		}
 
 		state = eHCS_StartBody;
+		[[fallthrough]];
 	}
 
 	case eHCS_StartBody:
@@ -298,6 +300,7 @@ REENTER:
 			stream = nullptr;
 			goto REENTER;
 		}
+		[[fallthrough]];
 	}
 
 	case eHCS_WaitResponse:

--- a/Sming/Components/Network/src/Network/Http/HttpClientConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/HttpClientConnection.cpp
@@ -61,7 +61,7 @@ void HttpClientConnection::reset()
 	HttpConnection::reset();
 }
 
-int HttpClientConnection::onMessageBegin(http_parser* parser)
+int HttpClientConnection::onMessageBegin(http_parser*)
 {
 	incomingRequest = executionQueue.peek();
 	if(incomingRequest == nullptr) {

--- a/Sming/Components/Network/src/Network/Http/HttpConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/HttpConnection.cpp
@@ -84,7 +84,7 @@ int HttpConnection::staticOnPath(http_parser* parser, const char* at, size_t len
 }
 
 #ifndef COMPACT_MODE
-int HttpConnection::staticOnStatus(http_parser* parser, const char* at, size_t length)
+int HttpConnection::staticOnStatus(http_parser* parser, const char*, size_t)
 {
 	GET_CONNECTION()
 
@@ -169,7 +169,7 @@ bool HttpConnection::onHttpError(HttpError error)
 	return false;
 }
 
-bool HttpConnection::onTcpReceive(TcpClient& client, char* data, int size)
+bool HttpConnection::onTcpReceive(TcpClient&, char* data, int size)
 {
 	if(HTTP_PARSER_ERRNO(&parser) != HPE_OK) {
 		// if the parser is in error state then just ignore the incoming data.
@@ -187,7 +187,8 @@ bool HttpConnection::onTcpReceive(TcpClient& client, char* data, int size)
 
 	if(parser.upgrade) {
 		return onProtocolUpgrade(&parser);
-	} else if(parsedBytes != size) {
+	}
+	if(parsedBytes != size) {
 		return false;
 	}
 

--- a/Sming/Components/Network/src/Network/Http/HttpConnection.h
+++ b/Sming/Components/Network/src/Network/Http/HttpConnection.h
@@ -96,10 +96,9 @@ protected:
 	virtual int onMessageBegin(http_parser* parser) = 0;
 
 	/** @brief Called when the URL path is known
-	 * 	@param uri
 	 * 	@retval int 0 on success, non-0 on error
 	 */
-	virtual int onPath(const Url& uri)
+	virtual int onPath(const Url&)
 	{
 		return 0;
 	}
@@ -111,17 +110,17 @@ protected:
 	virtual int onHeadersComplete(const HttpHeaders& headers) = 0;
 
 #ifndef COMPACT_MODE
-	virtual int onStatus(http_parser* parser)
+	virtual int onStatus(http_parser*)
 	{
 		return 0;
 	}
 
-	virtual int onChunkHeader(http_parser* parser)
+	virtual int onChunkHeader(http_parser*)
 	{
 		return 0;
 	}
 
-	virtual int onChunkComplete(http_parser* parser)
+	virtual int onChunkComplete(http_parser*)
 	{
 		return 0;
 	}
@@ -145,7 +144,7 @@ protected:
 	 * 	@param parser
 	 * 	@retval bool true on success
 	 */
-	virtual bool onProtocolUpgrade(http_parser* parser)
+	virtual bool onProtocolUpgrade([[maybe_unused]] http_parser* parser)
 	{
 		return true;
 	}

--- a/Sming/Components/Network/src/Network/Http/HttpHeaders.h
+++ b/Sming/Components/Network/src/Network/Http/HttpHeaders.h
@@ -74,9 +74,9 @@ public:
 
 	HttpHeaders() = default;
 
-	HttpHeaders(const HttpHeaders& headers)
+	HttpHeaders(const HttpHeaders& headers) : HttpHeaders()
 	{
-		*this = headers;
+		setMultiple(headers);
 	}
 
 	Iterator begin() const

--- a/Sming/Components/Network/src/Network/Http/HttpParams.h
+++ b/Sming/Components/Network/src/Network/Http/HttpParams.h
@@ -36,9 +36,9 @@ class HttpParams : public HashMap<String, String>
 public:
 	HttpParams() = default;
 
-	HttpParams(const HttpParams& params)
+	HttpParams(const HttpParams& params) : HttpParams()
 	{
-		*this = params;
+		setMultiple(params);
 	}
 
 	HttpParams(String query)

--- a/Sming/Components/Network/src/Network/Http/HttpRequestAuth.h
+++ b/Sming/Components/Network/src/Network/Http/HttpRequestAuth.h
@@ -25,7 +25,7 @@ public:
 
 	virtual void setRequest(HttpRequest* request) = 0;
 
-	virtual void setResponse(HttpResponse* response)
+	virtual void setResponse(HttpResponse*)
 	{
 	}
 };

--- a/Sming/Components/Network/src/Network/Http/HttpResource.h
+++ b/Sming/Components/Network/src/Network/Http/HttpResource.h
@@ -40,7 +40,7 @@ public:
 	/**
 	 * @brief Takes care to cleanup the connection
 	 */
-	virtual void shutdown(HttpServerConnection& connection)
+	virtual void shutdown(HttpServerConnection&)
 	{
 	}
 

--- a/Sming/Components/Network/src/Network/Http/HttpResourceTree.cpp
+++ b/Sming/Components/Network/src/Network/Http/HttpResourceTree.cpp
@@ -21,7 +21,7 @@ public:
 	}
 
 private:
-	int requestComplete(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
+	int requestComplete(HttpServerConnection&, HttpRequest& request, HttpResponse& response)
 	{
 		callback(request, response);
 		return 0;

--- a/Sming/Components/Network/src/Network/Http/HttpServerConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/HttpServerConnection.cpp
@@ -29,7 +29,7 @@ int HttpServerConnection::onMessageBegin(http_parser* parser)
 
 	// ... and Request
 	request.reset();
-	request.setMethod((const HttpMethod)parser->method);
+	request.setMethod(HttpMethod(parser->method));
 
 	// and temp data...
 	reset();

--- a/Sming/Components/Network/src/Network/Http/HttpServerConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/HttpServerConnection.cpp
@@ -210,6 +210,7 @@ void HttpServerConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 		}
 		sendResponseHeaders(&response);
 		state = eHCS_SendingHeaders;
+		[[fallthrough]];
 	}
 
 	case eHCS_SendingHeaders: {
@@ -218,6 +219,7 @@ void HttpServerConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 		}
 
 		state = eHCS_StartBody;
+		[[fallthrough]];
 	}
 
 	case eHCS_StartBody:
@@ -229,6 +231,7 @@ void HttpServerConnection::onReadyToSendData(TcpConnectionEvent sourceEvent)
 		delete stream;
 		stream = nullptr;
 		state = eHCS_Sent;
+		[[fallthrough]];
 	}
 
 	case eHCS_Sent: {

--- a/Sming/Components/Network/src/Network/Http/HttpServerConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/HttpServerConnection.cpp
@@ -57,7 +57,7 @@ int HttpServerConnection::onPath(const Url& uri)
 	return resource ? resource->handleUrl(*this, request, response) : 0;
 }
 
-int HttpServerConnection::onMessageComplete(http_parser* parser)
+int HttpServerConnection::onMessageComplete(http_parser*)
 {
 	// we are finished with this request
 	int hasError = 0;

--- a/Sming/Components/Network/src/Network/Http/HttpServerConnection.h
+++ b/Sming/Components/Network/src/Network/Http/HttpServerConnection.h
@@ -99,7 +99,7 @@ protected:
 	int onBody(const char* at, size_t length) override;
 	int onMessageComplete(http_parser* parser) override;
 
-	bool onProtocolUpgrade(http_parser* parser) override
+	bool onProtocolUpgrade(http_parser*) override
 	{
 		if(upgradeCallback) {
 			return upgradeCallback();

--- a/Sming/Components/Network/src/Network/Http/Resource/Auth/ResourceBasicAuth.h
+++ b/Sming/Components/Network/src/Network/Http/Resource/Auth/ResourceBasicAuth.h
@@ -22,7 +22,7 @@ public:
 	{
 	}
 
-	bool headersComplete(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response) override
+	bool headersComplete(HttpServerConnection&, HttpRequest& request, HttpResponse& response) override
 	{
 		auto& headers = request.headers;
 		auto authorization = headers[HTTP_HEADER_AUTHORIZATION];

--- a/Sming/Components/Network/src/Network/Http/Resource/Auth/ResourceIpAuth.h
+++ b/Sming/Components/Network/src/Network/Http/Resource/Auth/ResourceIpAuth.h
@@ -21,7 +21,7 @@ public:
 	{
 	}
 
-	bool urlComplete(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response) override
+	bool urlComplete(HttpServerConnection& connection, HttpRequest&, HttpResponse& response) override
 	{
 		auto remoteIp = connection.getRemoteIp();
 		if(remoteIp.compare(ip, netmask)) {

--- a/Sming/Components/Network/src/Network/Http/Resource/HttpResourcePlugin.h
+++ b/Sming/Components/Network/src/Network/Http/Resource/HttpResourcePlugin.h
@@ -30,27 +30,29 @@ protected:
 
 	virtual int getPriority() const = 0;
 
-	virtual bool urlComplete(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
+	virtual bool urlComplete(HttpServerConnection&, HttpRequest&, HttpResponse&)
 	{
 		return true;
 	}
 
-	virtual bool headersComplete(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
+	virtual bool headersComplete(HttpServerConnection&, HttpRequest&, HttpResponse&)
 	{
 		return true;
 	}
 
-	virtual bool upgradeReceived(HttpServerConnection& connection, HttpRequest&, char* data, size_t length)
+	virtual bool upgradeReceived(HttpServerConnection&, HttpRequest&, [[maybe_unused]] char* data,
+								 [[maybe_unused]] size_t length)
 	{
 		return true;
 	}
 
-	virtual bool bodyReceived(HttpServerConnection& connection, HttpRequest& request, char*& data, size_t& length)
+	virtual bool bodyReceived(HttpServerConnection&, HttpRequest&, [[maybe_unused]] char*& data,
+							  [[maybe_unused]] size_t& length)
 	{
 		return true;
 	}
 
-	virtual bool requestComplete(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
+	virtual bool requestComplete(HttpServerConnection&, HttpRequest&, HttpResponse&)
 	{
 		return true;
 	}

--- a/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/Websocket/WebsocketConnection.cpp
@@ -100,7 +100,7 @@ void WebsocketConnection::activate()
 	connection->setReceiveDelegate(TcpClientDataDelegate(&WebsocketConnection::processFrame, this));
 }
 
-bool WebsocketConnection::processFrame(TcpClient& client, char* at, int size)
+bool WebsocketConnection::processFrame(TcpClient&, char* at, int size)
 {
 	int rc = ws_parser_execute(&parser, &parserSettings, this, at, size);
 	if(rc != WS_OK) {
@@ -146,7 +146,7 @@ int WebsocketConnection::staticOnDataPayload(void* userData, const char* at, siz
 	return WS_OK;
 }
 
-int WebsocketConnection::staticOnDataEnd(void* userData)
+int WebsocketConnection::staticOnDataEnd(void*)
 {
 	return WS_OK;
 }

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -400,6 +400,7 @@ void MqttClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 		}
 
 		state = eMCS_SendingData;
+		[[fallthrough]];
 	}
 
 	case eMCS_SendingData:

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -101,7 +101,7 @@ MqttClient::~MqttClient()
 	clearMessage(incomingMessage);
 }
 
-bool MqttClient::onTcpReceive(TcpClient& client, char* data, int size)
+bool MqttClient::onTcpReceive(TcpClient&, char* data, int size)
 {
 	pingTimer.start();
 	int rc = mqtt_parser_execute(&parser, &incomingMessage, (uint8_t*)data, (size_t)size);
@@ -113,7 +113,7 @@ bool MqttClient::onTcpReceive(TcpClient& client, char* data, int size)
 	return true;
 }
 
-int MqttClient::staticOnMessageBegin(void* userData, mqtt_message_t* message)
+int MqttClient::staticOnMessageBegin(void*, mqtt_message_t*)
 {
 	// At that moment the message contains the type and its common length
 	return 0;

--- a/Sming/Components/Network/src/Network/NtpClient.cpp
+++ b/Sming/Components/Network/src/Network/NtpClient.cpp
@@ -48,7 +48,7 @@ void NtpClient::requestTime()
 	ip_addr_t resolvedIp;
 	int result = dns_gethostbyname(
 		server.c_str(), &resolvedIp,
-		[](const char* name, LWIP_IP_ADDR_T* ip, void* arg) {
+		[](const char*, LWIP_IP_ADDR_T* ip, void* arg) {
 			// We do a new request since the last one was never done.
 			if(ip)
 				reinterpret_cast<NtpClient*>(arg)->internalRequestTime(*ip);
@@ -118,7 +118,7 @@ void NtpClient::setAutoQueryInterval(unsigned seconds)
 	}
 }
 
-void NtpClient::onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort)
+void NtpClient::onReceive(pbuf* buf, [[maybe_unused]] IpAddress remoteIP, [[maybe_unused]] uint16_t remotePort)
 {
 	debug_d("NtpClient::onReceive(%s:%u)", remoteIP.toString().c_str(), remotePort);
 

--- a/Sming/Components/Network/src/Network/SmtpClient.cpp
+++ b/Sming/Components/Network/src/Network/SmtpClient.cpp
@@ -199,6 +199,7 @@ void SmtpClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 
 		state = eSMTP_SendMail;
 	}
+		[[fallthrough]];
 
 	case eSMTP_SendMail: {
 		sendString(F("MAIL FROM:") + outgoingMail->from + "\r\n");
@@ -230,17 +231,20 @@ void SmtpClient::onReadyToSendData(TcpConnectionEvent sourceEvent)
 
 		state = eSMTP_SendingHeaders;
 	}
+		[[fallthrough]];
 
 	case eSMTP_SendingHeaders: {
 		WAIT_FOR_STREAM(stream);
 
 		state = eSMTP_StartBody;
 	}
+		[[fallthrough]];
 
 	case eSMTP_StartBody: {
 		sendMailBody(outgoingMail);
 		state = eSMTP_SendingBody;
 	}
+		[[fallthrough]];
 
 	case eSMTP_SendingBody: {
 		WAIT_FOR_STREAM(stream);

--- a/Sming/Components/Network/src/Network/TcpClient.cpp
+++ b/Sming/Components/Network/src/Network/TcpClient.cpp
@@ -241,7 +241,7 @@ void TcpClient::onClosed()
 	state = eTCS_Ready;
 }
 
-void TcpClient::onFinished(TcpClientState finishState)
+void TcpClient::onFinished(TcpClientState)
 {
 	freeStreams();
 

--- a/Sming/Components/Network/src/Network/TcpConnection.cpp
+++ b/Sming/Components/Network/src/Network/TcpConnection.cpp
@@ -140,7 +140,7 @@ err_t TcpConnection::onReceive(pbuf* buf)
 	return ERR_OK;
 }
 
-err_t TcpConnection::onSent(uint16_t len)
+err_t TcpConnection::onSent([[maybe_unused]] uint16_t len)
 {
 	debug_tcp_d("sent: %u", len);
 
@@ -184,7 +184,7 @@ err_t TcpConnection::onConnected(err_t err)
 	return ERR_OK;
 }
 
-void TcpConnection::onError(err_t err)
+void TcpConnection::onError([[maybe_unused]] err_t err)
 {
 	if(ssl != nullptr) {
 		ssl->close();
@@ -308,9 +308,9 @@ void TcpConnection::initialize(tcp_pcb* pcb)
 	tcp_nagle_disable(tcp);
 	tcp_arg(tcp, this);
 
-	tcp_sent(tcp, [](void* arg, tcp_pcb* tcp, uint16_t len) -> err_t {
+	tcp_sent(tcp, [](void* arg, tcp_pcb*, uint16_t len) -> err_t {
 		auto con = static_cast<TcpConnection*>(arg);
-		return (con == nullptr) ? ERR_OK : con->internalOnSent(len);
+		return (con == nullptr) ? err_t(ERR_OK) : con->internalOnSent(len);
 	});
 
 	tcp_recv(tcp, [](void* arg, tcp_pcb* tcp, pbuf* p, err_t err) -> err_t {
@@ -558,7 +558,7 @@ void TcpConnection::internalOnError(err_t err)
 	debug_tcp_ext("<error");
 }
 
-void TcpConnection::internalOnDnsResponse(const char* name, LWIP_IP_ADDR_T* ipaddr, int port)
+void TcpConnection::internalOnDnsResponse([[maybe_unused]] const char* name, LWIP_IP_ADDR_T* ipaddr, int port)
 {
 	if(ipaddr != nullptr) {
 		IpAddress ip = *ipaddr;

--- a/Sming/Components/Network/src/Network/UdpConnection.cpp
+++ b/Sming/Components/Network/src/Network/UdpConnection.cpp
@@ -107,7 +107,7 @@ void UdpConnection::onReceive(pbuf* buf, IpAddress remoteIP, uint16_t remotePort
 	}
 }
 
-void UdpConnection::staticOnReceive(void* arg, struct udp_pcb* pcb, struct pbuf* p, LWIP_IP_ADDR_T* addr, u16_t port)
+void UdpConnection::staticOnReceive(void* arg, struct udp_pcb*, struct pbuf* p, LWIP_IP_ADDR_T* addr, u16_t port)
 {
 	auto conn = static_cast<UdpConnection*>(arg);
 	if(conn != nullptr) {
@@ -117,7 +117,7 @@ void UdpConnection::staticOnReceive(void* arg, struct udp_pcb* pcb, struct pbuf*
 	pbuf_free(p);
 }
 
-bool UdpConnection::setMulticast(IpAddress ip)
+bool UdpConnection::setMulticast([[maybe_unused]] IpAddress ip)
 {
 #if LWIP_MULTICAST_TX_OPTIONS
 	if(udp == nullptr) {
@@ -131,7 +131,7 @@ bool UdpConnection::setMulticast(IpAddress ip)
 	return false;
 }
 
-bool UdpConnection::setMulticastTtl(size_t ttl)
+bool UdpConnection::setMulticastTtl([[maybe_unused]] size_t ttl)
 {
 #if LWIP_MULTICAST_TX_OPTIONS
 	if(udp == nullptr) {

--- a/Sming/Components/Storage/src/include/Storage/ProgMem.h
+++ b/Sming/Components/Storage/src/include/Storage/ProgMem.h
@@ -41,12 +41,12 @@ public:
 
 	bool read(storage_size_t address, void* dst, size_t size) override;
 
-	bool write(storage_size_t address, const void* src, size_t size) override
+	bool write(storage_size_t, const void*, size_t) override
 	{
 		return false;
 	}
 
-	bool erase_range(storage_size_t address, storage_size_t size) override
+	bool erase_range(storage_size_t, storage_size_t) override
 	{
 		return false;
 	}

--- a/Sming/Components/axtls-8266/axtls-8266.patch
+++ b/Sming/Components/axtls-8266/axtls-8266.patch
@@ -250,6 +250,36 @@ index 1082733..097302a 100644
          W[t] |= ctx->Message_Block[t * 4 + 1] << 16;
          W[t] |= ctx->Message_Block[t * 4 + 2] << 8;
          W[t] |= ctx->Message_Block[t * 4 + 3];
+diff --git a/crypto/sha256.c b/crypto/sha256.c
+index ba1ac95..abfde8f 100644
+--- a/crypto/sha256.c
++++ b/crypto/sha256.c
+@@ -216,10 +216,10 @@ void SHA256_Update(SHA256_CTX *ctx, const uint8_t * msg, int len)
+     ctx->total[0] += len;
+     ctx->total[0] &= 0xFFFFFFFF;
+ 
+-    if (ctx->total[0] < len)
++    if ((int)ctx->total[0] < len)
+         ctx->total[1]++;
+ 
+-    if (left && len >= fill)
++    if (left && len >= (int)fill)
+     {
+         memcpy((void *) (ctx->buffer + left), (void *)msg, fill);
+         SHA256_Process(ctx->buffer, ctx);
+diff --git a/crypto/sha512.c b/crypto/sha512.c
+index f92b80a..4d37cec 100644
+--- a/crypto/sha512.c
++++ b/crypto/sha512.c
+@@ -160,7 +160,7 @@ void SHA512_Update(SHA512_CTX *ctx, const uint8_t * msg, int len)
+     while (len > 0)
+     {
+         // The buffer can hold at most 128 bytes
+-        size_t n = MIN(len, 128 - ctx->size);
++        size_t n = MIN((size_t)len, 128 - ctx->size);
+  
+         // Copy the data to the buffer
+         memcpy(ctx->w_buf.buffer + ctx->size, msg, n);
 diff --git a/replacements/time.c b/replacements/time.c
 index 4972119..1447711 100644
 --- a/replacements/time.c

--- a/Sming/Components/axtls-8266/axtls-8266.patch
+++ b/Sming/Components/axtls-8266/axtls-8266.patch
@@ -1,5 +1,5 @@
 diff --git a/crypto/bigint.c b/crypto/bigint.c
-index d90b093..9eebb72 100644
+index d90b093..9ddad77 100644
 --- a/crypto/bigint.c
 +++ b/crypto/bigint.c
 @@ -180,7 +180,7 @@ void bi_permanent(bigint *bi)
@@ -29,7 +29,15 @@ index d90b093..9eebb72 100644
                  "- double-freed bigint?\n");
  #endif
          abort();
-@@ -688,11 +688,11 @@ void bi_print(const char *label, bigint *x)
+@@ -508,6 +508,7 @@ bigint *bi_divide(BI_CTX *ctx, bigint *u, bigint *v, int is_mod)
+  */
+ static bigint *bi_int_divide(BI_CTX *ctx, bigint *biR, comp denom)
+ {
++    (void)ctx;
+     int i = biR->size - 1;
+     long_comp r = 0;
+ 
+@@ -688,11 +689,11 @@ void bi_print(const char *label, bigint *x)
          {
              comp mask = 0x0f << (j*4);
              comp num = (x->comps[i] & mask) >> (j*4);
@@ -43,7 +51,7 @@ index d90b093..9eebb72 100644
  }
  #endif
  
-@@ -1098,7 +1098,7 @@ static bigint *alloc(BI_CTX *ctx, int size)
+@@ -1098,7 +1099,7 @@ static bigint *alloc(BI_CTX *ctx, int size)
          if (biR->refs != 0)
          {
  #ifdef CONFIG_SSL_FULL_MODE
@@ -52,7 +60,7 @@ index d90b093..9eebb72 100644
  #endif
              abort();    /* create a stack trace from a core dump */
          }
-@@ -1174,13 +1174,13 @@ static void check(const bigint *bi)
+@@ -1174,13 +1175,13 @@ static void check(const bigint *bi)
  {
      if (bi->refs <= 0)
      {
@@ -95,7 +103,7 @@ index da24d31..4de139b 100644
          int key_len, uint8_t *digest);
  void hmac_sha1_v(const uint8_t **msg, int* length, int count, const uint8_t *key, 
 diff --git a/crypto/crypto_misc.c b/crypto/crypto_misc.c
-index dca7e5f..b028750 100644
+index dca7e5f..6198b9f 100644
 --- a/crypto/crypto_misc.c
 +++ b/crypto/crypto_misc.c
 @@ -44,7 +44,6 @@
@@ -106,7 +114,17 @@ index dca7e5f..b028750 100644
  #endif
  
  #if defined(CONFIG_USE_DEV_URANDOM)
-@@ -157,62 +156,6 @@ EXP_FUNC void STDCALL RNG_terminate(void)
+@@ -142,6 +141,9 @@ EXP_FUNC void STDCALL RNG_custom_init(const uint8_t *seed_buf, int size)
+ 
+     for (i = 0; i < ENTROPY_POOL_SIZE && i < size; i++)
+         entropy_pool[i] ^= seed_buf[i];
++#else
++    (void)seed_buf;
++    (void)size;
+ #endif
+ }
+ 
+@@ -157,62 +159,6 @@ EXP_FUNC void STDCALL RNG_terminate(void)
  #endif
  }
  
@@ -169,7 +187,7 @@ index dca7e5f..b028750 100644
  /**
   * Set a series of bytes with a random number. Individual bytes are not zero.
   */
-@@ -257,17 +200,17 @@ static void print_hex(uint8_t hex)
+@@ -257,17 +203,17 @@ static void print_hex(uint8_t hex)
      printf("%02x ", hex);
      if (++column == 8)
      {
@@ -190,7 +208,7 @@ index dca7e5f..b028750 100644
      }
  }
  
-@@ -374,7 +317,7 @@ EXP_FUNC int STDCALL base64_decode(const char *in, int len,
+@@ -374,7 +320,7 @@ EXP_FUNC int STDCALL base64_decode(const char *in, int len,
  error:
  #ifdef CONFIG_SSL_FULL_MODE
      if (ret < 0)
@@ -252,9 +270,18 @@ index 4972119..1447711 100644
 +
 +#endif
 diff --git a/ssl/asn1.c b/ssl/asn1.c
-index a08a618..3c64064 100644
+index a08a618..9487bb3 100644
 --- a/ssl/asn1.c
 +++ b/ssl/asn1.c
+@@ -183,7 +183,7 @@ int asn1_get_int(const uint8_t *buf, int *offset, int32_t *val)
+     int i;
+ 
+     if ((len = asn1_next_obj(buf, offset, ASN1_INTEGER)) < 0 || 
+-                len > sizeof(int32_t))
++                (size_t)len > sizeof(int32_t))
+     {
+         res = X509_NOT_OK;
+         goto end_int;
 @@ -271,7 +271,7 @@ int asn1_get_private_key(const uint8_t *buf, int len, RSA_CTX **rsa_ctx)
      if (buf[0] != ASN1_SEQUENCE) /* basic sanity check */
      {
@@ -333,10 +360,18 @@ index 093ae9c..d611ab0 100644
  error:
      return ret;
 diff --git a/ssl/loader.c b/ssl/loader.c
-index 6e41f40..874e5fd 100644
+index 6e41f40..5544434 100644
 --- a/ssl/loader.c
 +++ b/ssl/loader.c
-@@ -155,7 +155,7 @@ static int do_obj(SSL_CTX *ssl_ctx, int obj_type,
+@@ -126,6 +126,7 @@ EXP_FUNC int STDCALL ssl_obj_memory_load(SSL_CTX *ssl_ctx, int mem_type,
+ static int do_obj(SSL_CTX *ssl_ctx, int obj_type, 
+                     SSLObjLoader *ssl_obj, const char *password)
+ {
++    (void)password;
+     int ret = SSL_OK;
+ 
+     switch (obj_type)
+@@ -155,7 +156,7 @@ static int do_obj(SSL_CTX *ssl_ctx, int obj_type,
  #endif
          default:
  #ifdef CONFIG_SSL_FULL_MODE
@@ -345,7 +380,7 @@ index 6e41f40..874e5fd 100644
  #endif
              ret = SSL_ERROR_NOT_SUPPORTED;
              break;
-@@ -222,14 +222,14 @@ static int pem_decrypt(const char *where, const char *end,
+@@ -222,14 +223,14 @@ static int pem_decrypt(const char *where, const char *end,
      char *start = NULL;
      uint8_t iv[IV_SIZE];
      int i, pem_size;
@@ -362,7 +397,7 @@ index 6e41f40..874e5fd 100644
  #endif
          goto error;
      }
-@@ -246,7 +246,7 @@ static int pem_decrypt(const char *where, const char *end,
+@@ -246,7 +247,7 @@ static int pem_decrypt(const char *where, const char *end,
      else 
      {
  #ifdef CONFIG_SSL_FULL_MODE
@@ -371,7 +406,7 @@ index 6e41f40..874e5fd 100644
  #endif
          goto error;
      }
-@@ -269,18 +269,18 @@ static int pem_decrypt(const char *where, const char *end,
+@@ -269,18 +270,18 @@ static int pem_decrypt(const char *where, const char *end,
          goto error;
  
      /* work out the key */
@@ -399,7 +434,7 @@ index 6e41f40..874e5fd 100644
      }
  
      /* decrypt using the key/iv */
-@@ -481,7 +481,7 @@ error:
+@@ -481,7 +482,7 @@ error:
  #ifdef CONFIG_SSL_FULL_MODE
      if (ret)
      {
@@ -744,7 +779,7 @@ index 5bd2394..5363d22 100644
      if (memcmp(mac, orig_mac, SHA1_SIZE))
      {
 diff --git a/ssl/tls1.c b/ssl/tls1.c
-index 8f0fbfb..f099e2c 100644
+index 8f0fbfb..330f459 100644
 --- a/ssl/tls1.c
 +++ b/ssl/tls1.c
 @@ -85,7 +85,7 @@ static const cipher_info_t cipher_info[NUM_PROTOCOLS] =
@@ -783,7 +818,17 @@ index 8f0fbfb..f099e2c 100644
          (crypt_func)AES_cbc_encrypt,    /* encrypt */
          (crypt_func)AES_cbc_decrypt     /* decrypt */
      }
-@@ -843,15 +843,15 @@ void add_packet(SSL *ssl, const uint8_t *pkt, int len)
+@@ -334,7 +334,8 @@ EXP_FUNC int STDCALL ssl_read(SSL *ssl, uint8_t **in_data)
+  */
+ EXP_FUNC int STDCALL ssl_write(SSL *ssl, const uint8_t *out_data, int out_len)
+ {
+-    int n = out_len, nw, i, tot = 0;
++    int n = out_len, i, tot = 0;
++    size_t nw;
+     /* maximum size of a TLS packet is around 16kB, so fragment */
+ 
+     do 
+@@ -843,15 +844,15 @@ void add_packet(SSL *ssl, const uint8_t *pkt, int len)
      // TLS1.2+
      if (ssl->version >= SSL_PROTOCOL_VERSION_TLS1_2 || ssl->version == 0) 
      {
@@ -802,7 +847,7 @@ index 8f0fbfb..f099e2c 100644
      }
  }
  
-@@ -864,9 +864,9 @@ static void p_hash_md5(const uint8_t *sec, int sec_len,
+@@ -864,9 +865,9 @@ static void p_hash_md5(const uint8_t *sec, int sec_len,
      uint8_t a1[MD5_SIZE+77];
  
      /* A(1) */
@@ -814,7 +859,7 @@ index 8f0fbfb..f099e2c 100644
  
      while (olen > MD5_SIZE)
      {
-@@ -875,11 +875,11 @@ static void p_hash_md5(const uint8_t *sec, int sec_len,
+@@ -875,11 +876,11 @@ static void p_hash_md5(const uint8_t *sec, int sec_len,
          olen -= MD5_SIZE;
  
          /* A(N) */
@@ -828,7 +873,7 @@ index 8f0fbfb..f099e2c 100644
      }
  }
  
-@@ -892,9 +892,9 @@ static void p_hash_sha1(const uint8_t *sec, int sec_len,
+@@ -892,9 +893,9 @@ static void p_hash_sha1(const uint8_t *sec, int sec_len,
      uint8_t a1[SHA1_SIZE+77];
  
      /* A(1) */
@@ -840,7 +885,7 @@ index 8f0fbfb..f099e2c 100644
  
      while (olen > SHA1_SIZE)
      {
-@@ -903,11 +903,11 @@ static void p_hash_sha1(const uint8_t *sec, int sec_len,
+@@ -903,11 +904,11 @@ static void p_hash_sha1(const uint8_t *sec, int sec_len,
          olen -= SHA1_SIZE;
  
          /* A(N) */
@@ -854,7 +899,7 @@ index 8f0fbfb..f099e2c 100644
      }
  }
  
-@@ -920,9 +920,9 @@ static void p_hash_sha256(const uint8_t *sec, int sec_len,
+@@ -920,9 +921,9 @@ static void p_hash_sha256(const uint8_t *sec, int sec_len,
      uint8_t a1[SHA256_SIZE+77];
  
      /* A(1) */
@@ -866,7 +911,7 @@ index 8f0fbfb..f099e2c 100644
  
      while (olen > SHA256_SIZE)
      {
-@@ -931,11 +931,11 @@ static void p_hash_sha256(const uint8_t *sec, int sec_len,
+@@ -931,11 +932,11 @@ static void p_hash_sha256(const uint8_t *sec, int sec_len,
          olen -= SHA256_SIZE;
  
          // A(N)
@@ -880,7 +925,7 @@ index 8f0fbfb..f099e2c 100644
      }
  }
  
-@@ -1023,20 +1023,20 @@ int finished_digest(SSL *ssl, const char *label, uint8_t *digest)
+@@ -1023,20 +1024,20 @@ int finished_digest(SSL *ssl, const char *label, uint8_t *digest)
  
      if (ssl->version >= SSL_PROTOCOL_VERSION_TLS1_2) // TLS1.2+
      {
@@ -907,7 +952,7 @@ index 8f0fbfb..f099e2c 100644
          q += SHA1_SIZE;
          dgst_len = (int)(q-mac_buf);
      }
-@@ -1368,6 +1368,10 @@ int basic_read(SSL *ssl, uint8_t **in_data)
+@@ -1368,6 +1369,10 @@ int basic_read(SSL *ssl, uint8_t **in_data)
      int read_len, is_client = IS_SET_SSL_FLAG(SSL_IS_CLIENT);
      uint8_t *buf = ssl->bm_data;
  
@@ -918,7 +963,7 @@ index 8f0fbfb..f099e2c 100644
      if (IS_SET_SSL_FLAG(SSL_SENT_CLOSE_NOTIFY))
          return SSL_CLOSE_NOTIFY;
  
-@@ -1411,7 +1415,7 @@ int basic_read(SSL *ssl, uint8_t **in_data)
+@@ -1411,7 +1416,7 @@ int basic_read(SSL *ssl, uint8_t **in_data)
          if ((buf[0] & 0x80) && buf[2] == 1)
          {
  #ifdef CONFIG_SSL_FULL_MODE
@@ -927,7 +972,7 @@ index 8f0fbfb..f099e2c 100644
  #endif
              ret = SSL_ERROR_NOT_SUPPORTED;
              goto error; /* not an error - just get out of here */
-@@ -1432,7 +1436,7 @@ int basic_read(SSL *ssl, uint8_t **in_data)
+@@ -1432,7 +1437,7 @@ int basic_read(SSL *ssl, uint8_t **in_data)
          /* is the allocated buffer large enough to handle all the data? if not, increase its size*/
          if (ssl->need_bytes > ssl->max_plain_length+RT_EXTRA-BM_RECORD_OFFSET)
          {
@@ -936,7 +981,7 @@ index 8f0fbfb..f099e2c 100644
              ret = increase_bm_data_size(ssl, ssl->need_bytes + BM_RECORD_OFFSET - RT_EXTRA);
              if (ret != SSL_OK)
              {
-@@ -1562,7 +1566,7 @@ int increase_bm_data_size(SSL *ssl, size_t size)
+@@ -1562,7 +1567,7 @@ int increase_bm_data_size(SSL *ssl, size_t size)
      required = (required < RT_MAX_PLAIN_LENGTH) ? required : RT_MAX_PLAIN_LENGTH;
      uint8_t* new_bm_all_data = (uint8_t*) realloc(ssl->bm_all_data, required + RT_EXTRA);
      if (!new_bm_all_data) {
@@ -945,7 +990,15 @@ index 8f0fbfb..f099e2c 100644
          ssl->hs_status = SSL_ERROR_DEAD;
          return SSL_ERROR_CONN_LOST;
      }
-@@ -1845,9 +1849,9 @@ void disposable_new(SSL *ssl)
+@@ -1765,6 +1770,7 @@ int send_alert(SSL *ssl, int error_code)
+  */
+ int process_finished(SSL *ssl, uint8_t *buf, int hs_len)
+ {
++    (void)hs_len;
+     int ret = SSL_OK;
+     int is_client = IS_SET_SSL_FLAG(SSL_IS_CLIENT);
+     int resume = IS_SET_SSL_FLAG(SSL_SESSION_RESUME);
+@@ -1845,9 +1851,9 @@ void disposable_new(SSL *ssl)
      if (ssl->dc == NULL)
      {
          ssl->dc = (DISPOSABLE_CTX *)calloc(1, sizeof(DISPOSABLE_CTX));
@@ -958,7 +1011,7 @@ index 8f0fbfb..f099e2c 100644
      }
  }
  
-@@ -2248,15 +2252,15 @@ EXP_FUNC int STDCALL ssl_match_fingerprint(const SSL *ssl, const uint8_t* fp)
+@@ -2248,15 +2254,15 @@ EXP_FUNC int STDCALL ssl_match_fingerprint(const SSL *ssl, const uint8_t* fp)
          return 1;
      int res = memcmp(ssl->x509_ctx->fingerprint, fp, SHA1_SIZE);
      if (res != 0) {
@@ -977,7 +1030,7 @@ index 8f0fbfb..f099e2c 100644
      }
      return res;
  }
-@@ -2267,15 +2271,15 @@ EXP_FUNC int STDCALL ssl_match_spki_sha256(const SSL *ssl, const uint8_t* hash)
+@@ -2267,15 +2273,15 @@ EXP_FUNC int STDCALL ssl_match_spki_sha256(const SSL *ssl, const uint8_t* hash)
          return 1;
      int res = memcmp(ssl->x509_ctx->spki_sha256, hash, SHA256_SIZE);
      if (res != 0) {
@@ -996,7 +1049,7 @@ index 8f0fbfb..f099e2c 100644
      }
      return res;
  }
-@@ -2294,55 +2298,55 @@ void DISPLAY_STATE(SSL *ssl, int is_send, uint8_t state, int not_ok)
+@@ -2294,55 +2300,55 @@ void DISPLAY_STATE(SSL *ssl, int is_send, uint8_t state, int not_ok)
      if (!IS_SET_SSL_FLAG(SSL_DISPLAY_STATES))
          return;
  
@@ -1067,7 +1120,16 @@ index 8f0fbfb..f099e2c 100644
              break;
      }
  }
-@@ -2389,7 +2393,7 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code)
+@@ -2372,7 +2378,7 @@ void DISPLAY_BYTES(SSL *ssl, const char *format,
+ 
+     va_start(ap, size);
+     char fmt_ram[64];
+-    int len = strlen_P(format) + 1;
++    size_t len = strlen_P(format) + 1;
+     if (len > sizeof(fmt_ram)) len = sizeof(fmt_ram);
+     memcpy_P(fmt_ram, format, len);
+     fmt_ram[sizeof(fmt_ram)-1] = 0;
+@@ -2389,7 +2395,7 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code)
      if (error_code == SSL_OK)
          return;
  
@@ -1076,7 +1138,7 @@ index 8f0fbfb..f099e2c 100644
  
      /* X509 error? */
      if (error_code < SSL_X509_OFFSET)
-@@ -2409,67 +2413,67 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code)
+@@ -2409,67 +2415,67 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code)
      switch (error_code)
      {
          case SSL_ERROR_DEAD:
@@ -1160,7 +1222,7 @@ index 8f0fbfb..f099e2c 100644
              break;
  
          default:
-@@ -2477,7 +2481,7 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code)
+@@ -2477,7 +2483,7 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code)
              break;
      }
  
@@ -1169,7 +1231,7 @@ index 8f0fbfb..f099e2c 100644
  }
  
  /**
-@@ -2488,68 +2492,68 @@ void DISPLAY_ALERT(SSL *ssl, int alert)
+@@ -2488,68 +2494,68 @@ void DISPLAY_ALERT(SSL *ssl, int alert)
      if (!IS_SET_SSL_FLAG(SSL_DISPLAY_STATES))
          return;
  
@@ -1254,7 +1316,7 @@ index 8f0fbfb..f099e2c 100644
              break;
  
          default:
-@@ -2557,7 +2561,7 @@ void DISPLAY_ALERT(SSL *ssl, int alert)
+@@ -2557,7 +2563,7 @@ void DISPLAY_ALERT(SSL *ssl, int alert)
              break;
      }
  
@@ -1263,7 +1325,7 @@ index 8f0fbfb..f099e2c 100644
  }
  
  #endif /* CONFIG_SSL_FULL_MODE */
-@@ -2584,7 +2588,7 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code) {}
+@@ -2584,7 +2590,7 @@ EXP_FUNC void STDCALL ssl_display_error(int error_code) {}
  EXP_FUNC SSL * STDCALL ssl_client_new(SSL_CTX *ssl_ctx, int client_fd, const
          uint8_t *session_id, uint8_t sess_id_size)
  {
@@ -1272,7 +1334,7 @@ index 8f0fbfb..f099e2c 100644
      return NULL;
  }
  #endif
-@@ -2592,20 +2596,20 @@ EXP_FUNC SSL * STDCALL ssl_client_new(SSL_CTX *ssl_ctx, int client_fd, const
+@@ -2592,20 +2598,20 @@ EXP_FUNC SSL * STDCALL ssl_client_new(SSL_CTX *ssl_ctx, int client_fd, const
  #if !defined(CONFIG_SSL_CERT_VERIFICATION)
  EXP_FUNC int STDCALL ssl_verify_cert(const SSL *ssl)
  {

--- a/Sming/Components/libb64/cdecode.c
+++ b/Sming/Components/libb64/cdecode.c
@@ -47,6 +47,7 @@ unsigned base64_decode_block(const char* code_in, const int length_in, char* pla
 				fragment = base64_decode_value(*codechar++);
 			} while (fragment < 0);
 			*plainchar    = (fragment & 0x03f) << 2;
+		/* fallthrough */
 	case step_b:
 			do {
 				if (codechar == code_in+length_in)
@@ -59,6 +60,7 @@ unsigned base64_decode_block(const char* code_in, const int length_in, char* pla
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x030) >> 4;
 			*plainchar    = (fragment & 0x00f) << 4;
+		/* fallthrough */
 	case step_c:
 			do {
 				if (codechar == code_in+length_in)
@@ -71,6 +73,7 @@ unsigned base64_decode_block(const char* code_in, const int length_in, char* pla
 			} while (fragment < 0);
 			*plainchar++ |= (fragment & 0x03c) >> 2;
 			*plainchar    = (fragment & 0x003) << 6;
+		/* fallthrough */
 	case step_d:
 			do {
 				if (codechar == code_in+length_in)

--- a/Sming/Components/libb64/cencode.c
+++ b/Sming/Components/libb64/cencode.c
@@ -52,6 +52,7 @@ unsigned base64_encode_block(const char* plaintext_in, int length_in, char* code
 			result = (fragment & 0x0fc) >> 2;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x003) << 4;
+			/* fallthrough */
 	case step_B:
 			if (plainchar == plaintextend)
 			{
@@ -63,6 +64,7 @@ unsigned base64_encode_block(const char* plaintext_in, int length_in, char* code
 			result |= (fragment & 0x0f0) >> 4;
 			*codechar++ = base64_encode_value(result);
 			result = (fragment & 0x00f) << 2;
+			/* fallthrough */
 	case step_C:
 			if (plainchar == plaintextend)
 			{

--- a/Sming/Components/libb64/cencode.h
+++ b/Sming/Components/libb64/cencode.h
@@ -21,7 +21,7 @@ typedef struct
 {
 	base64_encodestep step;
 	char result;
-	int stepcount;
+	unsigned stepcount;
 	unsigned steps_per_line; ///< Non-zero to limit encoded line lengths
 } base64_encodestate;
 

--- a/Sming/Components/rboot/include/Data/Stream/RbootOutputStream.h
+++ b/Sming/Components/rboot/include/Data/Stream/RbootOutputStream.h
@@ -55,12 +55,12 @@ public:
 		return eSST_File;
 	}
 
-	uint16_t readMemoryBlock(char* data, int bufSize) override
+	uint16_t readMemoryBlock(char*, int) override
 	{
 		return 0;
 	}
 
-	bool seek(int len) override
+	bool seek(int) override
 	{
 		return false;
 	}

--- a/Sming/Components/rboot/src/Network/RbootHttpUpdater.cpp
+++ b/Sming/Components/rboot/src/Network/RbootHttpUpdater.cpp
@@ -47,7 +47,7 @@ void RbootHttpUpdater::start()
 	}
 }
 
-int RbootHttpUpdater::itemComplete(HttpConnection& client, bool success)
+int RbootHttpUpdater::itemComplete(HttpConnection&, bool success)
 {
 	auto& it = items[currentItem];
 

--- a/Sming/Components/simpleRPC/src/parser.cpp
+++ b/Sming/Components/simpleRPC/src/parser.cpp
@@ -82,10 +82,9 @@ ParserResult parse(ParserSettings& settings, const char* buffer, size_t length, 
 
 	REENTER:
 		switch(state) {
-		case ParserState::ready: {
+		case ParserState::ready:
 			state = ParserState::header_s;
-			/* fall through */
-		}
+			[[fallthrough]];
 		case ParserState::header_s:
 			EXPECT('s', ParserState::header_si);
 		case ParserState::header_si:
@@ -143,7 +142,7 @@ ParserResult parse(ParserSettings& settings, const char* buffer, size_t length, 
 
 			callbacks.startMethod();
 			state = ParserState::extract_method_signature;
-			/* fall-through */
+			[[fallthrough]];
 		}
 		case ParserState::extract_method_signature: {
 			if(ch == ';') {
@@ -172,7 +171,7 @@ ParserResult parse(ParserSettings& settings, const char* buffer, size_t length, 
 		case ParserState::end_methods: {
 			callbacks.endMethods();
 			state = ParserState::finished;
-			/* fall through */
+			[[fallthrough]];
 		}
 		case ParserState::finished: {
 			state = ParserState::ready;

--- a/Sming/Components/ssl/Axtls/AxContext.cpp
+++ b/Sming/Components/ssl/Axtls/AxContext.cpp
@@ -116,7 +116,7 @@ Connection* AxContext::createServer(tcp_pcb* tcp)
 }
 
 // Required by axtls-8266
-extern "C" int ax_get_file(const char* filename, uint8_t** buf)
+extern "C" int ax_get_file(const char*, uint8_t** buf)
 {
 	*buf = 0;
 	return 0;

--- a/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
+++ b/Sming/Components/ssl/BearSsl/BrClientConnection.cpp
@@ -63,7 +63,7 @@ int BrClientConnection::init()
 	return startHandshake();
 }
 
-void BrClientConnection::startCert(uint32_t length)
+void BrClientConnection::startCert(uint32_t)
 {
 	if(x509.count() != 0) {
 		return;

--- a/Sming/Components/ssl/BearSsl/BrClientConnection.h
+++ b/Sming/Components/ssl/BearSsl/BrClientConnection.h
@@ -47,7 +47,7 @@ public:
 
 	/* X509Handler */
 
-	virtual void startChain(const char* serverName) override
+	void startChain(const char*) override
 	{
 	}
 

--- a/Sming/Components/uzlib/uzlib.patch
+++ b/Sming/Components/uzlib/uzlib.patch
@@ -1,0 +1,26 @@
+diff --git a/src/genlz77.c b/src/genlz77.c
+index ede1fc9..a93c3b4 100644
+--- a/src/genlz77.c
++++ b/src/genlz77.c
+@@ -103,7 +103,7 @@ void uzlib_compress(struct uzlib_comp *data, const uint8_t *src, unsigned slen)
+         const uint8_t **bucket = &data->hash_table[h & (HASH_SIZE - 1)];
+         const uint8_t *subs = *bucket;
+         *bucket = src;
+-        if (subs && src > subs && (src - subs) <= MAX_OFFSET && !memcmp(src, subs, MIN_MATCH)) {
++        if (subs && src > subs && (unsigned)(src - subs) <= MAX_OFFSET && !memcmp(src, subs, MIN_MATCH)) {
+             src += MIN_MATCH;
+             const uint8_t *m = subs + MIN_MATCH;
+             int len = MIN_MATCH;
+diff --git a/src/tinflate.c b/src/tinflate.c
+index d719d80..07f3cec 100644
+--- a/src/tinflate.c
++++ b/src/tinflate.c
+@@ -465,7 +465,7 @@ static int tinf_inflate_block_data(TINF_DATA *d, TINF_TREE *lt, TINF_TREE *dt)
+             }
+         } else {
+             /* catch trying to point before the start of dest buffer */
+-            if (offs > d->dest - d->destStart) {
++            if ((int)offs > d->dest - d->destStart) {
+                 return TINF_DATA_ERROR;
+             }
+             d->lzOff = -offs;

--- a/Sming/Core/Data/CString.h
+++ b/Sming/Core/Data/CString.h
@@ -28,9 +28,8 @@ class CString : public std::unique_ptr<char[]>
 public:
 	CString() = default;
 
-	CString(const CString& src)
+	CString(const CString& src) : CString(src.get())
 	{
-		assign(src.get());
 	}
 
 	CString(CString&& other) = default;

--- a/Sming/Core/Data/Format/Standard.h
+++ b/Sming/Core/Data/Format/Standard.h
@@ -19,7 +19,7 @@ namespace Format
 class Standard : public Formatter
 {
 public:
-	void escape(String& value) const override
+	void escape(String&) const override
 	{
 	}
 

--- a/Sming/Core/Data/Stream/DataSourceStream.h
+++ b/Sming/Core/Data/Stream/DataSourceStream.h
@@ -96,6 +96,8 @@ public:
 	 */
 	virtual int seekFrom(int offset, SeekOrigin origin)
 	{
+		(void)offset;
+		(void)origin;
 		return -1;
 	}
 

--- a/Sming/Core/HardwareSerial.h
+++ b/Sming/Core/HardwareSerial.h
@@ -278,7 +278,7 @@ public:
 		return smg_uart_read(uart, buf, max_len);
 	}
 
-	bool seek(int len) override
+	bool seek(int) override
 	{
 		return false;
 	}
@@ -339,7 +339,7 @@ public:
 	 *
 	 *  @deprecated include <Services/CommandProcessing/Utils.h> and use `CommandProcessing::enable(Handler, Serial)` instead.
 	 */
-	void commandProcessing(bool reqEnable) SMING_DEPRECATED
+	void commandProcessing(bool) SMING_DEPRECATED
 	{
 	}
 

--- a/Sming/Core/Task.h
+++ b/Sming/Core/Task.h
@@ -139,7 +139,7 @@ protected:
 	/**
 	 * @brief Called immediately before calling to loop() to indicate a state change
 	 */
-	virtual void onNotify(Notify code)
+	virtual void onNotify([[maybe_unused]] Notify code)
 	{
 	}
 

--- a/Sming/Core/Wire.cpp
+++ b/Sming/Core/Wire.cpp
@@ -229,44 +229,6 @@ void TwoWire::flush()
 	txBufferLength = 0;
 }
 
-void TwoWire::onReceiveService(uint8_t* inBytes, int numBytes)
-{
-	// don't bother if user hasn't registered a callback
-	// if(!userReceiveCallback){
-	//   return;
-	// }
-	// // don't bother if rx buffer is in use by a master requestFrom() op
-	// // i know this drops data, but it allows for slight stupidity
-	// // meaning, they may not have read all the master requestFrom() data yet
-	// if(rxBufferIndex < rxBufferLength){
-	//   return;
-	// }
-	// // copy twi rx buffer into local read buffer
-	// // this enables new reads to happen in parallel
-	// for(uint8_t i = 0; i < numBytes; ++i){
-	//   rxBuffer[i] = inBytes[i];
-	// }
-	// // set rx iterator vars
-	// rxBufferIndex = 0;
-	// rxBufferLength = numBytes;
-	// // alert user program
-	// user_onReceive(numBytes);
-}
-
-void TwoWire::onRequestService()
-{
-	// // don't bother if user hasn't registered a callback
-	// if(!userRequestCallback){
-	//   return;
-	// }
-	// // reset tx buffer iterator vars
-	// // !!! this will kill any pending pre-master sendTo() activity
-	// txBufferIndex = 0;
-	// txBufferLength = 0;
-	// // alert user program
-	// user_onRequest();
-}
-
 void TwoWire::twi_delay(uint8_t v)
 {
 #pragma GCC diagnostic push

--- a/Sming/Core/Wire.h
+++ b/Sming/Core/Wire.h
@@ -155,8 +155,6 @@ private:
 	bool transmitting{false};
 	UserRequest userRequestCallback{nullptr};
 	UserReceive userReceiveCallback{nullptr};
-	void onRequestService();
-	void onReceiveService(uint8_t*, int);
 
 	void twi_delay(uint8_t v);
 	bool twi_write_start();

--- a/Sming/Core/Wire.h
+++ b/Sming/Core/Wire.h
@@ -126,13 +126,13 @@ public:
 	using Print::write;
 
 	// Slave mode not currently implemented
-	void onReceive(UserReceive callback)
+	void onReceive([[maybe_unused]] UserReceive callback)
 	{
 		// userReceiveCallback = callback;
 	}
 
 	// Slave mode not currently implemented
-	void onRequest(UserRequest callback)
+	void onRequest([[maybe_unused]] UserRequest callback)
 	{
 		// userRequestCallback = callback;
 	}

--- a/Sming/Libraries/ArduCAM/ArduCAM.cpp
+++ b/Sming/Libraries/ArduCAM/ArduCAM.cpp
@@ -981,6 +981,7 @@ void ArduCAM::InitCAM()
 				wrSensorReg16_16(0x332E, 0x0020);	//RGB565
 
 			#endif
+			break;
 		}
 		default:
 			

--- a/Sming/Libraries/CommandProcessing/samples/Arducam/app/application.cpp
+++ b/Sming/Libraries/CommandProcessing/samples/Arducam/app/application.cpp
@@ -124,7 +124,7 @@ void startCapture()
  * default http handler to check if server is up and running
  */
 
-void onIndex(HttpRequest& request, HttpResponse& response)
+void onIndex(HttpRequest&, HttpResponse& response)
 {
 	response.sendFile(_F("index.html"));
 }
@@ -162,7 +162,7 @@ void onCamSetup(HttpRequest& request, HttpResponse& response)
  * http request to capture and send an image from the camera
  * uses actual setting set by ArdCammCommand Handler
  */
-void onCapture(HttpRequest& request, HttpResponse& response)
+void onCapture(HttpRequest&, HttpResponse& response)
 {
 	Serial.printf("perform onCapture()\r\n");
 
@@ -202,7 +202,7 @@ MultipartStream::BodyPart snapshotProducer()
 	return result;
 }
 
-void onStream(HttpRequest& request, HttpResponse& response)
+void onStream(HttpRequest&, HttpResponse& response)
 {
 	Serial.println(_F("perform onCapture()"));
 
@@ -215,7 +215,7 @@ void onStream(HttpRequest& request, HttpResponse& response)
 	response.sendDataStream(stream, F("multipart/x-mixed-replace; boundary=") + stream->getBoundary());
 }
 
-void onFavicon(HttpRequest& request, HttpResponse& response)
+void onFavicon(HttpRequest&, HttpResponse& response)
 {
 	response.code = HTTP_STATUS_NOT_FOUND;
 }

--- a/Sming/Libraries/CommandProcessing/samples/TelnetServer/app/application.cpp
+++ b/Sming/Libraries/CommandProcessing/samples/TelnetServer/app/application.cpp
@@ -20,7 +20,7 @@ void clientConnected(TcpClient* client)
 	}
 }
 
-void clientComplete(TcpClient& client, bool successful)
+void clientComplete(TcpClient&, bool)
 {
 	Serial << _F("Client disconnected") << endl;
 }

--- a/Sming/Libraries/CommandProcessing/src/CommandProcessing/Handler.cpp
+++ b/Sming/Libraries/CommandProcessing/src/CommandProcessing/Handler.cpp
@@ -159,7 +159,7 @@ bool Handler::unregisterCommand(const Command& command)
 	return true;
 }
 
-void Handler::processHelpCommand(String commandLine, ReadWriteStream& outputStream)
+void Handler::processHelpCommand(String, ReadWriteStream& outputStream)
 {
 	debug_d("HelpCommand entered");
 	outputStream.println(_F("Commands available are :"));
@@ -168,7 +168,7 @@ void Handler::processHelpCommand(String commandLine, ReadWriteStream& outputStre
 	}
 }
 
-void Handler::processStatusCommand(String commandLine, ReadWriteStream& outputStream)
+void Handler::processStatusCommand(String, ReadWriteStream& outputStream)
 {
 	debug_d("StatusCommand entered");
 	outputStream << _F("Sming Framework Version : " SMING_VERSION) << endl;

--- a/Sming/Libraries/CommandProcessing/src/CommandProcessing/Utils.cpp
+++ b/Sming/Libraries/CommandProcessing/src/CommandProcessing/Utils.cpp
@@ -5,7 +5,7 @@ namespace CommandProcessing
 void enable(Handler& commandHandler, HardwareSerial& serial)
 {
 	commandHandler.setOutputStream(&serial, false);
-	Serial.onDataReceived([&commandHandler](Stream& source, char arrivedChar, uint16_t availableCharsCount) {
+	Serial.onDataReceived([&commandHandler](Stream& source, char, uint16_t availableCharsCount) {
 		while(availableCharsCount--) {
 			commandHandler.process(source.read());
 		}

--- a/Sming/Libraries/OneWire/OneWire.cpp
+++ b/Sming/Libraries/OneWire/OneWire.cpp
@@ -154,7 +154,7 @@ void OneWire::begin(uint8_t pinOneWire)
 uint8_t OneWire::reset()
 {
 	IO_REG_TYPE mask = bitmask;
-	SMING_UNUSED volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
+	[[maybe_unused]] volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
 	uint8_t r;
 	uint8_t retries = 125;
 
@@ -188,7 +188,7 @@ uint8_t OneWire::reset()
 void OneWire::write_bit(uint8_t v)
 {
 	IO_REG_TYPE mask=bitmask;
-	SMING_UNUSED volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
+	[[maybe_unused]] volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
 
 	if (v & 1) {
 		noInterrupts();
@@ -216,7 +216,7 @@ void OneWire::write_bit(uint8_t v)
 uint8_t OneWire::read_bit()
 {
 	IO_REG_TYPE mask=bitmask;
-	SMING_UNUSED volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
+	[[maybe_unused]] volatile IO_REG_TYPE *reg IO_REG_ASM = baseReg;
 	uint8_t r;
 
 	noInterrupts();

--- a/Sming/Libraries/Ota/src/include/Ota/UpgradeOutputStream.h
+++ b/Sming/Libraries/Ota/src/include/Ota/UpgradeOutputStream.h
@@ -46,12 +46,12 @@ public:
 		return eSST_File;
 	}
 
-	uint16_t readMemoryBlock(char* data, int bufSize) override
+	uint16_t readMemoryBlock(char*, int) override
 	{
 		return 0;
 	}
 
-	bool seek(int len) override
+	bool seek(int) override
 	{
 		return false;
 	}

--- a/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
+++ b/Sming/Libraries/OtaNetwork/src/HttpUpgrader.cpp
@@ -51,7 +51,7 @@ void HttpUpgrader::fetchNextItem()
 	}
 }
 
-int HttpUpgrader::itemComplete(HttpConnection& client, bool success)
+int HttpUpgrader::itemComplete(HttpConnection&, bool success)
 {
 	auto& it = items[currentItem];
 

--- a/Sming/Libraries/OtaUpgrade/OtaUpgrade/BasicStream.h
+++ b/Sming/Libraries/OtaUpgrade/OtaUpgrade/BasicStream.h
@@ -84,7 +84,7 @@ public:
 	}
 
 	// overrides from IDataSourceStream
-	uint16_t readMemoryBlock(char* data, int bufSize) override
+	uint16_t readMemoryBlock(char*, int) override
 	{
 		return 0;
 	}

--- a/Sming/Libraries/OtaUpgradeMqtt/src/StandardPayloadParser.cpp
+++ b/Sming/Libraries/OtaUpgradeMqtt/src/StandardPayloadParser.cpp
@@ -18,7 +18,7 @@ namespace OtaUpgrade
 {
 namespace Mqtt
 {
-bool StandardPayloadParser::switchRom(const UpdateState& updateState)
+bool StandardPayloadParser::switchRom(const UpdateState&)
 {
 	auto after = OtaManager.getNextBootPartition();
 #if DEBUG_VERBOSE_LEVEL >= DBG

--- a/Sming/Libraries/SPI/src/Arch/Esp32/SPI.cpp
+++ b/Sming/Libraries/SPI/src/Arch/Esp32/SPI.cpp
@@ -19,8 +19,11 @@
 #undef FLAG_ATTR
 #define FLAG_ATTR(TYPE)
 #include <soc/spi_periph.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include <hal/spi_ll.h>
 #include <hal/clk_gate_ll.h>
+#pragma GCC diagnostic pop
 #include <soc/rtc.h>
 #include <Data/BitSet.h>
 

--- a/Sming/Libraries/SPI/src/SPISettings.h
+++ b/Sming/Libraries/SPI/src/SPISettings.h
@@ -120,7 +120,7 @@ public:
 		return (speed == other.speed) && (bitOrder == other.bitOrder) && (dataMode == other.dataMode);
 	}
 
-	void print(const char* s)
+	void print([[maybe_unused]] const char* s)
 	{
 #ifdef SPI_DEBUG
 		debugf("->  %s -> SPISettings(%u, %u, %u)", s, speed.frequency, bitOrder, dataMode);

--- a/Sming/Libraries/SPI/src/SPISoft.cpp
+++ b/Sming/Libraries/SPI/src/SPISoft.cpp
@@ -143,12 +143,15 @@ uint32_t FUNC_OPT SPISoft::transferWordLSB(uint32_t word, uint8_t bits)
 	case 4:
 		res = transferByteLSB(word) << 24;
 		word >>= 8;
+		[[fallthrough]];
 	case 3:
 		res = (res >> 8) | transferByteLSB(word) << 24;
 		word >>= 8;
+		[[fallthrough]];
 	case 2:
 		res = (res >> 8) | transferByteLSB(word) << 24;
 		word >>= 8;
+		[[fallthrough]];
 	case 1:
 		res = (res >> 8) | transferByteLSB(word) << 24;
 		word >>= 8;
@@ -198,10 +201,13 @@ uint32_t FUNC_OPT SPISoft::transferWordMSB(uint32_t word, uint8_t bits)
 	switch(bit / 8) {
 	case 4:
 		res = transferByteMSB(word >> 24);
+		[[fallthrough]];
 	case 3:
 		res = (res << 8) | transferByteMSB(word >> 16);
+		[[fallthrough]];
 	case 2:
 		res = (res << 8) | transferByteMSB(word >> 8);
+		[[fallthrough]];
 	case 1:
 		res = (res << 8) | transferByteMSB(word);
 	}

--- a/Sming/Libraries/Servo/Servo.cpp
+++ b/Sming/Libraries/Servo/Servo.cpp
@@ -95,7 +95,7 @@ bool Servo::removeChannel(ServoChannel* channel)
 	return true;
 }
 
-void Servo::updateChannel(ServoChannel* channel)
+void Servo::updateChannel(ServoChannel*)
 {
 	updateTimer.startOnce();
 }

--- a/Sming/Libraries/Spiffs/src/FileSystem.cpp
+++ b/Sming/Libraries/Spiffs/src/FileSystem.cpp
@@ -213,7 +213,8 @@ int FileSystem::format()
 
 int FileSystem::check()
 {
-	fs.check_cb_f = [](spiffs* fs, spiffs_check_type type, spiffs_check_report report, u32_t arg1, u32_t arg2) {
+	fs.check_cb_f = [](spiffs*, [[maybe_unused]] spiffs_check_type type, [[maybe_unused]] spiffs_check_report report,
+					   [[maybe_unused]] u32_t arg1, [[maybe_unused]] u32_t arg2) {
 		if(report > SPIFFS_CHECK_PROGRESS) {
 			debug_d("SPIFFS check %d, %d, %u, %u", type, report, arg1, arg2);
 		}

--- a/Sming/Libraries/Yeelight/YeelightBulb.cpp
+++ b/Sming/Libraries/Yeelight/YeelightBulb.cpp
@@ -141,7 +141,7 @@ void YeelightBulb::parsePower(const String& value)
 	debugf("LED state: %s", value.c_str());
 }
 
-bool YeelightBulb::onResponse(TcpClient& client, char* data, int size)
+bool YeelightBulb::onResponse(TcpClient&, char* data, int size)
 {
 	String source(data, size);
 	debugf("LED > %s", source.c_str());

--- a/Sming/System/include/muldiv.h
+++ b/Sming/System/include/muldiv.h
@@ -85,12 +85,11 @@ template <uint64_t num, uint64_t den, typename ValType> struct MuldivLimits {
 /**
  * @brief Get the maximum value which can be passed to muldiv() without overflowing
  * @tparam ValType
- * @param timevar Result depends on size of variable used
  * @param num
  * @param den
  * @retval ValType Values greater than this will cause muldiv to return ValType(-1), i.e. range maximum
  */
-template <typename ValType> __forceinline ValType muldivMaxValue(ValType timevar, ValType num, ValType den)
+template <typename ValType> __forceinline ValType muldivMaxValue(ValType num, ValType den)
 {
 	constexpr auto max = std::numeric_limits<ValType>::max();
 	auto frac = den / 2;

--- a/Sming/System/include/sming_attr.h
+++ b/Sming/System/include/sming_attr.h
@@ -27,6 +27,7 @@
 
 /*
  * Use this definition in the cases where a function or a variable is meant to be possibly unused. GCC will not produce a warning for it.
+ * NOTE: Use `[[maybe_unused]]` attribute in C++ code
  */
 #define SMING_UNUSED __attribute__((unused))
 

--- a/Sming/Wiring/Stream.h
+++ b/Sming/Wiring/Stream.h
@@ -133,7 +133,7 @@ public:
 	 * @param c Character to search for
 	 * @retval int -1 if not found 0 or positive number otherwise
 	 */
-	virtual int indexOf(char c)
+	virtual int indexOf(char)
 	{
 		return -1;
 	}

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -182,7 +182,12 @@ CPPFLAGS = \
 BUILD_VARS += STRICT
 STRICT ?= 0
 export STRICT
-ifneq ($(STRICT),1)
+ifeq ($(STRICT),1)
+CPPFLAGS += \
+	-Wimplicit-fallthrough \
+	-Wunused-parameter \
+	-Wunused-but-set-parameter
+else
 CPPFLAGS += \
 	-Werror \
 	-Wno-sign-compare \

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -2,6 +2,9 @@
 
 include $(SMING_HOME)/util.mk
 
+# Cached build variables
+BUILD_VARS :=
+
 # Add debug variable names to DEBUG_VARS so they can be easily inspected via `make list-config`
 DEBUG_VARS := SMING_HOME
 SMING_HOME := $(patsubst %/,%,$(call FixPath,$(SMING_HOME)))
@@ -26,6 +29,7 @@ ifeq (,$(wildcard $(SMING_HOME)/Arch/$(SMING_ARCH)/build.mk))
   $(error Arch '$(SMING_ARCH)' not found)
 endif
 
+BUILD_VARS += CLANG_TIDY
 ifdef CLANG_TIDY
 ifneq (Host,$(SMING_ARCH))
   $(error CLANG_TIDY supported only for Host architecture.)
@@ -175,7 +179,7 @@ CPPFLAGS = \
 	-DARDUINO=106
 
 # If STRICT is enabled, show all warnings but don't treat as errors
-DEBUG_VARS += STRICT
+BUILD_VARS += STRICT
 STRICT ?= 0
 export STRICT
 ifneq ($(STRICT),1)
@@ -252,6 +256,21 @@ CPPFLAGS += \
 	-Wno-initializer-overrides
 endif
 
+# Sanitizers
+BUILD_VARS += ENABLE_SANITIZERS SANITIZERS
+ENABLE_SANITIZERS ?= 0
+SANITIZERS ?= \
+	address \
+	pointer-compare \
+	pointer-subtract \
+	leak \
+	undefined
+ifeq ($(ENABLE_SANITIZERS),1)
+CPPFLAGS += \
+	-fstack-protector-all \
+	-fsanitize-address-use-after-scope \
+	$(foreach s,$(SANITIZERS),-fsanitize=$s)
+endif
 
 # Use c11 by default. Every architecture can override it
 DEBUG_VARS			+= SMING_C_STD

--- a/Sming/building.rst
+++ b/Sming/building.rst
@@ -404,7 +404,13 @@ one of the following lists:
 .. envvar:: DEBUG_VARS
 
    These are generally for information only, and are not cached
-   (except for :envvar:`SMING_ARCH` and :envvar:`SMING_RELEASE`).
+   (except for :envvar:`SMING_SOC` and :envvar:`SMING_RELEASE`).
+
+
+.. envvar:: BUILD_VARS
+
+   These are optional user-provided build variables.
+   They are cached in ``out/build-type.mk`` so apply to all architectures.
 
 
 Note that the lists not prefixed ``COMPONENT_xx`` are global and so should only

--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -17,9 +17,21 @@ endif
 
 .NOTPARALLEL:
 
+ifneq ($(ENABLE_SANITIZERS),1)
+APPTARGET := application
+endif
+
 .PHONY: all
 all: checksoc checkdirs submodules ##(default) Build all Component libraries
-	$(Q) $(MAKE) components application
+	$(Q) $(MAKE) components $(APPTARGET)
+
+.PHONY: link_sanitizer
+ifeq ($(SMING_ARCH),Host)
+link_sanitizer: application
+else
+link_sanitizer:
+	@printf "\033[40;1;31mModules compiled, skipping link step as ENABLE_SANITIZERS=1.\033[0m\n"
+endif
 
 # Load current build type from file
 BUILD_TYPE_FILE	:= out/build-type.mk
@@ -351,7 +363,7 @@ export GLOBAL_CFLAGS
 export CONFIG_VARS
 
 # Export all config variables
-EXPORT_VARS := $(sort $(CONFIG_VARS) $(CACHE_VARS) $(RELINK_VARS))
+EXPORT_VARS := $(sort $(CONFIG_VARS) $(CACHE_VARS) $(RELINK_VARS) $(BUILD_VARS))
 $(foreach v,$(EXPORT_VARS),$(eval export $v))
 
 
@@ -480,6 +492,12 @@ $(BUILD_BASE) $(FW_BASE) $(TOOLS_BASE) $(APP_LIBDIR) $(USER_LIBDIR):
 
 # Targets to be built before anything else (e.g. source code generators)
 PREREQUISITES := $(foreach c,$(COMPONENTS),$(CMP_$c_PREREQUISITES))
+
+ifneq ($(SMING_ARCH),Host)
+ifeq ($(ENABLE_SANITIZERS),1)
+CUSTOM_TARGETS := link_sanitizer
+endif
+endif
 
 # Build all Component (user) libraries
 .PHONY: components
@@ -615,6 +633,7 @@ list-config: checksoc ##Print the contents of build variables
 	$(call PrintVariableRefs,CACHE_VARS)
 	$(call PrintVariableRefs,RELINK_VARS)
 	$(call PrintVariableRefs,DEBUG_VARS)
+	$(call PrintVariableRefs,BUILD_VARS)
 	$(info )
 	$(info )
 
@@ -688,7 +707,7 @@ endef
 
 # Update build type cache
 ifndef MAKE_CLEAN
-$(eval $(call WriteCacheValues,$(BUILD_TYPE_FILE),SMING_SOC SMING_RELEASE STRICT))
+$(eval $(call WriteCacheValues,$(BUILD_TYPE_FILE),SMING_SOC SMING_RELEASE $(BUILD_VARS)))
 endif
 
 # Update config cache file

--- a/Tools/ci/README.rst
+++ b/Tools/ci/README.rst
@@ -37,7 +37,7 @@ Fetch and scan the most recent build::
 
       python3 scanlog.py last-build.txt --fetch
 
-This will download all CI runs from the most recent worflow into ``last-build.txt``, then parse it.
+This will download all CI runs from the most recent workflow into ``last-build.txt``, then parse it.
 If the file already exists, downloading will be skipped.
 Output is to console and can be redirected to a file if required.
 

--- a/Tools/ci/README.rst
+++ b/Tools/ci/README.rst
@@ -1,0 +1,64 @@
+CI logs
+=======
+
+Overview
+--------
+
+Analysing CI logs is important for several reasons:
+
+Identifying sudden jumps in memory usage between builds
+    This can indicate a potential problem with SDK updates or the build system
+
+Checking warnings
+    - Compiler warnings are a very important indicator of potential problems in code.
+    - CI runs are built in STRICT mode so despite best efforts there can be many remaining messages.
+    - The same warning in a particular source file can occur multiple times in a run and across
+      multiple runs
+
+Logs can be downloaded via the web browser in 'raw' format, but getting these takes manual
+effort and has to be repeated for each build: currently there are 42 builds across two runs.
+
+Fortunately, github actions provides a CLI application to do this.
+The log files related to a run and therefore only two are required (the main build, and esp32).
+
+
+Setup
+-----
+
+The github CLI client must be installed and authenticated with the Sming repo (or fork).
+
+See https://docs.github.com/en/github-cli/github-cli/quickstart.
+
+
+Usage
+-----
+
+Fetch and scan the most recent build::
+
+      python3 scanlog.py last-build.txt --fetch
+
+This will download all CI runs from the most recent worflow into ``last-build.txt``, then parse it.
+If the file already exists, downloading will be skipped.
+Output is to console and can be redirected to a file if required.
+
+To compare with another previously fetched set of logs::
+
+      python3 scanlog.py last-build.txt -c previous-build.txt
+
+To fetch a specific build::
+
+      python3 scanlog.py custom-fixes.txt --fetch --branch feature/custom-fixes
+
+To explicitly specify the repository to fetch from::
+
+      python3 scanlog.py custom-fixes.txt --fetch --branch feature/custom-fixes --repo SmingHub/Sming
+
+To list all source locations with warnings::
+
+      python3 scanlog.py last-build.txt -w
+
+To filter out warnings::
+
+      python3 scanlog.py last-build.txt -w --exclude warn-exclude.lst
+
+The named exclusion file contains a list of regular expressions to match against.

--- a/Tools/ci/scanlog.py
+++ b/Tools/ci/scanlog.py
@@ -2,32 +2,36 @@
 #
 # Python application to scan CI build logs and extract useful information
 #
-# Github action logs must be in raw (text) format for processing.
+# Logs can be in two formats:
+#     1. Logs fetched using `gh run view --log nnn` have all jobs in single file.
+#        Each line is structured as "{job}\t{step}\t{datetime} {line}"
+#     2. Logs captured manually via web browser are for a single job.
+#        Each line is structured as "{datetime} {line}"
+#
+# The most useful is (1) since it can be scripted, and requires fewer steps.
+# The two separate logs (regular and esp32 runs) can also be combined and processed as a single file.
 #
 # Use cases:
 #
-#   Generate table of esp8266 memory usage
-#       Take two log files (cut & paste usually)
-#       Run scanlog on both
-#       Use kdiff3 to compare
+#   Generate table of memory usage per sample
+#   Given a second log file, compare each run to show summary of differences in memory usage
+#   Pull out all warnings
+#       There are many duplicates in a run and across runs, so we can filter these
+#       to produce a definitive list.
 #
 
 import argparse
 import os
+import sys
+import re
+import subprocess
+import json
 from enum import Enum
-
-
-class State(Enum):
-    searching = 1
-    building = 2
-    linking = 3
-
 
 class Table:
     COL_SEP = '  '
 
-    def __init__(self, name: str):
-        self.name = name
+    def __init__(self):
         self.headings = []
         self.rows = []
         self.col_widths = []
@@ -86,41 +90,140 @@ class TableFormatter:
         raise StopIteration
 
 
-def scan_log(filename: str):
-    BUILD_PREFIX = 'Building /home/runner/'
-    IGNORE_PREFIX = ['projects/', 'work/Sming/Sming/Sming/']
+class Job:
+    def __init__(self, log: "Log", name: str):
+        self.log = log
+        self.name = name
+        self.table: Table = Table()
+        self.warnings: dict[str, str] = {} # De-duplicated warnings
+        self.warning_count: int = 0 # Includes duplicates
+
+    @property
+    def caption(self):
+        return f'{self.log.name}: {self.name}'
+
+
+class Log:
+    def __init__(self, name: str):
+        self.name = os.path.splitext(name)[0]
+        self.jobs: list[Job] = []
+
+
+class PathPrefix:
+    # Paths vary by platform, so normalise them
+    IGNORE_PREFIX = [
+        # Linux
+        '/home/runner/projects/',
+        '/home/runner/work/Sming/Sming/Sming/',
+        '/opt/',
+        # MacOS
+        '/Users/runner/projects/',
+        '/Users/runner/work/Sming/Sming/Sming/',
+        # Windows
+        '/d/a/Sming/Sming/projects/',
+        '/d/a/Sming/Sming/Sming/',
+        'd:/a/Sming/Sming/projects/',
+        'd:/a/Sming/Sming/Sming/',
+        'c:/tools/',
+    ]
+    re_prefix = re.compile('|'.join(f'^{s}' for s in IGNORE_PREFIX), re.IGNORECASE)
+
+    @staticmethod
+    def remove(line: str) -> str:
+        return PathPrefix.re_prefix.sub('', line)
+
+
+def normalise_path(line: str) -> str:
+    line = line.replace('\\', '/')
+    line = PathPrefix.remove(line)
+    return os.path.normpath(line)
+
+
+def scan_log(filename: str) -> Log:
+    class State(Enum):
+        searching = 1
+        building = 2
+        linking = 3
+    BUILD_PREFIX = 'Building '
+    log = Log(filename)
+    job = None
+    warnings = {}
     state = State.searching
-    table = Table(os.path.basename(filename))
     target = None
     row = None
-    log = open(filename, 'rb')
-    for line in log:
-        line = line.decode('utf-8-sig')
-        dtstr, _, line = line.strip().partition(' ')
+
+    def finish_job():
+        if job is None:
+            return
+
+        nonlocal row
+        if row is not None:
+            job.table.append(row)
+            row = None
+
+        nonlocal warnings
+        job.warnings = warnings
+        warnings = {}
+
+    # Second figure in warning lines not reliable, remove it
+    warning_split = re.compile(r':(\d+): ?(\d+: )?(warning: )')
+
+    sys.stderr.write(f'Scanning {filename}\n')
+
+    logfile = open(filename, 'rb')
+    for line_index, line in enumerate(logfile):
+        line = line.decode('utf-8-sig').strip()
+        # Replace typographical quotes with normal ones to ensure equivalence
+        line = re.sub(r"‘|’", "'", line)
+        job_name = None
+        if not line[:4].isdigit(): # Not a date
+            if not line.startswith('build'):
+                continue
+            job_name, _, line = line.partition('\t')
+            job_name = re.search(r'\((.+?)\)', job_name)[1]
+            step, _, line = line.partition('\t')
+            if not step.startswith('Build and test'):
+                continue
+            if job and job.name != job_name:
+                finish_job()
+                sys.stderr.write(f'\r{job.name} ...\033[K')
+                job = None
+        if job is None:
+            job = Job(log, job_name)
+            log.jobs.append(job)
+            state = State.searching
+        dtstr, _, line = line.partition(' ')
         if not dtstr:
+            continue
+        if ': warning:' in line:
+            job.warning_count += 1
+            s = line.removeprefix('from ')
+            x = warning_split.split(line)
+            if len(x) == 5:
+                s = normalise_path(f'{x[0]}:{x[1]}')
+                lines = warnings.setdefault(s, set())
+                lines.add(x[4])
+            else:
+                warnings.setdefault(s, set())
             continue
         if state == State.searching:
             if not line.startswith(BUILD_PREFIX):
                 continue
             if 'clib-App' not in line:
                 continue
-            c = line[len(BUILD_PREFIX):]
-            for prefix in IGNORE_PREFIX:
-                c = c.removeprefix(prefix)
+            c = normalise_path(line[len(BUILD_PREFIX):])
             target, _, _ = c.partition('/out/')
-            row = {
-                'target': target
-            }
             state = State.building
             continue
         if state == State.building:
             if line.startswith(f'{os.path.basename(target)}: Linking'):
                 state = State.linking
+                row = None
                 continue
         if state == State.linking:
-            if 'Section' in line:
-                continue
-            if line.startswith('----'):
+            if row is None:
+                if line.startswith('----'):
+                    row = {'target': target}
                 continue
             if '|' in line:
                 cols = line.split('|')
@@ -128,72 +231,185 @@ def scan_log(filename: str):
             elif ' : ' in line:
                 k, v = line.split(':')
             else:
-                if len(row) > 1: # Not just target (discard host builds)
-                    table.append(row)
+                job.table.append(row)
                 row = None
                 state = State.searching
                 continue
             k, v = k.strip(), v.strip()
             row[k] = v
-            continue
 
-    return table
+    finish_job()
+
+    sys.stderr.write(f'\r\033[K')
+    log.jobs.sort(key=lambda job: job.name)
+
+    return log
 
 
 def print_table(table: Table):
-    print(f'{table.name}')
     for line in table:
         print(' ', line)
     print()
 
 
+def print_warnings(log: Log, exclude_file: str):
+    exclude = None
+    if exclude_file is not None:
+        with open(exclude_file, 'r') as f:
+            s = '|'.join(line.strip() for line in f)
+            exclude = re.compile(s, re.IGNORECASE)
+
+    warnings = {}
+    total_warning_count = 0
+    for job in log.jobs:
+        total_warning_count += job.warning_count
+        for location, details in job.warnings.items():
+            location_warnings = warnings.setdefault(location, {})
+            for det in details:
+                x = location_warnings.setdefault(det, [])
+                x.append(job.name)
+
+    print(f'{total_warning_count} warnings found in {len(warnings)} unique locations.')
+
+    exclude_count = 0
+    if exclude:
+        unfiltered_warnings = warnings
+        warnings = {}
+        for location, details in unfiltered_warnings.items():
+            filtered_details = []
+            for det in details:
+                if not exclude.match(f'{location}\t{det}'):
+                    filtered_details.append(det)
+            if filtered_details:
+                warnings[location] = filtered_details
+            else:
+                exclude_count += 1
+        print(f'{exclude_count} locations excluded.')
+
+    loc_width = min(2 + max(len(loc) for loc in warnings), 80)
+    loc_pad = ''.ljust(loc_width)
+    for location in sorted(warnings, key=lambda s: s.lower()):
+        if len(location) > loc_width:
+            print(f'\t{location}')
+            locstr = loc_pad
+        else:
+            locstr = f'{location}'.ljust(loc_width)
+        for det in sorted(warnings[location]):
+            print(f'\t{locstr}{det}')
+            locstr = loc_pad
+
+
+def fetch_logs(filename: str, repo: str = None, branch: str = None):
+    if os.path.exists(filename):
+        sys.stderr.write(f'{filename} exists, skipping download.\n')
+        return
+    def get_args(cmd: str):
+        args = ['gh', 'run', cmd]
+        if repo:
+            args.append(f'-R={repo}')
+        return args
+    args = get_args('list')
+    if branch:
+        args.append(f'-b={branch}')
+    args.append('--json=displayTitle,headBranch,number,name,databaseId,headSha,conclusion')
+    r = subprocess.run(args, capture_output=True, encoding='utf-8')
+    r.check_returncode()
+    data = json.loads(r.stdout)
+
+    joblist = []
+    for job in data:
+        if '(CI)' not in job['name']:
+            continue
+        if joblist and job['headSha'] != joblist[0]['headSha']:
+            break
+        joblist.append(job)
+
+    with open(filename, 'w') as f:
+        sys.stderr.write(f'Creating {filename}...\n')
+        for job in joblist:
+            id = job['databaseId']
+            sys.stderr.write(f'Fetching {id}: "{job["displayTitle"]}" - {job["headBranch"]} - {job["name"]} - {job["conclusion"]}\n')
+            try:
+                args = get_args('view') + ['--log', str(id)]
+                r = subprocess.run(args, stdout=f, encoding='utf-8')
+                r.check_returncode()
+            except:
+                os.unlink(filename)
+                raise
+
+
 def main():
     parser = argparse.ArgumentParser(description='Sming CI log parser')
-    parser.add_argument('filename', help='Log filename')
+    parser.add_argument('filename', help='Log filename to read/write')
+    parser.add_argument('-f', '--fetch', action='store_true', help='Fetch most recent CI runs from repo')
+    parser.add_argument('-R', '--repo', help='Override default repo for fetch')
+    parser.add_argument('-b', '--branch', help='Specify branch to fetch')
     parser.add_argument('-c', '--compare', help='Second log to compare')
+    parser.add_argument('-w', '--warnings', action='store_true', help='Summarise warnings')
+    parser.add_argument('-x', '--exclude', help='File containing source locations to exclude')
 
     args = parser.parse_args()
 
-    table1 = scan_log(args.filename)
+    if args.fetch:
+        fetch_logs(args.filename, repo=args.repo, branch=args.branch)
+
+    log1 = scan_log(args.filename)
     if args.compare is None:
-        print_table(table1)
+        if args.warnings:
+            print_warnings(log1, args.exclude)
+        else:
+            for job in log1.jobs:
+                print(job.caption)
+                print_table(job.table)
         return
 
-    table2 = scan_log(args.compare)
+    log2 = scan_log(args.compare)
 
-    for row1 in table1.rows:
-        target = row1[0]
-        i = table2.find_row(target)
-        if i < 0:
-            print(f'** {target} NOT found in {table2.name}')
+    for job1 in log1.jobs:
+        job_printed = False
+        try:
+            job2 = next(job for job in log2.jobs if job.name == job1.name)
+        except StopIteration:
+            print(f'** job "{job1.name}" not found in "{log2.name}"')
             continue
-        row2 = table2.rows.pop(i)
-        if row2 == row1:
-            continue
-
-        diff_table = Table(target)
-
-        data = {'log': table1.name}
-        for k, v in zip(table1.headings[1:], row1[1:]):
-            data[k] = v
-        diff_table.append(data)
-        data = {'log': table2.name}
-        for k, v in zip(table2.headings[1:], row2[1:]):
-            data[k] = v
-        diff_table.append(data)
-
-        data = {'log': 'Difference'}
-        for name, v1, v2 in zip(table1.headings[1:], row1[1:], row2[1:]):
-            if v1 == v2:
+        table1 = job1.table
+        table2 = job2.table
+        for row1 in table1.rows:
+            target = row1[0]
+            i = table2.find_row(target)
+            if i < 0:
+                print(f'** {target} NOT found in {table2.caption}')
                 continue
-            v1, v2 = int(v1, 0), int(v2, 0)
-            data[name] = f'{v2-v1:+}'
-        diff_table.append(data)
+            row2 = table2.rows.pop(i)
+            if row2 == row1:
+                continue
 
-        print_table(diff_table)
+            diff_table = Table()
+
+            data = {'log': job1.log.name}
+            for k, v in zip(table1.headings[1:], row1[1:]):
+                data[k] = v
+            diff_table.append(data)
+            data = {'log': job2.log.name}
+            for k, v in zip(table2.headings[1:], row2[1:]):
+                data[k] = v
+            diff_table.append(data)
+
+            data = {'log': 'Difference'}
+            for name, v1, v2 in zip(table1.headings[1:], row1[1:], row2[1:]):
+                if v1 == v2:
+                    continue
+                v1, v2 = int(v1, 0), int(v2, 0)
+                data[name] = f'{v2-v1:+}'
+            diff_table.append(data)
+
+            if not job_printed:
+                print(f'{job1.name}:')
+                job_printed = True
+            print_table(diff_table)
 
     if table2.rows:
-        print(f'** Targets not in {table1.name}')
+        print(f'** Targets not in {job1.name}')
         print_table(table2)
 
 

--- a/Tools/ci/warn-exclude.lst
+++ b/Tools/ci/warn-exclude.lst
@@ -1,0 +1,7 @@
+esp-idf/.*
+Libraries/Adafruit_VL53L0X/.*
+Libraries/Arduino_TensorFlowLite/.*
+Libraries/jerryscript/jerryscript/.*
+Libraries/NimBLE/esp-nimble-cpp/.*
+samples/.*\[-Wunused-parameter\]
+.*\.c.*\[-Wimplicit-fallthrough\]

--- a/samples/Basic_DateTime/app/application.cpp
+++ b/samples/Basic_DateTime/app/application.cpp
@@ -73,7 +73,7 @@ void showTime(const DateTime& dt)
 	print(F("toShortTimeString"), dt.toShortTimeString());
 }
 
-void onRx(Stream& source, char arrivedChar, unsigned short availableCharsCount)
+void onRx(Stream& source, char, uint16_t)
 {
 	static LineBuffer<32> buffer;
 

--- a/samples/Basic_Ota/app/application.cpp
+++ b/samples/Basic_Ota/app/application.cpp
@@ -29,7 +29,7 @@ Storage::Partition findSpiffsPartition(Storage::Partition appPart)
 	return part;
 }
 
-void upgradeCallback(Ota::Network::HttpUpgrader& client, bool result)
+void upgradeCallback(Ota::Network::HttpUpgrader&, bool result)
 {
 	Serial.println(_F("In callback..."));
 	if(result == true) {
@@ -215,7 +215,7 @@ void handleCommand(const String& str)
 	Serial << _F("unknown command: ") << str << endl;
 }
 
-void serialCallBack(Stream& stream, char arrivedChar, unsigned short availableCharsCount)
+void serialCallBack(Stream& stream, char, uint16_t)
 {
 	switch(commandBuffer.process(stream, Serial)) {
 	case LineBufferBase::Action::submit:

--- a/samples/WebcamServer/app/application.cpp
+++ b/samples/WebcamServer/app/application.cpp
@@ -19,7 +19,7 @@ FakeCamera* camera;
  * default http handler to check if server is up and running
  */
 
-void onIndex(HttpRequest& request, HttpResponse& response)
+void onIndex(HttpRequest&, HttpResponse& response)
 {
 	response.sendFile(_F("index.html"));
 }

--- a/samples/Websocket_Client/app/application.cpp
+++ b/samples/Websocket_Client/app/application.cpp
@@ -41,20 +41,20 @@ DEFINE_FSTR_LOCAL(ws_Url, WS_URL);
 
 void sendNewMessage();
 
-void wsConnected(WebsocketConnection& wsConnection)
+void wsConnected(WebsocketConnection&)
 {
 	Serial << _F("Start sending messages every ") << MESSAGE_INTERVAL << _F(" second(s)...") << endl;
 	msgTimer.initializeMs<MESSAGE_INTERVAL * 1000>(sendNewMessage);
 	msgTimer.startOnce();
 }
 
-void wsMessageReceived(WebsocketConnection& wsConnection, const String& message)
+void wsMessageReceived(WebsocketConnection&, const String& message)
 {
 	Serial << _F("WebSocket message received: ") << message << endl;
 	Serial << _F("Free Heap: ") << system_get_free_heap_size() << endl;
 }
 
-void wsBinReceived(WebsocketConnection& wsConnection, uint8_t* data, size_t size)
+void wsBinReceived(WebsocketConnection&, uint8_t* data, size_t size)
 {
 	m_printHex(_F("WebSocket BINARY received"), data, size);
 	Serial << _F("Free Heap: ") << system_get_free_heap_size() << endl;
@@ -69,7 +69,7 @@ void restart()
 	wsClient.connect(String(ws_Url));
 }
 
-void wsDisconnected(WebsocketConnection& wsConnection)
+void wsDisconnected(WebsocketConnection&)
 {
 	Serial << _F("Restarting websocket client after ") << RESTART_PERIOD << _F(" seconds") << endl;
 	msgTimer.initializeMs<RESTART_PERIOD * 1000>(restart);

--- a/tests/HostTests/app/application.cpp
+++ b/tests/HostTests/app/application.cpp
@@ -68,7 +68,7 @@ void init()
 	} else {
 		WifiStation.enable(true);
 		WifiStation.config(WIFI_SSID, WIFI_PWD);
-		WifiEvents.onStationGotIP([](IpAddress ip, IpAddress netmask, IpAddress gateway) { beginTests(); });
+		WifiEvents.onStationGotIP([](IpAddress, IpAddress, IpAddress) { beginTests(); });
 	}
 #endif
 }

--- a/tests/HostTests/modules/ArduinoString.cpp
+++ b/tests/HostTests/modules/ArduinoString.cpp
@@ -304,7 +304,9 @@ public:
 			}
 		}
 
-		auto repl = [](const String& key, const String& val, String& s, boolean useURLencode) { s.replace(key, val); };
+		auto repl = [](const String& key, const String& val, String& s, [[maybe_unused]] boolean useURLencode) {
+			s.replace(key, val);
+		};
 
 		TEST_CASE("String SSO handles junk in memory", "[core][String]")
 		{

--- a/tests/HostTests/modules/Network/Arch/Host/Hosted.cpp
+++ b/tests/HostTests/modules/Network/Arch/Host/Hosted.cpp
@@ -62,7 +62,7 @@ public:
 		parsedCommand = "";
 	}
 
-	void methodSignature(char c) override
+	void methodSignature(char) override
 	{
 	}
 

--- a/tests/HostTests/modules/Network/Arch/Host/HttpRequest.cpp
+++ b/tests/HostTests/modules/Network/Arch/Host/HttpRequest.cpp
@@ -70,7 +70,7 @@ public:
 		url.Path = String('/') + file.name;
 
 		auto req = new HttpRequest(url);
-		req->onRequestComplete([this, file](HttpConnection& connection, bool success) -> int {
+		req->onRequestComplete([this, file](HttpConnection& connection, bool) -> int {
 			auto response = connection.getResponse();
 			debug_i("Client received '%s'", connection.getRequest()->uri.toString().c_str());
 			Serial.print(response->toString());

--- a/tests/HostTests/modules/Network/Arch/Host/TcpClient.cpp
+++ b/tests/HostTests/modules/Network/Arch/Host/TcpClient.cpp
@@ -24,11 +24,11 @@ public:
 
 		// Tcp Server
 		server = new TcpServer(
-			[this](TcpClient& client, char* data, int size) -> bool {
+			[this](TcpClient&, char* data, int size) -> bool {
 				// on data
 				return receivedData.concat(data, size);
 			},
-			[this, inputData](TcpClient& client, bool successful) {
+			[this, inputData](TcpClient&, bool successful) {
 				// on client close
 				if(finished) {
 					return;
@@ -43,7 +43,7 @@ public:
 		server->setKeepAlive(USHRT_MAX); // disable connection timeout
 
 		// Tcp Client
-		SMING_UNUSED bool connected = client.connect(WifiStation.getIP(), port);
+		[[maybe_unused]] bool connected = client.connect(WifiStation.getIP(), port);
 		debug_d("Connected: %d", connected);
 
 		TEST_CASE("TcpClient::send stream")

--- a/tests/HostTests/modules/Network/Http.cpp
+++ b/tests/HostTests/modules/Network/Http.cpp
@@ -45,7 +45,7 @@ public:
 		}
 	}
 
-	static void printHeaders(const HttpHeaders& headers)
+	static void printHeaders([[maybe_unused]] const HttpHeaders& headers)
 	{
 #if DEBUG_VERBOSE_LEVEL == DBG
 		Serial << _F("  count: ") << headers.count() << endl;

--- a/tests/HostTests/modules/Storage.cpp
+++ b/tests/HostTests/modules/Storage.cpp
@@ -33,12 +33,12 @@ public:
 		return true;
 	}
 
-	bool write(storage_size_t address, const void* src, size_t size) override
+	bool write(storage_size_t, const void*, size_t) override
 	{
 		return false;
 	}
 
-	bool erase_range(storage_size_t address, storage_size_t size) override
+	bool erase_range(storage_size_t, storage_size_t) override
 	{
 		return false;
 	}

--- a/tests/HostTests/modules/String.cpp
+++ b/tests/HostTests/modules/String.cpp
@@ -19,7 +19,7 @@ public:
 		testMakeHexString();
 	}
 
-	template <typename T> void templateTest(T x)
+	template <typename T> void templateTest(T)
 	{
 #ifndef ARCH_HOST
 		auto pstr = PSTR("This PSTR should get moved out of RAM, filtered by __pstr__ in symbol name.");


### PR DESCRIPTION
**Move sanitizers to main build, add BUILD_VARS**

Although asan/ubsan aren't supported for embedded targets,
there do appear to be more extensive compile-time checks which are useful.
Just be nice at the end and don't try to link anything.

**Remove Windows esp32 `dist` directory after installing tools**

Saves 750+MB from cache (per image; 2 images).

**Build with additional warnings in STRICT, and fix most of them**

Switch statements may fall through: use [[falthrough]] for C++.
There isn't yet a standard for C, though `/* fallthrough */` comments seem to work for some compilers (not all).

Unused parameters. Happens for some code when debug isn't enabled - apply [[maybe_unused]] in C++.
  For others remove parameter name (C++ only), unless it's useful/descriptive.
  For C there is no standard, so just using `(void)` cast statement.
  Leave those which might mask other issues, such as code which isn't yet implemented.
  esp-idf has lots of unused parameter warnings; quench those.

Base class X should be explicitly initialized in the copy constructor

Fix 'type qualifiers ignored on function return type'

Fix use of signed/unsigned types


**Remove unused code from `Wire` library**

`I2Cdev` has similar crud but needs far more work. Leave it.

**Fix Graphics library bugs**

Unused parameter warnings highlighted bugs in `Region` and `SolidBrush` classes.
Make Region constructor explicit.



muldivMaxValue parameter 1 never used, not required

**Update scanlog.py**

There are lots of duplicate warnings in logs, so update this tool to de-duplicate and categorise them by source line.

Support scanning logs obtained via github CLI
Integrate GH fetch
Add Job information
Scan warnings, deduplicate and support filtering
Add README
