### PR TITLE
Add IDF caching for libraries

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -71,7 +71,7 @@ jobs:
     env:
       SMING_ARCH: ${{ matrix.arch }}
       SMING_SOC: ${{ matrix.variant }}
-      INSTALL_IDF_VER: ${{ matrix.idf_version }}
+      INSTALL_IDF_VER: ${{ matrix.idf_version || '5.2' }}
       CLANG_BUILD: ${{ matrix.toolchain == 'clang' && '15' || '0' }}
       BUILD64: ${{ matrix.toolchain == 'gcc64' && 1 || 0 }}
 
@@ -101,37 +101,47 @@ jobs:
     - name: Configure environment
       shell: pwsh
       run: |
+        "CI_BUILD_DIR=" + (Resolve-Path ".").path >> $env:GITHUB_ENV
         "SMING_HOME=" + (Resolve-Path "../../sming/Sming").path >> $env:GITHUB_ENV
         "COMPONENT_SEARCH_DIRS=" + (Resolve-Path "..").path >> $env:GITHUB_ENV
         "CI_MAKEFILE=" + (Resolve-Path "../../sming/Tools/ci/library/Makefile") >> $env:GITHUB_ENV
 
-    - name: Install build tools for Ubuntu
-      if: ${{ matrix.os ==  'ubuntu-latest' }}
+    - name: Fix permissions
+      if: ${{ matrix.os != 'windows-latest' }}
       run: |
-        $SMING_HOME/../Tools/ci/install.sh
+        sudo chown $USER /opt
 
-    - name: Install build tools for MacOS
-      if: ${{ matrix.os == 'macos-latest' }}
+    - name: Cache ESP-IDF
+      if: ${{ matrix.arch == 'Esp32' }}
+      uses: actions/cache@v4
+      with:
+        path: /opt/esp-idf-${{ env.INSTALL_IDF_VER }}
+        key: idf-${{ env.INSTALL_IDF_VER }}
+        enableCrossOsArchive: true
+
+    - name: Cache IDF build tools
+      if: ${{ matrix.arch == 'Esp32' }}
+      uses: actions/cache@v4
+      with:
+        path: /opt/esp32
+        key: ${{ matrix.os }}-esp32-${{ env.INSTALL_IDF_VER }}
+
+    - name: Install build tools for Ubuntu / MacOS
+      if: ${{ matrix.os != 'windows-latest' }}
       run: |
         $SMING_HOME/../Tools/ci/install.sh
 
     - name: Install build tools for Windows   
-      if: ${{ matrix.os ==  'windows-latest' }}
+      if: ${{ matrix.os == 'windows-latest' }}
       run: |
         cd $env:SMING_HOME/..
         . Tools/ci/setenv.ps1
         Tools/ci/install.cmd
 
-    - name: Build and Test for ${{matrix.arch}} on Ubuntu
+    - name: Build and Test for ${{matrix.arch}} on Ubuntu / MacOS
       env:
         CLANG_FORMAT: clang-format-8
-      if: ${{ matrix.os == 'ubuntu-latest' }}
-      run: |
-        source $SMING_HOME/../Tools/export.sh
-        make -j$(nproc) -f $CI_MAKEFILE
-
-    - name: Build and test for ${{matrix.variant}} on MacOS
-      if: ${{ matrix.os == 'macos-latest' }}
+      if: ${{ matrix.os != 'windows-latest' }}
       run: |
         source $SMING_HOME/../Tools/export.sh
         make -j$(nproc) -f $CI_MAKEFILE

--- a/Sming/Libraries/MultipartParser/src/HttpMultipartResource.cpp
+++ b/Sming/Libraries/MultipartParser/src/HttpMultipartResource.cpp
@@ -12,7 +12,7 @@
 
 #include "HttpMultipartResource.h"
 
-int HttpMultipartResource::setFileMap(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response)
+int HttpMultipartResource::setFileMap(HttpServerConnection&, HttpRequest& request, HttpResponse& response)
 {
 	String contentType = request.headers[HTTP_HEADER_CONTENT_TYPE];
 	String mimeType = toString(MIME_FORM_MULTIPART);
@@ -23,8 +23,4 @@ int HttpMultipartResource::setFileMap(HttpServerConnection& connection, HttpRequ
 	mapper(request.files);
 
 	return 0;
-}
-
-void HttpMultipartResource::shutdown(HttpServerConnection& connection)
-{
 }

--- a/Sming/Libraries/MultipartParser/src/HttpMultipartResource.h
+++ b/Sming/Libraries/MultipartParser/src/HttpMultipartResource.h
@@ -50,7 +50,9 @@ public:
 	 */
 	virtual int setFileMap(HttpServerConnection& connection, HttpRequest& request, HttpResponse& response);
 
-	void shutdown(HttpServerConnection& connection) override;
+	void shutdown(HttpServerConnection&) override
+	{
+	}
 
 private:
 	HttpFilesMapper mapper;

--- a/Sming/Libraries/SwitchJoycon/src/SwitchJoycon.h
+++ b/Sming/Libraries/SwitchJoycon/src/SwitchJoycon.h
@@ -121,7 +121,7 @@ public:
 	void resetButtons();
 
 protected:
-	virtual void onStarted(NimBLEServer* pServer){};
+	virtual void onStarted(NimBLEServer*){};
 
 private:
 	bool started{false};

--- a/Sming/Libraries/nanopb/src/Callback.cpp
+++ b/Sming/Libraries/nanopb/src/Callback.cpp
@@ -25,7 +25,7 @@ bool OutputCallback::encode(pb_ostream_t* stream, const pb_field_t* field)
 	return pb_encode_string(stream, data, length);
 }
 
-bool InputCallback::decode(pb_istream_t* stream, const pb_field_t* field)
+bool InputCallback::decode(pb_istream_t* stream, const pb_field_t*)
 {
 	size_t available = stream->bytes_left;
 	auto new_buf = realloc(data, length + available);

--- a/Sming/Libraries/nanopb/src/Stream.cpp
+++ b/Sming/Libraries/nanopb/src/Stream.cpp
@@ -24,7 +24,7 @@ bool InputStream::decode(const pb_msgdesc_t* fields, void* dest_struct)
 	is.callback = [](pb_istream_t* stream, pb_byte_t* buf, size_t count) -> bool {
 		auto self = static_cast<InputStream*>(stream->state);
 		assert(self != nullptr);
-		size_t read = self->stream.readBytes(reinterpret_cast<char*>(buf), count);
+		self->stream.readBytes(reinterpret_cast<char*>(buf), count);
 		return true;
 	};
 	is.state = this;

--- a/Sming/Libraries/nanopb/src/include/Protobuf/Stream.h
+++ b/Sming/Libraries/nanopb/src/include/Protobuf/Stream.h
@@ -63,7 +63,7 @@ protected:
 class DummyOutputStream : public OutputStream
 {
 protected:
-	bool write(const pb_byte_t* buf, size_t count) override
+	bool write(const pb_byte_t*, size_t) override
 	{
 		return true;
 	}

--- a/Tools/ci/README.rst
+++ b/Tools/ci/README.rst
@@ -55,10 +55,28 @@ To explicitly specify the repository to fetch from::
 
 To list all source locations with warnings::
 
-      python3 scanlog.py last-build.txt -w
+      python3 scanlog.py last-build.txt -w -m
+
+Note: The 'm' flag merges warnings from all jobs. Omitting this shows warnings for each job separately.
 
 To filter out warnings::
 
-      python3 scanlog.py last-build.txt -w --exclude warn-exclude.lst
+      python3 scanlog.py last-build.txt -w -m --exclude warn-exclude.lst
 
 The named exclusion file contains a list of regular expressions to match against.
+
+
+vscode
+------
+
+The warnings output using the scanlog tool can be used as hyperlinks in vscode:
+
+- Select a project, e.g. ``tests/HostTests`` and run ``make ide-vscode``
+- Open the resulting workspace in vscode
+- Add the ``sming`` folder to the project
+- Open an integrated terminal and dump the warnings as shown above.
+  Or, redirect them into a file and ``cat`` it.
+
+The file locations act as links to the source.
+Note that this isn't perfect. For example, esp-idf paths are not resolved to the specific version in use.
+Listing warnings for each job can be helpful as it shows which IDF version was used.

--- a/Tools/ci/scanlog.py
+++ b/Tools/ci/scanlog.py
@@ -124,18 +124,20 @@ class PathPrefix:
         '/d/a/Sming/Sming/Sming/',
         'd:/a/Sming/Sming/projects/',
         'd:/a/Sming/Sming/Sming/',
-        'c:/tools/',
     ]
-    re_prefix = re.compile('|'.join(f'^{s}' for s in IGNORE_PREFIX), re.IGNORECASE)
+    re_remove = re.compile('|'.join(f'^{s}' for s in IGNORE_PREFIX), re.IGNORECASE)
+    re_subst = re.compile(r'^d:/opt/esp-idf-\d.\d', re.IGNORECASE)
 
     @staticmethod
-    def remove(line: str) -> str:
-        return PathPrefix.re_prefix.sub('', line)
+    def normalise(line: str) -> str:
+        s = PathPrefix.re_remove.sub('', line)
+        s = PathPrefix.re_subst.sub('esp-idf', s)
+        return s
 
 
 def normalise_path(line: str) -> str:
     line = line.replace('\\', '/')
-    line = PathPrefix.remove(line)
+    line = PathPrefix.normalise(line)
     return os.path.normpath(line)
 
 

--- a/Tools/ci/warn-exclude.lst
+++ b/Tools/ci/warn-exclude.lst
@@ -3,5 +3,5 @@ Libraries/Adafruit_VL53L0X/.*
 Libraries/Arduino_TensorFlowLite/.*
 Libraries/jerryscript/jerryscript/.*
 Libraries/NimBLE/esp-nimble-cpp/.*
-samples/.*\[-Wunused-parameter\]
+(^|.*/)samples/.*\[-Wunused-parameter\]
 .*\.c.*\[-Wimplicit-fallthrough\]

--- a/samples/Basic_Audio/app/application.cpp
+++ b/samples/Basic_Audio/app/application.cpp
@@ -149,7 +149,7 @@ void checkReceive()
 	debug_i("RX: %u bytes", total);
 }
 
-void IRAM_ATTR i2sCallback(void* param, i2s_event_type_t event)
+void IRAM_ATTR i2sCallback(void*, i2s_event_type_t event)
 {
 	// For this sample, process the data in task context
 	switch(event) {


### PR DESCRIPTION
Cache esp-idf and tools for library builds. Be nice if we could use the cache from `SmingHub/Sming` directly but that sort of cross-repo sharing isn't supported.

Scanlog tool:

- Fix scanlog tool windows path normalisation - didn't account for change from c:/tools/ to d:/opt/, and that Windows idf path contains version.
- Print warnings for each job by default, add 'm' flag to merge them

Also fix a few more warnings.