### PR TITLE
More code quality fixes

### DIFF
--- a/Sming/Arch/Esp32/Platform/RTC.cpp
+++ b/Sming/Arch/Esp32/Platform/RTC.cpp
@@ -24,9 +24,7 @@ uint64_t clockOffset;
 
 } // namespace
 
-RtcClass::RtcClass()
-{
-}
+RtcClass::RtcClass() = default;
 
 uint64_t RtcClass::getRtcNanoseconds()
 {

--- a/Sming/Arch/Esp32/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Esp32/Services/Profiling/TaskStat.cpp
@@ -34,9 +34,7 @@ TaskStat::TaskStat(Print& out) : out(out)
 #endif
 }
 
-TaskStat::~TaskStat()
-{
-}
+TaskStat::~TaskStat() = default;
 
 bool TaskStat::update()
 {

--- a/Sming/Arch/Esp8266/Platform/RTC.cpp
+++ b/Sming/Arch/Esp8266/Platform/RTC.cpp
@@ -11,7 +11,7 @@
 #include <Platform/RTC.h>
 #include <esp_systemapi.h>
 #include <sys/time.h>
-#include <errno.h>
+#include <cerrno>
 
 RtcClass RTC;
 

--- a/Sming/Arch/Esp8266/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Esp8266/Services/Profiling/TaskStat.cpp
@@ -19,9 +19,7 @@ TaskStat::TaskStat(Print& out) : out(out)
 {
 }
 
-TaskStat::~TaskStat()
-{
-}
+TaskStat::~TaskStat() = default;
 
 bool TaskStat::update()
 {

--- a/Sming/Arch/Host/Components/driver/adc.cpp
+++ b/Sming/Arch/Host/Components/driver/adc.cpp
@@ -1,5 +1,5 @@
 #include <driver/adc.h>
-#include <string.h>
+#include <cstring>
 #include <esp_system.h>
 
 uint16_t system_adc_read(void)

--- a/Sming/Arch/Host/Components/gdbstub/gdb_syscall.cpp
+++ b/Sming/Arch/Host/Components/gdbstub/gdb_syscall.cpp
@@ -1,5 +1,5 @@
 #include <gdb/gdb_syscall.h>
-#include <errno.h>
+#include <cerrno>
 
 int gdb_syscall(const GdbSyscallInfo&)
 {

--- a/Sming/Arch/Host/Components/hostlib/keyb.cpp
+++ b/Sming/Arch/Host/Components/hostlib/keyb.cpp
@@ -19,9 +19,9 @@
 
 #include "keyb.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <ctype.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cctype>
 
 #ifdef __WIN32
 

--- a/Sming/Arch/Host/Components/hostlib/options.cpp
+++ b/Sming/Arch/Host/Components/hostlib/options.cpp
@@ -20,8 +20,8 @@
 #include "options.h"
 #include "include/hostlib/hostmsg.h"
 #include <getopt.h>
-#include <string.h>
-#include <stdlib.h>
+#include <cstring>
+#include <cstdlib>
 
 struct option_help_t {
 	const char* brief;

--- a/Sming/Arch/Host/Components/hostlib/sockets.cpp
+++ b/Sming/Arch/Host/Components/hostlib/sockets.cpp
@@ -19,7 +19,7 @@
 
 #include "sockets.h"
 #include "include/hostlib/hostmsg.h"
-#include <string.h>
+#include <cstring>
 
 #ifndef __WIN32
 // For FIONREAD

--- a/Sming/Arch/Host/Components/hostlib/startup.cpp
+++ b/Sming/Arch/Host/Components/hostlib/startup.cpp
@@ -31,7 +31,7 @@
 #include <driver/os_timer.h>
 #include <driver/hw_timer.h>
 #include <esp_tasks.h>
-#include <stdlib.h>
+#include <cstdlib>
 #include "include/hostlib/emu.h"
 #include "include/hostlib/hostlib.h"
 #include "include/hostlib/CommandLine.h"

--- a/Sming/Arch/Host/Components/hostlib/threads.cpp
+++ b/Sming/Arch/Host/Components/hostlib/threads.cpp
@@ -20,9 +20,9 @@
 #include "threads.h"
 #include <cstring>
 #include <cstdarg>
-#include <signal.h>
+#include <csignal>
 #include <sys/time.h>
-#include <errno.h>
+#include <cerrno>
 
 unsigned CThread::interrupt_mask;
 

--- a/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
+++ b/Sming/Arch/Host/Components/spi_flash/flashmem.cpp
@@ -19,7 +19,7 @@
 
 #include <hostlib/hostlib.h>
 #include "flashmem.h"
-#include <string.h>
+#include <cstring>
 #include <esp_spi_flash.h>
 #include <IFS/File.h>
 #include <hostlib/hostmsg.h>

--- a/Sming/Arch/Host/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Host/Core/HardwarePWM.cpp
@@ -29,9 +29,7 @@ HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_o
 {
 }
 
-HardwarePWM::~HardwarePWM()
-{
-}
+HardwarePWM::~HardwarePWM() = default;
 
 uint8_t HardwarePWM::getChannel(uint8_t pin)
 {

--- a/Sming/Arch/Host/Platform/RTC.cpp
+++ b/Sming/Arch/Host/Platform/RTC.cpp
@@ -19,9 +19,7 @@ namespace
 int timeDiff; // Difference between set time and system time
 }
 
-RtcClass::RtcClass()
-{
-}
+RtcClass::RtcClass() = default;
 
 uint64_t RtcClass::getRtcNanoseconds()
 {

--- a/Sming/Arch/Host/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Host/Services/Profiling/TaskStat.cpp
@@ -19,9 +19,7 @@ TaskStat::TaskStat(Print& out) : out(out)
 {
 }
 
-TaskStat::~TaskStat()
-{
-}
+TaskStat::~TaskStat() = default;
 
 bool TaskStat::update()
 {

--- a/Sming/Arch/Rp2040/Platform/RTC.cpp
+++ b/Sming/Arch/Rp2040/Platform/RTC.cpp
@@ -26,9 +26,7 @@ void system_init_rtc()
 	rtc_set_datetime(&t);
 }
 
-RtcClass::RtcClass()
-{
-}
+RtcClass::RtcClass() = default;
 
 uint64_t RtcClass::getRtcNanoseconds()
 {

--- a/Sming/Arch/Rp2040/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Rp2040/Services/Profiling/TaskStat.cpp
@@ -19,9 +19,7 @@ TaskStat::TaskStat(Print& out) : out(out)
 {
 }
 
-TaskStat::~TaskStat()
-{
-}
+TaskStat::~TaskStat() = default;
 
 bool TaskStat::update()
 {

--- a/Sming/Components/Hosted/include/Hosted/Transport/BaseTransport.h
+++ b/Sming/Components/Hosted/include/Hosted/Transport/BaseTransport.h
@@ -23,9 +23,7 @@ class BaseTransport
 public:
 	using DataHandler = Delegate<bool(Stream&)>;
 
-	virtual ~BaseTransport()
-	{
-	}
+	virtual ~BaseTransport() = default;
 
 	void onData(DataHandler handler)
 	{

--- a/Sming/Components/Network/src/IpAddress.h
+++ b/Sming/Components/Network/src/IpAddress.h
@@ -50,9 +50,7 @@ private:
 
 public:
 	// Constructors
-	IpAddress()
-	{
-	}
+	IpAddress() = default;
 
 	IpAddress(uint8_t first_octet, uint8_t second_octet, uint8_t third_octet, uint8_t fourth_octet)
 	{

--- a/Sming/Components/Network/src/Network/Http/HttpClient.h
+++ b/Sming/Components/Network/src/Network/Http/HttpClient.h
@@ -35,9 +35,7 @@ public:
 	 * 		1. Delete all instances of HttpClient
 	 * 		2. Call the static method HttpClient::cleanup();
 	*/
-	virtual ~HttpClient()
-	{
-	}
+	virtual ~HttpClient() = default;
 
 	/* High-Level Methods */
 

--- a/Sming/Components/Network/src/Network/Http/HttpRequest.h
+++ b/Sming/Components/Network/src/Network/Http/HttpRequest.h
@@ -39,9 +39,7 @@ class HttpRequest
 	friend class HttpServerConnection;
 
 public:
-	HttpRequest()
-	{
-	}
+	HttpRequest() = default;
 
 	HttpRequest(const Url& uri) : uri(uri)
 	{

--- a/Sming/Components/Network/src/Network/Http/HttpRequestAuth.h
+++ b/Sming/Components/Network/src/Network/Http/HttpRequestAuth.h
@@ -19,9 +19,7 @@ class HttpRequest;
 class AuthAdapter
 {
 public:
-	virtual ~AuthAdapter()
-	{
-	}
+	virtual ~AuthAdapter() = default;
 
 	virtual void setRequest(HttpRequest* request) = 0;
 

--- a/Sming/Components/Network/src/Network/Http/HttpResource.h
+++ b/Sming/Components/Network/src/Network/Http/HttpResource.h
@@ -33,9 +33,7 @@ using HttpResourceDelegate =
 class HttpResource
 {
 public:
-	virtual ~HttpResource()
-	{
-	}
+	virtual ~HttpResource() = default;
 
 	/**
 	 * @brief Takes care to cleanup the connection

--- a/Sming/Components/Network/src/Platform/AccessPoint.h
+++ b/Sming/Components/Network/src/Platform/AccessPoint.h
@@ -34,9 +34,7 @@
 class AccessPointClass
 {
 public:
-	virtual ~AccessPointClass()
-	{
-	}
+	virtual ~AccessPointClass() = default;
 
 	/** @brief  Enable or disable WiFi AP
      *  @param  enabled True to enable AP. False to disable.

--- a/Sming/Components/Network/src/Platform/Station.h
+++ b/Sming/Components/Network/src/Platform/Station.h
@@ -119,9 +119,7 @@ public:
 		bool save = true;				  ///< Store new settings in NV memory
 	};
 
-	virtual ~StationClass()
-	{
-	}
+	virtual ~StationClass() = default;
 
 	/**	@brief	Enable / disable WiFi station
 	 *	@note	Disabling WiFi station will also disable and clear the handler set with <i>waitConnection</i>.

--- a/Sming/Components/Network/src/Platform/StationList.h
+++ b/Sming/Components/Network/src/Platform/StationList.h
@@ -36,9 +36,7 @@ public:
 class StationList : public OwnedLinkedObjectListTemplate<StationInfo>
 {
 public:
-	virtual ~StationList()
-	{
-	}
+	virtual ~StationList() = default;
 };
 
 /** @} */

--- a/Sming/Components/Storage/src/Debug.cpp
+++ b/Sming/Components/Storage/src/Debug.cpp
@@ -2,9 +2,7 @@
 #include "include/Storage.h"
 #include "include/Storage/SpiFlash.h"
 
-namespace Storage
-{
-namespace Debug
+namespace Storage::Debug
 {
 void listPartitions(Print& out)
 {
@@ -49,5 +47,4 @@ void listDevices(Print& out, bool fullPartitionInfo)
 	out.println();
 }
 
-} // namespace Debug
-} // namespace Storage
+} // namespace Storage::Debug

--- a/Sming/Components/Storage/src/include/Storage/Debug.h
+++ b/Sming/Components/Storage/src/include/Storage/Debug.h
@@ -3,13 +3,10 @@
 #include <Print.h>
 #include "Partition.h"
 
-namespace Storage
-{
-namespace Debug
+namespace Storage::Debug
 {
 void listPartitions(Print& out);
 void listPartitions(Print& out, const Device& device);
 void listDevices(Print& out, bool fullPartitionInfo = true);
 
-} // namespace Debug
-} // namespace Storage
+} // namespace Storage::Debug

--- a/Sming/Components/Storage/src/include/Storage/Partition.h
+++ b/Sming/Components/Storage/src/include/Storage/Partition.h
@@ -188,9 +188,7 @@ public:
 		uint8_t subtype{SubType::invalid};
 		Flags flags;
 
-		Info()
-		{
-		}
+		Info() = default;
 
 		Info(const String& name, FullType fullType, storage_size_t offset, storage_size_t size, Flags flags = 0)
 			: name(name), offset(offset), size(size), type(fullType.type), subtype(fullType.subtype), flags(flags)
@@ -215,13 +213,9 @@ public:
 		size_t printTo(Print& p) const override;
 	};
 
-	Partition()
-	{
-	}
+	Partition() = default;
 
-	Partition(const Partition& other) : mDevice(other.mDevice), mPart(other.mPart)
-	{
-	}
+	Partition(const Partition& other) = default;
 
 	Partition(Partition&& other) = default;
 
@@ -229,9 +223,7 @@ public:
 	{
 	}
 
-	~Partition()
-	{
-	}
+	~Partition() = default;
 
 	Partition& operator=(const Partition& other) = default;
 	Partition& operator=(Partition&& other) = default;

--- a/Sming/Components/crypto/src/sha2.h
+++ b/Sming/Components/crypto/src/sha2.h
@@ -22,11 +22,7 @@
 #include "stdhash.h"
 #include "../include/Crypto/HashApi/sha2.h"
 
-namespace Crypto
-{
-namespace Internal
-{
-namespace sha2
+namespace Crypto::Internal::sha2
 {
 template <typename T> __forceinline T CH(T x, T y, T z)
 {
@@ -160,6 +156,4 @@ __forceinline void process(T state[], const uint8_t block[], const T k[])
 	state[7] += h;
 }
 
-} // namespace sha2
-} // namespace Internal
-} // namespace Crypto
+} // namespace Crypto::Internal::sha2

--- a/Sming/Components/crypto/src/stdhash.h
+++ b/Sming/Components/crypto/src/stdhash.h
@@ -16,9 +16,7 @@
 
 using namespace Crypto::Internal;
 
-namespace Crypto
-{
-namespace Internal
+namespace Crypto::Internal
 {
 /**
  * @brief Block hash operation transposes incoming block of data into state
@@ -109,5 +107,4 @@ void hashFinal(const Context* ctx, HashProcess<T> process, decltype(Context::sta
 	process(digest, buf);
 }
 
-} // namespace Internal
-} // namespace Crypto
+} // namespace Crypto::Internal

--- a/Sming/Components/crypto/src/util.h
+++ b/Sming/Components/crypto/src/util.h
@@ -14,9 +14,7 @@
 #include <stringutil.h>
 #include <sming_attr.h>
 
-namespace Crypto
-{
-namespace Internal
+namespace Crypto::Internal
 {
 /*
  * Common operations
@@ -134,5 +132,4 @@ template <typename T> void clean(T& t)
 	}
 }
 
-} // namespace Internal
-} // namespace Crypto
+} // namespace Crypto::Internal

--- a/Sming/Components/lwip/src/Arch/Host/Linux/lwip_arch.cpp
+++ b/Sming/Components/lwip/src/Arch/Host/Linux/lwip_arch.cpp
@@ -26,7 +26,7 @@
 #include <lwip/timeouts.h>
 #include <cstring>
 #include <ifaddrs.h>
-#include <errno.h>
+#include <cerrno>
 #include <net/if.h>
 #include <netinet/in.h>
 #include <sys/ioctl.h>

--- a/Sming/Components/simpleRPC/include/simpleRPC/parser.h
+++ b/Sming/Components/simpleRPC/include/simpleRPC/parser.h
@@ -51,9 +51,7 @@ enum class ParserState {
 class ParserCallbacks
 {
 public:
-	virtual ~ParserCallbacks()
-	{
-	}
+	virtual ~ParserCallbacks() = default;
 
 	virtual void startMethods() = 0;
 	virtual void startMethod() = 0;

--- a/Sming/Components/ssl/include/Network/Ssl/Certificate.h
+++ b/Sming/Components/ssl/include/Network/Ssl/Certificate.h
@@ -66,9 +66,7 @@ public:
 			MAX
 	};
 
-	virtual ~Certificate()
-	{
-	}
+	virtual ~Certificate() = default;
 
 	/**
 	 * @brief Obtain certificate fingerprint

--- a/Sming/Components/ssl/include/Network/Ssl/Connection.h
+++ b/Sming/Components/ssl/include/Network/Ssl/Connection.h
@@ -41,9 +41,7 @@ public:
 		assert(tcp != nullptr);
 	}
 
-	virtual ~Connection()
-	{
-	}
+	virtual ~Connection() = default;
 
 	/**
 	 * @brief Checks if the handshake has finished

--- a/Sming/Components/ssl/include/Network/Ssl/Context.h
+++ b/Sming/Components/ssl/include/Network/Ssl/Context.h
@@ -32,9 +32,7 @@ public:
 	{
 	}
 
-	virtual ~Context()
-	{
-	}
+	virtual ~Context() = default;
 
 	/**
 	 * @brief Initializer method that must be called after object creation and before the creation

--- a/Sming/Components/ssl/include/Network/Ssl/Factory.h
+++ b/Sming/Components/ssl/include/Network/Ssl/Factory.h
@@ -23,9 +23,7 @@ namespace Ssl
 class Factory
 {
 public:
-	virtual ~Factory()
-	{
-	}
+	virtual ~Factory() = default;
 
 	/**
 	 * @brief Create SSL context that can be used to create new client or server connections

--- a/Sming/Components/ssl/include/Network/Ssl/Validator.h
+++ b/Sming/Components/ssl/include/Network/Ssl/Validator.h
@@ -29,9 +29,7 @@ namespace Ssl
 class Validator
 {
 public:
-	virtual ~Validator()
-	{
-	}
+	virtual ~Validator() = default;
 
 	virtual bool validate(const Certificate& certificate) = 0;
 };

--- a/Sming/Core/CallbackTimer.h
+++ b/Sming/Core/CallbackTimer.h
@@ -33,9 +33,7 @@ template <typename ApiDef> struct CallbackTimerApi {
 		return ApiDef::typeName();
 	}
 
-	CallbackTimerApi()
-	{
-	}
+	CallbackTimerApi() = default;
 
 	CallbackTimerApi(const CallbackTimerApi&) = delete;
 

--- a/Sming/Core/Data/LinkedObject.h
+++ b/Sming/Core/Data/LinkedObject.h
@@ -21,9 +21,7 @@
 class LinkedObject
 {
 public:
-	virtual ~LinkedObject()
-	{
-	}
+	virtual ~LinkedObject() = default;
 
 	virtual LinkedObject* next() const
 	{

--- a/Sming/Core/Data/LinkedObjectList.h
+++ b/Sming/Core/Data/LinkedObjectList.h
@@ -18,9 +18,7 @@
 class LinkedObjectList
 {
 public:
-	LinkedObjectList()
-	{
-	}
+	LinkedObjectList() = default;
 
 	LinkedObjectList(LinkedObject* object) : mHead(object)
 	{

--- a/Sming/Core/Data/ObjectMap.h
+++ b/Sming/Core/Data/ObjectMap.h
@@ -48,9 +48,7 @@
 template <typename K, typename V> class ObjectMap
 {
 public:
-	ObjectMap()
-	{
-	}
+	ObjectMap() = default;
 
 	~ObjectMap()
 	{

--- a/Sming/Core/Data/ObjectQueue.h
+++ b/Sming/Core/Data/ObjectQueue.h
@@ -25,9 +25,7 @@
 template <typename T, int rawSize> class ObjectQueue : public FIFO<T*, rawSize>
 {
 public:
-	virtual ~ObjectQueue()
-	{
-	}
+	virtual ~ObjectQueue() = default;
 
 	T* peek() const
 	{

--- a/Sming/Core/Data/Range.h
+++ b/Sming/Core/Data/Range.h
@@ -67,9 +67,7 @@ template <typename T> struct TRange {
 		T value;
 	};
 
-	constexpr TRange()
-	{
-	}
+	constexpr TRange() = default;
 
 	constexpr TRange(T min, T max) : min(min), max(max)
 	{

--- a/Sming/Core/Data/Uuid.h
+++ b/Sming/Core/Data/Uuid.h
@@ -36,9 +36,7 @@ struct Uuid {
 	 */
 	static constexpr size_t stringSize = 36;
 
-	constexpr Uuid()
-	{
-	}
+	constexpr Uuid() = default;
 
 	explicit Uuid(const char* s)
 	{

--- a/Sming/Core/Data/WebHelpers/escape.cpp
+++ b/Sming/Core/Data/WebHelpers/escape.cpp
@@ -1,9 +1,9 @@
 /* escape.c - encode/decode URI and HTML style escapes. */
 /* PUBLIC DOMAIN - Jon Mayo - Aug 20, 2007 */
 #include "escape.h"
-#include <stdlib.h>
+#include <cstdlib>
 #include <c_types.h>
-#include <ctype.h>
+#include <cctype>
 
 // Append str to dest with checks
 static unsigned safe_append(char* dest, size_t len, const char* str)

--- a/Sming/Core/DateTime.h
+++ b/Sming/Core/DateTime.h
@@ -183,9 +183,7 @@ public:
 
 	/** @brief  Instantiate an uninitialised date and time object
 	 */
-	DateTime()
-	{
-	}
+	DateTime() = default;
 
 	/** @brief  Instantiate a date and time object from a Unix timestamp
 	 *  @param  time Unix time to assign to object

--- a/Sming/Core/Task.h
+++ b/Sming/Core/Task.h
@@ -53,9 +53,7 @@ public:
 		Waking,
 	};
 
-	virtual ~Task()
-	{
-	}
+	virtual ~Task() = default;
 
 	/**
 	 * @brief Call to set task running

--- a/Sming/Core/Timer.h
+++ b/Sming/Core/Timer.h
@@ -278,9 +278,7 @@ protected:
 	friend OsTimer64Api<AutoDeleteTimer>;
 
 	// Ensures object may only be created on the heap
-	~AutoDeleteTimer()
-	{
-	}
+	~AutoDeleteTimer() = default;
 
 	void expired()
 	{

--- a/Sming/Libraries/AtClient/src/AtClient.h
+++ b/Sming/Libraries/AtClient/src/AtClient.h
@@ -60,9 +60,7 @@ public:
 
 	AtClient(HardwareSerial& stream);
 
-	virtual ~AtClient()
-	{
-	}
+	virtual ~AtClient() = default;
 
 	/**
 	 * @brief Sends AT command

--- a/Sming/Libraries/SPI/src/SPIBase.h
+++ b/Sming/Libraries/SPI/src/SPIBase.h
@@ -54,9 +54,7 @@ public:
 	{
 	}
 
-	virtual ~SPIBase()
-	{
-	}
+	virtual ~SPIBase() = default;
 
 	/**
 	 * @brief Initialize the SPI bus by setting SCK and MOSI to outputs, pulling SCK and MOSI low.

--- a/Sming/Libraries/Servo/ServoChannel.h
+++ b/Sming/Libraries/Servo/ServoChannel.h
@@ -30,9 +30,7 @@ public:
 	{
 	}
 
-	virtual ~ServoChannel()
-	{
-	}
+	virtual ~ServoChannel() = default;
 
 	/** @brief  attach servo channel to a unused pin
      *  @param  pin GPIO to use; pin will be set to output

--- a/Sming/Libraries/Spiffs/src/Error.cpp
+++ b/Sming/Libraries/Spiffs/src/Error.cpp
@@ -25,9 +25,7 @@
 #include <FlashString/Map.hpp>
 #include "../spiffs/src/spiffs.h"
 
-namespace IFS
-{
-namespace SPIFFS
+namespace IFS::SPIFFS
 {
 /*
  * @todo Return generic FSERR codes wherever possible by mapping from SPIFFS codes
@@ -114,5 +112,4 @@ String spiffsErrorToStr(int err)
 	return errorMap[std::min(err, 0)].content();
 }
 
-} // namespace SPIFFS
-} // namespace IFS
+} // namespace IFS::SPIFFS

--- a/Sming/Libraries/Spiffs/src/FileMeta.cpp
+++ b/Sming/Libraries/Spiffs/src/FileMeta.cpp
@@ -22,9 +22,7 @@
 #include "include/IFS/SPIFFS/FileMeta.h"
 #include <IFS/Error.h>
 
-namespace IFS
-{
-namespace SPIFFS
+namespace IFS::SPIFFS
 {
 void* FileMeta::getAttributePtr(AttributeTag tag)
 {
@@ -224,5 +222,4 @@ int SpiffsMetaBuffer::setUserAttribute(unsigned userTag, const void* data, size_
 	return Error::BufferTooSmall;
 }
 
-} // namespace SPIFFS
-} // namespace IFS
+} // namespace IFS::SPIFFS

--- a/Sming/Libraries/Spiffs/src/FileSystem.cpp
+++ b/Sming/Libraries/Spiffs/src/FileSystem.cpp
@@ -23,9 +23,7 @@
 #include "include/IFS/SPIFFS/Error.h"
 #include <IFS/Util.h>
 
-namespace IFS
-{
-namespace SPIFFS
+namespace IFS::SPIFFS
 {
 #define CHECK_MOUNTED()                                                                                                \
 	if(!SPIFFS_mounted(handle())) {                                                                                    \
@@ -885,5 +883,4 @@ int FileSystem::getFilePath(FileID fileid, NameBuffer& buffer)
 	return translateSpiffsError(err);
 }
 
-} // namespace SPIFFS
-} // namespace IFS
+} // namespace IFS::SPIFFS

--- a/Sming/Libraries/Spiffs/src/include/IFS/SPIFFS/Error.h
+++ b/Sming/Libraries/Spiffs/src/include/IFS/SPIFFS/Error.h
@@ -24,9 +24,7 @@
 
 #include <IFS/Types.h>
 
-namespace IFS
-{
-namespace SPIFFS
+namespace IFS::SPIFFS
 {
 inline bool isSpiffsError(int err)
 {
@@ -36,5 +34,4 @@ inline bool isSpiffsError(int err)
 int translateSpiffsError(int spiffs_error);
 
 String spiffsErrorToStr(int err);
-} // namespace SPIFFS
-} // namespace IFS
+} // namespace IFS::SPIFFS

--- a/Sming/Libraries/Spiffs/src/include/IFS/SPIFFS/FileMeta.h
+++ b/Sming/Libraries/Spiffs/src/include/IFS/SPIFFS/FileMeta.h
@@ -23,9 +23,7 @@
 
 #include <IFS/Attribute.h>
 
-namespace IFS
-{
-namespace SPIFFS
+namespace IFS::SPIFFS
 {
 /**
  * @brief Content of SPIFFS metadata area
@@ -121,5 +119,4 @@ struct SpiffsMetaBuffer {
 	int setUserAttribute(unsigned userTag, const void* data, size_t size);
 };
 
-} // namespace SPIFFS
-} // namespace IFS
+} // namespace IFS::SPIFFS

--- a/Sming/Libraries/Spiffs/src/include/IFS/SPIFFS/FileSystem.h
+++ b/Sming/Libraries/Spiffs/src/include/IFS/SPIFFS/FileSystem.h
@@ -48,9 +48,7 @@ extern "C" {
 #include "../../../../spiffs/src/spiffs_nucleus.h"
 }
 
-namespace IFS
-{
-namespace SPIFFS
+namespace IFS::SPIFFS
 {
 /*
  * Wraps SPIFFS
@@ -143,5 +141,4 @@ private:
 	uint8_t cache[CACHE_SIZE];
 };
 
-} // namespace SPIFFS
-} // namespace IFS
+} // namespace IFS::SPIFFS

--- a/Sming/Libraries/WebCam/src/Camera/CameraInterface.h
+++ b/Sming/Libraries/WebCam/src/Camera/CameraInterface.h
@@ -24,9 +24,7 @@ enum CameraState {
 class CameraInterface
 {
 public:
-	virtual ~CameraInterface()
-	{
-	}
+	virtual ~CameraInterface() = default;
 
 	virtual const String getMimeType() const = 0;
 

--- a/Sming/Platform/System.h
+++ b/Sming/Platform/System.h
@@ -55,9 +55,7 @@ using SystemReadyDelegate = TaskDelegate;
 class ISystemReadyHandler
 {
 public:
-	virtual ~ISystemReadyHandler()
-	{
-	}
+	virtual ~ISystemReadyHandler() = default;
 
 	/** @brief  Handle <i>system ready</i> events
 	 */
@@ -100,9 +98,7 @@ enum SystemState {
 class SystemClass
 {
 public:
-	SystemClass()
-	{
-	}
+	SystemClass() = default;
 
 	/** @brief System initialisation
 	 *  @retval bool true on success

--- a/Sming/Services/HexDump/HexDump.h
+++ b/Sming/Services/HexDump/HexDump.h
@@ -12,9 +12,7 @@
 class HexDump
 {
 public:
-	virtual ~HexDump()
-	{
-	}
+	virtual ~HexDump() = default;
 
 	void print(unsigned char* data, int len);
 	void resetAddr();

--- a/Sming/System/stringconversion.cpp
+++ b/Sming/System/stringconversion.cpp
@@ -8,7 +8,7 @@
  *
  ****/
 
-#include <math.h>
+#include <cmath>
 #include <cstdlib>
 #include <cstdint>
 #include <cstring>
@@ -124,9 +124,9 @@ char *dtostrf_p(double floatVar, int minStringWidthIncDecimalPoint, int numDigit
 	if (outputBuffer == nullptr)
 		return nullptr;
 
-	if (isnan(floatVar))
+	if (std::isnan(floatVar))
 		strcpy(outputBuffer, "NaN");
-	else if (isinf(floatVar))
+	else if (std::isinf(floatVar))
 		strcpy(outputBuffer, "Inf");
 	else if (floatVar > 4294967040.0)  // constant determined empirically
 		strcpy(outputBuffer, "OVF");

--- a/Sming/System/stringutil.cpp
+++ b/Sming/System/stringutil.cpp
@@ -14,9 +14,9 @@
  */
 
 #include "stringutil.h"
-#include <stdlib.h>
-#include <string.h>
-#include <ctype.h>
+#include <cstdlib>
+#include <cstring>
+#include <cctype>
 
 const char* strstri(const char* pString, const char* pToken)
 {

--- a/Sming/Wiring/Countable.h
+++ b/Sming/Wiring/Countable.h
@@ -19,18 +19,14 @@
 template <typename T> class Countable
 {
 public:
-	Countable()
-	{
-	}
+	Countable() = default;
 
 	Countable(const Countable&) = delete;
 	Countable(Countable&&) = delete;
 	Countable& operator=(const Countable&) = delete;
 	Countable& operator=(Countable&&) = delete;
 
-	virtual ~Countable()
-	{
-	}
+	virtual ~Countable() = default;
 
 	virtual unsigned int count() const = 0;
 

--- a/Sming/Wiring/Print.h
+++ b/Sming/Wiring/Print.h
@@ -36,16 +36,12 @@
 class Print
 {
 public:
-	Print()
-	{
-	}
+	Print() = default;
 
 	Print(const Print&) = delete;
 	Print(Print&&) = delete;
 
-	virtual ~Print()
-	{
-	}
+	virtual ~Print() = default;
 
 	Print& operator=(const Print&) = delete;
 	Print& operator=(Print&&) = delete;

--- a/Sming/Wiring/Printable.h
+++ b/Sming/Wiring/Printable.h
@@ -42,18 +42,14 @@ class Print;
 class Printable
 {
 public:
-	Printable()
-	{
-	}
+	Printable() = default;
 
 	Printable(const Printable&) = delete;
 	Printable(Printable&&) = delete;
 	Printable& operator=(const Printable&) = delete;
 	Printable& operator=(Printable&&) = delete;
 
-	virtual ~Printable()
-	{
-	}
+	virtual ~Printable() = default;
 
 	virtual size_t printTo(Print& p) const = 0;
 };

--- a/Sming/Wiring/Stream.h
+++ b/Sming/Wiring/Stream.h
@@ -37,9 +37,7 @@ public:
 	virtual int read() = 0;
 	virtual void flush() = 0;
 
-	Stream()
-	{
-	}
+	Stream() = default;
 
 	// parsing methods
 

--- a/Sming/Wiring/WHashMap.h
+++ b/Sming/Wiring/WHashMap.h
@@ -185,9 +185,7 @@ public:
     || | Default constructor
     || #
     */
-	HashMap()
-	{
-	}
+	HashMap() = default;
 
 	/*
     || @constructor

--- a/Sming/Wiring/WString.cpp
+++ b/Sming/Wiring/WString.cpp
@@ -17,7 +17,7 @@
 */
 
 #include "WString.h"
-#include <string.h>
+#include <cstring>
 #include <stringutil.h>
 #include <stringconversion.h>
 #include <cassert>

--- a/Sming/Wiring/WString.h
+++ b/Sming/Wiring/WString.h
@@ -58,7 +58,7 @@
 
 #include "WConstants.h"
 #include <cstddef>
-#include <string.h>
+#include <cstring>
 #include <sming_attr.h>
 
 #include <FlashString/String.hpp>

--- a/Sming/Wiring/WVector.h
+++ b/Sming/Wiring/WVector.h
@@ -54,9 +54,7 @@ public:
 		{
 		}
 
-		~Iterator()
-		{
-		}
+		~Iterator() = default;
 
 		Iterator& operator++()
 		{
@@ -115,9 +113,7 @@ public:
 
 	Vector(Vector&&) = delete;
 
-	~Vector()
-	{
-	}
+	~Vector() = default;
 
 	// methods
 	unsigned int capacity() const

--- a/Sming/Wiring/WiringList.h
+++ b/Sming/Wiring/WiringList.h
@@ -21,9 +21,7 @@ template <typename T> struct ScalarList {
 	T* values{nullptr};
 	size_t size{0};
 
-	ScalarList()
-	{
-	}
+	ScalarList() = default;
 
 	ScalarList(const ScalarList&) = delete;
 	ScalarList(ScalarList&&) = default;

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -243,7 +243,6 @@ ifeq (,$(findstring clang,$(COMPILER_NAME)))
 $(shell LANG=C $(CC) -v)
 $(error Compiler '$(COMPILER_VERSION_FULL)' not recognised. Please install GCC tools.)
 endif
-COMPILER_VERSION_MIN := 14
 ifndef COMPILER_NOTICE_PRINTED
 $(info Note: Building with $(COMPILER_NAME) $(COMPILER_VERSION).)
 COMPILER_NOTICE_PRINTED := 1
@@ -253,6 +252,7 @@ endif
 endif
 
 ifdef USE_CLANG
+COMPILER_VERSION_MIN := 14
 CPPFLAGS += \
 	-Wno-vla-extension \
 	-Wno-unused-private-field \

--- a/tests/HostTests/modules/Network/Crypto/AxHash.h
+++ b/tests/HostTests/modules/Network/Crypto/AxHash.h
@@ -13,9 +13,7 @@
 #include <Crypto/HashContext.h>
 #include <axtls-8266/crypto/crypto.h>
 
-namespace Crypto
-{
-namespace Ax
+namespace Crypto::Ax
 {
 #define AX_HASH_ENGINE(class_, name_, hashsize_, statesize_, blocksize_)                                               \
 	class class_##Engine                                                                                               \
@@ -58,6 +56,4 @@ using Sha256 = HashContext<Sha256Engine>;
 using Sha384 = HashContext<Sha384Engine>;
 using Sha512 = HashContext<Sha512Engine>;
 
-} // namespace Ax
-
-} // namespace Crypto
+} // namespace Crypto::Ax

--- a/tests/HostTests/modules/Network/Crypto/BrHash.h
+++ b/tests/HostTests/modules/Network/Crypto/BrHash.h
@@ -13,9 +13,7 @@
 #include <Crypto/HashContext.h>
 #include <bearssl_hash.h>
 
-namespace Crypto
-{
-namespace Br
+namespace Crypto::Br
 {
 #define BR_HASH_ENGINE(class_, name_, hashsize_, statesize_, blocksize_)                                               \
 	class class_##Engine                                                                                               \
@@ -70,6 +68,4 @@ using Sha256 = HashContext<Sha256Engine>;
 using Sha384 = HashContext<Sha384Engine>;
 using Sha512 = HashContext<Sha512Engine>;
 
-} // namespace Br
-
-} // namespace Crypto
+} // namespace Crypto::Br


### PR DESCRIPTION
Made use of clang-tidy to apply some fixes. Unfortunately it can only deal with code it can see, so fixes for `Arch/` other than Host were done manually.

- Fix `expr >= message` when using `CLANG_TIDY`
- Apply `modernize-use-equals-default`. Replaces default bodies of special member functions with = default;.
- Fix use of deprecated C headers in C++. e.g. `string.h` -> `cstring`
- Use more concise nested namespace syntax, e.g. `Crypto::Internal::sha2`
