### PR TITLE
Add Esp32 Serial USB JTAG support to uart driver

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/include/driver/uart.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/uart.h
@@ -1,8 +1,15 @@
 #pragma once
 
+#include <esp_idf_version.h>
 #include <soc/soc_caps.h>
 
+#if SOC_USB_SERIAL_JTAG_SUPPORTED && ESP_IDF_VERSION >= ESP_IDF_VERSION_VAL(5, 2, 0)
+#define UART_PHYSICAL_COUNT (SOC_UART_NUM + 1) ///< Number of physical UARTs on the system
+#define UART_ID_SERIAL_USB_JTAG SOC_UART_NUM
+#else
 #define UART_PHYSICAL_COUNT SOC_UART_NUM ///< Number of physical UARTs on the system
-#define UART_COUNT SOC_UART_NUM			 ///< Number of UARTs on the system, virtual or otherwise
+#endif
+
+#define UART_COUNT SOC_UART_NUM ///< Number of UARTs on the system, virtual or otherwise
 
 #include_next <driver/uart.h>

--- a/Sming/Arch/Esp32/Components/driver/uart.rst
+++ b/Sming/Arch/Esp32/Components/driver/uart.rst
@@ -1,7 +1,23 @@
 UART: Universal Asynchronous Receive/Transmit
 =============================================
 
-Custom asynchronous driver.
+Custom asynchronous serial port driver.
+
+.. c:macro:: UART_ID_SERIAL_USB_JTAG
+
+   Some SOC variants, such as esp32c3, have an integrated USB JTAG/Serial port.
+   If so, then this value defines the associated serial port number.
+
+   Requires ESP-IDF version 5.2 or later.
+
+   Example usage::
+
+      #ifdef UART_ID_SERIAL_USB_JTAG
+      Serial.setPort(UART_ID_SERIAL_USB_JTAG);
+      #endif
+      Serial.begin(...);
+
 
 .. doxygengroup:: uart_driver
    :content-only:
+   :members:

--- a/Sming/Components/arch_driver/component.mk
+++ b/Sming/Components/arch_driver/component.mk
@@ -1,2 +1,3 @@
 COMPONENT_INCDIRS := src/include
 COMPONENT_SRCDIRS := src
+COMPONENT_DOXYGEN_INPUT := src/include


### PR DESCRIPTION
This PR adds UART driver support for esp32 variants with an integrated USB JTAG/Serial port, such as esp32c3.
Requires ESP-IDF version 5.2 or later.

Example usage::

```
#ifdef UART_ID_SERIAL_USB_JTAG
  Serial.setPort(UART_ID_SERIAL_USB_JTAG);
#endif
Serial.begin(...);
```

See issue #2772