### PR TITLE
Fix Rp2040 cyw43 firmware build bug

### DIFF
--- a/Sming/Arch/Rp2040/Components/rp2040/firmware/build.sh
+++ b/Sming/Arch/Rp2040/Components/rp2040/firmware/build.sh
@@ -8,7 +8,7 @@
 set -e
 
 write_chunk() {
-    sz=$(printf "%08x" $(wc -c "$1" | awk '{print $$1}'))
+    sz=$(printf "%08x" $(wc -c "$1" | awk '{print $1}'))
     # Output 8-byte header containing chunk tag plus length in little-endian format
     printf "CHNK\x${sz:6:2}\x${sz:4:2}\x${sz:2:2}\x${sz:0:2}" >> $2
     # Append chunk data

--- a/Sming/Arch/Rp2040/app.mk
+++ b/Sming/Arch/Rp2040/app.mk
@@ -6,11 +6,14 @@
 
 # linker flags used to generate the main object file
 LDFLAGS	+= \
-	-Wl,--no-warn-rwx-segments \
 	-Wl,--build-id=none \
 	--specs=nosys.specs \
 	-mcpu=cortex-m0plus \
 	-mthumb
+
+ifneq ($(COMPILER_VERSION_MAJOR),10)
+LDFLAGS += -Wl,--no-warn-rwx-segments
+endif
 
 TARGET_DIS = $(TARGET_OUT:.out=.dis)
 TARGET_SYM = $(TARGET_OUT:.out=.sym)


### PR DESCRIPTION
Bad Rp2040 cyw43 firmware build bug, introduced in #2804.

Also ensure builds work with previous 10.3.1 toolchain.