### PR TITLE
Fix CI library builds

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -74,6 +74,7 @@ jobs:
       INSTALL_IDF_VER: ${{ matrix.idf_version || '5.2' }}
       CLANG_BUILD: ${{ matrix.toolchain == 'clang' && '15' || '0' }}
       BUILD64: ${{ matrix.toolchain == 'gcc64' && 1 || 0 }}
+      ENABLE_CCACHE: 1
 
     steps:
     - name: Fix autocrlf setting
@@ -120,6 +121,12 @@ jobs:
           /opt/esp32
         key: ${{ matrix.os }}-idf-${{ env.INSTALL_IDF_VER }}
 
+    - name: Compiler Cache
+      uses: actions/cache@v4
+      with:
+        path: .ccache
+        key: ${{ matrix.os }}-ccache-${{ matrix.variant }}-${{ matrix.arch == 'Esp32' && env.INSTALL_IDF_VER || '' }}
+
     - name: Install build tools for Ubuntu / MacOS
       if: matrix.os != 'windows-latest'
       run: |
@@ -145,3 +152,6 @@ jobs:
       run: |
         . "$env:SMING_HOME/../Tools/ci/setenv.ps1"
         make -j $env:NUMBER_OF_PROCESSORS -f $env:CI_MAKEFILE
+
+    - name: Compiler Cache stats
+      run: ccache -sv

--- a/Tools/ci/install.cmd
+++ b/Tools/ci/install.cmd
@@ -1,6 +1,11 @@
 REM
 REM Windows CI install script
 REM
+REM May also be used for library CI builds. The following variables must be set:
+REM
+REM   CI_BUILD_DIR
+REM   SMING_HOME
+REM
 
 if "%SMING_TOOLS_PREINSTALLED%" NEQ "" goto :EOF
 
@@ -8,12 +13,14 @@ if "%BUILD_DOCS%" == "true" (
     set INSTALL_OPTS=doc
 )
 
-call %CI_BUILD_DIR%\Tools\install.cmd %SMING_ARCH% %INSTALL_OPTS%
+call %SMING_HOME%\..\Tools\install.cmd %SMING_ARCH% %INSTALL_OPTS%
 
 REM Configure ccache
-ccache --set-config cache_dir="%CI_BUILD_DIR%\.ccache"
-ccache --set-config max_size=500M
-ccache -z
+if "%ENABLE_CCACHE%"=="1" (
+    ccache --set-config cache_dir="%CI_BUILD_DIR%\.ccache"
+    ccache --set-config max_size=500M
+    ccache -z
+)
 
 REM Clean up tools installation
-python "%CI_BUILD_DIR%\Tools\ci\clean-tools.py" clean --delete
+python "%SMING_HOME%\..\Tools\ci\clean-tools.py" clean --delete

--- a/Tools/ci/install.sh
+++ b/Tools/ci/install.sh
@@ -19,15 +19,17 @@ fi
 # Ensure default path is writeable
 sudo chown "$USER" /opt
 
-"$CI_BUILD_DIR/Tools/install.sh" "$SMING_ARCH" "${INSTALL_OPTS[@]}"
+"$SMING_HOME/../Tools/install.sh" "$SMING_ARCH" "${INSTALL_OPTS[@]}"
 
 fi
 
 # Configure ccache
-ccache --set-config cache_dir="$CI_BUILD_DIR/.ccache"
-ccache --set-config max_size=500M
-ccache -z
+if [ "$ENABLE_CCACHE" == "1" ]; then
+    ccache --set-config cache_dir="$CI_BUILD_DIR/.ccache"
+    ccache --set-config max_size=500M
+    ccache -z
+fi
 
 # Clean up tools installation
-source "$CI_BUILD_DIR/Tools/export.sh"
-python "$CI_BUILD_DIR/Tools/ci/clean-tools.py" clean --delete
+source "$SMING_HOME/../Tools/export.sh"
+python "$SMING_HOME/../Tools/ci/clean-tools.py" clean --delete

--- a/Tools/ci/setenv.ps1
+++ b/Tools/ci/setenv.ps1
@@ -1,8 +1,5 @@
 $TOOLS_DIR = "D:/opt"
 
-$env:CI_BUILD_DIR = (Resolve-Path "$PSScriptRoot/../..").Path
-$env:SMING_HOME = Join-Path $env:CI_BUILD_DIR "Sming"
-
 # Esp8266 
 $env:ESP_HOME = Join-Path $TOOLS_DIR "esp-quick-toolchain"
 


### PR DESCRIPTION
Broken by #2857. Also enable ccache.

- `CI_BUILD_DIR` does not point to Sming build: must use SMING_HOME.
- Don't set CI_BUILD_DIR or SMING_HOME in `setenv.ps1` - it's wrong and already set in `.yml`
