### PR TITLE
Update windows installer

### DIFF
--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -83,8 +83,8 @@ jobs:
     - name: Install build tools for Windows
       if: matrix.os == 'windows-latest'
       run: |
-         . Tools/ci/setenv.ps1
-         Tools/ci/install.cmd
+        . Tools/ci/setenv.ps1
+        Tools/ci/install.cmd
 
     - name: Compiler Cache
       uses: actions/cache@v4
@@ -95,7 +95,7 @@ jobs:
     - name: Build and test for ${{matrix.variant}} with IDF v${{matrix.idf_version}} on Ubuntu / MacOS
       if: matrix.os != 'windows-latest'
       run: |
-        source $SMING_HOME/../Tools/export.sh
+        . Tools/export.sh
         Tools/ci/build.sh
 
     - name: Build and test for ${{matrix.variant}} with IDF v${{matrix.idf_version}} on Windows

--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -75,12 +75,6 @@ jobs:
           /opt/esp32
         key: ${{ matrix.os }}-idf-${{ matrix.idf_version }}
 
-    - name: Compiler Cache
-      uses: actions/cache@v4
-      with:
-        path: .ccache
-        key: ${{ matrix.os }}-ccache-${{ matrix.variant }}-${{ matrix.idf_version }}
-
     - name: Install build tools for Ubuntu / MacOS
       if: matrix.os != 'windows-latest'
       run: |
@@ -91,6 +85,12 @@ jobs:
       run: |
          . Tools/ci/setenv.ps1
          Tools/ci/install.cmd
+
+    - name: Compiler Cache
+      uses: actions/cache@v4
+      with:
+        path: .ccache
+        key: ${{ matrix.os }}-ccache-${{ matrix.variant }}-${{ matrix.idf_version }}
 
     - name: Build and test for ${{matrix.variant}} with IDF v${{matrix.idf_version}} on Ubuntu / MacOS
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
     - name: Install build tools for Windows
       if: matrix.os == 'windows-latest'
       run: |
-         . Tools/ci/setenv.ps1
-         Tools/ci/install.cmd
+        . Tools/ci/setenv.ps1
+        Tools/ci/install.cmd
 
     - name: Compiler Cache
       uses: actions/cache@v4
@@ -86,7 +86,7 @@ jobs:
         CLANG_FORMAT: clang-format-8
       if: matrix.os != 'windows-latest'
       run: |
-        source $SMING_HOME/../Tools/export.sh
+        . Tools/export.sh
         Tools/ci/build.sh
 
     - name: Build and test for ${{matrix.variant}} on Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,12 +64,6 @@ jobs:
         "CI_BUILD_DIR=" + (Resolve-Path ".").path >> $env:GITHUB_ENV
         "SMING_HOME=" + (Resolve-Path "Sming").path >> $env:GITHUB_ENV
 
-    - name: Compiler Cache
-      uses: actions/cache@v4
-      with:
-        path: .ccache
-        key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ matrix.variant }}
-
     - name: Install build tools for Ubuntu / MacOS
       if: matrix.os != 'windows-latest'
       run: |
@@ -80,6 +74,12 @@ jobs:
       run: |
          . Tools/ci/setenv.ps1
          Tools/ci/install.cmd
+
+    - name: Compiler Cache
+      uses: actions/cache@v4
+      with:
+        path: .ccache
+        key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ matrix.variant }}
 
     - name: Build and test for ${{matrix.variant}} on Ubuntu / MacOS
       env:

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -121,12 +121,6 @@ jobs:
           /opt/esp32
         key: ${{ matrix.os }}-idf-${{ env.INSTALL_IDF_VER }}
 
-    - name: Compiler Cache
-      uses: actions/cache@v4
-      with:
-        path: .ccache
-        key: ${{ matrix.os }}-ccache-${{ matrix.variant }}-${{ matrix.arch == 'Esp32' && env.INSTALL_IDF_VER || '' }}
-
     - name: Install build tools for Ubuntu / MacOS
       if: matrix.os != 'windows-latest'
       run: |
@@ -138,6 +132,12 @@ jobs:
         cd $env:SMING_HOME/..
         . Tools/ci/setenv.ps1
         Tools/ci/install.cmd
+
+    - name: Compiler Cache
+      uses: actions/cache@v4
+      with:
+        path: .ccache
+        key: ${{ matrix.os }}-ccache-${{ matrix.variant }}-${{ matrix.arch == 'Esp32' && env.INSTALL_IDF_VER || '' }}
 
     - name: Build and Test for ${{matrix.arch}} on Ubuntu / MacOS
       env:

--- a/Sming/Arch/Esp32/Tools/install.cmd
+++ b/Sming/Arch/Esp32/Tools/install.cmd
@@ -5,9 +5,11 @@ if "%IDF_TOOLS_PATH%"=="" goto :undefined
 
 if "%INSTALL_IDF_VER%"=="" set INSTALL_IDF_VER=5.2
 
-for %%I in (%IDF_PATH%) do set IDF_CLONE_PATH=%%~dpIesp-idf-%INSTALL_IDF_VER%
+echo.
+echo ** Installing Esp32 IDF version %INSTALL_IDF_VER%
+echo.
 
-echo "IDF_CLONE_PATH: %IDF_CLONE_PATH%"
+for %%I in (%IDF_PATH%) do set IDF_CLONE_PATH=%%~dpIesp-idf-%INSTALL_IDF_VER%
 
 if exist "%IDF_CLONE_PATH%" goto :cloned
 
@@ -32,7 +34,7 @@ goto :EOF
 
 :cloned
 echo.
-echo ** Skipping ESP-IDF clone: '%IDF_PATH%' exists
+echo ** Skipping ESP-IDF clone: '%IDF_CLONE_PATH%' exists
 echo.
 goto :setup
 

--- a/Sming/Arch/Esp32/Tools/install.cmd
+++ b/Sming/Arch/Esp32/Tools/install.cmd
@@ -42,7 +42,6 @@ if "%CI_BUILD_DIR%" NEQ "" (
 
 REM Install IDF tools and packages
 python "%IDF_PATH%\tools\idf_tools.py" --non-interactive install
-python -m pip install %SMINGTOOLS%/gevent-1.5.0-cp39-cp39-win_amd64.whl
 python3 "%IDF_PATH%\tools\idf_tools.py" --non-interactive install-python-env
 
 if "%CI_BUILD_DIR%" NEQ "" (

--- a/Sming/Arch/Esp32/Tools/install.cmd
+++ b/Sming/Arch/Esp32/Tools/install.cmd
@@ -3,16 +3,22 @@ REM Esp32 install.cmd
 if "%IDF_PATH%"=="" goto :undefined
 if "%IDF_TOOLS_PATH%"=="" goto :undefined
 
-if exist "%IDF_PATH%" goto :cloned
+if "%INSTALL_IDF_VER%"=="" set INSTALL_IDF_VER=5.2
+
+for %%I in (%IDF_PATH%) do set IDF_CLONE_PATH=%%~dpIesp-idf-%INSTALL_IDF_VER%
+
+echo "IDF_CLONE_PATH: %IDF_CLONE_PATH%"
+
+if exist "%IDF_CLONE_PATH%" goto :cloned
 
 if "%IDF_REPO%"=="" set IDF_REPO="https://github.com/mikee47/esp-idf.git"
-if "%INSTALL_IDF_VER%"=="" set INSTALL_IDF_VER=5.2
 set IDF_BRANCH="sming/release/v%INSTALL_IDF_VER%"
 
 if "%CI_BUILD_DIR%" NEQ "" (
     set IDF_INSTALL_OPTIONS=--depth 1 --recurse-submodules --shallow-submodules
 )
-git clone -b %IDF_BRANCH% %IDF_REPO% %IDF_PATH% %IDF_INSTALL_OPTIONS%
+git clone -b %IDF_BRANCH% %IDF_REPO% %IDF_CLONE_PATH% %IDF_INSTALL_OPTIONS%
+if errorlevel 1 goto :EOF
 
 goto :setup
 
@@ -33,16 +39,22 @@ goto :setup
 
 :setup
 
-REM Skip installation for CI if already present
-if "%CI_BUILD_DIR%" NEQ "" (
+@echo Create link from "%IDF_PATH%" to "%IDF_CLONE_PATH%"
+if exist "%IDF_PATH%" rmdir /q %IDF_PATH%
+mklink /j %IDF_PATH% %IDF_CLONE_PATH%
+
+if "%CI_BUILD_DIR%"=="" (
+set IDF_TOOL_PACKAGES=*openocd*
+) else (
+    REM Skip installation for CI if already present
     if exist "%IDF_TOOLS_PATH%\tools" (
         goto :EOF
     )
 )
 
 REM Install IDF tools and packages
-python "%IDF_PATH%\tools\idf_tools.py" --non-interactive install
-python3 "%IDF_PATH%\tools\idf_tools.py" --non-interactive install-python-env
+python "%IDF_PATH%\tools\idf_tools.py" --non-interactive install install "*elf*" %IDF_TOOL_PACKAGES%
+python "%IDF_PATH%\tools\idf_tools.py" --non-interactive install-python-env
 
 if "%CI_BUILD_DIR%" NEQ "" (
     del /q "%IDF_TOOLS_PATH%\dist\*"

--- a/Sming/Arch/Esp32/Tools/install.sh
+++ b/Sming/Arch/Esp32/Tools/install.sh
@@ -65,7 +65,7 @@ ln -s "$IDF_CLONE_PATH" "$IDF_PATH"
 if [ -z "$CI_BUILD_DIR" ] || [ ! -d "$IDF_TOOLS_PATH/tools" ]; then
 
 # Install IDF tools and packages
-python3 "$IDF_PATH/tools/idf_tools.py" --non-interactive install
+python3 "$IDF_PATH/tools/idf_tools.py" --non-interactive install "*elf*"
 if [ -n "$VIRTUAL_ENV" ]; then
     unset VIRTUAL_ENV
     unset VIRTUAL_ENV_PROMPT

--- a/Sming/Arch/Esp32/build.mk
+++ b/Sming/Arch/Esp32/build.mk
@@ -86,29 +86,9 @@ IDF_PATH_LIST := \
 	$(ESP32_ULP_PATH)/$(ESP_VARIANT)ulp-elf-binutils/bin \
 	$(ESP32_OPENOCD_PATH)/openocd-esp32/bin
 
-ifeq ($(UNAME),Windows)
-DEBUG_VARS += ESP32_NINJA_PATH
-ifndef ESP32_NINJA_PATH
-ESP32_NINJA_PATH	:= $(call FindTool,tools/ninja/)
-endif
-ifeq (,$(wildcard $(ESP32_NINJA_PATH)/ninja.exe))
-$(error Failed to find NINJA)
-endif
-IDF_PATH_LIST += $(ESP32_NINJA_PATH)
-
-DEBUG_VARS += ESP32_IDFEXE_PATH
-ifndef ESP32_IDFEXE_PATH
-ESP32_IDFEXE_PATH := $(call FindTool,tools/idf-exe/)
-endif
-IDF_PATH_LIST += $(ESP32_IDFEXE_PATH)
-endif
-
 ifeq ($(ENABLE_CCACHE),1)
 export IDF_CCACHE_ENABLE := 1
 endif
-
-DEBUG_VARS += NINJA
-NINJA := $(if $(ESP32_NINJA_PATH),$(ESP32_NINJA_PATH)/,)ninja
 
 empty:=
 space:= $(empty) $(empty)

--- a/Sming/Arch/Esp8266/Tools/install.cmd
+++ b/Sming/Arch/Esp8266/Tools/install.cmd
@@ -3,12 +3,16 @@ REM Esp8266 install.cmd
 if "%ESP_HOME%" == "" goto :undefined
 if exist "%ESP_HOME%" goto :installed
 
+echo.
+echo ** Installing ESP8266 toolchain
+echo.
+
 set EQT_REPO=https://github.com/earlephilhower/esp-quick-toolchain/releases/download/3.2.0-gcc10.3
 set EQT_TOOLCHAIN=x86_64-w64-mingw32.xtensa-lx106-elf-c791b74.230224.zip
 
 mkdir %ESP_HOME%
-curl -Lo %DOWNLOADS%/%EQT_TOOLCHAIN% %EQT_REPO%/%EQT_TOOLCHAIN%
-7z -o%ESP_HOME% x %DOWNLOADS%/%EQT_TOOLCHAIN%
+curl -Lo %DOWNLOADS%/%EQT_TOOLCHAIN% %EQT_REPO%/%EQT_TOOLCHAIN% || goto :EOF
+7z -o%ESP_HOME% x %DOWNLOADS%/%EQT_TOOLCHAIN% || goto :EOF
 
 goto :EOF
 

--- a/Sming/Arch/Rp2040/Tools/install.cmd
+++ b/Sming/Arch/Rp2040/Tools/install.cmd
@@ -3,6 +3,10 @@ REM Rp2040 install.cmd
 if "%PICO_TOOLCHAIN_PATH%"=="" goto :undefined
 if exist "%PICO_TOOLCHAIN_PATH%/arm-none-eabi" goto :installed
 
+echo.
+echo ** Installing Rp2040 toolchain
+echo.
+
 set TOOLCHAIN_VERSION=13.2.rel1
 set TOOLCHAIN_BASE_URL=https://developer.arm.com/-/media/Files/downloads/gnu
 set TOOLCHAIN_NAME=arm-gnu-toolchain-%TOOLCHAIN_VERSION%-mingw-w64-i686-arm-none-eabi

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -160,7 +160,7 @@ DEBUG_VARS += PYTHON
 ifdef PYTHON
 export PYTHON := $(call FixPath,$(PYTHON))
 else
-PYTHON := python3
+PYTHON := python
 endif
 
 PYTHON_VERSION := $(shell $(PYTHON) --version 2>&1)

--- a/Sming/build.mk
+++ b/Sming/build.mk
@@ -160,7 +160,7 @@ DEBUG_VARS += PYTHON
 ifdef PYTHON
 export PYTHON := $(call FixPath,$(PYTHON))
 else
-PYTHON := python
+PYTHON := $(shell which python)
 endif
 
 PYTHON_VERSION := $(shell $(PYTHON) --version 2>&1)

--- a/Sming/project.mk
+++ b/Sming/project.mk
@@ -609,7 +609,7 @@ TCP_SERIAL_REDIRECT = $(SMING_HOME)/../Tools/tcp_serial_redirect.py $(COM_PORT) 
 tcp-serial-redirect: ##Redirect COM port to TCP port
 	$(info Starting serial redirector)
 ifeq ($(WSL_COMPORT_POWERSHELL),1)
-	$(Q) cmd.exe /c start /MIN python3 $(WSL_ROOT)/$(TCP_SERIAL_REDIRECT)
+	$(Q) cmd.exe /c start /MIN python $(WSL_ROOT)/$(TCP_SERIAL_REDIRECT)
 else
 	$(Q) $(call DetachCommand,$(PYTHON) $(TCP_SERIAL_REDIRECT))
 endif

--- a/Tools/check-packages.cmd
+++ b/Tools/check-packages.cmd
@@ -1,0 +1,18 @@
+@echo off
+
+REM Check pre-requisites are installed and working, from whatever source
+
+set MISSING_PACKAGES=
+call :check_package python Python
+call :check_package mingw-get MinGW
+call :check_package cmake CMake
+call :check_package ninja Ninja
+where /q 7z
+if errorlevel 1 set MISSING_PACKAGES=%MISSING_PACKAGES% 7zip
+goto :EOF
+
+REM Could use 'where' but Windows has a stub for python which isn't helpful
+:check_package
+%1 --version >nul 2>&1
+if errorlevel 1 set MISSING_PACKAGES=%MISSING_PACKAGES% %2
+goto :EOF

--- a/Tools/choco-install.cmd
+++ b/Tools/choco-install.cmd
@@ -4,16 +4,50 @@ REM
 REM Sming installer bootstrap script for Windows
 REM
 
+echo.
+echo Welcome to Sming bootstrap installer
+echo.
+
+REM Check we have administrative priviledge
+net session >nul 2>&1
+if errorlevel 1 (
+    echo Opening an administrative command prompt to continue installation...
+    powershell -Command "Start-Process cmd.exe -ArgumentList '/K %~f0' -Verb RunAs"
+    goto :EOF
+)
+
+REM Sync working directory
+cd /d %~dp0
+
+REM See if choco is already installed
+choco --version >nul 2>&1
+if not errorlevel 1 goto :install_packages
+
 REM Fetch the Chocolatey powershell installer script.
 REM Note: Local scripts are blocked by default for 'security reasons'
 REM Microsoft have kindly set up some hoops for us to jump through
 REM (presumably making this 'secure'). OK, lets jump now.
 REM Warning: Get the fire extinguisher, hoops may be on fire.
 @powershell -NoProfile -ExecutionPolicy unrestricted -Command "iex ((new-object net.webclient).DownloadString('https://chocolatey.org/install.ps1'))"
-if "%errorlevel%" == "1" then goto :EOF
+if errorlevel 1 goto :EOF
 
-SET PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin
+setlocal
+SET PATH=%ALLUSERSPROFILE%\chocolatey\bin;%PATH%
 
-choco sources add -name smingrepo -source 'https://www.myget.org/F/sming/'
+:install_packages
 
-choco install -y sming
+REM Install standard packages
+choco install -y git Python CMake Ninja 7zip ccache || goto :EOF
+
+REM Fetch Sming
+echo Fetch sming...
+git clone https://github.com/SmingHub/Sming sming || goto :EOF
+REM Fix ownership - we'd prefer to just clone as a regular user but that requires impersonation. Don't go there.
+icacls sming /setowner %USERNAME% /T /C /L /Q
+
+REM Install MinGW: Fine to leave this with admin priviledge as it should be considered read-only
+call sming\tools\mingw-install.cmd
+if errorlevel 1 goto :EOF
+
+echo.
+echo OK. Now open a regular (non-administrative) command prompt and run 'sming\tools\install.cmd' to install required toolchains

--- a/Tools/ci/build.cmd
+++ b/Tools/ci/build.cmd
@@ -9,6 +9,13 @@ if "%BUILD_DOCS%"=="true" (
     goto :EOF
 )
 
+REM Configure ccache
+if "%ENABLE_CCACHE%"=="1" (
+    ccache --set-config cache_dir="%CI_BUILD_DIR%\.ccache"
+    ccache --set-config max_size=500M
+    ccache -z
+)
+
 cd /d %SMING_HOME%
 call Arch\%SMING_ARCH%\Tools\ci\build.setup.cmd || goto :error
 

--- a/Tools/ci/build.sh
+++ b/Tools/ci/build.sh
@@ -9,6 +9,13 @@ if [ "$BUILD_DOCS" = "true" ]; then
     exit 0
 fi
 
+# Configure ccache
+if [ "$ENABLE_CCACHE" == "1" ]; then
+    ccache --set-config cache_dir="$CI_BUILD_DIR/.ccache"
+    ccache --set-config max_size=500M
+    ccache -z
+fi
+
 # Build times benefit from parallel building
 export MAKE_PARALLEL="make -j$(nproc)"
 

--- a/Tools/ci/install.cmd
+++ b/Tools/ci/install.cmd
@@ -13,7 +13,19 @@ if "%BUILD_DOCS%" == "true" (
     set INSTALL_OPTS=doc
 )
 
-call %SMING_HOME%\..\Tools\install.cmd %SMING_ARCH% %INSTALL_OPTS%
+REM Python and CMake are preconfigured
+choco install ninja ccache -y --no-progress || goto :error
+
+call %~dp0..\mingw-install.cmd || goto :error
+
+call %~dp0..\install.cmd %SMING_ARCH% %INSTALL_OPTS% || goto :error
 
 REM Clean up tools installation
-python "%SMING_HOME%\..\Tools\ci\clean-tools.py" clean --delete
+python "%~dp0clean-tools.py" clean --delete
+
+goto :EOF
+
+
+:error
+echo Failed with error #%errorlevel%.
+exit /b %errorlevel%

--- a/Tools/ci/install.cmd
+++ b/Tools/ci/install.cmd
@@ -15,12 +15,5 @@ if "%BUILD_DOCS%" == "true" (
 
 call %SMING_HOME%\..\Tools\install.cmd %SMING_ARCH% %INSTALL_OPTS%
 
-REM Configure ccache
-if "%ENABLE_CCACHE%"=="1" (
-    ccache --set-config cache_dir="%CI_BUILD_DIR%\.ccache"
-    ccache --set-config max_size=500M
-    ccache -z
-)
-
 REM Clean up tools installation
 python "%SMING_HOME%\..\Tools\ci\clean-tools.py" clean --delete

--- a/Tools/ci/install.sh
+++ b/Tools/ci/install.sh
@@ -23,13 +23,6 @@ sudo chown "$USER" /opt
 
 fi
 
-# Configure ccache
-if [ "$ENABLE_CCACHE" == "1" ]; then
-    ccache --set-config cache_dir="$CI_BUILD_DIR/.ccache"
-    ccache --set-config max_size=500M
-    ccache -z
-fi
-
 # Clean up tools installation
 source "$SMING_HOME/../Tools/export.sh"
 python "$SMING_HOME/../Tools/ci/clean-tools.py" clean --delete

--- a/Tools/ci/setenv.ps1
+++ b/Tools/ci/setenv.ps1
@@ -1,40 +1,26 @@
-$TOOLS_DIR = "D:/opt"
+#
+# Set environment for CI build
+#
+# This script is sourced from the CI action script via powershell,
+# so that environment variables are persisted.
+#
+# Note that we can't do this in a batch script (export.cmd or build.cmd) because
+# PATH gets truncated to 4095 characters: It's typically rather longer than this.
+# Nor can we source a batch script from powershell, so everything has to be here.
+#
+
+# Use same path for all platforms, so CI action script can just use "\opt"
+$env:SMING_TOOLS_DIR = Join-Path (Split-Path -Path $env:CI_BUILD_DIR -Qualifier) "opt"
 
 # Esp8266 
-$env:ESP_HOME = Join-Path $TOOLS_DIR "esp-quick-toolchain"
+$env:ESP_HOME = Join-Path $env:SMING_TOOLS_DIR "esp-quick-toolchain"
 
 # Esp32
-$env:IDF_PATH = Join-Path $TOOLS_DIR "esp-idf-$env:INSTALL_IDF_VER"
-$env:IDF_TOOLS_PATH = Join-Path $TOOLS_DIR "esp32"
+$env:IDF_PATH = Join-Path $env:SMING_TOOLS_DIR "esp-idf"
+$env:IDF_TOOLS_PATH = Join-Path $env:SMING_TOOLS_DIR "esp32"
 
 # Rp2040
-$env:PICO_TOOLCHAIN_PATH = Join-Path $TOOLS_DIR "rp2040"
+$env:PICO_TOOLCHAIN_PATH = Join-Path $env:SMING_TOOLS_DIR "rp2040"
 
-if (Test-Path "$env:PICO_TOOLCHAIN_PATH" ) {
-    $env:SMING_TOOLS_PREINSTALLED = "true"
-}
-
-if ($IsWindows) {
-    $env:PATH = "C:\MinGW\msys\1.0\bin;C:\MinGW\bin;$env:PATH"
-
-    if ($null -eq $env:PYTHON_PATH) {
-        $env:PYTHON_PATH = "C:\Python39-x64"
-        if ( -not (Test-Path "$env:PYTHON_PATH") ) {
-            $env:PYTHON_PATH = "C:\Python39"
-        }
-        if ( -not (Test-Path "$env:PYTHON_PATH") ) {
-            $env:PYTHON_PATH = $(Get-Command python | Split-Path)
-        }
-    }
-
-    $env:PATH = "$env:PYTHON_PATH;$env:PYTHON_PATH\Scripts;$env:PATH"
-    $env:PYTHON = "$env:PYTHON_PATH\python"
-
-    $env:PATH = "$env:PROGRAMFILES\CMake\bin;$env:PATH"
-
-    $env:PATH = "$env:PROGRAMFILES\doxygen\bin;$env:PROGRAMFILES\Graphviz\bin;$env:PATH"
-
-    if (Test-Path "$TOOLS_DIR" ) {
-        $env:NINJA = (get-childitem -path "$TOOLS_DIR" -recurse -include "ninja.exe" | select-object -first 1).FullName
-    }
-}
+# MinGW
+$env:PATH = "C:\MinGW\msys\1.0\bin;C:\MinGW\bin;$env:PATH"

--- a/Tools/export.cmd
+++ b/Tools/export.cmd
@@ -1,0 +1,61 @@
+@echo off
+
+REM
+REM Configure all Sming environment variables for this session
+REM
+
+if "%1"=="" (
+    echo ** Setting values for current session ONLY
+    set PERSIST_VARS=
+) else if "%1"=="-persist" (
+    echo ** Values will be persisted
+    set PERSIST_VARS=1
+) else (
+    echo Configures Sming environment variables
+    echo export [-persist]
+    echo   --persist Optionally persist values in user registry
+    echo.
+    goto :EOF
+)
+
+REM Set SMING_HOME using this script location as starting point
+set CUR_DIR=%CD%
+cd %~dp0..\Sming
+call :setvar SMING_HOME "%CD%"
+cd %CUR_DIR%
+set CUR_DIR=
+
+REM Location for toolchains
+if "%SMING_TOOLS_DIR%"=="" set SMING_TOOLS_DIR=C:\tools
+
+REM Esp8266
+call :setvar ESP_HOME "%SMING_TOOLS_DIR%\esp-quick-toolchain"
+
+REM Esp32
+call :setvar IDF_PATH "%SMING_TOOLS_DIR%\esp-idf"
+call :setvar IDF_TOOLS_PATH "%SMING_TOOLS_DIR%\esp32"
+
+REM Rp2040
+call :setvar PICO_TOOLCHAIN_PATH "%SMING_TOOLS_DIR%\rp2040"
+
+call %~dp0check-packages.cmd
+if "%MISSING_PACKAGES%" NEQ "" (
+    echo ** ERROR: Missing packages:%MISSING_PACKAGES%.
+    echo Please run choco-install.cmd or install these manually.
+)
+
+goto :EOF
+
+:setvar
+setlocal enabledelayedexpansion
+set CUR_VALUE=!%1!
+if "%CUR_VALUE%" NEQ "" (
+    if "%CUR_VALUE%" NEQ "%~2" (
+        echo ** WARNING: Overriding existing %1 value "%CUR_VALUE%"
+    )
+)
+endlocal
+echo %1 = %~2
+if "%PERSIST_VARS%"=="1" setx %1 %2
+set "%1=%~2"
+goto :EOF

--- a/Tools/install.cmd
+++ b/Tools/install.cmd
@@ -1,13 +1,30 @@
+@echo off
+
 REM
 REM Windows install script
 REM
-REM GIT, Python3 and Chocolatey must be installed and in the system path
-REM
 
-set DOWNLOADS=downloads
-mkdir %DOWNLOADS%
+if "%1"=="" (
+    echo.
+    echo Sming Installation options:
+    echo   host      Host development tools
+    echo   esp8266   ESP8266 development tools
+    echo   esp32     ESP32 development tools
+    echo   rp2040    RP2040 tools [Raspberry Pi Pico]
+    echo   all       Install all architectures
+    echo   doc       Tools required to build documentation
+    echo.
+    goto :EOF
+)
 
-set SMINGTOOLS=https://github.com/SmingHub/SmingTools/releases/download/1.0
+call %~dp0check-packages.cmd
+if "%MISSING_PACKAGES%" NEQ "" (
+    echo Missing packages:%MISSING_PACKAGES%
+    echo Please install manually or run `choco-install.cmd` from an administrative command prompt
+    echo If already installed, please ensure they are in the system path
+    echo See https://sming.readthedocs.io/en/latest/getting-started/windows/index.html
+    goto :EOF
+)
 
 REM Leave file endings alone
 git config --global --add core.autocrlf input
@@ -16,42 +33,38 @@ echo.
 echo.
 echo ** Installing common python requirements
 echo.
-python -m pip install --upgrade pip -r %SMING_HOME%\..\Tools\requirements.txt
-
-choco install ninja ccache
-
-if exist "C:\MinGW\bin" goto :mingw_installed
-
-echo.
-echo.
-echo ** Installing MinGW
-echo.
-rmdir /s /q c:\MinGW
-curl -Lo %DOWNLOADS%\MinGW.7z %SMINGTOOLS%/MinGW-2020-10-19.7z
-7z -oC:\ x %DOWNLOADS%\MinGW.7z
-
-goto :install
-
-:mingw_installed
-echo.
-echo ** MinGW found, not re-installing
-echo.
+python -m pip install --upgrade pip -r %~dp0requirements.txt
 
 :install
 
-if "%1" == "" goto :EOF
+REM Configure environment variables
+call %~dp0export.cmd || goto :EOF
+
+REM 
+set DOWNLOADS=%SMING_TOOLS_DIR%\downloads
+if not exist "%DOWNLOADS%" mkdir %DOWNLOADS%
+
 if "%1" == "all" (
-    call :install Host Esp8266 Esp32 Rp2040
+    call :install_loop Host Esp8266 Esp32 Rp2040
+    goto :EOF
+)
+
+:install_loop
+if "%1" == "" (
+    echo.
+    echo OK, install complete.
+    echo.
+    goto :EOF
+)
+if "%1" == "doc" (
+    call %~dp0..\docs\Tools\install.cmd || goto :error
 ) else (
-    echo.
-    echo.
-    echo ** Installing %1 toolchain
-    echo.
-    if "%1" == "doc" (
-        call %SMING_HOME%\..\docs\Tools\install.cmd
-    ) else (
-        call %SMING_HOME%\Arch\%1\Tools\install.cmd
-    )
+    call %SMING_HOME%\Arch\%1\Tools\install.cmd || goto :error
 )
 shift
-goto :install
+goto :install_loop
+
+:error
+echo.
+echo Installation failed
+echo.

--- a/Tools/mingw-install.cmd
+++ b/Tools/mingw-install.cmd
@@ -1,0 +1,34 @@
+@echo off
+REM Install MinGW
+
+set MINGW_PATH=C:\MinGW
+set MINGW_SRC=MinGW-2021-04-12.7z
+
+%MINGW_PATH%\bin\mingw-get --version >nul 2>&1
+if not errorlevel 1 goto :mingw_installed
+
+if exist "%MINGW_PATH%" (
+    echo.
+    echo ** Found existing installation at %MINGW_PATH%
+    echo.
+    echo Please rename or remove then try again.
+    echo.
+    exit /b 1
+)
+
+set SMINGTOOLS=https://github.com/SmingHub/SmingTools/releases/download/1.0
+
+echo.
+echo.
+echo ** Installing MinGW
+echo.
+curl -Lo %MINGW_SRC% %SMINGTOOLS%/%MINGW_SRC% || goto :EOF
+7z -o%MINGW_PATH% x %MINGW_SRC% || goto :EOF
+del %MINGW_SRC%
+goto :update_path
+
+:mingw_installed
+echo MinGW found
+
+:update_path
+@powershell -NoProfile -ExecutionPolicy unrestricted %~dp0update-path.ps1 '%MINGW_PATH%\bin;%MINGW_PATH%\msys\1.0\bin'

--- a/Tools/update-path.ps1
+++ b/Tools/update-path.ps1
@@ -31,7 +31,7 @@ try {
     $userpathArray = ($userpath -split ";").where({ "" -ne $_ })
     $dirstoinsertArray = ($dirstoinsert -split ";")
 
-    Write-Host "Checking system PATH..."
+    echo "Checking system PATH..."
 
     # Check if we need to update path
     $needupdate = $false
@@ -42,7 +42,7 @@ try {
         }
     }
     if (! $needupdate) {
-        Write-Host "No changes to system PATH required"
+        echo "No changes to system PATH required"
         return
     }
 
@@ -53,17 +53,17 @@ try {
             continue
         }
         if (contains $userpathArray $dir) {
-            Write-Host "WARNING: '$dir' in user path"
+            echo "WARNING: '$dir' in user path"
         }
         $newsyspathArray += $dir
     }
 
-    Write-Host "Updating system PATH"
+    echo "Updating system PATH"
     $newsyspath = ($newsyspathArray -join ";")
-    Write-Host "  From: $syspath"
-    Write-Host "  To:   $newsyspath"
+    echo "  From: $syspath"
+    echo "  To:   $newsyspath"
     [Environment]::SetEnvironmentVariable("PATH", $newsyspath, [EnvironmentVariableTarget]::Machine)
-    Write-Host "System PATH updated"
+    echo "System PATH updated"
 }
 catch {
     $_

--- a/Tools/update-path.ps1
+++ b/Tools/update-path.ps1
@@ -1,0 +1,71 @@
+#
+# Given a semicolon-delimited list of directories, check machine PATH from registry to see
+# if they're present. If not, insert them at the beginning.
+# Updating the user PATH is insufficient as the machine PATH takes precedence.
+# We need the specified directories to be checked before others to avoid the
+# wrong tool being executed (make, sh, etc.)
+#
+
+param (
+    [Parameter(Mandatory=$true)]
+    [String]$dirstoinsert
+)
+
+function contains{
+    param(
+        [array]$array,
+        [string]$value
+    )
+    foreach ($elem in $array) {
+        if ($elem -eq $value) {
+            return $true
+        }
+    }
+    return $false
+}
+
+try {
+    $syspath = [Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::Machine)
+    $syspathArray = ($syspath -split ";").where({ "" -ne $_ })
+    $userpath = [Environment]::GetEnvironmentVariable("PATH", [System.EnvironmentVariableTarget]::User)
+    $userpathArray = ($userpath -split ";").where({ "" -ne $_ })
+    $dirstoinsertArray = ($dirstoinsert -split ";")
+
+    Write-Host "Checking system PATH..."
+
+    # Check if we need to update path
+    $needupdate = $false
+    foreach ($dir in $dirstoinsertArray) {
+        if (! (contains $syspathArray $dir) ) {
+            $needupdate = $true
+            break
+        }
+    }
+    if (! $needupdate) {
+        Write-Host "No changes to system PATH required"
+        return
+    }
+
+    # Update and de-duplicate entries (PATH can get very messy over time)
+    $newsyspathArray = @()
+    foreach ($dir in $dirstoinsertArray+$syspathArray) {
+        if (contains $newsyspathArray $dir) {
+            continue
+        }
+        if (contains $userpathArray $dir) {
+            Write-Host "WARNING: '$dir' in user path"
+        }
+        $newsyspathArray += $dir
+    }
+
+    Write-Host "Updating system PATH"
+    $newsyspath = ($newsyspathArray -join ";")
+    Write-Host "  From: $syspath"
+    Write-Host "  To:   $newsyspath"
+    [Environment]::SetEnvironmentVariable("PATH", $newsyspath, [EnvironmentVariableTarget]::Machine)
+    Write-Host "System PATH updated"
+}
+catch {
+    $_
+    exit 1
+}

--- a/docs/Tools/install.cmd
+++ b/docs/Tools/install.cmd
@@ -1,7 +1,9 @@
 REM Docs install.cmd
 
-choco install -y --no-progress doxygen.install graphviz
-setx PATH "%PROGRAMFILES%\doxygen\bin;%PROGRAMFILES%\Graphviz\bin;%PATH%"
+where /q doxygen
+if errorlevel 1 (
+    choco install -y --no-progress doxygen.install graphviz
+)
 
 python -m pip install --upgrade pip wheel
 python -m pip install -r %~dp0/../requirements.txt

--- a/docs/Tools/install.cmd
+++ b/docs/Tools/install.cmd
@@ -2,7 +2,7 @@ REM Docs install.cmd
 
 where /q doxygen
 if errorlevel 1 (
-    choco install -y --no-progress doxygen.install graphviz
+    choco install -y --no-progress doxygen.install graphviz gtk-runtime
 )
 
 python -m pip install --upgrade pip wheel

--- a/docs/Tools/install.cmd
+++ b/docs/Tools/install.cmd
@@ -1,10 +1,14 @@
 REM Docs install.cmd
 
+echo.
+echo ** Installing documentation tools
+echo.
+
 where /q doxygen
 if errorlevel 1 (
     choco install -y --no-progress doxygen.install graphviz gtk-runtime
 )
 
 python -m pip install --upgrade pip wheel
-python -m pip install -r %~dp0/../requirements.txt
+python -m pip install -r %~dp0..\requirements.txt
 python -m pip uninstall -y xcffib

--- a/docs/source/getting-started/windows/index.rst
+++ b/docs/source/getting-started/windows/index.rst
@@ -19,13 +19,14 @@ See also:
 Quick Install
 -------------
 
-Open an *administrative* **cmd.exe** command prompt and paste the text from the box below and press enter::
+1. Install Sming with essential tools
+
+Open an *administrative* **cmd.exe** command prompt and navigate to a directory of your choosing.
+The Sming framework will be cloned into a subdirectory named ``sming``.
+
+Paste the following text press enter::
 
    curl -LO https://raw.githubusercontent.com/SmingHub/Sming/develop/Tools/choco-install.cmd && choco-install.cmd
-
-At the moment the Esp32 toolchain is not installed by default. If you want to install it run the following command::
-
-   choco install -y sming.esp32
 
 .. important::
 
@@ -35,79 +36,50 @@ At the moment the Esp32 toolchain is not installed by default. If you want to in
 
    It is also inadvisable to continue running with elevated privileges.
 
+
+2. Install toolchains
+
+   To install toolchains for all supported architectures, type this command::
+
+      sming\tools\install all
+
+   If you want to save disk space (and installation time) then you can select which tools to install.
+   Get a list of available options like this::
+
+      sming\tools\install
+
+
+3. Set environment variables
+
+   This command must be run every time a new command shell is opened::
+
+      sming\tools\export
+
+   This sets important environment variables such as ``SMING_HOME``, but **only** for the current session.
+
+   To persist these via the Windows registry::
+
+      sming\tools\export -persist
+
+   This means they do not need to be set every time a command prompt is opened, and will be seen by
+   integrated development environments such as Eclipse or VSCode without any further configuration.
+
+
 If you followed and executed carefully the steps above Sming should be installed and configured.
 You can scroll down to `Build Basic_Blink`_ to check the installation.
-
-Optional step: Switch to stable version
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The installer uses the latest **develop** branch. This one contains great new features and bugfixes but can be ``unstable`` at times.
-
-Switching to our ``stable`` release will guarantee you that Sming's code will not change so often.
-On the downside you will have to wait for all new shiny features and bugfixes.
-
-If you really want to use the latest ``stable`` release you can type the command below::
-
-      cd %SMING_HOME%
-      git checkout master
-      git pull
 
 
 Optional step: Re-installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In case something is broken, this will perform a forced re-install of all packages::
+The installer scripts do not overwrite existing installations.
+If something is broken or you want to upgrade, delete the appropriate directory before running the installation.
 
-   rmdir /s /q c:\tools\sming
-   choco install sming -y -f -x
+For example, to reinstall the ESP8266 toolchain::
 
-Packages
---------
-
-You can find the installer sources at https://github.com/slaff/chocolatey-packages.
-Packages are as follows:
-
-git
-   `GIT <https://git-scm.com/>`__ CLI client.
-
-   Please configure after installation to leave line-endings intact or else patching will fail::
-
-      git config --global core.autocrlf input
-
-python
-   `Python <https://www.python.org/>`__ version 3.
-
-cmake
-   `CMake <https://cmake.org/>`__.
-
-   Required to build some Components, also for Host mode.
-
-mingw
-   `MinGW <http://www.mingw.org/>`__ 32-bit.
-
-   The installer updates the system ``PATH`` but please check by running::
-
-      where make.exe
-
-   The output should show only one result::
-
-      "C:\MinGW\msys\1.0\bin\make.exe"
-
-esp8266-eqt
-   `ESP Quick Toolchain <https://github.com/earlephilhower/esp-quick-toolchain/>`__.
-
-   Sets a system-wide :envvar:`ESP_HOME` variable.
-
-sming.esp32
-   Sming-compatible version of ESP-IDF and tools.
-
-sming.core
-   Latest stable version of `Sming <https://github.com/SmingHub/Sming/tree/master>`__.
-
-   Sets a system-wide :envvar:`SMING_HOME` environment variable.
-
-Note that setting `SMING_HOME` and `ESP_HOME` as system-wide variables means they do
-not need to be set every time a command prompt is opened, and will be seen by eclipse
-without any further configuration.
+   cd c:\tools
+   rmdir /s esp-quick-toolchain
+   sming\tools\install
 
 
 Build Basic_Blink
@@ -115,14 +87,23 @@ Build Basic_Blink
 
 To check the installation, open a command prompt and type these commands::
 
-   cd %SMING_HOME%\..\samples\Basic_Blink
+   cd c:\tools\sming
+   tools\export
+   cd samples\Basic_Blink
    make
 
 The project should build without error.
+
+If you want to try out the Host emulator, do this::
+
+   make -j SMING_ARCH=Host
+
+For build options::
+
+   make help
 
 
 Next steps
 ----------
 
 Proceed to :doc:`../config`.
-

--- a/docs/source/getting-started/windows/index.rst
+++ b/docs/source/getting-started/windows/index.rst
@@ -77,9 +77,8 @@ If something is broken or you want to upgrade, delete the appropriate directory 
 
 For example, to reinstall the ESP8266 toolchain::
 
-   cd c:\tools
-   rmdir /s esp-quick-toolchain
-   sming\tools\install
+   rmdir /s c:\tools\esp-quick-toolchain
+   %SMING_HOME%\..\tools\install
 
 
 Build Basic_Blink

--- a/docs/source/getting-started/windows/manual.rst
+++ b/docs/source/getting-started/windows/manual.rst
@@ -3,24 +3,72 @@ Manual Windows Installation
 
 .. highlight:: batch
 
+These notes are provided for informational purposes.
+
+Packages
+--------
+
+These packages must be installed on the system and accessible via system PATH. This is handled by the ``tools\choco-install.cmd`` script, which also installs the chocolatey package manager.
+
+git
+   `GIT <https://git-scm.com/>`__ CLI client.
+
+   Please configure after installation to leave line-endings intact or else patching will fail::
+
+      git config --global core.autocrlf input
+
+Python
+   `Python <https://www.python.org/>`__ version 3.8 or newer.
+
+CMake
+   `CMake <https://cmake.org/>`__.
+
+   Required to build some Components, also for Host mode.
+
+Ninja
+   `https://ninja-build.org/`__.
+
+   Required to build some Components, also for Host mode.
+
+MinGW
+   `MinGW <https://osdn.net/projects/mingw/>`__ 32-bit.
+
+   This is **NOT** a choco package, but installed via the ``mingw-install.cmd`` script. The script updates the system ``PATH``, and can be checked by running::
+
+      where make.exe
+
+   The output should show only one result::
+
+      "C:\MinGW\msys\1.0\bin\make.exe"
+
+If you have specific installation requirements it is usually simpler to customise the installation scripts.
+
+SMING_TOOLS_DIR
+   This defaults to ``C:\tools`` and determines the root location for all toolchains.
+
+   If you want to install to a different directory, set this globally. For example::
+
+      setx SMING_TOOLS_DIR C:\opt
+
+   When ``Tools\export.cmd`` is next run the paths will change to reflect this value.
+
+   The ``Tools\install.cmd`` script will also install to this new location.
+
+
 MinGW
 -----
 
-Code built for the ESP8266 uses a separate Espressif compiler, but Components such as SPIFFS
-require additional tools which are built as Windows executable applications.
+Code built for target devices such as the ESP8266 use a separate toolchain, but the Host Emulator and Components such as SPIFFS require additional tools which are built as Windows executable applications.
 
-MinGW provides a (mostly) POSIX-compliant development environment for Windows, including GNU Make and
-various other command-line tools.
+MinGW provides a (mostly) POSIX-compliant development environment for Windows, including GNU Make and various other command-line tools.
 
 .. note::
 
    There are two versions of MinGW.
 
-   `MinGW <http://mingw.org/>`__ is the original, and the version recommended for use with Sming.
+   `MinGW <https://osdn.net/projects/mingw/>`__ is the original, and the version currently used with Sming. It does not appear to be maintained any more.
 
-   `MinGW-w64 <http://mingw-w64.org/>`__ was forked from MinGW in 2007 *in order to provide support
-   for 64 bits and new APIs*. (Which we don't need!)
-
+   `MinGW-w64 <http://mingw-w64.org/>`__ was forked from MinGW in 2007 *in order to provide support for 64 bits and new APIs*. More recent toolchains are available but at present this is not supported by Sming.
 
 To find out if you already have GCC on your system, type::
 
@@ -30,150 +78,42 @@ If it shows ``C:\MinGW\bin\gcc.exe`` then you have a standard MinGW installation
 
    gcc --version
 
-The current version is 8.2.0. You can upgrade by renaming or removing your existing installation then
-following these instructions.
+The current version is 9.2.0. Refer to the ``tools\mingw-install.cmd`` script for installation details.
 
-Fast install
-~~~~~~~~~~~~
-
-1. Download `MinGW.7z <https://github.com/SmingHub/SmingTools/releases/download/1.0/MinGW.7z>`__ from the SmingTools repository.
-
-2. Unzip to default location::
-
-      7z -oC:\ x MinGW.7z
-
-   .. note::
-   
-      You can obtain 7-zip from https://www.7-zip.org/.
-
-3. Update :envvar:`PATH` environment variable::
+Note that the system PATH must be updated as follows::
 
       SETX PATH "C:\mingw\bin;C:\mingw\msys\1.0\bin;%PATH%"
 
-   Make sure it is in this exact order. If you have Cygwin installed make sure the above entries appear first.
+Make sure it is in this exact order. This is to ensure that ``make`` and ``sh`` are run from the correct locations.
 
-   You will need to restart your command prompt (and Eclipse, if already running) for these changes to take effect.
-   
-
-Alternative install
-~~~~~~~~~~~~~~~~~~~
-
-To install from the original MinGW source repository:
-
-1. Get the `MingGW Setup <https://osdn.net/projects/mingw/downloads/68260/mingw-get-setup.exe>`__ and run it.
-   This will create the ``C:\MinGW`` directory with minimal content.
-
-2. Set PATH environment variable as above.
-
-3. Install required MinGW packages::
-
-      mingw-get install mingw32-base-bin mingw-developer-toolkit-bin mingw32-gcc-g++-bin mingw32-pthreads-w32-dev mingw32-libmingwex
-
-   Note that you can upgrade packages using::
-   
-      mingw-get update
-      mingw-get upgrade
-
-   However this will not upgrade a 6.3.0 installation to 8.2.0.
-
-
-Install ESP8266 Toolchain
--------------------------
-
-1. Download toolchain `ESP Quick Toolchain <https://github.com/SmingHub/SmingTools/releases/download/1.0/x86_64-w64-mingw32.xtensa-lx106-elf-e6a192b.201211.zip>`__.
-
-2. Unzip to default location::
-
-      7z -oC:\tools\esp-quick-toolchain x x86_64-w64-mingw32.xtensa-lx106-elf-e6a192b.201211.zip
-
-3. Set :envvar:`ESP_HOME` environment variable::
-
-      SETX ESP_HOME C:\tools\esp-quick-toolchain
-
-.. note::
-   There is NO trailing slash on the path!
-   
-   If you want to set environment variables system-wide, append /M to the command.
-   You'll need to do this from an administrative command prompt.
-
-
-Install Python
---------------
-
-Get the current version from https://www.python.org/.
-
-By default, python gets installed here::
-
-   C:\Users\xxx\AppData\Local\Programs\Python\Python38\python.exe
-
-Wherever it ends up will either need to be in the path::
-
-   setx PATH "C:\Users\xxx\AppData\Local\Programs\Python\Python38;%PATH%"
-
-or located using the :envvar:`PYTHON` environment variable::
-
-   setx PYTHON "C:\Users\xxx\AppData\Local\Programs\Python\Python38"
+You will need to restart your command prompt (and Eclipse, if already running) for these changes to take effect.
 
 .. important::
 
-   The PYTHON variable may not contain spaces.
-   This is a MinGW restriction.
+   The above ``setx`` command, and its sibling ``set``, are both flawed in that the path will be truncated to 4095 characters. For this reason, the installer uses powershell to update the path which does not have this issue. The script includes extra checks to ensure paths are not duplicated.
 
 
-Install GIT
------------
+Paths and locations
+-------------------
 
-This is required to fetch and update Sming code from its repository.
+You can put Sming anywhere convenient.
+The ``tools\export.cmd`` script will ensure that ``SMING_HOME`` is set correctly.
 
-1. Install command-line `GIT <https://git-scm.com/downloads>`__ client.
+Please observe the following precautions::
 
-These steps are optional, but highly recommended:
+There must be **no spaces** in the path
+   GNU make cannot handle spaces.
 
-2. Install Graphical client `Git Extensions <https://gitextensions.github.io/>`__.
-3. Create an account at https://github.com. This will allow you to participate in discussions, raise issues
-   and, if you like, :doc:`/contribute/index` to the framework!
-
-
-Download Sming
---------------
-
-1. You can put Sming anywhere convenient, provided there are **no spaces** in the path!
-   For example, *C:\\tools\\sming*::
-
-      mkdir C:\tools
-      cd /d C:\tools
-
-2. To obtain the latest develop code with all the latest features and fixes::
-
-      git clone https://github.com/SmingHub/Sming
-
-   To obtain the latest release::
-
-      git clone https://github.com/SmingHub/Sming --branch master
-
-3. Set :envvar:`SMING_HOME` environment variable::
-
-      SETX SMING_HOME C:\tools\Sming\Sming
-
-   Note: there is NO trailing slash on the path!
-   
-.. note::
-   Whilst Windows filenames are not (by default) case-sensitive, the compiler tools are.
-   
+Be consistent with case
+   Whilst Windows filenames are not (by default) case-sensitive, the compiler tools are.   
    Please take care to type paths exactly as shown.
 
-At this stage you should be able to build a sample::
+Don't use excessively long paths
+   This can avoid some weird issues if paths become too long.
+   If you encounter problems, you can always remap paths using ``subst``.
+   For example::
 
-   cd samples\Basic_Blink
-   make -j
-
-If you want to try out the Host emulator, do this::
-
-   make -j SMING_ARCH=Host
-
-For build options::
-
-   make help
+      subst S: C:\Users\Kevin\Documents\Development\Embedded
 
 
 Install Eclipse IDE
@@ -210,9 +150,3 @@ For example, to switch to a Host emulator build, do this::
 
 This also displays the current configuration settings. Whether you build from command line or Eclipse,
 the same settings will be used.
-
-
-Next steps
-----------
-
-Proceed to :doc:`../config`.

--- a/docs/source/upgrading/5.1-5.2.rst
+++ b/docs/source/upgrading/5.1-5.2.rst
@@ -3,6 +3,21 @@ From v5.1 to v5.2
 
 .. highlight:: c++
 
+**Windows installer**
+
+The Windows installer makes use of custom chocolatey packages, which are out of date.
+These packages are separate from the main Sming repository which makes maintenance problematic.
+
+The procedure has therefore been revised to use installation scripts instead of these chocolatey packages. This brings the installation procedure closer to that for linux/MacOS.
+
+The initial installation step to bootstrap the installation remains unchanged: The ``choco-install.cmd`` script is fetched from the Sming ``develop`` branch and executed.
+The custom choco scripts have been replaced with scripted logic.
+
+Installation of toolchains is done as a separate step as it does not require administrative priviledges.
+
+The documentation at https://sming.readthedocs.io/en/latest/getting-started/windows/index.html has been updated to reflect these changes.
+
+
 **PartitionStream: Breaking change**
 
 The :cpp:class:`Storage::PartitionStream` constructors with ``blockErase`` parameter have been deprecated.


### PR DESCRIPTION
The Windows installer makes use of custom chocolatey packages, which are out of date. See issue #2514.
These packages are separate from the main Sming repository and represent an un-necessary maintenance overhead.

This PR updates the installation scripts so these custom chocolatey packages are no longer required.
The scripts were previously only used for CI testing so have been reworked appropriately.
The installation procedure is now similar to that for linux/MacOS.

The initial bootstrap installation remains unchanged: The ``choco-install.cmd`` script is fetched from the Sming ``develop`` branch and executed.

Note: Contrary to other installs and the documentation, the current sming choco script installs the `master` branch.

The user runs a second install script `tools\install` to install required toolchains.
This is separate because:

- Administrative priviledges are not required
- The user gets more control over which toolchains get installed
- The script doesn't change anything outside of the `C:\tools` directory (other than python packages)

The directory can also be customised by setting `SMING_TOOLS_DIR`.

The documentation at https://sming.readthedocs.io/en/latest/getting-started/windows/index.html has been updated to reflect these changes.


**CI Compiler Cache**

I've moved caching to just before the build starts, so that configuration and zeroing ccache is handled by the build script. This is more logical than doing it as part of the install phase.


**Esp32 install/build**

A standard IDF tools installation includes the following packages:

- cmake
- ninja
- ccache

As Sming installs these system-wide, these are not required.
Also, as we now have Ninja in the system path for all platforms some logic in build.mk can be removed.

These additional items are not used:

- idf-exe
- dfu-util

The Sming Esp32 installer omits all the above items, for linux/MacOS also.
Turns out we can just pass the filter `"*elf*"` to the installer to get all the stuff we **do** actually need.


**Python**

This defaulted to `python3`, which failed in testing as current installers don't provide it, so change to `python`.

The `PYTHON` variable now defaults to the full path determined by `which python`. In Windows, the makefile resolves this to something like `/c/Python312/python.exe`.


**MinGW**

I've also added `MinGW-2021-04-12.7z` to the [SmingTools](https://github.com/SmingHub/SmingTools/releases).
This differs from `MinGW-2020-10-19.7z` which was previously used (in both choco package and CI install) in the following ways:

- MinGW version changed from 5.4.1 to 5.4.2
- Files unpack into `./` instead of `MinGw/` so makes it easier to relocate during installation if required
- Contents of `var/cache` removed to reduce size of archive (48MB vs 133MB)

No changes to GCC, still 9.2.0.


**Docs build**

Documentation build fails in Windows, problems with libcairo-2.dll.
Initially, the error was about not finding the DLL.
Some reserach suggests installing gtk+ runtime should fix this.
Still fails but with error "can't find .so".

Leaving this as a known issue, just build in Linux or WSL.

Todo:
* [x] Check library CI builds still work