### PR TITLE
Revert SmingLocale.h encoding

### DIFF
--- a/Sming/Core/SmingLocale.h
+++ b/Sming/Core/SmingLocale.h
@@ -36,13 +36,13 @@
 #elif LOCALE == LOCALE_FR_FR
 
 #define LOCALE_MONTH_NAMES                                                                                             \
-	"janvier\0fï¿½vrier\0mars\0avril\0mai\0juin\0juillet\0aoï¿½t\0septembre\0octobre\0novembre\0dï¿½cembre"
+	"janvier\0février\0mars\0avril\0mai\0juin\0juillet\0août\0septembre\0octobre\0novembre\0décembre"
 #define LOCALE_DAY_NAMES "dimanche\0lundi\0mardi\0mercredi\0jeudi\0vendredi\0samedi"
 
 #elif LOCALE == LOCALE_DE_DE
 
 #define LOCALE_MONTH_NAMES                                                                                             \
-	"Januar\0Februar\0Mï¿½rz\0April\0Mai\0Juni\0Juli\0August\0September\0Oktober\0November\0Dezember"
+	"Januar\0Februar\0März\0April\0Mai\0Juni\0Juli\0August\0September\0Oktober\0November\0Dezember"
 #define LOCALE_DAY_NAMES "Sonntag\0Montag\0Dienstag\0Mittwoch\0Donnerstag\0Freitag\0Samstag"
 #define LOCALE_DATE "%d.%m.%Y"
 


### PR DESCRIPTION
The french and german strings defined in `SmingLocale.h` appear to have been corrupted.

Taking the é in février as an example:

PR #1549 Initial commit as ascii (probably Windows) `e9`
PR #1715 changed to UTF-8 'replacement character' ef bf bd.

The UTF-8 code would be ce a9 but as that's two bytes it could break existing code.
Best to stick with original encoding.
