### PR TITLE
Update CI ccache on every push to develop

### DIFF
--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -109,7 +109,7 @@ jobs:
       run: ccache -sv
 
     - name: Delete Previous Compiler Cache
-      if: ${{ steps.ccache.outputs.cache-hit }}
+      if: github.ref_name == github.event.repository.default_branch && steps.ccache.outputs.cache-hit
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache

--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -86,8 +86,9 @@ jobs:
         . Tools/ci/setenv.ps1
         Tools/ci/install.cmd
 
-    - name: Compiler Cache
-      uses: actions/cache@v4
+    - name: Restore Compiler Cache
+      id: ccache
+      uses: actions/cache/restore@v4
       with:
         path: .ccache
         key: ${{ matrix.os }}-ccache-${{ matrix.variant }}-${{ matrix.idf_version }}
@@ -106,3 +107,19 @@ jobs:
 
     - name: Compiler Cache stats
       run: ccache -sv
+
+    - name: Delete Previous Compiler Cache
+      if: ${{ steps.ccache.outputs.cache-hit }}
+      continue-on-error: true
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete "${{ steps.ccache.outputs.cache-primary-key }}" --branch ${{ github.ref_name }} --confirm
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Save Compiler Cache
+      if: github.ref_name == github.event.repository.default_branch || !steps.ccache.outputs.cache-hit
+      uses: actions/cache/save@v4
+      with:
+        path: .ccache
+        key: ${{ steps.ccache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,9 @@ jobs:
         . Tools/ci/setenv.ps1
         Tools/ci/install.cmd
 
-    - name: Compiler Cache
-      uses: actions/cache@v4
+    - name: Restore Compiler Cache
+      id: ccache
+      uses: actions/cache/restore@v4
       with:
         path: .ccache
         key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ matrix.variant }}
@@ -97,3 +98,19 @@ jobs:
 
     - name: Compiler Cache stats
       run: ccache -sv
+
+    - name: Delete Previous Compiler Cache
+      if: ${{ steps.ccache.outputs.cache-hit }}
+      continue-on-error: true
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete "${{ steps.ccache.outputs.cache-primary-key }}" --branch ${{ github.ref_name }} --confirm
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Save Compiler Cache
+      if: github.ref_name == github.event.repository.default_branch || !steps.ccache.outputs.cache-hit
+      uses: actions/cache/save@v4
+      with:
+        path: .ccache
+        key: ${{ steps.ccache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       run: ccache -sv
 
     - name: Delete Previous Compiler Cache
-      if: ${{ steps.ccache.outputs.cache-hit }}
+      if: github.ref_name == github.event.repository.default_branch && steps.ccache.outputs.cache-hit
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -158,7 +158,7 @@ jobs:
       run: ccache -sv
 
     - name: Delete Previous Compiler Cache
-      if: ${{ steps.ccache.outputs.cache-hit }}
+      if: github.ref_name == github.event.repository.default_branch && steps.ccache.outputs.cache-hit
       continue-on-error: true
       run: |
         gh extension install actions/gh-actions-cache

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -133,8 +133,9 @@ jobs:
         . Tools/ci/setenv.ps1
         Tools/ci/install.cmd
 
-    - name: Compiler Cache
-      uses: actions/cache@v4
+    - name: Restore Compiler Cache
+      id: ccache
+      uses: actions/cache/restore@v4
       with:
         path: .ccache
         key: ${{ matrix.os }}-ccache-${{ matrix.variant }}-${{ matrix.arch == 'Esp32' && env.INSTALL_IDF_VER || '' }}
@@ -155,3 +156,19 @@ jobs:
 
     - name: Compiler Cache stats
       run: ccache -sv
+
+    - name: Delete Previous Compiler Cache
+      if: ${{ steps.ccache.outputs.cache-hit }}
+      continue-on-error: true
+      run: |
+        gh extension install actions/gh-actions-cache
+        gh actions-cache delete "${{ steps.ccache.outputs.cache-primary-key }}" --branch ${{ github.ref_name }} --confirm
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Save Compiler Cache
+      if: github.ref_name == github.event.repository.default_branch || !steps.ccache.outputs.cache-hit
+      uses: actions/cache/save@v4
+      with:
+        path: .ccache
+        key: ${{ steps.ccache.outputs.cache-primary-key }}


### PR DESCRIPTION
Build times are increasing faster than I expected, so it's clear that to be effective the ccache needs to be kept up to date.
This needs to happen automatically so we can forget about it.

Github caching behaviour is to fail the save operation if a hit occurred on primary key.
In other words, a cache entry will never be overwritten (updated).
There is no provision for a cache update as such: https://github.com/actions/cache/issues/342

The workaround is fairly easy though: break into discrete restore/delete/save steps.

Only the cache for the current branch is deleted, using the `--branch` option to `gh action-cache delete`.
This prevents pull requests from contributors with repo write access from deleting the main `develop` cache.

This table shows the intended progression of cache updates, starting from an empty cache:

| Event   | Branch       | Restore      | Delete  | Save         |
| ------- | ------------ | --------     | ------- | ------------ |
| PR      | feature/new  | -            | -       | feature/new  |
| PR      | feature/new  | feature/new  | -       | -            |
| Merge   | develop      | -            | -       | develop      |
| PR      | fix/lwip     | develop      | -       | -            |
| Merge   | develop      | develop      | develop | develop      |

So always save if (event.branch == develop) or no cache hit
