### PR TITLE
Fix CI ccache for library and restrict size

### DIFF
--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -106,7 +106,9 @@ jobs:
         Tools/ci/build.cmd
 
     - name: Compiler Cache stats
-      run: ccache -sv
+      run: |
+        ccache --evict-older-than 14400s
+        ccache -sv
 
     - name: Delete Previous Compiler Cache
       if: github.ref_name == github.event.repository.default_branch && steps.ccache.outputs.cache-hit

--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -44,6 +44,8 @@ jobs:
       INSTALL_IDF_VER: ${{ matrix.idf_version }}
       IDF_SKIP_CHECK_SUBMODULES: 1
       ENABLE_CCACHE: 1
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 500M
 
     steps:
     - name: Fix autocrlf setting
@@ -86,18 +88,20 @@ jobs:
       id: ccache
       uses: actions/cache/restore@v4
       with:
-        path: .ccache
+        path: ${{ env.CCACHE_DIR }}
         key: ${{ matrix.os }}-ccache-${{ matrix.variant }}-${{ matrix.idf_version }}
 
     - name: Build and test for ${{matrix.variant}} with IDF v${{matrix.idf_version}} on Ubuntu / MacOS
       if: matrix.os != 'windows-latest'
       run: |
+        ccache -z
         . Tools/export.sh
         Tools/ci/build.sh
 
     - name: Build and test for ${{matrix.variant}} with IDF v${{matrix.idf_version}} on Windows
       if: matrix.os == 'windows-latest'
       run: |
+        ccache -z
         . Tools/ci/setenv.ps1
         Tools/ci/build.cmd
 
@@ -117,5 +121,5 @@ jobs:
       if: github.ref_name == github.event.repository.default_branch || !steps.ccache.outputs.cache-hit
       uses: actions/cache/save@v4
       with:
-        path: .ccache
+        path: ${{ env.CCACHE_DIR }}
         key: ${{ steps.ccache.outputs.cache-primary-key }}

--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
+      CI_BUILD_DIR: ${{ github.workspace }}
+      SMING_HOME: ${{ github.workspace }}/Sming
       SMING_ARCH: Esp32
       SMING_SOC: ${{ matrix.variant }}
       INSTALL_IDF_VER: ${{ matrix.idf_version }}
@@ -55,12 +57,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.idf_version == '4.3' && '3.8' || '3.12' }}
-
-    - name: Configure environment
-      shell: pwsh
-      run: |
-        "CI_BUILD_DIR=" + (Resolve-Path ".").path >> $env:GITHUB_ENV
-        "SMING_HOME=" + (Resolve-Path "Sming").path >> $env:GITHUB_ENV
 
     - name: Fix permissions
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
+      CI_BUILD_DIR: ${{ github.workspace }}
+      SMING_HOME: ${{ github.workspace }}/Sming
       SMING_ARCH: ${{ matrix.arch }}
       SMING_SOC: ${{ matrix.variant }}
       CLANG_BUILD: ${{ matrix.toolchain == 'clang' && '15' || '0' }}
@@ -57,12 +59,6 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.12"
-
-    - name: Configure environment
-      shell: pwsh
-      run: |
-        "CI_BUILD_DIR=" + (Resolve-Path ".").path >> $env:GITHUB_ENV
-        "SMING_HOME=" + (Resolve-Path "Sming").path >> $env:GITHUB_ENV
 
     - name: Install build tools for Ubuntu / MacOS
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,8 @@ jobs:
       CLANG_BUILD: ${{ matrix.toolchain == 'clang' && '15' || '0' }}
       BUILD64: ${{ matrix.toolchain == 'gcc64' && 1 || 0 }}
       ENABLE_CCACHE: 1
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 500M
 
     steps:
     - name: Fix autocrlf setting
@@ -75,7 +77,7 @@ jobs:
       id: ccache
       uses: actions/cache/restore@v4
       with:
-        path: .ccache
+        path: ${{ env.CCACHE_DIR }}
         key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ matrix.variant }}
 
     - name: Build and test for ${{matrix.variant}} on Ubuntu / MacOS
@@ -83,12 +85,14 @@ jobs:
         CLANG_FORMAT: clang-format-8
       if: matrix.os != 'windows-latest'
       run: |
+        ccache -z
         . Tools/export.sh
         Tools/ci/build.sh
 
     - name: Build and test for ${{matrix.variant}} on Windows
       if: matrix.os == 'windows-latest'
       run: |
+        ccache -z
         . Tools/ci/setenv.ps1
         Tools/ci/build.cmd
 
@@ -108,5 +112,5 @@ jobs:
       if: github.ref_name == github.event.repository.default_branch || !steps.ccache.outputs.cache-hit
       uses: actions/cache/save@v4
       with:
-        path: .ccache
+        path: ${{ env.CCACHE_DIR }}
         key: ${{ steps.ccache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,9 @@ jobs:
         Tools/ci/build.cmd
 
     - name: Compiler Cache stats
-      run: ccache -sv
+      run: |
+        ccache --evict-older-than 14400s
+        ccache -sv
 
     - name: Delete Previous Compiler Cache
       if: github.ref_name == github.event.repository.default_branch && steps.ccache.outputs.cache-hit

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -69,6 +69,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
+      CI_BUILD_DIR: ${{ github.workspace }}
       SMING_ARCH: ${{ matrix.arch }}
       SMING_SOC: ${{ matrix.variant }}
       INSTALL_IDF_VER: ${{ matrix.idf_version || '5.2' }}
@@ -102,7 +103,6 @@ jobs:
     - name: Configure environment
       shell: pwsh
       run: |
-        "CI_BUILD_DIR=" + (Resolve-Path ".").path >> $env:GITHUB_ENV
         "SMING_HOME=" + (Resolve-Path "../../sming/Sming").path >> $env:GITHUB_ENV
         "COMPONENT_SEARCH_DIRS=" + (Resolve-Path "..").path >> $env:GITHUB_ENV
         "CI_MAKEFILE=" + (Resolve-Path "../../sming/Tools/ci/library/Makefile") >> $env:GITHUB_ENV

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -76,6 +76,8 @@ jobs:
       CLANG_BUILD: ${{ matrix.toolchain == 'clang' && '15' || '0' }}
       BUILD64: ${{ matrix.toolchain == 'gcc64' && 1 || 0 }}
       ENABLE_CCACHE: 1
+      CCACHE_DIR: ${{ github.workspace }}/.ccache
+      CCACHE_MAXSIZE: 500M
 
     steps:
     - name: Fix autocrlf setting
@@ -137,7 +139,7 @@ jobs:
       id: ccache
       uses: actions/cache/restore@v4
       with:
-        path: .ccache
+        path: ${{ env.CCACHE_DIR }}
         key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ matrix.variant }}-${{ matrix.arch == 'Esp32' && env.INSTALL_IDF_VER || '' }}
 
     - name: Build and Test for ${{matrix.arch}} on Ubuntu / MacOS
@@ -145,12 +147,14 @@ jobs:
         CLANG_FORMAT: clang-format-8
       if: matrix.os != 'windows-latest'
       run: |
-        source $SMING_HOME/../Tools/export.sh
+        ccache -z
+        . $SMING_HOME/../Tools/export.sh
         make -j$(nproc) -f $CI_MAKEFILE
 
     - name: Build and Test for ${{matrix.arch}} on Windows
       if: matrix.os == 'windows-latest'
       run: |
+        ccache -z
         . "$env:SMING_HOME/../Tools/ci/setenv.ps1"
         make -j $env:NUMBER_OF_PROCESSORS -f $env:CI_MAKEFILE
 
@@ -170,5 +174,5 @@ jobs:
       if: github.ref_name == github.event.repository.default_branch || !steps.ccache.outputs.cache-hit
       uses: actions/cache/save@v4
       with:
-        path: .ccache
+        path: ${{ env.CCACHE_DIR }}
         key: ${{ steps.ccache.outputs.cache-primary-key }}

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -138,7 +138,7 @@ jobs:
       uses: actions/cache/restore@v4
       with:
         path: .ccache
-        key: ${{ matrix.os }}-ccache-${{ matrix.variant }}-${{ matrix.arch == 'Esp32' && env.INSTALL_IDF_VER || '' }}
+        key: ${{ matrix.os }}-ccache-${{ matrix.toolchain }}-${{ matrix.variant }}-${{ matrix.arch == 'Esp32' && env.INSTALL_IDF_VER || '' }}
 
     - name: Build and Test for ${{matrix.arch}} on Ubuntu / MacOS
       env:

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -159,7 +159,9 @@ jobs:
         make -j $env:NUMBER_OF_PROCESSORS -f $env:CI_MAKEFILE
 
     - name: Compiler Cache stats
-      run: ccache -sv
+      run: |
+        ccache --evict-older-than 14400s
+        ccache -sv
 
     - name: Delete Previous Compiler Cache
       if: github.ref_name == github.event.repository.default_branch && steps.ccache.outputs.cache-hit

--- a/Tools/ci/build.cmd
+++ b/Tools/ci/build.cmd
@@ -9,13 +9,6 @@ if "%BUILD_DOCS%"=="true" (
     goto :EOF
 )
 
-REM Configure ccache
-if "%ENABLE_CCACHE%"=="1" (
-    ccache --set-config cache_dir="%CI_BUILD_DIR%\.ccache"
-    ccache --set-config max_size=500M
-    ccache -z
-)
-
 cd /d %SMING_HOME%
 call Arch\%SMING_ARCH%\Tools\ci\build.setup.cmd || goto :error
 

--- a/Tools/ci/build.sh
+++ b/Tools/ci/build.sh
@@ -9,13 +9,6 @@ if [ "$BUILD_DOCS" = "true" ]; then
     exit 0
 fi
 
-# Configure ccache
-if [ "$ENABLE_CCACHE" == "1" ]; then
-    ccache --set-config cache_dir="$CI_BUILD_DIR/.ccache"
-    ccache --set-config max_size=500M
-    ccache -z
-fi
-
 # Build times benefit from parallel building
 export MAKE_PARALLEL="make -j$(nproc)"
 


### PR DESCRIPTION
**Fix CI library caching**

#2865 broken library CI because:

- ccache initialisation commands never get executed to set ccache directory
- library ccache key must have toolchain in it

Fixed by removing the ccache commands from script and updating workflow `env` instead.
Just requires call to clear stats before building.

NB. This leads to a fair bit of duplication in all 3 workflow files. This is the simplest I can come up with for now.

**Simplify workflows**

Don't need the `Configure environment` step, just add values to `env`.

**Use explicit ccache path**

In testing was getting failures saving cache due to ccache not found.
Use explicit absolute path to ccache directory.

**Restrict ccache size**

The cache for each job will increase over time to hit 500MB.
Over 40 jobs that's 20GB and will cause cache thrashing.

Easy fix: ask ccache to evict anything older than 4 hours from ccache.
Do this before printing stats so we can see the resulting size.
