### PR TITLE
Fix conflict with stdc++ `operator delete[](void*, size_t)`

### DIFF
--- a/Sming/Arch/Esp8266/Components/heap/alloc.cpp
+++ b/Sming/Arch/Esp8266/Components/heap/alloc.cpp
@@ -46,7 +46,7 @@ void operator delete(void* ptr, size_t)
 	free(ptr);
 }
 
-void operator delete[](void* ptr, size_t)
+void __attribute__((weak)) operator delete[](void* ptr, size_t)
 {
 	free(ptr);
 }


### PR DESCRIPTION
Happens under some situations only so make it weak just in case. Fixes delightful error message:

```
xtensa-lx106-elf/bin/ld: .../out/Esp8266/debug/lib/clib-heap-e92ce383a1d93c576825dc47f463e4fe.a(alloc.o):
    in function `_ZdaPvj': alloc.cpp:(.text._ZdaPvj+0x4):
    multiple definition of `_ZdaPvj';
    .../lib/libstdc++.a(del_opvs.o):/workdir/repo/gcc-gnu/libstdc++-v3/libsupc++/del_opvs.cc:33: first defined here
```