### PR TITLE
Include unicode formatting support for JSON escapes

### DIFF
--- a/Sming/Core/Data/Format/Formatter.cpp
+++ b/Sming/Core/Data/Format/Formatter.cpp
@@ -24,12 +24,8 @@ char escapeChar(char c)
 	switch(c) {
 	case '\0':
 		return '0';
-	case '\'':
-		return '\'';
 	case '\"':
 		return '"';
-	case '\?':
-		return '?';
 	case '\\':
 		return '\\';
 	case '\a':

--- a/Sming/Core/Data/Format/Formatter.cpp
+++ b/Sming/Core/Data/Format/Formatter.cpp
@@ -59,6 +59,9 @@ unsigned escapeControls(String& value, Options options)
 			extra += 1; // "\"
 		} else if(uint8_t(c) < 0x20) {
 			extra += options[Option::unicode] ? 5 : 3; // "\uNNNN" or "\xnn"
+		} else if(options[Option::utf8] && (c & 0x80)) {
+			// Characters such as £ (0xa3) are escaped to 0xc2 0xa3 in UTF-8
+			extra += 1; // '\xc2' prefix
 		}
 	}
 	if(extra == 0) {
@@ -89,6 +92,9 @@ unsigned escapeControls(String& value, Options options)
 			}
 			*out++ = hexchar(uint8_t(c) >> 4);
 			*out++ = hexchar(uint8_t(c) & 0x0f);
+		} else if(options[Option::utf8] && (c & 0x80)) {
+			*out++ = '\xc2';
+			*out++ = c;
 		} else {
 			*out++ = c;
 		}

--- a/Sming/Core/Data/Format/Formatter.h
+++ b/Sming/Core/Data/Format/Formatter.h
@@ -20,9 +20,10 @@ namespace Format
 /**
  * @brief Escape standard control codes such as `\n` (below ASCII 0x20)
  * @param value String to be modified
+ * @param unicode If true, use unicode escapes \uNNNN, otherwise hex \xNN
  * @retval unsigned Number of control characters found and replaced
  */
-unsigned escapeControls(String& value);
+unsigned escapeControls(String& value, bool unicode);
 
 /**
  * @brief Virtual class to perform format-specific String adjustments

--- a/Sming/Core/Data/Format/Formatter.h
+++ b/Sming/Core/Data/Format/Formatter.h
@@ -14,16 +14,25 @@
 
 #include <WString.h>
 #include <Data/WebConstants.h>
+#include <Data/BitSet.h>
 
 namespace Format
 {
+enum class Option {
+	unicode, //< Use unicode escapes \uNNNN, otherwise hex \xNN
+	doublequote,
+	singlequote,
+	backslash,
+};
+using Options = BitSet<uint8_t, Option, 3>;
+
 /**
  * @brief Escape standard control codes such as `\n` (below ASCII 0x20)
  * @param value String to be modified
- * @param unicode If true, use unicode escapes \uNNNN, otherwise hex \xNN
+ * @param options
  * @retval unsigned Number of control characters found and replaced
  */
-unsigned escapeControls(String& value, bool unicode);
+unsigned escapeControls(String& value, Options options);
 
 /**
  * @brief Virtual class to perform format-specific String adjustments

--- a/Sming/Core/Data/Format/Formatter.h
+++ b/Sming/Core/Data/Format/Formatter.h
@@ -20,6 +20,7 @@ namespace Format
 {
 enum class Option {
 	unicode, //< Use unicode escapes \uNNNN, otherwise hex \xNN
+	utf8,	///< Convert extended ASCII to UTF8
 	doublequote,
 	singlequote,
 	backslash,

--- a/Sming/Core/Data/Format/Formatter.h
+++ b/Sming/Core/Data/Format/Formatter.h
@@ -25,7 +25,7 @@ enum class Option {
 	singlequote,
 	backslash,
 };
-using Options = BitSet<uint8_t, Option, 3>;
+using Options = BitSet<uint8_t, Option, 5>;
 
 /**
  * @brief Escape standard control codes such as `\n` (below ASCII 0x20)

--- a/Sming/Core/Data/Format/Json.cpp
+++ b/Sming/Core/Data/Format/Json.cpp
@@ -66,7 +66,7 @@ bool IsValidUtf8(const char* str, unsigned length)
  */
 void Json::escape(String& value) const
 {
-	escapeControls(value, true);
+	escapeControls(value, Option::unicode | Option::doublequote | Option::backslash);
 	if(!IsValidUtf8(value.c_str(), value.length())) {
 		debug_w("Invalid UTF8: %s", value.c_str());
 		for(unsigned i = 0; i < value.length(); ++i) {
@@ -75,8 +75,6 @@ void Json::escape(String& value) const
 				c = '_';
 		}
 	}
-
-	value.replace("\"", "\\\"");
 }
 
 } // namespace Format

--- a/Sming/Core/Data/Format/Json.cpp
+++ b/Sming/Core/Data/Format/Json.cpp
@@ -66,7 +66,7 @@ bool IsValidUtf8(const char* str, unsigned length)
  */
 void Json::escape(String& value) const
 {
-	escapeControls(value);
+	escapeControls(value, true);
 	if(!IsValidUtf8(value.c_str(), value.length())) {
 		debug_w("Invalid UTF8: %s", value.c_str());
 		for(unsigned i = 0; i < value.length(); ++i) {

--- a/Sming/Core/Data/Format/Json.cpp
+++ b/Sming/Core/Data/Format/Json.cpp
@@ -55,6 +55,19 @@ bool IsValidUtf8(const char* str, unsigned length)
 	return true;
 }
 
+void escapeText(String& value)
+{
+	escapeControls(value, Option::unicode | Option::utf8 | Option::doublequote | Option::backslash);
+	if(!IsValidUtf8(value.c_str(), value.length())) {
+		debug_w("Invalid UTF8: %s", value.c_str());
+		for(unsigned i = 0; i < value.length(); ++i) {
+			char& c = value[i];
+			if(c < 0x20 || uint8_t(c) > 127)
+				c = '_';
+		}
+	}
+}
+
 } // namespace
 
 /*
@@ -66,14 +79,18 @@ bool IsValidUtf8(const char* str, unsigned length)
  */
 void Json::escape(String& value) const
 {
-	escapeControls(value, Option::unicode | Option::doublequote | Option::backslash);
-	if(!IsValidUtf8(value.c_str(), value.length())) {
-		debug_w("Invalid UTF8: %s", value.c_str());
-		for(unsigned i = 0; i < value.length(); ++i) {
-			char& c = value[i];
-			if(c < 0x20 || uint8_t(c) > 127)
-				c = '_';
-		}
+	escapeText(value);
+}
+
+void Json::quote(String& value) const
+{
+	escapeText(value);
+	auto len = value.length();
+	if(value.setLength(len + 2)) {
+		auto s = value.begin();
+		memmove(s + 1, s, len);
+		s[0] = '"';
+		s[len + 1] = '"';
 	}
 }
 

--- a/Sming/Core/Data/Format/Json.h
+++ b/Sming/Core/Data/Format/Json.h
@@ -20,6 +20,7 @@ class Json : public Standard
 {
 public:
 	void escape(String& value) const override;
+	void quote(String& value) const override;
 
 	MimeType mimeType() const override
 	{

--- a/tests/HostTests/modules/Formatter.cpp
+++ b/tests/HostTests/modules/Formatter.cpp
@@ -11,16 +11,29 @@ public:
 	void execute() override
 	{
 		DEFINE_FSTR_LOCAL(text1, "A JSON\ntest string\twith escapes\x12\0\n"
-								 "Worth maybe \xc2\xa3"
+								 "Worth \"maybe\" \xc2\xa3"
 								 "0.53.")
-		DEFINE_FSTR_LOCAL(text1b, "A JSON\\ntest string\\twith escapes\\x12\\0\\n"
-								  "Worth maybe \xc2\xa3"
-								  "0.53.")
 
-		Serial << text1 << endl;
-		String s(text1);
-		Format::json.escape(s);
-		REQUIRE_EQ(s, text1b);
+		TEST_CASE("JSON")
+		{
+			DEFINE_FSTR_LOCAL(text1b, "A JSON\\ntest string\\twith escapes\\u0012\\u0000\\n"
+									  "Worth \\\"maybe\\\" \xc2\xa3"
+									  "0.53.")
+
+			Serial << text1 << endl;
+			String s(text1);
+			Format::json.escape(s);
+			REQUIRE_EQ(s, text1b);
+		}
+
+		TEST_CASE("C++")
+		{
+			DEFINE_FSTR_LOCAL(text1b, "A JSON\\ntest string\\twith escapes\\x12\\0\\nWorth \\\"maybe\\\" £0.53.")
+
+			String s(text1);
+			Format::escapeControls(s, Format::Option::doublequote | Format::Option::backslash);
+			REQUIRE_EQ(s, text1b);
+		}
 	}
 };
 

--- a/tests/HostTests/modules/Formatter.cpp
+++ b/tests/HostTests/modules/Formatter.cpp
@@ -17,7 +17,7 @@ public:
 		TEST_CASE("JSON")
 		{
 			DEFINE_FSTR_LOCAL(text1b, "A JSON\\ntest string\\twith escapes\\u0012\\u0000\\n"
-									  "Worth \\\"maybe\\\" \xc2\xa3 0.53. Yen \xc2\xa5 5bn.")
+									  "Worth \\\"maybe\\\" \\u00a3 0.53. Yen \\u00a5 5bn.")
 
 			Serial << text1 << endl;
 			String s(text1);

--- a/tests/HostTests/modules/Formatter.cpp
+++ b/tests/HostTests/modules/Formatter.cpp
@@ -10,28 +10,39 @@ public:
 
 	void execute() override
 	{
+		// Note: \xa3 is unicode for £
 		DEFINE_FSTR_LOCAL(text1, "A JSON\ntest string\twith escapes\x12\0\n"
-								 "Worth \"maybe\" \xc2\xa3"
-								 "0.53.")
+								 "Worth \"maybe\" \xa3 0.53. Yen \xa5 5bn.")
 
 		TEST_CASE("JSON")
 		{
 			DEFINE_FSTR_LOCAL(text1b, "A JSON\\ntest string\\twith escapes\\u0012\\u0000\\n"
-									  "Worth \\\"maybe\\\" \xc2\xa3"
-									  "0.53.")
+									  "Worth \\\"maybe\\\" \xc2\xa3 0.53. Yen \xc2\xa5 5bn.")
 
 			Serial << text1 << endl;
 			String s(text1);
 			Format::json.escape(s);
 			REQUIRE_EQ(s, text1b);
+
+			s = text1;
+			Format::json.quote(s);
+			String quoted = String('"') + text1b + '"';
+			REQUIRE_EQ(s, quoted);
 		}
 
 		TEST_CASE("C++")
 		{
-			DEFINE_FSTR_LOCAL(text1b, "A JSON\\ntest string\\twith escapes\\x12\\0\\nWorth \\\"maybe\\\" £0.53.")
-
+			DEFINE_FSTR_LOCAL(
+				text1a, "A JSON\\ntest string\\twith escapes\\x12\\0\\nWorth \\\"maybe\\\" \xa3 0.53. Yen \xa5 5bn.")
 			String s(text1);
 			Format::escapeControls(s, Format::Option::doublequote | Format::Option::backslash);
+			REQUIRE_EQ(s, text1a);
+
+			DEFINE_FSTR_LOCAL(
+				text1b,
+				"A JSON\\ntest string\\twith escapes\\x12\\0\\nWorth \\\"maybe\\\" \xc2\xa3 0.53. Yen \xc2\xa5 5bn.")
+			s = text1;
+			Format::escapeControls(s, Format::Option::utf8 | Format::Option::doublequote | Format::Option::backslash);
 			REQUIRE_EQ(s, text1b);
 		}
 	}


### PR DESCRIPTION
This PR improves on #2875 for JSON string formatting, updating the `escapeControls` function to handle unicode escaping correctly.

The check for valid UTF8 has been removed. That's erroneous and got in there because of my lack of understanding about how JSON is encoded. It's fundamentally UNICODE, so characters outside of standard ASCII must all be encoded using `\uNNNN` escapes. That ensures output is always valid JSON, even if string input is garbage.

The `escapeControls` function has a `options` parameter which makes it a lot more useful for various escaping requirements. This is also more efficient as the input string requires only two passes for both escaping and quoting: the first pass establishes the new string length, the buffer is re-allocated then the modified string produced.