### PR TITLE
Remove official support for older ESP32 IDF versions: 4.3, 4.4 and 5.0.

### DIFF
--- a/.github/workflows/ci-esp32.yml
+++ b/.github/workflows/ci-esp32.yml
@@ -15,20 +15,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         variant: [esp32, esp32s2, esp32c3, esp32s3, esp32c2]
-        idf_version: ["4.4", "5.0", "5.2"]
-        include:
-          - os: ubuntu-latest
-            variant: esp32
-            idf_version: "4.3"
-        exclude:
-          - variant: esp32c2
-            idf_version: "4.4"
-          - os: macos-latest
-            idf_version: "4.4"
-          - os: macos-latest
-            idf_version: "5.0"
-          - os: windows-latest
-            idf_version: "5.0"
+        idf_version: ["5.2"]
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ toJson(matrix) }}
@@ -58,7 +45,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.idf_version == '4.3' && '3.8' || '3.12' }}
+        python-version: '3.12'
 
     - name: Fix permissions
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         variant: [esp8266, host, esp32, esp32s2, esp32c3, esp32s3, esp32c2, rp2040]
-        idf_version: ["4.4", ""] # "" denotes default, currently 5.2
+        idf_version: [""] # "" denotes default, currently 5.2
         toolchain: [gcc]
         include:
           - variant: esp8266
@@ -50,17 +50,6 @@ jobs:
             arch: Esp32
           - variant: rp2040
             arch: Rp2040
-        exclude:
-          - variant: esp32c2
-            idf_version: "4.4"
-          - variant: esp8266
-            idf_version: "4.4"
-          - variant: host
-            idf_version: "4.4"
-          - variant: rp2040
-            idf_version: "4.4"
-          - os: macos-latest
-            idf_version: "4.4"
 
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}-${{ toJson(matrix) }}

--- a/Sming/Arch/Esp32/README.rst
+++ b/Sming/Arch/Esp32/README.rst
@@ -116,9 +116,9 @@ See :component-esp32:`esp32` for further details.
 IDF versions
 ------------
 
-Sming currently supports IDF versions 4.3, 4.4, 5.0 and 5.2.
-The recommended version is 5.2.
-This is installed by default.
+Sming currently supports IDF versions 5.2. This is installed by default.
+Older versions 4.3, 4.4 and 5.0 are no longer officially supported. If you use one of the old versions, please, consider upgrading to 5.2.
+
 
 A different version can be installed if necessary::
 

--- a/Sming/Arch/Esp32/app.mk
+++ b/Sming/Arch/Esp32/app.mk
@@ -25,9 +25,9 @@ endif
 .PHONY: application
 application: $(TARGET_BIN)
 ifeq ($(IDF_VERSION),v4.3)
-	@printf "\033[47;1;31mWARNING! ESP-IDF 4.3 reached 'End of Life' in December 2023.\033[0m Upgrade to v5.2 recommended.\n"
+	@printf "\033[47;1;31mWARNING! ESP-IDF 4.3 reached 'End of Life' in December 2023.\033[0m Please upgrade to v5.2.\n"
 else ifeq ($(IDF_VERSION),v4.4)
-	@printf "\033[47;1;31mWARNING! ESP-IDF 4.4 support ends August 2024!\033[0m Upgrade to v5.2 recommended.\n"
+	@printf "\033[47;1;31mWARNING! ESP-IDF 4.4 support has ended in August 2024!\033[0m Please upgrade to v5.2.\n"
 else ifeq ($(IDF_VERSION),v5.0)
 	@printf "\033[47;1;34mNOTE! ESP-IDF 5.0 not recommended for new designs.\033[0m Please consider upgrading to v5.2.\n"
 endif


### PR DESCRIPTION
It is highly recommended to upgrade to version 5.2 if not done yet.
Related to #2732.