### PR TITLE
Fix MallocCount for MinGW

### DIFF
--- a/Sming/Components/malloc_count/component.mk
+++ b/Sming/Components/malloc_count/component.mk
@@ -29,6 +29,11 @@ MC_WRAP_FUNCS += \
 	pvPortZallocIram \
 	vPortFree
 endif
+ifeq ($(SMING_ARCH)$(UNAME),HostWindows)
+MC_WRAP_FUNCS += \
+	__mingw_realloc \
+	__mingw_free
+endif
 
 EXTRA_LDFLAGS := $(call UndefWrap,$(MC_WRAP_FUNCS))
 

--- a/Sming/Components/malloc_count/malloc_count.cpp
+++ b/Sming/Components/malloc_count/malloc_count.cpp
@@ -364,6 +364,11 @@ extern "C" void WRAP(free)(void*) __attribute__((alias("mc_free")));
 
 using namespace MallocCount;
 
+#ifdef __WIN32
+extern "C" void* WRAP(__mingw_realloc)(void*, size_t) __attribute__((alias("mc_realloc")));
+extern "C" void WRAP(__mingw_free)(void*) __attribute__((alias("mc_free")));
+#endif
+
 #ifdef ARCH_ESP8266
 
 extern "C" void* WRAP(pvPortMalloc)(size_t) __attribute__((alias("mc_malloc")));


### PR DESCRIPTION
MinGW defines aliases in stdlib.h for `realloc` and `free` which require wrapping.