### PR TITLE
Improved Sming installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ GPATH
 .submodule
 *.built
 *.completed
+
+/esp-idf*
+/esp-quick-toolchain/
+/esp32/
+/rp2040/
+/samples/Basic_Serial/files/

--- a/Sming/Arch/Esp32/Tools/install.sh
+++ b/Sming/Arch/Esp32/Tools/install.sh
@@ -31,6 +31,29 @@ case $DIST in
     darwin)
         ;;
 
+    *)
+	_OK=1
+	_COMMANDS=(dfu-util bison flex gperf)
+	for _COMMAND in "${_COMMANDS[@]}"; do
+	    if ! [ -x "$(command -v ${_COMMAND})" ]; then
+		_OK=0
+		echo "Install programm ${_COMMAND}"
+	    fi
+	done
+	_INCLUDES=("/usr/include/ffi.h" "/usr/include/ssl/ssl.h")
+	for _INCLUDE in "${_INCLUDES[@]}"; do
+	    if ! [ -f "${_INCLUDE}" ]; then
+		_OK=0
+		echo "Install development package providing ${_INCLUDE}"
+	    fi
+	done
+	if [ $_OK != 1 ]; then
+	    echo "ABORTING"
+	    exit 1
+	fi
+	PACKAGES=()
+        ;;
+
 esac
 
 $PKG_INSTALL "${PACKAGES[@]}"

--- a/Tools/export.sh
+++ b/Tools/export.sh
@@ -24,7 +24,8 @@ if [ -z "$SMING_HOME" ]; then
     else
         _SOURCEDIR=$(dirname "${BASH_SOURCE[0]}")
     fi
-    SMING_HOME=$(realpath "$_SOURCEDIR/../Sming")
+    _SMIG_BASE=$(realpath "$_SOURCEDIR/..")
+    SMING_HOME=${_SMIG_BASE}"/Sming"
     export SMING_HOME
     echo "SMING_HOME: $SMING_HOME"
 fi
@@ -33,14 +34,14 @@ fi
 export PYTHON=${PYTHON:=$(which python3)}
 
 # Esp8266
-export ESP_HOME=${ESP_HOME:=/opt/esp-quick-toolchain}
+export ESP_HOME=${ESP_HOME:=${_SMIG_BASE}/esp-quick-toolchain}
 
 # Esp32
-export IDF_PATH=${IDF_PATH:=/opt/esp-idf}
-export IDF_TOOLS_PATH=${IDF_TOOLS_PATH:=/opt/esp32}
+export IDF_PATH=${IDF_PATH:=${_SMIG_BASE}/esp-idf}
+export IDF_TOOLS_PATH=${IDF_TOOLS_PATH:=${_SMIG_BASE}/esp32}
 
 # Rp2040
-export PICO_TOOLCHAIN_PATH=${PICO_TOOLCHAIN_PATH:=/opt/rp2040}
+export PICO_TOOLCHAIN_PATH=${PICO_TOOLCHAIN_PATH:=${_SMIG_BASE}/rp2040}
 
 # Provide non-apple CLANG (e.g. for rbpf library)
 if [ -n "$GITHUB_ACTIONS" ] && [ "$(uname)" = "Darwin" ]; then

--- a/Tools/install.sh
+++ b/Tools/install.sh
@@ -99,11 +99,33 @@ elif [ -n "$(command -v dnf)" ]; then
     DIST=fedora
     PKG_INSTALL="sudo dnf install -y"
 else
+    _OK=1
     echo "Unsupported distribution"
+    _REQUIRED_TOOLS=(
+            ccache \
+            cmake \
+            curl \
+            git \
+            make \
+            ninja \
+            unzip \
+            g++ \
+            python3 \
+            pip3 \
+	    wget \
+	    )
+    for _TOOL in "${_REQUIRED_TOOLS[@]}"; do
+	if ! [ -x "$(command -v $_TOOL)" ]; then
+	    _OK=0
+	    echo "Install required tool ${_TOOL}"
+	fi
+    done
+    if [ $_OK != 1 ]; then
     if [ $sourced = 1 ]; then
         return 1
     else
         exit 1
+    fi
     fi
 fi
 
@@ -183,8 +205,10 @@ case $DIST in
 
 esac
 
+if [ $(/usr/bin/python -c "import sys;print(sys.version_info[0])") != 3 ]; then
 if [ "$DIST" != "darwin" ]; then
     sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 100
+fi
 fi
 
 set -e


### PR DESCRIPTION
- Support for linux platforms not providing apt or dnf. Installation script searches for required tools and list missing.

- Better support for installing outside "/opt". esp and rp2040 tools are not installed in "/opt" if Sming isn't.

I tried to install Sming on my OpenSuse Tumbleseed system. For one, I did not like the forced usage of "sudo" without knowing what was going on (I had a wrapper installed that provided "apt", using zypper in the background). 

I would have liked code better that checks for required tools and asks the user to install them to install them if missing.

Second installing the tools to "/opt" did not work for me with user install. I don't want "/opt" to be user writable, and even installing the tools using "sudo" lead to fails later, when I tried to compile a project for ESP32.

My patch simply looks for required tools if neither apt nor dnf are found and lets the tools install in the Base directory Sming is installed.