### PR TITLE
Allow installation on Ubuntu 24.04 

### DIFF
--- a/Tools/export.sh
+++ b/Tools/export.sh
@@ -32,6 +32,11 @@ fi
 # Common
 export PYTHON=${PYTHON:=$(which python3)}
 
+# Python Virtual Environment
+if [ -f ~/.venvs/Sming/bin/activate ]; then
+	source ~/.venvs/Sming/bin/activate
+fi
+
 # Esp8266
 export ESP_HOME=${ESP_HOME:=/opt/esp-quick-toolchain}
 

--- a/Tools/export.sh
+++ b/Tools/export.sh
@@ -30,12 +30,13 @@ if [ -z "$SMING_HOME" ]; then
 fi
 
 # Common
-export PYTHON=${PYTHON:=$(which python3)}
 
 # Python Virtual Environment
 if [ -f ~/.venvs/Sming/bin/activate ]; then
 	source ~/.venvs/Sming/bin/activate
 fi
+
+export PYTHON=${PYTHON:=$(which python3)}
 
 # Esp8266
 export ESP_HOME=${ESP_HOME:=/opt/esp-quick-toolchain}

--- a/Tools/install.sh
+++ b/Tools/install.sh
@@ -254,7 +254,7 @@ fi
 
 PYTHON_INSTALL_CMD="python3 -m pip install --upgrade pip protobuf -r \"$SMING_HOME/../Tools/requirements.txt\""
 
-eval "$PYTHON_INSTALL_CMD" || install_venv "$PYTHON_INSTALL_CMD"  
+eval "$PYTHON_INSTALL_CMD" || $PKG_INSTALL python3-venv && install_venv "$PYTHON_INSTALL_CMD"  
 
 
 install() {

--- a/Tools/install.sh
+++ b/Tools/install.sh
@@ -252,7 +252,7 @@ if [ -f "/usr/bin/clang-format-8" ]; then
     sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8 100
 fi
 
-PYTHON_INSTALL_CMD="python3 -m pip install --upgrade pip protobuf -r \"$SMING_HOME/../Tools/requirements.txt\""
+PYTHON_INSTALL_CMD="python3 -m pip install --upgrade pip -r \"$SMING_HOME/../Tools/requirements.txt\""
 
 eval "$PYTHON_INSTALL_CMD" || $PKG_INSTALL python3-venv && install_venv "$PYTHON_INSTALL_CMD"  
 

--- a/Tools/install.sh
+++ b/Tools/install.sh
@@ -254,7 +254,7 @@ fi
 
 PYTHON_INSTALL_CMD="python3 -m pip install --upgrade pip protobuf -r \"$SMING_HOME/../Tools/requirements.txt\""
 
-eval $PYTHON_INSTALL_CMD || install_venv "$PYTHON_INSTALL_CMD"  
+eval "$PYTHON_INSTALL_CMD" || install_venv "$PYTHON_INSTALL_CMD"  
 
 
 install() {

--- a/Tools/install.sh
+++ b/Tools/install.sh
@@ -125,6 +125,15 @@ check_for_installed_files() {
     fi
 }
 
+install_venv() {
+	echo 
+	echo "!!! Trying to install Python Virtual Environment !!!"
+	mkdir -p ~/.venvs/
+	python3 -m venv ~/.venvs/Sming
+	source ~/.venvs/Sming/bin/activate
+	eval "$1"
+}
+
 # Installers put downloaded archives here
 DOWNLOADS="downloads"
 mkdir -p $DOWNLOADS
@@ -243,7 +252,9 @@ if [ -f "/usr/bin/clang-format-8" ]; then
     sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-8 100
 fi
 
-python3 -m pip install --upgrade pip protobuf -r "$SMING_HOME/../Tools/requirements.txt"
+PYTHON_INSTALL_CMD="python3 -m pip install --upgrade pip protobuf -r \"$SMING_HOME/../Tools/requirements.txt\""
+
+eval $PYTHON_INSTALL_CMD || install_venv "$PYTHON_INSTALL_CMD"  
 
 
 install() {

--- a/Tools/requirements.txt
+++ b/Tools/requirements.txt
@@ -1,3 +1,4 @@
+protobuf
 pyserial
 jsonschema
 kconfiglib


### PR DESCRIPTION
Ubuntu 24.04 is not allowing the overwriting of system python packages.

This PR creates a virtual environment and activates it to avoid conflicts with the python packages coming from the OS.