### PR TITLE
update mqttClient to catch empty clientNames

### DIFF
--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -206,7 +206,7 @@ bool MqttClient::connect(const Url& url, const String& clientName)
 		return false;
 	}
   if(clientName==""){
-    debug_e("no client name configured");
+    debug_e("clientName cannot be empty");
     return false;
   }
     

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -199,11 +199,17 @@ bool MqttClient::setWill(const String& topic, const String& message, uint8_t fla
 bool MqttClient::connect(const Url& url, const String& clientName)
 {
 	this->url = url;
+
 	bool useSsl{url.Scheme == URI_SCHEME_MQTT_SECURE};
 	if(!useSsl && url.Scheme != URI_SCHEME_MQTT) {
 		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
+  if(clientName==""){
+    debug_e("no client name configured");
+    return false;
+  }
+    
 
 	if(getConnectionState() != eTCS_Ready) {
 		close();

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -205,11 +205,11 @@ bool MqttClient::connect(const Url& url, const String& clientName)
 		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
-  if(clientName==""){
-    debug_e("clientName cannot be empty");
-    return false;
-  }
-    
+
+	if(clientName==""){
+		debug_e("clientName cannot be empty");
+		return false;
+	}
 
 	if(getConnectionState() != eTCS_Ready) {
 		close();


### PR DESCRIPTION
catch situations where mqttClient::connect is called with an empty clientName that would otherwise lead to a failing malloc