### PR TITLE
Fix/Hardware_PWM

### DIFF
--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -140,11 +140,13 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 
 HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	debug_d("starting HardwarePWM init");
-	periph_module_enable(PERIPH_LEDC_MODULE);
-	if((no_of_pins == 0) || (no_of_pins > SOC_LEDC_CHANNEL_NUM)) {
+	assert(no_of_pins <= SOC_LEDC_CHANNEL_NUM);
+
+	if(no_of_pins == 0) {
 		return;
 	}
+
+	periph_module_enable(PERIPH_LEDC_MODULE);
 
 	for(uint8_t i = 0; i < no_of_pins; i++) {
 		channels[i] = pins[i];
@@ -221,6 +223,11 @@ uint32_t HardwarePWM::getDutyChan(uint8_t chan)
 {
 	// esp32 defines the frequency / period per timer
 	return (chan == PWM_BAD_CHANNEL) ? 0 : ledc_get_duty(pinToGroup(chan), pinToChannel(chan));
+}
+
+uint32_t HardwarePWM::getMaxDuty()
+{
+	return maxduty;
 }
 
 bool HardwarePWM::setDutyChan(uint8_t chan, uint32_t duty, bool update)

--- a/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
@@ -125,6 +125,10 @@ uint32_t HardwarePWM::getPeriod()
 	return pwm_get_period();
 }
 
+uint32_t HardwarePWM::getMaxDuty()
+{
+	return maxduty;
+}
 void HardwarePWM::setPeriod(uint32_t period)
 {
 	maxduty = PERIOD_TO_MAX_DUTY(period);

--- a/Sming/Arch/Host/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Host/Core/HardwarePWM.cpp
@@ -51,6 +51,11 @@ uint32_t HardwarePWM::getPeriod()
 	return 0;
 }
 
+uint32_t HardwarePWM::getMaxDuty()
+{
+	return 0;
+}
+
 void HardwarePWM::setPeriod(uint32_t period)
 {
 }

--- a/Sming/Arch/Rp2040/Core/HardwarePWM.cpp.todo
+++ b/Sming/Arch/Rp2040/Core/HardwarePWM.cpp.todo
@@ -127,6 +127,10 @@ void HardwarePWM::setPeriod(uint32 period)
 	update();
 }
 
+uint32_t getMaxDuty()
+{
+	
+}
 /* Function Name: update
  * Description: This function is used to actually update the PWM.
  */

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -206,7 +206,7 @@ bool MqttClient::connect(const Url& url, const String& clientName)
 		return false;
 	}
   if(clientName==""){
-    debug_e("no client name configured");
+    debug_e("clientName cannot be empty");
     return false;
   }
     

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -199,11 +199,17 @@ bool MqttClient::setWill(const String& topic, const String& message, uint8_t fla
 bool MqttClient::connect(const Url& url, const String& clientName)
 {
 	this->url = url;
+
 	bool useSsl{url.Scheme == URI_SCHEME_MQTT_SECURE};
 	if(!useSsl && url.Scheme != URI_SCHEME_MQTT) {
 		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
+  if(clientName==""){
+    debug_e("no client name configured");
+    return false;
+  }
+    
 
 	if(getConnectionState() != eTCS_Ready) {
 		close();

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -205,11 +205,11 @@ bool MqttClient::connect(const Url& url, const String& clientName)
 		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
-  if(clientName==""){
-    debug_e("clientName cannot be empty");
-    return false;
-  }
-    
+
+	if(clientName==""){
+		debug_e("clientName cannot be empty");
+		return false;
+	}
 
 	if(getConnectionState() != eTCS_Ready) {
 		close();

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -205,6 +205,10 @@ bool MqttClient::connect(const Url& url, const String& clientName)
 		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
+	if(clientName == "") {
+		debug_e("clientName cannot be empty");
+		return false;
+	}
 
 	if(clientName==""){
 		debug_e("clientName cannot be empty");

--- a/Sming/Core/HardwarePWM.h
+++ b/Sming/Core/HardwarePWM.h
@@ -113,10 +113,7 @@ public:
      *  @retval uint32_t Maximum permissible duty cycle
      *  @note   Attempt to set duty of a pin above this value will fail
      */
-	uint32_t getMaxDuty()
-	{
-		return maxduty;
-	}
+	uint32_t getMaxDuty();
 
 	/** @brief  This function is used to actually update the PWM.
 	 */


### PR DESCRIPTION
- moved the getMaxDuty() implementation to the class implementations for all architectures. Before that, for esp32c3, it would always return 0, despite maxduty being correctly set.
- added an assert() to catch situations where the Hardware_PWM is initialized with more than `SOC_LEDC_CHANNEL_NUM`. Otherwise, the constructor would fail silently and the PWM fails. I'm wondering if it might be a good idea to just configure all pins up to `SOC_LEDC_CHANNEL_NUM` and silently drop the rest instead of failing with an assert.