### PR TITLE
Fix/getMaxDuty

### DIFF
--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -223,6 +223,11 @@ uint32_t HardwarePWM::getDutyChan(uint8_t chan)
 	return (chan == PWM_BAD_CHANNEL) ? 0 : ledc_get_duty(pinToGroup(chan), pinToChannel(chan));
 }
 
+uint32_t HardwarePWM::getMaxDuty()
+{
+	return maxduty;
+}
+
 bool HardwarePWM::setDutyChan(uint8_t chan, uint32_t duty, bool update)
 {
 	if(chan == PWM_BAD_CHANNEL) {

--- a/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
@@ -125,6 +125,11 @@ uint32_t HardwarePWM::getPeriod()
 	return pwm_get_period();
 }
 
+uint32_t getMaxDuty()
+{
+	return maxduty;
+}
+
 void HardwarePWM::setPeriod(uint32_t period)
 {
 	maxduty = PERIOD_TO_MAX_DUTY(period);

--- a/Sming/Arch/Host/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Host/Core/HardwarePWM.cpp
@@ -46,6 +46,11 @@ bool HardwarePWM::setDutyChan(uint8_t chan, uint32_t duty, bool update)
 	return false;
 }
 
+uint32_t HardwarePWM::getMaxDuty()
+{
+	return 0;
+}
+
 uint32_t HardwarePWM::getPeriod()
 {
 	return 0;

--- a/Sming/Arch/Rp2040/Core/HardwarePWM.cpp.todo
+++ b/Sming/Arch/Rp2040/Core/HardwarePWM.cpp.todo
@@ -116,6 +116,11 @@ uint32 HardwarePWM::getPeriod()
 	return pwm_get_period();
 }
 
+uint32_t HardwarePWM::getMaxDuty()
+{
+	return maxduty;
+}
+
 /* Function Name: setPeriod
  * Description: This function is used to set Period of PWM.
  *				Period / frequency will remain same for all pins.

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -206,7 +206,7 @@ bool MqttClient::connect(const Url& url, const String& clientName)
 		return false;
 	}
   if(clientName==""){
-    debug_e("no client name configured");
+    debug_e("clientName cannot be empty");
     return false;
   }
     

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -199,11 +199,17 @@ bool MqttClient::setWill(const String& topic, const String& message, uint8_t fla
 bool MqttClient::connect(const Url& url, const String& clientName)
 {
 	this->url = url;
+
 	bool useSsl{url.Scheme == URI_SCHEME_MQTT_SECURE};
 	if(!useSsl && url.Scheme != URI_SCHEME_MQTT) {
 		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
+  if(clientName==""){
+    debug_e("no client name configured");
+    return false;
+  }
+    
 
 	if(getConnectionState() != eTCS_Ready) {
 		close();

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -205,11 +205,11 @@ bool MqttClient::connect(const Url& url, const String& clientName)
 		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
-  if(clientName==""){
-    debug_e("clientName cannot be empty");
-    return false;
-  }
-    
+
+	if(clientName==""){
+		debug_e("clientName cannot be empty");
+		return false;
+	}
 
 	if(getConnectionState() != eTCS_Ready) {
 		close();

--- a/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
+++ b/Sming/Components/Network/src/Network/Mqtt/MqttClient.cpp
@@ -205,6 +205,10 @@ bool MqttClient::connect(const Url& url, const String& clientName)
 		debug_e("Only mqtt and mqtts protocols are allowed");
 		return false;
 	}
+	if(clientName == "") {
+		debug_e("clientName cannot be empty");
+		return false;
+	}
 
 	if(clientName==""){
 		debug_e("clientName cannot be empty");

--- a/Sming/Core/HardwarePWM.h
+++ b/Sming/Core/HardwarePWM.h
@@ -113,10 +113,7 @@ public:
      *  @retval uint32_t Maximum permissible duty cycle
      *  @note   Attempt to set duty of a pin above this value will fail
      */
-	uint32_t getMaxDuty()
-	{
-		return maxduty;
-	}
+	uint32_t getMaxDuty();
 
 	/** @brief  This function is used to actually update the PWM.
 	 */


### PR DESCRIPTION
- moved the getMaxDuty() implementation to the class implementations for all architectures. Before that, for esp32c3, it would always return 0, despite maxduty being correctly set.
