### PR TITLE
HardwarePWM Esp32 - added assert for max pwm channels

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -7,7 +7,7 @@
  * pwm.h
  *
  ****/
-#include <soc/soc_caps.h>
+
 
 #pragma once
 

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -1,16 +1,15 @@
-/****
- * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
- * Created 2015 by Skurydin Alexey
- * http://github.com/SmingHub/Sming
- * All files of the Sming Core are provided under the LGPL v3 license.
- *
- * pwm.h
- *
- ****/
+/****  
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.  
+ * Created 2015 by Skurydin Alexey  
+ * http://github.com/SmingHub/Sming  
+ * All files of the Sming Core are provided under the LGPL v3 license.  
+ *  
+ * pwm.h  
+ *  
+ ****/  
 
-#include <soc/soc_caps.h>
+#pragma once  
 
+#include <soc/soc_caps.h>  
 
-#pragma once
-
-#define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM
+#define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM  

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -8,12 +8,9 @@
  *
  ****/
 
+#include <soc/soc_caps.h>
+
 
 #pragma once
 
-#ifdef SOC_LEDC_CHANNEL_NUM
 #define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM
-#else
-// this should not happen if the correct esp32 includes are used, just to be absolutely sure
-#define PWM_CHANNEL_NUM_MAX 8
-#endif

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -7,6 +7,7 @@
  * pwm.h
  *
  ****/
+#include <soc/soc_caps.h>
 
 #pragma once
 

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -6,10 +6,10 @@
  *  
  * pwm.h  
  *  
- ****/  
+ ****/
 
-#pragma once  
+#pragma once
 
-#include <soc/soc_caps.h>  
+#include <soc/soc_caps.h>
 
-#define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM  
+#define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -1,11 +1,11 @@
-/****  
- * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.  
- * Created 2015 by Skurydin Alexey  
- * http://github.com/SmingHub/Sming  
- * All files of the Sming Core are provided under the LGPL v3 license.  
- *  
- * pwm.h  
- *  
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * pwm.h
+ *
  ****/
 
 #pragma once

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -142,19 +142,10 @@ HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_o
 {
 	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);
 	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);
-	debug_i("initializing PERIPH_LEDC_MODULE");
+
 	periph_module_enable(PERIPH_LEDC_MODULE);
 
 	for(uint8_t i = 0; i < no_of_pins; i++) {
-//make sure we don't try to use pins unavailable for the SoC
-#if defined(__riscv)
-		//esp32c3
-		assert((pins[i] >= 0 && pins[i] <= 9) || (pins[i] >= 18 && pins[i] <= 21));
-#elif
-		//esp32
-		if((pins[i] >= 0 && pins[i] <= 19) || (pins[i] >= 22 && pins[i] <= 28) || (pins[i] >= 32 && pins[i] <= 39))
-			;
-#endif
 		channels[i] = pins[i];
 
 		/* 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -140,12 +140,16 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 
 HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	debug_d("starting HardwarePWM init");
-	periph_module_enable(PERIPH_LEDC_MODULE);
-	if((no_of_pins == 0) || (no_of_pins > SOC_LEDC_CHANNEL_NUM)) {
+	
+	assert(no_of_pins <= SOC_LEDC_CHANNEL_NUM);
+	
+	if(no_of_pins == 0)
+	{
 		return;
 	}
 
+	periph_module_enable(PERIPH_LEDC_MODULE);
+	
 	for(uint8_t i = 0; i < no_of_pins; i++) {
 		channels[i] = pins[i];
 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -140,11 +140,8 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 
 HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	assert(no_of_pins <= SOC_LEDC_CHANNEL_NUM);
-
-	if(no_of_pins == 0) {
-		return;
-	}
+	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);  
+	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);  
 
 	periph_module_enable(PERIPH_LEDC_MODULE);
 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -142,10 +142,19 @@ HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_o
 {
 	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);
 	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);
-
+	debug_i("initializing PERIPH_LEDC_MODULE");
 	periph_module_enable(PERIPH_LEDC_MODULE);
 
 	for(uint8_t i = 0; i < no_of_pins; i++) {
+//make sure we don't try to use pins unavailable for the SoC
+#if defined(__riscv)
+		//esp32c3
+		assert((pins[i] >= 0 && pins[i] <= 9) || (pins[i] >= 18 && pins[i] <= 21));
+#elif
+		//esp32
+		if((pins[i] >= 0 && pins[i] <= 19) || (pins[i] >= 22 && pins[i] <= 28) || (pins[i] >= 32 && pins[i] <= 39))
+			;
+#endif
 		channels[i] = pins[i];
 
 		/* 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -140,16 +140,14 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 
 HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	
 	assert(no_of_pins <= SOC_LEDC_CHANNEL_NUM);
-	
-	if(no_of_pins == 0)
-	{
+
+	if(no_of_pins == 0) {
 		return;
 	}
 
 	periph_module_enable(PERIPH_LEDC_MODULE);
-	
+
 	for(uint8_t i = 0; i < no_of_pins; i++) {
 		channels[i] = pins[i];
 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -140,8 +140,8 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 
 HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);  
-	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);  
+	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);
+	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);
 
 	periph_module_enable(PERIPH_LEDC_MODULE);
 


### PR DESCRIPTION
if called with more than the supported channels (depending on the SoC), the constructor would silently fail, yielding a misleading error message. 
