### PR TITLE
fixed network scan

### DIFF
--- a/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/StationImpl.cpp
@@ -420,8 +420,8 @@ void StationImpl::staticScanCompleted(wifi_event_sta_scan_done_t* event, uint8_t
 			wifi_ap_record_t ap_info[number];
 			uint16_t ap_count{0};
 			memset(ap_info, 0, sizeof(ap_info));
-			ESP_ERROR_CHECK(esp_wifi_scan_get_ap_records(&number, ap_info));
 			ESP_ERROR_CHECK(esp_wifi_scan_get_ap_num(&ap_count));
+			ESP_ERROR_CHECK(esp_wifi_scan_get_ap_records(&number, ap_info));
 			// TODO: Handle hidden APs
 			for(unsigned i = 0; (i < event->number) && (i < ap_count); i++) {
 				list.addElement(new BssInfoImpl(&ap_info[i]));


### PR DESCRIPTION
`esp_wifi_scan_get_ap_records()` clears the ap data structure, so calling `esp_wifi_scan_get_ap_num()` *after* it will return zero. Switching the order fixes the error of Sming `WifiStation.scan()` not returning any networks on the esp32 platform