### PR TITLE
Fix/check valid pins

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -7,7 +7,7 @@
  * pwm.h
  *
  ****/
-#include <soc/soc_caps.h>
+
 
 #pragma once
 

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -1,16 +1,15 @@
-/****
- * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
- * Created 2015 by Skurydin Alexey
- * http://github.com/SmingHub/Sming
- * All files of the Sming Core are provided under the LGPL v3 license.
- *
- * pwm.h
- *
- ****/
+/****  
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.  
+ * Created 2015 by Skurydin Alexey  
+ * http://github.com/SmingHub/Sming  
+ * All files of the Sming Core are provided under the LGPL v3 license.  
+ *  
+ * pwm.h  
+ *  
+ ****/  
 
-#include <soc/soc_caps.h>
+#pragma once  
 
+#include <soc/soc_caps.h>  
 
-#pragma once
-
-#define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM
+#define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM  

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -8,12 +8,9 @@
  *
  ****/
 
+#include <soc/soc_caps.h>
+
 
 #pragma once
 
-#ifdef SOC_LEDC_CHANNEL_NUM
 #define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM
-#else
-// this should not happen if the correct esp32 includes are used, just to be absolutely sure
-#define PWM_CHANNEL_NUM_MAX 8
-#endif

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -7,6 +7,7 @@
  * pwm.h
  *
  ****/
+#include <soc/soc_caps.h>
 
 #pragma once
 

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -6,10 +6,10 @@
  *  
  * pwm.h  
  *  
- ****/  
+ ****/
 
-#pragma once  
+#pragma once
 
-#include <soc/soc_caps.h>  
+#include <soc/soc_caps.h>
 
-#define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM  
+#define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM

--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -1,11 +1,11 @@
-/****  
- * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.  
- * Created 2015 by Skurydin Alexey  
- * http://github.com/SmingHub/Sming  
- * All files of the Sming Core are provided under the LGPL v3 license.  
- *  
- * pwm.h  
- *  
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * pwm.h
+ *
  ****/
 
 #pragma once

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -142,19 +142,10 @@ HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_o
 {
 	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);
 	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);
-	debug_i("initializing PERIPH_LEDC_MODULE");
+
 	periph_module_enable(PERIPH_LEDC_MODULE);
 
 	for(uint8_t i = 0; i < no_of_pins; i++) {
-//make sure we don't try to use pins unavailable for the SoC
-#if defined(__riscv)
-		//esp32c3
-		assert((pins[i] >= 0 && pins[i] <= 9) || (pins[i] >= 18 && pins[i] <= 21));
-#elif
-		//esp32
-		if((pins[i] >= 0 && pins[i] <= 19) || (pins[i] >= 22 && pins[i] <= 28) || (pins[i] >= 32 && pins[i] <= 39))
-			;
-#endif
 		channels[i] = pins[i];
 
 		/* 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -146,15 +146,9 @@ HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_o
 	periph_module_enable(PERIPH_LEDC_MODULE);
 
 	for(uint8_t i = 0; i < no_of_pins; i++) {
-//make sure we don't try to use pins unavailable for the SoC
-#if defined(__riscv)
-		//esp32c3
-		assert((pins[i] >= 0 && pins[i] <= 9) || (pins[i] >= 18 && pins[i] <= 21));
-#elif
-		//esp32
-		if((pins[i] >= 0 && pins[i] <= 19) || (pins[i] >= 22 && pins[i] <= 28) || (pins[i] >= 32 && pins[i] <= 39))
-			;
-#endif
+	//make sure we don't try to use pins unavailable for the SoC
+	assert(SOC_GPIO_VALID_OUTPUT_GPIO_MASK & (1U<<pins[i]));
+		debug_i("configuring pin %i", pins[i]);
 		channels[i] = pins[i];
 
 		/* 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -140,12 +140,16 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 
 HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	debug_d("starting HardwarePWM init");
-	periph_module_enable(PERIPH_LEDC_MODULE);
-	if((no_of_pins == 0) || (no_of_pins > SOC_LEDC_CHANNEL_NUM)) {
+	
+	assert(no_of_pins <= SOC_LEDC_CHANNEL_NUM);
+	
+	if(no_of_pins == 0)
+	{
 		return;
 	}
 
+	periph_module_enable(PERIPH_LEDC_MODULE);
+	
 	for(uint8_t i = 0; i < no_of_pins; i++) {
 		channels[i] = pins[i];
 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -146,8 +146,8 @@ HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_o
 	periph_module_enable(PERIPH_LEDC_MODULE);
 
 	for(uint8_t i = 0; i < no_of_pins; i++) {
-	//make sure we don't try to use pins unavailable for the SoC
-	assert(SOC_GPIO_VALID_OUTPUT_GPIO_MASK & (1U<<pins[i]));
+		//make sure we don't try to use pins unavailable for the SoC
+		assert(SOC_GPIO_VALID_OUTPUT_GPIO_MASK & (1U << pins[i]));
 		channels[i] = pins[i];
 
 		/* 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -140,11 +140,8 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 
 HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	assert(no_of_pins <= SOC_LEDC_CHANNEL_NUM);
-
-	if(no_of_pins == 0) {
-		return;
-	}
+	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);  
+	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);  
 
 	periph_module_enable(PERIPH_LEDC_MODULE);
 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -148,7 +148,6 @@ HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_o
 	for(uint8_t i = 0; i < no_of_pins; i++) {
 	//make sure we don't try to use pins unavailable for the SoC
 	assert(SOC_GPIO_VALID_OUTPUT_GPIO_MASK & (1U<<pins[i]));
-		debug_i("configuring pin %i", pins[i]);
 		channels[i] = pins[i];
 
 		/* 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -142,10 +142,19 @@ HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_o
 {
 	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);
 	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);
-
+	debug_i("initializing PERIPH_LEDC_MODULE");
 	periph_module_enable(PERIPH_LEDC_MODULE);
 
 	for(uint8_t i = 0; i < no_of_pins; i++) {
+//make sure we don't try to use pins unavailable for the SoC
+#if defined(__riscv)
+		//esp32c3
+		assert((pins[i] >= 0 && pins[i] <= 9) || (pins[i] >= 18 && pins[i] <= 21));
+#elif
+		//esp32
+		if((pins[i] >= 0 && pins[i] <= 19) || (pins[i] >= 22 && pins[i] <= 28) || (pins[i] >= 32 && pins[i] <= 39))
+			;
+#endif
 		channels[i] = pins[i];
 
 		/* 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -140,16 +140,14 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 
 HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	
 	assert(no_of_pins <= SOC_LEDC_CHANNEL_NUM);
-	
-	if(no_of_pins == 0)
-	{
+
+	if(no_of_pins == 0) {
 		return;
 	}
 
 	periph_module_enable(PERIPH_LEDC_MODULE);
-	
+
 	for(uint8_t i = 0; i < no_of_pins; i++) {
 		channels[i] = pins[i];
 

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -140,8 +140,8 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 
 HardwarePWM::HardwarePWM(uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);  
-	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);  
+	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);
+	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);
 
 	periph_module_enable(PERIPH_LEDC_MODULE);
 


### PR DESCRIPTION
not all pins are good to use for pwm.
The first check is, if the given pin is within `SOC_GPIO_VALID_OUTPUT_GPIO_MASK` but depending on the module, there will be strapping pins and, most problematic probably, the pins that are connecting to the SPI Flash chip. 
On the esp32c3, those are primarily SPIHD(GPIO12) and SPIWP(GPIO13)
I'm unsure what a good way forward is - in the huge majority of modules, those pins will be unavailable (see discussion here: https://esp32.com/viewtopic.php?t=38718) but making assumptions is not good either.  If somebody uses or designs a board that allows using those pins, they should be able to do so.

@mikee47 what's the general SMING policy about this? 
If someone configures a pin that is being used for SPI flash, the SoC won't stop them doing it, but the code will, obviously, stall (as the cpu can't fetch any code anymore) and get a watchdog timeout. That's a bit difficult to troubleshoot (ask me why I know). 
This question is beyond just Hardware_PWM and also depending on the module layout, so we may not be able to do much about it. My only thought would be a make config like "ENFORCE_SAFE_GPIO_PINS" which would then disallow the use of pins that are known to be not safe such as SPIHD and SPIWP.
Extra complication: those can be remapped by the bootloader if I'm not mistaken.