### PR TITLE
Add Message-ID header in email when not set.

### DIFF
--- a/Sming/Components/Network/src/Network/SmtpClient.cpp
+++ b/Sming/Components/Network/src/Network/SmtpClient.cpp
@@ -300,7 +300,7 @@ void SmtpClient::sendMailHeaders(MailMessage* mail)
 	if(!mail->headers.contains(F("Message-ID"))) {
 		Uuid uuid;
 		uuid.generate();
-		mail->headers[F("Message-ID")] =  "<" + uuid.toString() + "@" + url.Host + ">";
+		mail->headers[F("Message-ID")] = "<" + uuid.toString() + "@" + url.Host + ">";
 	}
 
 	if(!mail->attachments.isEmpty()) {

--- a/Sming/Components/Network/src/Network/SmtpClient.cpp
+++ b/Sming/Components/Network/src/Network/SmtpClient.cpp
@@ -21,6 +21,7 @@
 #include <Data/Stream/QuotedPrintableOutputStream.h>
 #include <Data/Stream/Base64OutputStream.h>
 #include <Data/HexString.h>
+#include <Data/Uuid.h>
 #include <Crypto/Md5.h>
 #include <Network/Ssl/Factory.h>
 
@@ -294,6 +295,12 @@ void SmtpClient::sendMailHeaders(MailMessage* mail)
 	if(!mail->headers.contains(HTTP_HEADER_CONTENT_TRANSFER_ENCODING)) {
 		mail->headers[HTTP_HEADER_CONTENT_TRANSFER_ENCODING] = _F("quoted-printable");
 		mail->stream = std::make_unique<QuotedPrintableOutputStream>(mail->stream.release());
+	}
+
+	if(!mail->headers.contains(F("Message-ID"))) {
+		auto uuid = Uuid();
+		uuid.generate();
+		mail->headers[F("Message-ID")] =  "<" + uuid.toString() + "@" + url.Host + ">";
 	}
 
 	if(!mail->attachments.isEmpty()) {

--- a/Sming/Components/Network/src/Network/SmtpClient.cpp
+++ b/Sming/Components/Network/src/Network/SmtpClient.cpp
@@ -298,7 +298,7 @@ void SmtpClient::sendMailHeaders(MailMessage* mail)
 	}
 
 	if(!mail->headers.contains(F("Message-ID"))) {
-		auto uuid = Uuid();
+		Uuid uuid;
 		uuid.generate();
 		mail->headers[F("Message-ID")] =  "<" + uuid.toString() + "@" + url.Host + ">";
 	}


### PR DESCRIPTION
Google Mail and others started requesting Message-ID header to be present, otherwise messages are blocked/getting marked as spam.