### PR TITLE
Fix esp32 multicore lockup

### DIFF
--- a/Sming/Arch/Esp32/Components/esp32/sdk/esp_system.mk
+++ b/Sming/Arch/Esp32/Components/esp32/sdk/esp_system.mk
@@ -12,10 +12,10 @@ ifndef CONFIG_ESP_SYSTEM_SINGLE_CORE_MODE
 SDK_UNDEF_SYMBOLS += start_app_other_cores
 endif
 
-# ld_include_panic_highint_hdl is added as an undefined symbol because otherwise the
-# linker will ignore panic_highint_hdl.S as it has no other files depending on any
+# ld_include_highint_hdl is added as an undefined symbol because otherwise the
+# linker will ignore highint_hdl.S as it has no other files depending on any
 # symbols in it.
-SDK_UNDEF_SYMBOLS += ld_include_panic_highint_hdl
+SDK_UNDEF_SYMBOLS += ld_include_highint_hdl
 
 # IDF 5.2
 SDK_WRAP_SYMBOLS += esp_newlib_init_global_stdio

--- a/Sming/Components/Network/Arch/Esp32/Platform/AccessPointImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/AccessPointImpl.cpp
@@ -57,7 +57,7 @@ void AccessPointImpl::enable(bool enabled, bool save)
 		}
 	}
 	ESP_ERROR_CHECK(esp_wifi_set_storage(save ? WIFI_STORAGE_FLASH : WIFI_STORAGE_RAM));
-	ESP_ERROR_CHECK(esp_wifi_set_mode((wifi_mode_t)mode));
+	ESP_ERROR_CHECK(esp_wifi_set_mode(mode));
 }
 
 bool AccessPointImpl::isEnabled() const
@@ -88,10 +88,13 @@ bool AccessPointImpl::config(const String& ssid, String password, WifiAuthMode m
 	config.ap.authmode = (wifi_auth_mode_t)mode;
 	config.ap.max_connection = 8;
 
+	bool enabled = isEnabled();
 	enable(true, false);
 
 	ESP_ERROR_CHECK(esp_wifi_set_config(WIFI_IF_AP, &config));
-	ESP_ERROR_CHECK(esp_wifi_start());
+	if(enabled) {
+		System.queueCallback(esp_wifi_start);
+	}
 
 	return true;
 }


### PR DESCRIPTION
This PR fixes the broken IPC calling interrupts on esp32 chips. Closes #2653.

Cause is due to an incorrect linker flag which resulted in critical high-level interrupt handling code from the ESP IDF not getting linked.

Testing also revealed a race condition during access point initialisation. The `Basic_Wifi` sample first initialises the access point, then the station. Shortly after startup, some internal structure for the access point gets invalidated and causes an access violation. It appears to be related to calling `esp_wifi_start` twice.