### PR TITLE
Fix vscode error invalid `miDebuggerPath` for esp32

### DIFF
--- a/Tools/ide/common/sming.py
+++ b/Tools/ide/common/sming.py
@@ -49,7 +49,6 @@ class Env(dict):
         path = self.replace(path, 'SMING_HOME', prefix)
         path = self.replace(path, 'ESP_HOME', prefix)
         path = self.replace(path, 'IDF_PATH', prefix)
-        path = self.replace(path, 'IDF_TOOLS_PATH', prefix)
         return path
 
     def isWsl(self):


### PR DESCRIPTION
The `make ide-vscode` script generates the default `launch.json` configuration, containing the following entry:

```
"miDebuggerPath": "${env:IDF_TOOLS_PATH}/tools/riscv32-esp-elf-gdb/12.1_20231023/riscv32-esp-elf-gdb/bin/riscv32-esp-elf-gdb"
```

The error occurs where `IDF_TOOLS_PATH` isn't available in the global environment. There does not appear to be a way to include definitions for environment variables other than within the configuration itself, which renders it pointless. Since `IDF_TOOLS_PATH` is very unlikely to change we can just use the expanded path:

```
"miDebuggerPath": "/opt/esp32/tools/riscv32-esp-elf-gdb/12.1_20231023/riscv32-esp-elf-gdb/bin/riscv32-esp-elf-gdb",
```
