### PR TITLE
Add USB host support for esp32s2(s3), support OTG dual-mode

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/include/driver/hw_timer.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/hw_timer.h
@@ -15,11 +15,14 @@
 #include <stdint.h>
 #include <esp_idf_version.h>
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #if CONFIG_ESP_TIMER_IMPL_TG0_LAC
 #include <soc/timer_group_reg.h>
 #else
 #include <hal/systimer_ll.h>
 #endif
+#pragma GCC diagnostic pop
 
 #ifdef __cplusplus
 extern "C" {

--- a/Sming/Arch/Esp32/Components/esp32/component.mk
+++ b/Sming/Arch/Esp32/Components/esp32/component.mk
@@ -117,7 +117,8 @@ SDK_INCDIRS := \
 	esp_netif/include \
 	esp_eth/include \
 	esp_wifi/include \
-	lwip/include/apps/sntp
+	lwip/include/apps/sntp \
+	usb/include
 
 ifdef IDF_VERSION_4x
 SDK_INCDIRS += \
@@ -261,6 +262,10 @@ SDK_COMPONENTS := \
 	pthread \
 	soc \
 	spi_flash
+
+ifneq (,$(filter esp32s2 esp32s3,$(SMING_SOC)))
+SDK_COMPONENTS += usb
+endif
 
 ifdef IDF_VERSION_43
 SDK_COMPONENTS += $(ESP_VARIANT)

--- a/samples/Basic_IFS/app/application.cpp
+++ b/samples/Basic_IFS/app/application.cpp
@@ -246,7 +246,7 @@ bool initFileSystem()
 #endif
 
 #ifdef ENABLE_USB_STORAGE
-	USB::begin();
+	USB::begin(true);
 	USB::MSC::onMount([](auto inst) {
 		usbStorage.begin(inst);
 		usbStorage.enumerate([](auto& unit, const USB::MSC::Inquiry& inquiry) {


### PR DESCRIPTION
This PR updates the USB library to enable Host support for esp32s2 and s3 (untested).
This is by switching ot the synopsis DWC2 driver.

The basic CDC, HID and MSC interfaces work OK but isochronous are transfers not yet supported. (I'd like this for attaching a USB DAC.)

In addition, the OTG hardware (for rp2040 and esp32s2) supports dual-mode operation and this PR allows the operation mode to be selected at run time. The application still needs to decide which mode is required: this can be as simple as connecting a GPIO input to the ID pin. Mode switching between two OTG hosts is more complex and involves session negotiation support which hasn't been investigated yet.

**Disconnection events**

The esp32s2 doesn't report when devices are disconnected in host mode. There's an open issue for this in tinyusb https://github.com/hathach/tinyusb/issues/564. There's a reference to the IDF regarding [self-powered devices](https://docs.espressif.com/projects/esp-idf/en/latest/esp32s2/api-reference/peripherals/usb_device.html#self-powered-device) which states that a separate GPIO is required to sense VBUS for disconnect events. A quick look at the IDF usb code suggests that it handles this using polling and a debounce timer.

However, there is a separate disconnect interrupt which requires only a few lines of code to enable and seems to work reliably. Doubtless there will be further host improvements in the future but this is pretty functional as-is.

**Todo:**

* [x] Disconnection events not reported via `tuh_umount_cb` for esp32s2
* [x] Re-test on rp2040

