### PR TITLE
Add `TaskStat::setOutput` to dynamically switch output stream

### DIFF
--- a/Sming/Arch/Esp8266/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Esp8266/Services/Profiling/TaskStat.cpp
@@ -15,7 +15,7 @@ namespace Profiling
 struct TaskStat::Info {
 };
 
-TaskStat::TaskStat(Print& out) : out(out)
+TaskStat::TaskStat(Print& out) : out(&out)
 {
 }
 
@@ -23,7 +23,7 @@ TaskStat::~TaskStat() = default;
 
 bool TaskStat::update()
 {
-	out.println("[TaskStat] Not Implemented");
+	out->println("[TaskStat] Not Implemented");
 	return false;
 }
 

--- a/Sming/Arch/Host/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Host/Services/Profiling/TaskStat.cpp
@@ -15,7 +15,7 @@ namespace Profiling
 struct TaskStat::Info {
 };
 
-TaskStat::TaskStat(Print& out) : out(out)
+TaskStat::TaskStat(Print& out) : out(&out)
 {
 }
 
@@ -23,7 +23,7 @@ TaskStat::~TaskStat() = default;
 
 bool TaskStat::update()
 {
-	out.println("[TaskStat] Not Implemented");
+	out->println("[TaskStat] Not Implemented");
 	return false;
 }
 

--- a/Sming/Arch/Rp2040/Services/Profiling/TaskStat.cpp
+++ b/Sming/Arch/Rp2040/Services/Profiling/TaskStat.cpp
@@ -15,7 +15,7 @@ namespace Profiling
 struct TaskStat::Info {
 };
 
-TaskStat::TaskStat(Print& out) : out(out)
+TaskStat::TaskStat(Print& out) : out(&out)
 {
 }
 
@@ -23,7 +23,7 @@ TaskStat::~TaskStat() = default;
 
 bool TaskStat::update()
 {
-	out.println("[TaskStat] Not Implemented");
+	out->println("[TaskStat] Not Implemented");
 	return false;
 }
 

--- a/Sming/Services/Profiling/TaskStat.h
+++ b/Sming/Services/Profiling/TaskStat.h
@@ -47,8 +47,16 @@ public:
 	 */
 	bool update();
 
+	/**
+	 * @brief Change the output stream
+	 */
+	void setOutput(Print& out)
+	{
+		this->out = &out;
+	}
+
 private:
-	Print& out;
+	Print* out;
 	static constexpr size_t maxTasks{32};
 	struct Info;
 	std::unique_ptr<Info[]> taskInfo;


### PR DESCRIPTION
This PR supports switching the output of `TaskStat` at runtime. This allows monitoring of freeRTOS task usage for esp32 devices. I use this to switch output between standard serial and USB serial.
