### PR TITLE
add a base hardware config without 'factory' 

### DIFF
--- a/Sming/Arch/Esp32/single-rom-for-ota.hw
+++ b/Sming/Arch/Esp32/single-rom-for-ota.hw
@@ -1,0 +1,42 @@
+{
+	"name": "OTA base config with single ROM",
+	"arch": "Esp32",
+	"comment": "ota base config to eliminate the factory partition and instead build two rom partitions.",
+	"bootloader_size": "0x8000",
+	"partition_table_offset": "0x8000",
+	"devices": {
+		"spiFlash": {
+			"type": "flash",
+			"size": "4M",
+			"mode": "dio",
+			"speed": "60 if SMING_SOC=='esp32c2' else 40"
+		}
+	},
+	"partitions": {
+		"phy_init": {
+			"address": "0x00f000",
+			"size": "0x1000",
+			"type": "data",
+			"subtype": "phy"
+		},
+		"nvs": {
+			"address": "0x009000",
+			"size": "0x6000",
+			"type": "data",
+			"subtype": "nvs"
+		},
+		"rom0": {
+			"address": "0x010000",
+			"size": "0x0f0000",
+			"type": "app",
+			"subtype": "ota_0",
+			"filename": "$(TARGET_BIN)"
+		},
+		"otadata":{
+			"address":"0x3fe000",
+			"size":"8k",
+			"type":"data",
+			"subtype":"ota"
+		}
+	}
+}


### PR DESCRIPTION
partition to allow two large OTA partitions

when working with OTA on the esp32c3, it became clear that `factory` would never be overwritten by OTA, making it difficult to fully upgrade the device over OTA when running an OTA version already. 
ESP-IDF suggests to drop the `factory` partition altogether to be able to configure two large OTA.
```
    factory (0x00) is the default app partition. The bootloader will execute the factory app unless there it sees a partition of type data/ota, in which case it reads this partition to determine which OTA image to boot.

        OTA never updates the factory partition.

        If you want to conserve flash usage in an OTA project, you can remove the factory partition and use ota_0 instead.
```
this hardware definition does provide a basis for a `factory` less OTA setup including the OTADATA partition the bootloader needs. For size considerations, I have moved it to the end of the 4M flash area to avoid moving around the first partition.