### PR TITLE
Fix breaking `DiskStorage` library tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       SMING_HOME: ${{ github.workspace }}/Sming
       SMING_ARCH: ${{ matrix.arch }}
       SMING_SOC: ${{ matrix.variant }}
-      CLANG_BUILD: ${{ matrix.toolchain == 'clang' && '15' || '0' }}
+      CLANG_BUILD: ${{ matrix.toolchain == 'clang' && '18' || '0' }}
       BUILD64: ${{ matrix.toolchain == 'gcc64' && 1 || 0 }}
       ENABLE_CCACHE: 1
       CCACHE_DIR: ${{ github.workspace }}/.ccache


### PR DESCRIPTION
Checking partition layouts uses a script with the `blkid` command. the output of which has recently changed to include a `DISKSEQ` field. Discard this before comparison.

Also includes commit which improves cache performance.

CI runner for Ubuntu 24 has dropped clang 15, so changed script to use the latest available (clang 18).