### PR TITLE
Fix clang version for library CI testing.

### DIFF
--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -62,7 +62,7 @@ jobs:
       SMING_ARCH: ${{ matrix.arch }}
       SMING_SOC: ${{ matrix.variant }}
       INSTALL_IDF_VER: ${{ matrix.idf_version || '5.2' }}
-      CLANG_BUILD: ${{ matrix.toolchain == 'clang' && '15' || '0' }}
+      CLANG_BUILD: ${{ matrix.toolchain == 'clang' && '18' || '0' }}
       BUILD64: ${{ matrix.toolchain == 'gcc64' && 1 || 0 }}
       ENABLE_CCACHE: 1
       CCACHE_DIR: ${{ github.workspace }}/.ccache


### PR DESCRIPTION
As identified in #2939, the CI runner for Ubuntu 24 has dropped clang 15. Change script to use the latest available (clang 18).