### PR TITLE
Fix Formatter UTF8 encoding

### DIFF
--- a/Sming/Core/Data/Format/Formatter.cpp
+++ b/Sming/Core/Data/Format/Formatter.cpp
@@ -58,7 +58,7 @@ unsigned escapeControls(String& value, Options options)
 		if(escapeChar(c, options)) {
 			extra += 1; // "\"
 		} else if(options[Option::unicode]) {
-			if(uint8_t(c) < 0x20 || (c & 0x80)) {
+			if(uint8_t(c) < 0x20) {
 				extra += 5; // "\uNNNN"
 			}
 		} else if(uint8_t(c) < 0x20) {
@@ -86,7 +86,7 @@ unsigned escapeControls(String& value, Options options)
 			*out++ = '\\';
 			c = esc;
 		} else if(options[Option::unicode]) {
-			if(uint8_t(c) < 0x20 || (c & 0x80)) {
+			if(uint8_t(c) < 0x20) {
 				*out++ = '\\';
 				*out++ = 'u';
 				*out++ = '0';

--- a/Sming/Core/Data/Format/Formatter.cpp
+++ b/Sming/Core/Data/Format/Formatter.cpp
@@ -64,8 +64,8 @@ unsigned escapeControls(String& value, Options options)
 		} else if(uint8_t(c) < 0x20) {
 			extra += 3; // "\xnn"
 		} else if((c & 0x80) && options[Option::utf8]) {
-			// Characters such as £ (0xa3) are escaped to 0xc2 0xa3 in UTF-8
-			extra += 1; // 0xc2
+			// Characters from U+0080 to U+07FF are encoded in two bytes in UTF-8
+			extra += 1;
 		}
 	}
 	if(extra == 0) {
@@ -100,7 +100,8 @@ unsigned escapeControls(String& value, Options options)
 			*out++ = hexchar(uint8_t(c) >> 4);
 			c = hexchar(uint8_t(c) & 0x0f);
 		} else if((c & 0x80) && options[Option::utf8]) {
-			*out++ = 0xc2;
+			*out++ = 0xc0 | (c >> 6);
+			c = 0x80 | (c & 0x3f);
 		}
 		*out++ = c;
 	}

--- a/Sming/Core/Data/Format/Json.cpp
+++ b/Sming/Core/Data/Format/Json.cpp
@@ -27,7 +27,7 @@ Json json;
  */
 void Json::escape(String& value) const
 {
-	escapeControls(value, Option::doublequote | Option::backslash);
+	escapeControls(value, Option::unicode | Option::doublequote | Option::backslash);
 }
 
 void Json::quote(String& value) const

--- a/Sming/Core/Data/Format/Json.cpp
+++ b/Sming/Core/Data/Format/Json.cpp
@@ -18,15 +18,16 @@ namespace Format
 Json json;
 
 /*
- * Check for invalid characters and replace them - can break browser
- * operation otherwise.
+ * JSON requires control characters, quotes and reverse solidus (backslash) to be escaped.
  *
- * This can occur if filenames become corrupted, so here we just
- * substitute an underscore _ for anything which fails to match UTF8.
+ * All other codepoints from 0x20 to 0xff are left unchanged.
+ * This is typically UTF8 but it could be binary or some other application-defined encoding.
+ *
+ * Therefore no validation is performed on the data.
  */
 void Json::escape(String& value) const
 {
-	escapeControls(value, Option::unicode | Option::doublequote | Option::backslash);
+	escapeControls(value, Option::doublequote | Option::backslash);
 }
 
 void Json::quote(String& value) const

--- a/tests/HostTests/modules/Formatter.cpp
+++ b/tests/HostTests/modules/Formatter.cpp
@@ -17,7 +17,7 @@ public:
 		TEST_CASE("JSON")
 		{
 			DEFINE_FSTR_LOCAL(text1b, "A JSON\\ntest string\\twith escapes\\u0012\\u0000\\n"
-									  "Worth \\\"maybe\\\" \\u00a3 0.53. Yen \\u00a5 5bn.")
+									  "Worth \\\"maybe\\\" \xa3 0.53. Yen \xa5 5bn.")
 
 			Serial << text1 << endl;
 			String s(text1);


### PR DESCRIPTION
PR #2880 added a generic `Format::escapeControls()` function to work towards providing an efficient and standard way for the framework to support escaping textual data in various ways.

This PR fixes the ASCII -> UTF8 conversion (via `Format::Option::utf8`) which was too simplistic and did not correctly handle all codepoints from 0x80 to 0xff as intended.

It also reverts the unicode output for `Format::Json::escape` as this produces incorrect output when the text is already encoded, such as with UTF8. Only the mandatory escaping is performed. Non-standard control characters below 0x20 are escaped using the unicode syntax. For example, "one\0two" is escaped as "one\u0000two".

This means applications are responsible for validating, encoding and decoding text formats as required.

Note: Prior to PR #2880 the `Format::Json::escape` call checked for invalid UTF8 and corrected it. This code was never properly validated and may not be required. If so, the issue of validating/fixing UTF8 can be revisited. It's potentially complex so I don't intend to address that here.
