### PR TITLE
Support dropping named partitions using string values for size

### DIFF
--- a/Sming/Components/Storage/Tools/hwconfig/partition.py
+++ b/Sming/Components/Storage/Tools/hwconfig/partition.py
@@ -144,7 +144,7 @@ class Table(list):
             partnames += name
             part = self.find_by_name(name)
             # Setting size=0 drops partition if it exists
-            if entry.get('size') == 0:
+            if parse_int(entry.get('size')) == 0:
                 if part:
                     self.remove(part)
                 continue


### PR DESCRIPTION
When dropping partitions by setting size to zero, string values such as `{"size": "0K"}` do not work. This PR fixes this oversight.

Closes #2947.
