### PR TITLE
Remove the cstdbool include for newer C++ compilers

### DIFF
--- a/Sming/Components/lwip/src/Arch/Host/include/host_lwip.h
+++ b/Sming/Components/lwip/src/Arch/Host/include/host_lwip.h
@@ -20,7 +20,10 @@
 #pragma once
 
 #include <cstdint>
+#if __cplusplus < 201703L
+// Only include for older C++ standards
 #include <cstdbool>
+#endif
 
 struct lwip_param {
 	const char* ifname;  ///< Name of interface to use

--- a/Sming/Components/lwip/src/Arch/Host/include/host_lwip.h
+++ b/Sming/Components/lwip/src/Arch/Host/include/host_lwip.h
@@ -20,10 +20,6 @@
 #pragma once
 
 #include <cstdint>
-#if __cplusplus < 201703L
-// Only include for older C++ standards
-#include <cstdbool>
-#endif
 
 struct lwip_param {
 	const char* ifname;  ///< Name of interface to use


### PR DESCRIPTION
newer c++ compilers don't need to include cstdbool anymore and compiling will fail with it still in. 
This PR removes the include from host_lwip.h for compilers newer than c++17
