### PR TITLE
[WIP] Refactor/i hardware pwm

### DIFF
--- a/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp32/Components/driver/include/driver/pwm.h
@@ -13,3 +13,106 @@
 #include <soc/soc_caps.h>
 
 #define PWM_CHANNEL_NUM_MAX SOC_LEDC_CHANNEL_NUM
+
+/**
+ * @file pwm.h
+ * @brief PWM (Pulse Width Modulation) configuration structures and enumerations for ESP32.
+ */
+
+/**
+ * @enum PWM_phase_shift_mode
+ * @brief Defines the modes for phase shifting in PWM.
+ * 
+ * @var PWM_PHASE_OFF
+ * No phase shifting.
+ * 
+ * @var PWM_PHASE_CUSTOM
+ * Use custom per-channel phase delay values.
+ * 
+ * @var PWM_PHASE_AUTO
+ * Evenly distribute phases across the PWM period.
+ */
+enum PWM_phase_shift_mode {
+    PWM_PHASE_OFF,           // No phase shifting
+    PWM_PHASE_CUSTOM,        // Use custom per-channel values
+    PWM_PHASE_AUTO    // Evenly distribute phases across period
+};
+
+/**
+ * @enum PWM_spread_spectrum_mode
+ * @brief Defines the modes for spread spectrum in PWM.
+ * 
+ * @var PWM_SPREAD_OFF
+ * No spread spectrum.
+ * 
+ * @var PWM_SPREAD_CUSTOM
+ * Use custom per-channel frequency offset values.
+ * 
+ * @var PWM_SPREAD_AUTO
+ * Automatically apply spread spectrum with a specified percentage.
+ */
+enum PWM_spread_spectrum_mode {
+    PWM_SPREAD_OFF,
+    PWM_SPREAD_CUSTOM,
+    PWM_SPREAD_AUTO
+};
+
+/**
+ * @struct PWM_phase_shift
+ * @brief Configuration structure for PWM phase shifting.
+ * 
+ * @var PWM_phase_shift::mode
+ * Specifies the phase shift mode. See @ref PWM_phase_shift_mode.
+ * 
+ * @var PWM_phase_shift::phaseDelayPercent
+ * Array of phase delay percentages for each channel (used when mode is PWM_PHASE_CUSTOM).
+ * 
+ * @var PWM_phase_shift::phaseStartPercent
+ * Optional starting phase percentage for automatic phase distribution (used when mode is PWM_PHASE_AUTO).
+ */
+ struct PWM_phase_shift {
+    PWM_phase_shift_mode mode = PWM_PHASE_OFF;
+    union {
+        uint8_t phaseDelayPercent[PWM_CHANNEL_NUM_MAX]; // Used when mode is PWM_PHASE_CUSTOM
+        uint8_t phaseStartPercent;                      // Optional starting phase for PWM_PHASE_AUTO
+    } ;
+};
+
+/**
+ * @struct PWM_spread_spectrum
+ * @brief Configuration structure for PWM spread spectrum.
+ * 
+ * @var PWM_spread_spectrum::mode
+ * Specifies the spread spectrum mode. See @ref PWM_spread_spectrum_mode.
+ * 
+ * @var PWM_spread_spectrum::frequencyOffsetHz
+ * Array of frequency offsets in Hz for each channel (used when mode is PWM_SPREAD_CUSTOM).
+ * 
+ * @var PWM_spread_spectrum::spreadPercentage
+ * Spread percentage for automatic spread spectrum (used when mode is PWM_SPREAD_AUTO).
+ */
+struct PWM_spread_spectrum {
+    PWM_spread_spectrum_mode mode = PWM_SPREAD_OFF;
+    union {
+        int32_t frequencyOffsetHz[PWM_CHANNEL_NUM_MAX];     // Used when mode is PWM_SPREAD_CUSTOM
+        uint8_t spreadPercentage;                         // Percentage for PWM_SPREAD_AUTO (0.0-100.0)
+    } ;
+};
+
+/**
+ * @struct PWM_Options
+ * @brief Configuration options for PWM (Pulse Width Modulation).
+ *
+ * This structure defines the configuration parameters for PWM, including
+ * phase shift and spread spectrum options.
+ *
+ * @var PWM_Options::phaseShift
+ * Specifies the phase shift configuration for the PWM signal.
+ * 
+ * @var PWM_Options::spreadSpectrum
+ * Specifies the spread spectrum configuration for the PWM signal.
+ */
+struct PWM_Options {
+    PWM_phase_shift phaseShift;
+    PWM_spread_spectrum spreadSpectrum;
+};

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -135,29 +135,32 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 {
 	return (1U << bits) - 1;
 }
-int hpointForPin(uint8_t channelIndex, uint8_t channel_count)
-{
-/*
-	debug_i("calculating hpoint for channel: %d\n", channelIndex);
-	debug_i("            channel_count    : %d\n", channel_count);
-	debug_i("            maxDuty           : %d\n", maxDuty(DEFAULT_RESOLUTION));
-*/
-	int _hpoint=maxDuty(DEFAULT_RESOLUTION) * channelIndex / channel_count;
-//	debug_i("hpoint is %d\n", _hpoint);
-	return _hpoint;	
-}
 
 } //namespace
 
-HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseShift ) : channel_count(no_of_pins)
+HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
+	PWM_Options options;
+	options.phaseShift.mode=PWM_PHASE_OFF;
+	options.spreadSpectrum.mode=PWM_SPREAD_OFF;
+	Init(pins, no_of_pins, options);
+}
+
+HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, PWM_Options& options) : channel_count(no_of_pins), _options(options)
+{
+	Init(pins, no_of_pins, options);
+}
+
+void HardwarePWM::Init(const uint8_t* pins, uint8_t no_of_pins, PWM_Options& options)
+{
+	_options = options;
+	
 	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);
 	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);
 
-	_usePhaseShift = usePhaseShift;
 	periph_module_enable(PERIPH_LEDC_MODULE);
 
-	if (_usePhaseShift) {
+	if (_options.phaseShift.mode!=PWM_PHASE_OFF) {
 		debug_i("Using phase shift for %d channels\n", no_of_pins);
 	}
 
@@ -197,7 +200,7 @@ HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseS
 			.intr_type = LEDC_INTR_DISABLE,
 			.timer_sel = pinToTimer(i),
 			.duty = 0,
-			.hpoint = _usePhaseShift?hpointForPin(i,channel_count):0,
+			.hpoint = hpointForPin(i,channel_count),
 		};
 		debug_d("ledc_channel\n"
 				"\tspeed_mode: %i\r\n"
@@ -207,7 +210,7 @@ HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseS
 				"\tgpio_num: %i\r\n"
 				"\tduty: %i\r\n"
 				"\thpoint: %i\r\n\n",
-				pinToGroup(i), pinToChannel(i), pinToTimer(i), ledc_channel.intr_type, pins[i], 0, _usePhaseShift?hpointForPin(i,channel_count):0);
+				pinToGroup(i), pinToChannel(i), pinToTimer(i), ledc_channel.intr_type, pins[i], 0, hpointForPin(i,channel_count));
 		ESP_ERROR_CHECK(ledc_channel_config(&ledc_channel));
 		ledc_bind_channel_timer(pinToGroup(i), pinToChannel(i), pinToTimer(i));
 	}
@@ -263,7 +266,7 @@ void HardwarePWM::setPeriod(uint32_t period)
 	// Set the frequency globally, will add per timer functions later.
 	// Also, this can be done smarter.
 	for(uint8_t i = 0; i < channel_count; i++) {
-		if(_usePhaseShift){
+		if(_options.phaseShift.mode!= PWM_PHASE_OFF) {
 			ESP_ERROR_CHECK(ledc_set_duty_with_hpoint(pinToGroup(i), pinToChannel(i), period, hpointForPin(i,channel_count)));
 		}else{
 			ESP_ERROR_CHECK(ledc_set_freq(pinToGroup(i), pinToTimer(i), periodToFrequency(period)));
@@ -281,4 +284,22 @@ void HardwarePWM::update()
 uint32_t HardwarePWM::getFrequency(uint8_t pin) const
 {
 	return ledc_get_freq(pinToGroup(pin), pinToTimer(pin));
+}
+
+uint32_t HardwarePWM::getMaxDuty() const
+{
+	return maxduty;
+}
+
+int HardwarePWM::hpointForPin(uint8_t channelIndex, uint8_t channel_count)
+{
+	switch (_options.phaseShift.mode) {
+		case PWM_PHASE_AUTO:
+			return (maxDuty(DEFAULT_RESOLUTION) * channelIndex / channel_count) + (maxDuty(DEFAULT_RESOLUTION) / channel_count / 2);
+		case PWM_PHASE_CUSTOM:
+			return _options.phaseShift.phaseDelayPercent[channelIndex];
+		case PWM_PHASE_OFF:
+		default:
+			return 0;
+	}
 }

--- a/Sming/Arch/Esp32/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.cpp
@@ -135,15 +135,31 @@ uint32_t maxDuty(ledc_timer_bit_t bits)
 {
 	return (1U << bits) - 1;
 }
+int hpointForPin(uint8_t channelIndex, uint8_t channel_count)
+{
+/*
+	debug_i("calculating hpoint for channel: %d\n", channelIndex);
+	debug_i("            channel_count    : %d\n", channel_count);
+	debug_i("            maxDuty           : %d\n", maxDuty(DEFAULT_RESOLUTION));
+*/
+	int _hpoint=maxDuty(DEFAULT_RESOLUTION) * channelIndex / channel_count;
+//	debug_i("hpoint is %d\n", _hpoint);
+	return _hpoint;	
+}
 
 } //namespace
 
-HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
+HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseShift ) : channel_count(no_of_pins)
 {
 	assert(no_of_pins > 0 && no_of_pins <= SOC_LEDC_CHANNEL_NUM);
 	no_of_pins = std::min(uint8_t(SOC_LEDC_CHANNEL_NUM), no_of_pins);
 
+	_usePhaseShift = usePhaseShift;
 	periph_module_enable(PERIPH_LEDC_MODULE);
+
+	if (_usePhaseShift) {
+		debug_i("Using phase shift for %d channels\n", no_of_pins);
+	}
 
 	for(uint8_t i = 0; i < no_of_pins; i++) {
 		channels[i] = pins[i];
@@ -181,7 +197,7 @@ HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins) : channel_coun
 			.intr_type = LEDC_INTR_DISABLE,
 			.timer_sel = pinToTimer(i),
 			.duty = 0,
-			.hpoint = 0,
+			.hpoint = _usePhaseShift?hpointForPin(i,channel_count):0,
 		};
 		debug_d("ledc_channel\n"
 				"\tspeed_mode: %i\r\n"
@@ -191,7 +207,7 @@ HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins) : channel_coun
 				"\tgpio_num: %i\r\n"
 				"\tduty: %i\r\n"
 				"\thpoint: %i\r\n\n",
-				pinToGroup(i), pinToChannel(i), pinToTimer(i), ledc_channel.intr_type, pins[i], 0, 0);
+				pinToGroup(i), pinToChannel(i), pinToTimer(i), ledc_channel.intr_type, pins[i], 0, _usePhaseShift?hpointForPin(i,channel_count):0);
 		ESP_ERROR_CHECK(ledc_channel_config(&ledc_channel));
 		ledc_bind_channel_timer(pinToGroup(i), pinToChannel(i), pinToTimer(i));
 	}
@@ -247,7 +263,11 @@ void HardwarePWM::setPeriod(uint32_t period)
 	// Set the frequency globally, will add per timer functions later.
 	// Also, this can be done smarter.
 	for(uint8_t i = 0; i < channel_count; i++) {
-		ESP_ERROR_CHECK(ledc_set_freq(pinToGroup(i), pinToTimer(i), periodToFrequency(period)));
+		if(_usePhaseShift){
+			ESP_ERROR_CHECK(ledc_set_duty_with_hpoint(pinToGroup(i), pinToChannel(i), period, hpointForPin(i,channel_count)));
+		}else{
+			ESP_ERROR_CHECK(ledc_set_freq(pinToGroup(i), pinToTimer(i), periodToFrequency(period)));
+		}
 	}
 	// ledc_update_duty();
 	update();

--- a/Sming/Arch/Esp32/Core/HardwarePWM.h
+++ b/Sming/Arch/Esp32/Core/HardwarePWM.h
@@ -1,0 +1,110 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HardwarePWM.h
+ *
+ ****/
+
+ #pragma once
+
+ #include <IHardwarePWM.h>
+ 
+ /**
+  * @brief ESP32-specific implementation of pulse width modulation
+  * 
+  * ESP8266 has no hardware PWM and uses an interrupt-based software implementation.
+  * Period of PWM is fixed to 1000us / Frequency = 1kHz by default
+  * For a period of 1000, max duty = 25000
+  * You can use function setPeriod() to change frequency/period.
+  */
+
+
+
+
+  /* *  @param  usePhaseShift Use ledc's hpoint phase shift feature to stagger the rising edge of the PWM 
+	 * 						  singals evenly across the period. This is useful for driving multiple LEDs
+	 * 						  connected to the same power rail to reduce the peak current draw and help with 
+	 * 						  electromagnetic interference.
+	 *  @param  useSpreadSpectrum implement minimal spread spectrum modulation to further reduce EMI. This 
+	 * 						  feature uses a hardware timer to modulate the base frequency of the PWM signal.
+	 * 						  Depending on the base frequency, this may cause quite some system load, so 
+	 *                        choosing a good balance between CPU resources and acceptable EMI is important.
+     * 
+     * */
+ class HardwarePWM : public IHardwarePWM
+ {
+ public:
+     /** @brief  Instantiate hardware PWM object
+      *  @param  pins Pointer to array of pins to control
+      *  @param  no_of_pins Quantity of elements in array of pins
+      *  @param  usePhaseShift Parameter ignored on ESP8266 (present for API compatibility)
+      */
+     HardwarePWM(const uint8_t* pins, uint8_t no_of_pins);
+     HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, PWM_Options& options);
+    
+     virtual ~HardwarePWM();
+ 
+      /** @brief  initialize PWM hardware
+      *  @param  pins Pointer to array of pins to control
+      *  @param  no_of_pins Quantity of elements in array of pins
+      *  @param  options PWM options
+      */
+     void Init(const uint8_t* pins, uint8_t no_of_pins, PWM_Options& options);
+
+     /** @brief  Set PWM duty cycle for a channel
+      *  @param  chan Channel to set
+      *  @param  duty Value of duty cycle to set channel to
+      *  @param  update Update PWM output
+      *  @retval bool True on success
+      */
+     bool setDutyChan(uint8_t chan, uint32_t duty, bool update = true) override;
+ 
+     /** @brief  Get PWM duty cycle
+      *  @param  chan Channel to get duty cycle for
+      *  @retval uint32_t Value of PWM duty cycle
+      */
+     uint32_t getDutyChan(uint8_t chan) const override;
+ 
+     /** @brief  Set PWM period
+      *  @param  period PWM period in microseconds
+      */
+     void setPeriod(uint32_t period) override;
+ 
+     /** @brief  Get PWM period
+      *  @retval uint32_t Value of PWM period in microseconds
+      */
+     uint32_t getPeriod() const override;
+ 
+     /** @brief  Get channel number for a pin
+      *  @param  pin GPIO to interrogate
+      *  @retval uint8_t Channel of GPIO
+      */
+     uint8_t getChannel(uint8_t pin) const override;
+ 
+     /** @brief  Get the maximum duty cycle value
+      *  @retval uint32_t Maximum permissible duty cycle
+      */
+     uint32_t getMaxDuty() const override;
+ 
+     /** @brief  Update PWM to use new settings
+      */
+     void update() override;
+ 
+     /** @brief Get PWM Frequency
+      *  @param pin GPIO to get frequency for
+      *  @retval uint32_t Value of Frequency 
+      */
+     uint32_t getFrequency(uint8_t pin) const override;
+ 
+     
+ private:
+     int hpointForPin(uint8_t channelIndex, uint8_t channel_count);
+
+     uint8_t channel_count;
+     uint8_t channels[PWM_CHANNEL_NUM_MAX];
+     uint32_t maxduty{0};
+     PWM_Options _options;
+ };

--- a/Sming/Arch/Esp8266/Components/driver/include/driver/pwm.h
+++ b/Sming/Arch/Esp8266/Components/driver/include/driver/pwm.h
@@ -6,6 +6,8 @@ extern "C" {
 
 #include <pwm.h>
 
+struct PWM_Options{};
+
 /**
  * @defgroup pwm_driver PWM driver
  * @ingroup drivers

--- a/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
@@ -51,17 +51,16 @@ static const uint8_t gpioPinFunc[]{
 	FUNC_GPIO14, //
 	FUNC_GPIO15, //
 };
-
-HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseShift ) : channel_count(no_of_pins)
+HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins) : channel_count(no_of_pins)
 {
-	if(noOfPins == 0) {
+	if(no_of_pins == 0) {
 		return;
 	}
 
 	uint32_t ioInfo[PWM_CHANNEL_NUM_MAX][3];   // pin information
 	uint32_t pwmDutyInit[PWM_CHANNEL_NUM_MAX]; // pwm duty
 	unsigned pinCount = 0;
-	for(uint8_t i = 0; i < noOfPins; i++) {
+	for(uint8_t i = 0; i < no_of_pins; i++) {
 		auto pin = pins[i];
 		assert(pin < 16);
 		if(pin >= 16) {
@@ -130,4 +129,9 @@ uint32_t HardwarePWM::getFrequency(uint8_t pin) const
 	(void)pin;
 	auto period = pwm_get_period();
 	return (period == 0) ? 0 : 1000000U / period;
+}
+
+uint32_t HardwarePWM::getMaxDuty() const
+{
+	return maxduty;
 }

--- a/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Esp8266/Core/HardwarePWM.cpp
@@ -52,7 +52,7 @@ static const uint8_t gpioPinFunc[]{
 	FUNC_GPIO15, //
 };
 
-HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t noOfPins) : channel_count(noOfPins)
+HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseShift ) : channel_count(no_of_pins)
 {
 	if(noOfPins == 0) {
 		return;

--- a/Sming/Arch/Esp8266/Core/HardwarePWM.h
+++ b/Sming/Arch/Esp8266/Core/HardwarePWM.h
@@ -1,0 +1,82 @@
+/****
+ * Sming Framework Project - Open Source framework for high efficiency native ESP8266 development.
+ * Created 2015 by Skurydin Alexey
+ * http://github.com/SmingHub/Sming
+ * All files of the Sming Core are provided under the LGPL v3 license.
+ *
+ * HardwarePWM.h
+ *
+ ****/
+
+#pragma once
+
+#include <IHardwarePWM.h>
+ 
+/*
+* @brief Interface class for HardwarePWM 
+* bust be subclassed by hardware specific implementation
+*/
+ class HardwarePWM : public IHardwarePWM
+ {
+ public:
+     /** @brief  Instantiate hardware PWM object
+      *  @param  pins Pointer to array of pins to control
+      *  @param  no_of_pins Quantity of elements in array of pins
+      *  @param  usePhaseShift Parameter ignored on ESP8266 (present for API compatibility)
+      */
+     HardwarePWM(const uint8_t* pins, uint8_t no_of_pins);
+     HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, PWM_Options& options);
+     
+     virtual ~HardwarePWM();
+ 
+     /** @brief  Set PWM duty cycle for a channel
+      *  @param  chan Channel to set
+      *  @param  duty Value of duty cycle to set channel to
+      *  @param  update Update PWM output
+      *  @retval bool True on success
+      */
+     bool setDutyChan(uint8_t chan, uint32_t duty, bool update = true) override;
+ 
+     /** @brief  Get PWM duty cycle
+      *  @param  chan Channel to get duty cycle for
+      *  @retval uint32_t Value of PWM duty cycle
+      */
+     uint32_t getDutyChan(uint8_t chan) const override;
+ 
+     /** @brief  Set PWM period
+      *  @param  period PWM period in microseconds
+      */
+     void setPeriod(uint32_t period) override;
+ 
+     /** @brief  Get PWM period
+      *  @retval uint32_t Value of PWM period in microseconds
+      */
+     uint32_t getPeriod() const override;
+ 
+     /** @brief  Get channel number for a pin
+      *  @param  pin GPIO to interrogate
+      *  @retval uint8_t Channel of GPIO
+      */
+     uint8_t getChannel(uint8_t pin) const override;
+ 
+     /** @brief  Get the maximum duty cycle value
+      *  @retval uint32_t Maximum permissible duty cycle
+      */
+     uint32_t getMaxDuty() const override;
+ 
+     /** @brief  Update PWM to use new settings
+      */
+     void update() override;
+ 
+     /** @brief Get PWM Frequency
+      *  @param pin GPIO to get frequency for
+      *  @retval uint32_t Value of Frequency 
+      */
+     uint32_t getFrequency(uint8_t pin) const override;
+ 
+ private:
+     uint8_t channel_count;
+     uint8_t channels[PWM_CHANNEL_NUM_MAX];
+     uint32_t maxduty{0};
+     PWM_Options _options;
+ };

--- a/Sming/Arch/Host/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Host/Core/HardwarePWM.cpp
@@ -25,7 +25,7 @@
 
 #include <HardwarePWM.h>
 
-HardwarePWM::HardwarePWM(const uint8_t*, uint8_t no_of_pins) : channel_count(no_of_pins)
+HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseShift ) : channel_count(no_of_pins)
 {
 }
 

--- a/Sming/Arch/Rp2040/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Rp2040/Core/HardwarePWM.cpp
@@ -31,7 +31,7 @@
 
 #define PWM_FREQ_DEFAULT 1000
 
-HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t noOfPins) : channel_count(noOfPins)
+HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseShift ) : channel_count(no_of_pins)
 {
 	assert(noOfPins > 0 && noOfPins <= PWM_CHANNEL_NUM_MAX);
 	noOfPins = std::min(uint8_t(PWM_CHANNEL_NUM_MAX), noOfPins);

--- a/Sming/Arch/Rp2040/Core/HardwarePWM.cpp
+++ b/Sming/Arch/Rp2040/Core/HardwarePWM.cpp
@@ -33,12 +33,12 @@
 
 HardwarePWM::HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseShift ) : channel_count(no_of_pins)
 {
-	assert(noOfPins > 0 && noOfPins <= PWM_CHANNEL_NUM_MAX);
-	noOfPins = std::min(uint8_t(PWM_CHANNEL_NUM_MAX), noOfPins);
-	std::copy_n(pins, noOfPins, channels);
+	assert(no_of_pins > 0 && no_of_pins <= PWM_CHANNEL_NUM_MAX);
+	no_of_pins = std::min(uint8_t(PWM_CHANNEL_NUM_MAX), no_of_pins);
+	std::copy_n(pins, no_of_pins, channels);
 	setPeriod(1e6 / PWM_FREQ_DEFAULT);
 
-	for(unsigned i = 0; i < noOfPins; ++i) {
+	for(unsigned i = 0; i < no_of_pins; ++i) {
 		auto pin = channels[i];
 		gpio_set_function(pin, GPIO_FUNC_PWM);
 		gpio_set_dir(pin, GPIO_OUT);

--- a/Sming/Core/HardwarePWM.h
+++ b/Sming/Core/HardwarePWM.h
@@ -62,9 +62,16 @@ public:
 	/** @brief  Instantiate hardware PWM object
      *  @param  pins Pointer to array of pins to control
      *  @param  no_of_pins Quantity of elements in array of pins
+	 *  @param  usePhaseShift Use ledc's hpoint phase shift feature to stagger the rising edge of the PWM 
+	 * 						  singals evenly across the period. This is useful for driving multiple LEDs
+	 * 						  connected to the same power rail to reduce the peak current draw and help with 
+	 * 						  electromagnetic interference.
+	 *  @param  useSpreadSpectrum implement minimal spread spectrum modulation to further reduce EMI. This 
+	 * 						  feature uses a hardware timer to modulate the base frequency of the PWM signal.
+	 * 						  Depending on the base frequency, this may cause quite some system load, so 
+	 *                        choosing a good balance between CPU resources and acceptable EMI is important.
      */
-	HardwarePWM(const uint8_t* pins, uint8_t no_of_pins);
-
+	HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseShift=false);
 	virtual ~HardwarePWM();
 
 	/** @brief  Set PWM duty cycle
@@ -154,6 +161,8 @@ public:
 
 private:
 	uint8_t channel_count;
+	bool _usePhaseShift;
+	bool _useSpreadSpectrum;
 	uint8_t channels[PWM_CHANNEL_NUM_MAX];
 	uint32_t maxduty{0};
 };

--- a/Sming/Core/IHardwarePWM.h
+++ b/Sming/Core/IHardwarePWM.h
@@ -32,6 +32,7 @@
 
 #define PWM_BAD_CHANNEL 0xff ///< Invalid PWM channel
 
+
 /**
  * @brief Basic pulse width modulation support.
  *
@@ -56,23 +57,15 @@
  * Note: Esp32 and Rp2040 hardware offers more capability which requires use of SDK calls
  * or direct hardware access. To avoid resource conflicts avoid using this class in those cases.
  */
-class HardwarePWM
+class IHardwarePWM
 {
 public:
 	/** @brief  Instantiate hardware PWM object
      *  @param  pins Pointer to array of pins to control
      *  @param  no_of_pins Quantity of elements in array of pins
-	 *  @param  usePhaseShift Use ledc's hpoint phase shift feature to stagger the rising edge of the PWM 
-	 * 						  singals evenly across the period. This is useful for driving multiple LEDs
-	 * 						  connected to the same power rail to reduce the peak current draw and help with 
-	 * 						  electromagnetic interference.
-	 *  @param  useSpreadSpectrum implement minimal spread spectrum modulation to further reduce EMI. This 
-	 * 						  feature uses a hardware timer to modulate the base frequency of the PWM signal.
-	 * 						  Depending on the base frequency, this may cause quite some system load, so 
-	 *                        choosing a good balance between CPU resources and acceptable EMI is important.
      */
-	HardwarePWM(const uint8_t* pins, uint8_t no_of_pins, bool usePhaseShift=false);
-	virtual ~HardwarePWM();
+
+	virtual ~IHardwarePWM() =default;
 
 	/** @brief  Set PWM duty cycle
      *  @param  pin GPIO to set
@@ -80,7 +73,7 @@ public:
      *  @retval bool True on success
      *  @note   Default frequency is 1khz but can be varied by various function
      */
-	bool analogWrite(uint8_t pin, uint32_t duty)
+	virtual bool analogWrite(uint8_t pin, uint32_t duty)
 	{
 		return setDuty(pin, duty);
 	}
@@ -91,7 +84,7 @@ public:
      *  @param  update Update PWM output
      *  @retval bool True on success
      */
-	bool setDutyChan(uint8_t chan, uint32_t duty, bool update = true);
+	virtual bool setDutyChan(uint8_t chan, uint32_t duty, bool update = true);
 
 	/** @brief  Set PWM duty cycle
      *  @param  pin GPIO to set
@@ -111,13 +104,13 @@ public:
 	 *  @param  chan Channel to get duty cycle for
 	 *  @retval uint32_t Value of PWM duty cycle in timer ticks
 	 */
-	uint32_t getDutyChan(uint8_t chan) const;
+	virtual uint32_t getDutyChan(uint8_t chan) const;
 
 	/** @brief  Get PWM duty cycle
      *  @param  pin GPIO to get duty cycle for
      *  @retval uint32_t Value of PWM duty cycle in timer ticks
      */
-	uint32_t getDuty(uint8_t pin)
+	virtual uint32_t getDuty(uint8_t pin)
 	{
 		uint8_t chan = getChannel(pin);
 		return getDutyChan(chan);
@@ -127,42 +120,40 @@ public:
      *  @param  period PWM period in microseconds
      *  @note   All PWM pins share the same period
      */
-	void setPeriod(uint32_t period);
+	virtual void setPeriod(uint32_t period);
 
 	/** @brief  Get PWM period
      *  @retval uint32_t Value of PWM period in microseconds
      */
-	uint32_t getPeriod() const;
+	virtual uint32_t getPeriod() const;
 
 	/** @brief  Get channel number for a pin
      *  @param  pin GPIO to interrogate
      *  @retval uint8_t Channel of GPIO
      */
-	uint8_t getChannel(uint8_t pin) const;
+	virtual uint8_t getChannel(uint8_t pin) const;
 
 	/** @brief  Get the maximum duty cycle value
      *  @retval uint32_t Maximum permissible duty cycle in timer ticks
      *  @note   Attempt to set duty of a pin above this value will fail
      */
-	uint32_t getMaxDuty() const
+	virtual uint32_t getMaxDuty() const
 	{
 		return maxduty;
 	}
 
 	/** @brief  This function is used to actually update the PWM.
 	 */
-	void update();
+	virtual void update();
 
 	/** @brief Get PWM Frequency
 	 *  @param pin GPIO to get frequency for
 	 *  @retval uint32_t Value of Frequency 
 	*/
-	uint32_t getFrequency(uint8_t pin) const;
+	virtual uint32_t getFrequency(uint8_t pin) const;
 
 private:
 	uint8_t channel_count;
-	bool _usePhaseShift;
-	bool _useSpreadSpectrum;
 	uint8_t channels[PWM_CHANNEL_NUM_MAX];
 	uint32_t maxduty{0};
 };


### PR DESCRIPTION
after the discussion in #2955, I started thinking a bit more about how I could implement a richer HardwarePWM interface without breaking compatibility and while maintaining the core API in place, too.

My goal was to:

- provide a richer set of options when instantiating HardwarePWM (currently used to initialize phase shifting, spread spectrum will come later, but also configuring channel groups to timers - which gets rather close to the Esp32 ledc API)
- provide extensibility to abstract functions provided by hardware and / or the platform API and allow them to be used as part of the SMING HardwarePWM interface - those will often be hardware specific but might be implemented as hardware independent, too

I took the suggestion of extending the C header at `pwm.h` to provide the configuration option structures necessary at HardwarePWM instantiation. I'm not perfectly happy with that as it creates quite a bit of opportunity to mess up memory - and no good way to test for correct parameters. But I guess that's what we get for using C.

I have also moved the pre-existing `HardwarePWM` class to an interface only implementation `IHardwarePWM` that all hardware specific classes now inherit from. This allows me to extend the interface in the the child classes while maintaining a coherent set of base functions for any older code to work with. Code that wants to use the extended functionality will have to be platform specific.

This PR currently only implements the Hardware specific classes for Esp32 and Esp8266, CI failures for Host and RP2040 are expected. 

The main goal is to get feedback.