### PR TITLE
Fix Rp2040 issue calling wifistation `enable` after `config`

### DIFF
--- a/Sming/Components/Network/Arch/Rp2040/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Rp2040/Platform/StationImpl.cpp
@@ -29,9 +29,15 @@ StationImpl station;
 void StationImpl::enable(bool enabled, bool save)
 {
 	debug_d("%s", __PRETTY_FUNCTION__);
-	if(enabled != this->enabled) {
-		cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_STA, enabled, cyw43_arch_get_country_code());
-		this->enabled = enabled;
+	if(enabled == this->enabled) {
+		return;
+	}
+
+	cyw43_wifi_set_up(&cyw43_state, CYW43_ITF_STA, enabled, cyw43_arch_get_country_code());
+	this->enabled = enabled;
+
+	if(enabled) {
+		internalConnect();
 	}
 }
 


### PR DESCRIPTION
This PR fixes a bug with the Rp2040 WiFi Station implementation where WiFi only starts if `config` is called *after* `enable`: either should work.

This works:

```
WifiStation.enable(true);
WifiStation.config(WIFI_SSID, WIFI_PWD);
```

but this does not:

```
WifiStation.config(WIFI_SSID, WIFI_PWD);
WifiStation.enable(true);
```
