### PR TITLE
Avoid divide-by-zero in Rational tests

### DIFF
--- a/tests/HostTests/app/application.cpp
+++ b/tests/HostTests/app/application.cpp
@@ -47,7 +47,7 @@ void beginTests()
 
 void init()
 {
-	Serial.setTxBufferSize(1024);
+	Serial.setTxBufferSize(0);
 	Serial.begin(SERIAL_BAUD_RATE);
 	Serial.systemDebugOutput(true);
 

--- a/tests/HostTests/modules/Rational.cpp
+++ b/tests/HostTests/modules/Rational.cpp
@@ -20,8 +20,8 @@ public:
 
 		for(unsigned i = 0; i < 10000; ++i) {
 			T a = os_random() % max;
-			T b = os_random() % max;
-			T c = os_random() % max;
+			T b = 1 + os_random() % max;
+			T c = 1 + os_random() % max;
 
 			auto r = Ratio<T>(b, c);
 
@@ -29,21 +29,8 @@ public:
 				T rnd = (isinf(ref) || ref >= T(-1)) ? T(-1) : T(round(ref));
 
 				if(res != rnd) {
-					Serial.print(a);
-					Serial.print(' ');
-					Serial.print(op);
-					Serial.print(" (");
-					Serial.print(b);
-					Serial.print(" / ");
-					Serial.print(c);
-					Serial.print(") = ");
-					Serial.print(res);
-					Serial.print(", ref = ");
-					Serial.print(ref);
-					Serial.print(" (");
-					Serial.print(rnd);
-					Serial.print(')');
-					Serial.println();
+					Serial << a << ' ' << op << " (" << b << " / " << c << ") = " << res << ", ref = " << ref << " ("
+						   << rnd << ')' << endl;
 				}
 
 				TEST_ASSERT(res == rnd);


### PR DESCRIPTION
HostTests fails on Rp2040 (Pico) because library code returns 0, not INF (as for ESP devices), but technically it's undefined so both are incorrect. System could just as well raise a hardware exception so best to just avoid this situation.

Also, don't buffer debug output in HostTests so that text from any assertions get printed.
Note: A "proper" fix for assertions is more complex, requiring serial flushing, etc.
