### PR TITLE
Update Rp2040 `picotool` to 2.1.2 dev (from 2.1.0)

### DIFF
--- a/Sming/Arch/Rp2040/Components/picotool/component.mk
+++ b/Sming/Arch/Rp2040/Components/picotool/component.mk
@@ -36,7 +36,7 @@ $(COMPONENT_RULE)$(PICOTOOL):
 ##@Flashing
 
 .PHONY: picotool
-picotool: ##Pass options to picotool, e.g. `make picotool -- help`
+picotool: ##Pass options to picotool, e.g. `make picotool CMD=help`
 	$(Q) $(PICOTOOL) $(CMD)
 
 comma := ,


### PR DESCRIPTION
Support utility with various bug fixes and improvements for RP2350.
See https://sming.readthedocs.io/en/latest/_inc/Sming/Arch/Rp2040/Components/picotool/.