### PR TITLE
Fix build errors in MacOS (jerryscript)

### DIFF
--- a/Tools/export.sh
+++ b/Tools/export.sh
@@ -53,6 +53,6 @@ export PICO_TOOLCHAIN_PATH=${PICO_TOOLCHAIN_PATH:=$SMING_TOOLCHAINS/rp2040}
 
 # Provide non-apple CLANG (e.g. for rbpf library)
 if [ -n "$GITHUB_ACTIONS" ] && [ "$(uname)" = "Darwin" ]; then
-CLANG="$(brew --prefix llvm@15)/bin/clang"
+CLANG="$(brew --prefix llvm@18)/bin/clang"
 export CLANG
 fi


### PR DESCRIPTION
This PR provides some maintenance fixes for the follow issues with jerryscript:

- Patch CMake minimum version < 3.10: CI build is failing on MacOS
- Fix missing IMPORT_FSTR data building with GCC 15.2
- `day_names_p` and `month_names_p` ill-defined

MacOS CI runner latest now at version 15 (Sequoia) which uses clang 18 (up from 15).

TODO:

* [x] Find out why `rbpf` library is failing. Looks probable that we need to use a newer version of llvm, version 15 isn't found in MacOS runner. `macos-latest` changed from version 14 to version 15 3 weeks ago.