### PR TITLE
`Basic_Tasks` sample gets watchdog resets on esp32

### DIFF
--- a/samples/Basic_Tasks/app/application.cpp
+++ b/samples/Basic_Tasks/app/application.cpp
@@ -51,6 +51,14 @@ void hwTimerDelegate(uint32_t count)
 
 	lastCount = count;
 	timer.start();
+
+#ifdef ARCH_ESP32
+	/*
+	 * The task queue gets hammered very hard, with no idle time.
+	 * We need to occasionally reset the watchdog timer just to let the system know everything's OK.
+	*/
+	WDT.alive();
+#endif
 }
 
 void IRAM_ATTR hwTimerCallback()

--- a/samples/Basic_Tasks/app/application.cpp
+++ b/samples/Basic_Tasks/app/application.cpp
@@ -20,6 +20,8 @@ constexpr unsigned hwTimerReportInterval{1000000}; //< How often to print hardwa
 
 volatile unsigned hwTimerCount;
 
+ElapseTimer hwTimer(hwTimerReportInterval);
+
 /*
  * Analogue reader task
  */
@@ -65,12 +67,11 @@ void IRAM_ATTR hwTimerCallback()
 {
 	++hwTimerCount;
 
-	static ElapseTimer timer(hwTimerReportInterval);
-	if(timer.expired()) {
+	if(hwTimer.expired()) {
 		unsigned count = hwTimerCount;
 		//	System.queueCallback([count]() { hwTimerDelegate(count); });
 		System.queueCallback(hwTimerDelegate, count);
-		timer.start();
+		hwTimer.start();
 	}
 }
 


### PR DESCRIPTION
Task queue gets hammered so needs additional consideration for esp32.

There's also an issue with having a `static ElapseTimer` inside an interrupt service routine because the constructor gets called on first use from ISR, which is problematic and leads to unpredictable crashing-type behaviour.

Closes #2971 