### PR TITLE
Fix `TRange` issues with `clip`, `contains` and `random`

### DIFF
--- a/Sming/Core/Data/Range.h
+++ b/Sming/Core/Data/Range.h
@@ -80,7 +80,7 @@ template <typename T> struct TRange {
 	/**
 	 * @brief Determine if range contains a value
 	 */
-	bool contains(T value) const
+	template <typename V> constexpr bool contains(V value) const
 	{
 		return (value >= min) && (value <= max);
 	}
@@ -96,9 +96,9 @@ template <typename T> struct TRange {
 	/**
 	 * @brief Clip values to within the range
 	 */
-	T clip(T value) const
+	template <typename V> constexpr T clip(V value) const
 	{
-		return (value < min) ? min : (value > max) ? max : value;
+		return (value < min) ? min : (value > max) ? max : T(value);
 	}
 
 	/**

--- a/Sming/Core/Data/Range.h
+++ b/Sming/Core/Data/Range.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <WString.h>
+#include <limits>
 #include <esp_systemapi.h>
 
 /**
@@ -106,11 +107,14 @@ template <typename T> struct TRange {
 	 */
 	T random() const
 	{
-		auto n = 1 + max - min;
+		uint64_t n = 1 + max - min;
 		if(n == 0) {
 			return 0;
 		}
-		auto value = os_random();
+		T value = os_random();
+		if(n > std::numeric_limits<uint32_t>::max()) {
+			value |= uint64_t(os_random()) << 32;
+		}
 		return min + value % n;
 	}
 

--- a/tests/HostTests/include/modules.h
+++ b/tests/HostTests/include/modules.h
@@ -22,6 +22,7 @@
 	XX(Libc)                                                                                                           \
 	XX(PreCache)                                                                                                       \
 	XX(BitSet)                                                                                                         \
+	XX(Range)                                                                                                          \
 	XX(String)                                                                                                         \
 	XX(ArduinoString)                                                                                                  \
 	XX(Wiring)                                                                                                         \

--- a/tests/HostTests/modules/Range.cpp
+++ b/tests/HostTests/modules/Range.cpp
@@ -1,0 +1,44 @@
+#include <HostTests.h>
+#include <Data/Range.h>
+
+class RangeTest : public TestGroup
+{
+public:
+	RangeTest() : TestGroup(_F("Range"))
+	{
+	}
+
+	void execute() override
+	{
+		TEST_CASE("constexpr")
+		{
+			constexpr TRange<int> range(0, 100);
+			constexpr auto int64 = 120000000000LL;
+			constexpr auto val = range.clip(int64);
+			static_assert(val == 100, "Bad clip");
+
+			constexpr int64_t tmp = 0x8000000000LL;
+			static_assert(!range.contains(tmp));
+		}
+
+		TEST_CASE("truncation")
+		{
+			constexpr TRange<int8_t> range(0, 100);
+			int val = 0x1020;
+			val = range.clip(val);
+			REQUIRE_EQ(val, 100);
+		}
+
+		TEST_CASE("Membership")
+		{
+			constexpr TRange<int8_t> range(0, 100);
+			int val = 0x8000;
+			REQUIRE(!range.contains(val));
+		}
+	}
+};
+
+void REGISTER_TEST(Range)
+{
+	registerGroup<RangeTest>();
+}

--- a/tests/HostTests/modules/Range.cpp
+++ b/tests/HostTests/modules/Range.cpp
@@ -19,6 +19,10 @@ public:
 
 			constexpr int64_t tmp = 0x8000000000LL;
 			static_assert(!range.contains(tmp));
+
+			for(unsigned i = 0; i < 10; ++i) {
+				Serial << range.random() << endl;
+			}
 		}
 
 		TEST_CASE("truncation")
@@ -34,6 +38,14 @@ public:
 			constexpr TRange<int8_t> range(0, 100);
 			int val = 0x8000;
 			REQUIRE(!range.contains(val));
+		}
+
+		TEST_CASE("Random")
+		{
+			constexpr TRange<int64_t> range(-0x10000000000LL, 0x10000000000LL);
+			for(unsigned i = 0; i < 10; ++i) {
+				Serial << range.random() << endl;
+			}
 		}
 	}
 };


### PR DESCRIPTION
**Avoid truncation of parameter to TRange `clip()` and `contains()` methods**

For instance, if `TRange<int8_t>::clip()` is passed an `int` value which exceeds the natural range of `int8_t` then it is truncated and the clipping returns an unexpected value. For example:

```c++
TRange<int8_t> range(0, 100);

/* Compiler catches this with an overflow error, attempting to convert `int` to `int8_t` */
range.clip(0x1005);

/* But here the compiler says nothing, and 0x1005 is silently truncated to 0x05,
   thus 5 is returned where 100 is expected */
int v = 0x1005;
range.clip(v);
```

Both `clip` and `contain` methods are now declared `constexpr` so they can be evaluated at compile time if required.

**Fix random() for 64-bit values.** May need second 32-bit random value to cover range properly

Add tests.
