### PR TITLE
Fix: call esp_netif_dhcps_stop before destrying the interface 

### DIFF
--- a/Sming/Components/Network/Arch/Esp32/Platform/AccessPointImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp32/Platform/AccessPointImpl.cpp
@@ -52,6 +52,7 @@ void AccessPointImpl::enable(bool enabled, bool save)
 			break;
 		}
 		if(apNetworkInterface) {
+			esp_netif_dhcps_stop(apNetworkInterface);
 			esp_netif_destroy(apNetworkInterface);
 			apNetworkInterface = nullptr;
 		}


### PR DESCRIPTION
when stopping the AccessPoint

originally, stopping the Access Point just called `esp_netif_destroy()`. If a dhcp package was queued at that point, the dhcp server would still process it, leading to a use after free condition in lwip.