### PR TITLE
Fix nanopb build issues

### DIFF
--- a/Sming/Libraries/nanopb/component.mk
+++ b/Sming/Libraries/nanopb/component.mk
@@ -2,3 +2,5 @@ COMPONENT_SRCDIRS := nanopb src
 COMPONENT_INCDIRS := nanopb src/include
 
 COMPONENT_SUBMODULES += nanopb
+
+NANOPB_GENERATE := $(PYTHON) $(COMPONENT_PATH)/nanopb/generator/nanopb_generator.py

--- a/Sming/Libraries/nanopb/component.mk
+++ b/Sming/Libraries/nanopb/component.mk
@@ -3,4 +3,4 @@ COMPONENT_INCDIRS := nanopb src/include
 
 COMPONENT_SUBMODULES += nanopb
 
-NANOPB_GENERATE := $(PYTHON) $(COMPONENT_PATH)/nanopb/generator/nanopb_generator.py
+export NANOPB_GENERATE := $(PYTHON) $(COMPONENT_PATH)/nanopb/generator/nanopb_generator.py


### PR DESCRIPTION
Fix random CI build failures associated with nanopb.

Updates the `nanopb` library to export `NANOPB_GENERATE` for use by e.g. `Sming-GoogleCast` library.
