### PR TITLE
Fix `llhttp` parser issues with closed connections

### DIFF
--- a/Sming/Components/Network/src/Network/Http/BasicHttpHeaders.cpp
+++ b/Sming/Components/Network/src/Network/Http/BasicHttpHeaders.cpp
@@ -42,6 +42,7 @@ HttpError BasicHttpHeaders::parse(char* data, size_t len, http_parser_type type)
 	return HttpError(HTTP_PARSER_ERRNO(&parser));
 #else
 	llhttp_init(&parser, type, &parserSettings);
+	parser.data = this;
 	return HttpError(llhttp_execute(&parser, data, len));
 #endif
 }

--- a/Sming/Components/Network/src/Network/Http/HttpClientConnection.h
+++ b/Sming/Components/Network/src/Network/Http/HttpClientConnection.h
@@ -86,7 +86,9 @@ protected:
 	{
 		if(err == ERR_OK) {
 			state = eHCS_Ready;
+#ifdef USE_LEGACY_HTTP_PARSER
 			init(HTTP_RESPONSE);
+#endif
 		}
 
 		return HttpConnection::onConnected(err);


### PR DESCRIPTION
Fixes #3006

- HttpClientConnection re-initialises parser on connect, but this resets parser state and causes error
- `BasicHttpHeaders::parse` needs to set `parser.data` as `llhttp_init` does not preserve this value (unlike http-parser)

TODO:

* [x] Check for regression with issue #2158