### PR TITLE
New module: Esp32HardwarePwm

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -433,6 +433,10 @@
 	path = Sming/Libraries/BLEKeyboard/ESP32-BLE-Keyboard
 	url = https://github.com/T-vK/ESP32-BLE-Keyboard.git
 	ignore = dirty
+[submodule "Libraries.Esp32HardwarePwm"]
+	path = Sming/Libraries/Esp32HardwarePwm
+	url = https://github.com/pljakobs/Esp32HardwarePwm
+	ignore = dirty
 [submodule "Libraries.esp-nimble-cpp"]
 	path = Sming/Libraries/NimBLE/esp-nimble-cpp
 	url = https://github.com/h2zero/esp-nimble-cpp.git
@@ -451,7 +455,3 @@
 # END OF .gitmodules
 #
 #################################################################################################
-[submodule "Sming/Arch/Esp32/Components/Esp32HardwarePwm"]
-	path = Sming/Arch/Esp32/Components/Esp32HardwarePwm
-	url = https://github.com/pljakobs/Esp32HardwarePwm
-	branch = devel

--- a/.gitmodules
+++ b/.gitmodules
@@ -454,3 +454,4 @@
 [submodule "Sming/Arch/Esp32/Components/Esp32HardwarePwm"]
 	path = Sming/Arch/Esp32/Components/Esp32HardwarePwm
 	url = https://github.com/pljakobs/Esp32HardwarePwm
+	branch = devel

--- a/.gitmodules
+++ b/.gitmodules
@@ -451,3 +451,6 @@
 # END OF .gitmodules
 #
 #################################################################################################
+[submodule "Sming/Arch/Esp32/Components/Esp32HardwarePwm"]
+	path = Sming/Arch/Esp32/Components/Esp32HardwarePwm
+	url = https://github.com/pljakobs/Esp32HardwarePwm


### PR DESCRIPTION
## Summary
This PR adds Esp32HardwarePwm, a comprehensive C++ wrapper for the ESP32 LEDC PWM peripheral, to Arch/Esp32/Components

## Motivation
The ESP32 LEDC hardware is significantly more capable than the ESP8266 PWM — it supports up to 20-bit resolution, frequencies up to 40 MHz, hardware-accelerated linear fading, and phase shifting across multiple independent timer+channel groups. The pre-existing HardwarePWM API surface does not expose these capabilities on Esp32. This component provides a native Esp32-specific driver that takes full advantage of the hardware.

## Features

- Multiple independent instances — each with its own timer configuration (frequency, resolution, speed mode, timer index); multiple instances coexist by using non-overlapping channel ranges
- Flexible duty cycle control — both channel-indexed and legacy pin-indexed analogWrite API; configurable 1–20-bit resolution
- Phase shifting — OFF, AUTO (evenly distributed), or MANUAL (per-pin hpoint values) to reduce inrush current spikes and EMI
- Spread spectrum — optional frequency dithering around the base frequency for EMI reduction
- Hardware fade — hardware-accelerated linear transitions via the LEDC fade engine; ISR installed lazily on first use
- Per-channel fade queue — chain multiple fades per channel without application polling:
  - FIFO mode: plays entries once in order, auto-starts on first enqueue, fires onQueueEmpty callback when drained
CYCLIC mode: loops the entry set endlessly, fires onCyclicWrap each loop, requires explicit startQueue() after seeding
  - Per-channel configurable queue depth (default 10, uint16_t); runtime resize while queue is empty
  - Three callback slots: onFadeDone, onQueueEmpty, onCyclicWrap — dispatched via System.queueCallback (task context, ISR-safe)