### PR TITLE
Ensure `PSTR(s)` macro word-aligns string data

### DIFF
--- a/Sming/Arch/Esp32/Components/libc/src/include/sys/pgmspace.h
+++ b/Sming/Arch/Esp32/Components/libc/src/include/sys/pgmspace.h
@@ -25,7 +25,12 @@ extern "C" {
 
 #define PROGMEM STORE_ATTR ICACHE_RODATA_ATTR
 #define PROGMEM_PSTR PROGMEM
-#define PSTR(str) (str)
+
+#define PSTR(str)                                                                                                      \
+	(__extension__({                                                                                                   \
+		static const char __pstr__[] PROGMEM_PSTR = str;                                                               \
+		&__pstr__[0];                                                                                                  \
+	}))
 
 #define PGM_P const char*
 #define PGM_VOID_P const void*

--- a/Sming/Arch/Rp2040/Components/libc/src/include/sys/pgmspace.h
+++ b/Sming/Arch/Rp2040/Components/libc/src/include/sys/pgmspace.h
@@ -29,7 +29,12 @@ extern "C" {
 
 #define PROGMEM STORE_ATTR ICACHE_RODATA_ATTR
 #define PROGMEM_PSTR PROGMEM
-#define PSTR(str) (str)
+
+#define PSTR(str)                                                                                                      \
+	(__extension__({                                                                                                   \
+		static const char __pstr__[] PROGMEM_PSTR = str;                                                               \
+		&__pstr__[0];                                                                                                  \
+	}))
 
 #define PGM_P const char*
 #define PGM_VOID_P const void*


### PR DESCRIPTION
Issue #3018 is due to misaligned string data when `String` is passed a pointer to flash data. Whilst the esp32 (and rp2040) allow this, the esp8266 is very particular about alignment so for consistency we should keep the behaviour the same to avoid problems like this.