### PR TITLE
Increase TCP_SND_BUF for more reliable SSL comms

### DIFF
--- a/Sming/Arch/Esp8266/Components/esp-lwip/lwipopts.h
+++ b/Sming/Arch/Esp8266/Components/esp-lwip/lwipopts.h
@@ -954,7 +954,7 @@
  * TCP_SND_BUF: TCP sender buffer space (bytes). 
  */
 #ifndef TCP_SND_BUF
-#define TCP_SND_BUF                     2 * TCP_MSS
+#define TCP_SND_BUF                     3 * TCP_MSS
 #endif
 
 /**

--- a/Sming/Arch/Esp8266/Components/esp-open-lwip/esp-open-lwip.patch
+++ b/Sming/Arch/Esp8266/Components/esp-open-lwip/esp-open-lwip.patch
@@ -101,7 +101,7 @@ index ff03b30..5089589 100644
  #define LWIP_PLATFORM_DIAG(x)
  #define LWIP_PLATFORM_ASSERT(x)
 diff --git a/include/lwipopts.h b/include/lwipopts.h
-index eaa8dd6..6568657 100644
+index eaa8dd6..fee5ce7 100644
 --- a/include/lwipopts.h
 +++ b/include/lwipopts.h
 @@ -403,7 +403,7 @@
@@ -155,6 +155,15 @@ index eaa8dd6..6568657 100644
 -#define TCP_MSS                         1460
 -#endif
 +#define TCP_MSS                        1390 
+ #endif
+ 
+ /**
+@@ -974,7 +972,7 @@
+  * TCP_SND_BUF: TCP sender buffer space (bytes). 
+  */
+ #ifndef TCP_SND_BUF
+-#define TCP_SND_BUF                     2 * TCP_MSS
++#define TCP_SND_BUF                     3 * TCP_MSS
  #endif
  
  /**

--- a/Sming/Arch/Esp8266/Components/lwip2/lwip2.patch
+++ b/Sming/Arch/Esp8266/Components/lwip2/lwip2.patch
@@ -1,3 +1,16 @@
+diff --git a/glue-esp/lwip-1.4-arduino/include/lwipopts.h b/glue-esp/lwip-1.4-arduino/include/lwipopts.h
+index 2081b3a..be58876 100644
+--- a/glue-esp/lwip-1.4-arduino/include/lwipopts.h
++++ b/glue-esp/lwip-1.4-arduino/include/lwipopts.h
+@@ -984,7 +984,7 @@
+  * TCP_SND_BUF: TCP sender buffer space (bytes).
+  */
+ #ifndef TCP_SND_BUF
+-#define TCP_SND_BUF                     2 * TCP_MSS
++#define TCP_SND_BUF                     3 * TCP_MSS
+ #endif
+ 
+ /**
 diff --git a/glue-lwip/arch/cc.h b/glue-lwip/arch/cc.h
 index 0b73cba..fff12b0 100644
 --- a/glue-lwip/arch/cc.h
@@ -11,6 +24,19 @@ index 0b73cba..fff12b0 100644
  #include "glue.h" // include assembly locking macro used below
  typedef uint32_t sys_prot_t;
  #define SYS_ARCH_DECL_PROTECT(lev) sys_prot_t lev
+diff --git a/glue-lwip/arduino/lwipopts.h b/glue-lwip/arduino/lwipopts.h
+index 26cd649..c23cf0d 100644
+--- a/glue-lwip/arduino/lwipopts.h
++++ b/glue-lwip/arduino/lwipopts.h
+@@ -1317,7 +1317,7 @@
+  * To achieve good performance, this should be at least 2 * TCP_MSS.
+  */
+ #if !defined TCP_SND_BUF || defined __DOXYGEN__
+-#define TCP_SND_BUF                     (2 * TCP_MSS)
++#define TCP_SND_BUF                     (3 * TCP_MSS)
+ #endif
+ 
+ /**
 diff --git a/glue-lwip/esp-dhcpserver.c b/glue-lwip/esp-dhcpserver.c
 index 6ac8a41..cd1faf0 100644
 --- a/glue-lwip/esp-dhcpserver.c
@@ -24,6 +50,19 @@ index 6ac8a41..cd1faf0 100644
  
  #include "glue.h"
  #include "lwip-helper.h"
+diff --git a/glue-lwip/open/lwipopts.h b/glue-lwip/open/lwipopts.h
+index 1790fd1..8e45b28 100644
+--- a/glue-lwip/open/lwipopts.h
++++ b/glue-lwip/open/lwipopts.h
+@@ -1318,7 +1318,7 @@
+  * To achieve good performance, this should be at least 2 * TCP_MSS.
+  */
+ #if !defined TCP_SND_BUF || defined __DOXYGEN__
+-#define TCP_SND_BUF                     (2 * TCP_MSS)
++#define TCP_SND_BUF                     (3 * TCP_MSS)
+ #endif
+ 
+ /**
 diff --git a/glue/esp-missing.h b/glue/esp-missing.h
 index b9fea2a..63bbb45 100644
 --- a/glue/esp-missing.h

--- a/Sming/Components/lwip/lwipopts.h
+++ b/Sming/Components/lwip/lwipopts.h
@@ -350,6 +350,8 @@
 #define LWIP_TCP_KEEPALIVE              1
 #define TCP_MSS                         1390
 
+#define TCP_SND_BUF                     (3 * TCP_MSS)
+
 /*
    ----------------------------------
    ---------- Pbuf options ----------

--- a/docs/source/upgrading/6.2-6.3.rst
+++ b/docs/source/upgrading/6.2-6.3.rst
@@ -18,3 +18,11 @@ Main differences:
 
 If any of this is a problem, you can revert to the legacy http-parser by (re-)building with `USE_LEGACY_HTTP_PARSER=1`.
 Once the codebase starts making use of the newer features of *llhttp* this may be removed.
+
+
+**Bear SSL comms and TCP buffering**
+
+The default value of TCP_SND_BUF has been increased from (2*TCP_MSS) to (3*TCP_MSS) for Esp8266 and Host architectures.
+This does not appear to directly increase memory usage as buffers are pre-allocated internally by LWIP.
+
+See :issue:3022.


### PR DESCRIPTION
This PR address issue #3022 by increasing the lwip TCP send buffer allocation. RP2040 and esp32 already use larger values.

Checked `HttpClient` sample operation on host, esp8266 (with ENABLE_CUSTOM_LWIP=1 and ENABLE_CUSTOM_LWIP=2), esp32c3, rp2040.