### PR TITLE
Fix `hwconfig-edit` failure with mulitiple `HWCONFIG_OPTS` values

### DIFF
--- a/Sming/Arch/Rp2040/Components/rp2040/README.rst
+++ b/Sming/Arch/Rp2040/Components/rp2040/README.rst
@@ -39,9 +39,9 @@ Configuration variables
     This can be wasteful when using OTA as the firmware must be contained in all application images.
 
     Setting this value to '0' will omit firmware from the image, and instead load it from a partition called 'cyw43_fw'.
-    This partition can be added to the standard map using the 'cyw43_fw' :envvar:`HWCONFIG_OPT` setting::
+    This partition can be added to the standard map using the 'cyw43_fw' :envvar:`HWCONFIG_OPTS` setting::
 
-        make LINK_CYW43_FIRMWARE=0 HWCONFIG_OPT=cyw43_fw
+        make LINK_CYW43_FIRMWARE=0 HWCONFIG_OPTS=cyw43_fw
 
     This is not the default setting since the additional partition must be managed by the end application.
 

--- a/Sming/Components/Storage/README.rst
+++ b/Sming/Components/Storage/README.rst
@@ -308,7 +308,8 @@ Configuration
 
 .. envvar:: HWCONFIG_OPTS
 
-   Set this to adjust the hardware profile using option fragments. See :ref:`hwconfig_options`.
+   Set this to adjust the hardware profile using option fragments.
+   Values are comma-separated. See :ref:`hwconfig_options`.
 
 
 .. envvar:: ENABLE_STORAGE_SIZE64

--- a/Sming/Components/Storage/Tools/hwconfig/editor.py
+++ b/Sming/Components/Storage/Tools/hwconfig/editor.py
@@ -1278,7 +1278,7 @@ class Editor:
         self._filename = os.path.basename(filename)
 
         options = get_dict_value(self.json, 'options', [])
-        for opt in configVars.get('HWCONFIG_OPTS', '').replace(' ', '').split():
+        for opt in configVars.get('HWCONFIG_OPTS', '').replace(' ', '').split(','):
             if opt not in options:
                 options.append(opt)
 

--- a/docs/source/information/tips-n-tricks.rst
+++ b/docs/source/information/tips-n-tricks.rst
@@ -5,19 +5,19 @@ Tips and Tricks
 
 Reading VCC on ESP8266
 ----------------------
-If you are running on a battery operated device then function `system_get_vdd33()` from
+If you are running on a battery operated device then function ``system_get_vdd33()`` from
 the official ESP8266 NONOS SDK can help you read the power voltage.
-For the latter to work properly you should make a small change in your application `component.mk`
-file and add `vdd` to the `HWCONFIG_OPTS` configuration variable.
+For the latter to work properly you should make a small change in your application ``component.mk``
+file and add ``vdd`` to the :envvar:`HWCONFIG_OPTS` configuration variable.
 
 If you cannot see such a variable in your `component.mk` file then append the following line to it::
 
-   HWCONFIG := vdd
+   HWCONFIG_OPTS := vdd
 
-You can have multiple options selected. They should be separated by comma.
+You can have multiple options selected. They should be separated by a comma.
 For example the command below will add 4MB flash, spiffs and vdd support::
 
-   HWCONFIG := 4m,spiffs,vdd
+   HWCONFIG_OPTS := 4m,spiffs,vdd
 
 You can check the final hardware configuration using the command below::
 


### PR DESCRIPTION
For example:

```bash
make hwconfig-edit HWCONFIG_OPTS=4m,vdd
```

fails with *Option '4m,vdd' undefined*.

This PR fixes that plus a few related documentation typos.