### PR TITLE
Fix `hwconfig-edit` failure with empty `HWCONFIG_OPTS`

### DIFF
--- a/Sming/Components/Storage/Tools/hwconfig/editor.py
+++ b/Sming/Components/Storage/Tools/hwconfig/editor.py
@@ -1279,7 +1279,7 @@ class Editor:
 
         options = get_dict_value(self.json, 'options', [])
         for opt in configVars.get('HWCONFIG_OPTS', '').replace(' ', '').split(','):
-            if opt not in options:
+            if opt and opt not in options:
                 options.append(opt)
 
         self.reload()


### PR DESCRIPTION
PR #3024 introduced a further subtle bug where empty `HWCONFIG_OPTS` values cause `make hwconfig-edit` to fail.

This is because changing `str.split()` to `str.split(',')` does not behave consistently. The former returns `[ ]` whilst the latter returns `[ '' ]`.