### PR TITLE
Fix handling of 32-character SSID strings when scanning for access points on Esp8266

### DIFF
--- a/Sming/Components/Network/Arch/Esp8266/Platform/StationImpl.cpp
+++ b/Sming/Components/Network/Arch/Esp8266/Platform/StationImpl.cpp
@@ -19,7 +19,7 @@ class BssInfoImpl : public BssInfo
 public:
 	explicit BssInfoImpl(const bss_info* info)
 	{
-		ssid = reinterpret_cast<const char*>(info->ssid);
+		ssid = String(reinterpret_cast<const char*>(info->ssid), info->ssid_len);
 		bssid = info->bssid;
 		authorization = info->authmode;
 		channel = info->channel;


### PR DESCRIPTION
This PR fixes a bug when scanning for access points on the Esp8266.

The code currently assumes that the SSID is NUL-terminated, but this cannot be relied upon.

I today started getting weird behaviour sending the network list over a websocket connection in JSON format.
If any of the JSON is malformed then the browser closes the connection.

The offending SSID was this:

```
44 49 52 45 43 54 2d 43 46 2d 48 50 20 44 65 73  DIRECT-CF-HP Des
6b 4a 65 74 20 32 39 30 30 20 73 65 72 69 65 73  kJet 2900 series
20 06 be                                          ..
```

The SSID buffer is only 32 characters long so the `20 06 be` is junk which is not part of the name.
Clearly the `ssid_len` should have been used: we cannot assume SSID is NUL-terminated.
