### PR TITLE
Fix HttpServerConnection ETag check to use If-None-Match

### DIFF
--- a/Sming/Components/Network/src/Network/Http/HttpHeaderFields.h
+++ b/Sming/Components/Network/src/Network/Http/HttpHeaderFields.h
@@ -59,6 +59,9 @@
 	   "Precondition check using ETag to avoid accidental overwrites when servicing multiple user requests. Ensures "  \
 	   "resource entity tag matches before proceeding.")                                                               \
 	XX(IF_MODIFIED_SINCE, "If-Modified-Since", 0, "Precondition check using Date")                                     \
+	XX(IF_NONE_MATCH, "If-None-Match", 0,                                                                              \
+	   "Precondition check using ETag for cache revalidation. Used by GET/HEAD requests to avoid re-fetching a "       \
+	   "resource which has not changed.")                                                                              \
 	XX(LAST_MODIFIED, "Last-Modified", 0, "Server timestamp indicating date and time resource was last modified")      \
 	XX(LOCATION, "Location", 0, "Used in redirect responses, amongst other places")                                    \
 	XX(SEC_WEBSOCKET_ACCEPT, "Sec-WebSocket-Accept", 0, "Server response to opening Websocket handshake")              \

--- a/Sming/Components/Network/src/Network/Http/HttpServerConnection.cpp
+++ b/Sming/Components/Network/src/Network/Http/HttpServerConnection.cpp
@@ -268,8 +268,8 @@ void HttpServerConnection::sendResponseHeaders(HttpResponse* response)
 		}
 	}
 
-	if(request.headers.contains(HTTP_HEADER_IF_MATCH) && response->headers.contains(HTTP_HEADER_ETAG) &&
-	   request.headers[HTTP_HEADER_IF_MATCH] == response->headers[HTTP_HEADER_ETAG]) {
+	if(request.headers.contains(HTTP_HEADER_IF_NONE_MATCH) && response->headers.contains(HTTP_HEADER_ETAG) &&
+	   request.headers[HTTP_HEADER_IF_NONE_MATCH] == response->headers[HTTP_HEADER_ETAG]) {
 		if(request.method == HTTP_GET || request.method == HTTP_HEAD) {
 			response->code = HTTP_STATUS_NOT_MODIFIED;
 			response->headers[HTTP_HEADER_CONTENT_LENGTH] = "0";


### PR DESCRIPTION
The ETag caching in `HttpServerConnection::sendResponseHeaders()` returns 304 Not Modified when the *If-Match* request header matches the response ETag. That's the wrong header for this - If-Match is for optimistic-concurrency checks on writes (RFC 7232 §3.1), not for cache revalidation. The header a normal browser sends when revalidating a cached GET is If-None-Match, and that one isn't handled at all.

It goes a bit deeper than just checking the wrong constant, too: `HttpHeaderFieldName`/`HTTP_HEADER_FIELDNAME_MAP` in HttpHeaderFields.h never had an entry for If-None-Match in the first place. Without an entry in the table, an incoming `If-None-Match` header falls through to the custom-field path in `HttpHeaderFields::fromString()`/`findOrCreate()` and gets stored under its own dynamically-allocated field id, completely separate from `HTTP_HEADER_IF_MATCH`. So `request.headers.contains(HTTP_HEADER_IF_MATCH)` was always false for a request that only carries If-None-Match, and the 304 path could basically never be reached by a real client - only by something that deliberately sends If-Match on a GET, which isn't standard browser behavior.

Fix: add an `IF_NONE_MATCH` entry to the header field map, and switch the check in HttpServerConnection.cpp to use it instead of IF_MATCH.

I confirmed the logic by porting the field-table lookup and the 304 condition (unchanged) into a small standalone program and running both the old and new versions: with the current code, a request carrying only If-None-Match never triggers 304; with the fix it does, and a bare If-Match no longer incorrectly triggers 304 on a GET. I didn't spin up the full Sming Host build for this (submodules like FlashString aren't initialized in my checkout), so I can't point to an in-tree test run, but the header-matching code path itself is unchanged from upstream in the repro.
